### PR TITLE
releaze/2.1.2

### DIFF
--- a/.github/workflows/build-chain-indexer.yaml
+++ b/.github/workflows/build-chain-indexer.yaml
@@ -62,7 +62,7 @@ jobs:
             ${{ github.ref_type == 'tag' && 'midnightntwrk/chain-indexer' || '' }}
           tags: |
             type=semver,pattern={{version}}
-            type=sha,prefix=${{env.version}}-,format=short
+            ${{ github.ref_type != 'tag' && format('type=sha,prefix={0}-,format=short', env.version) || '' }}
           labels: |
             org.opencontainers.image.source=https://github.com/midnightntwrk/midnight-indexer/
             org.opencontainers.image.title=chain-indexer

--- a/.github/workflows/build-indexer-api.yaml
+++ b/.github/workflows/build-indexer-api.yaml
@@ -62,7 +62,7 @@ jobs:
             ${{ github.ref_type == 'tag' && 'midnightntwrk/indexer-api' || '' }}
           tags: |
             type=semver,pattern={{version}}
-            type=sha,prefix=${{env.version}}-,format=short
+            ${{ github.ref_type != 'tag' && format('type=sha,prefix={0}-,format=short', env.version) || '' }}
           labels: |
             org.opencontainers.image.source=https://github.com/midnightntwrk/midnight-indexer/
             org.opencontainers.image.title=indexer-api

--- a/.github/workflows/build-indexer-standalone.yaml
+++ b/.github/workflows/build-indexer-standalone.yaml
@@ -62,7 +62,7 @@ jobs:
             ${{ github.ref_type == 'tag' && 'midnightntwrk/indexer-standalone' || '' }}
           tags: |
             type=semver,pattern={{version}}
-            type=sha,prefix=${{env.version}}-,format=short
+            ${{ github.ref_type != 'tag' && format('type=sha,prefix={0}-,format=short', env.version) || '' }}
           labels: |
             org.opencontainers.image.source=https://github.com/midnightntwrk/midnight-indexer/
             org.opencontainers.image.title=indexer-standalone

--- a/.github/workflows/build-indexer-tests.yaml
+++ b/.github/workflows/build-indexer-tests.yaml
@@ -62,7 +62,7 @@ jobs:
             ${{ github.ref_type == 'tag' && 'midnightntwrk/indexer-tests' || '' }}
           tags: |
             type=semver,pattern={{version}}
-            type=sha,prefix=${{env.version}}-,format=short
+            ${{ github.ref_type != 'tag' && format('type=sha,prefix={0}-,format=short', env.version) || '' }}
           labels: |
             org.opencontainers.image.source=https://github.com/midnightntwrk/midnight-indexer/
             org.opencontainers.image.title=indexer-tests

--- a/.github/workflows/build-wallet-indexer.yaml
+++ b/.github/workflows/build-wallet-indexer.yaml
@@ -62,7 +62,7 @@ jobs:
             ${{ github.ref_type == 'tag' && 'midnightntwrk/wallet-indexer' || '' }}
           tags: |
             type=semver,pattern={{version}}
-            type=sha,prefix=${{env.version}}-,format=short
+            ${{ github.ref_type != 'tag' && format('type=sha,prefix={0}-,format=short', env.version) || '' }}
           labels: |
             org.opencontainers.image.source=https://github.com/midnightntwrk/midnight-indexer/
             org.opencontainers.image.title=wallet-indexer

--- a/.github/workflows/ci-cloud.yaml
+++ b/.github/workflows/ci-cloud.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - feat/*
+      - release/*
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-standalone.yaml
+++ b/.github/workflows/ci-standalone.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - feat/*
+      - release/*
   workflow_dispatch:
 
 concurrency:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,12 +131,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql"
-version = "7.0.16"
+version = "7.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3ee559e72d983e7e04001ba3bf32e6b71c1d670595780723727fd8a29d36e87"
+checksum = "036618f842229ba0b89652ffe425f96c7c16a49f7e3cb23b56fca7f61fd74980"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-axum"
-version = "7.0.16"
+version = "7.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95b41ba3c0f4ecccd73bf7e7aa7be3c41ff054968e988317bd9133ed210a4a2"
+checksum = "8725874ecfbf399e071150b8619c4071d7b2b7a2f117e173dddef53c6bdb6bb1"
 dependencies = [
  "async-graphql",
  "axum",
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "7.0.16"
+version = "7.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29db05b624fb6352fc11bfe30c54ab1b16a1fe937d7c05a783f4e88ef1292b3b"
+checksum = "fd45deb3dbe5da5cdb8d6a670a7736d735ba65b455328440f236dfb113727a3d"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-parser"
-version = "7.0.16"
+version = "7.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4904895044116aab098ca82c6cec831ec43ed99efd04db9b70a390419bc88c5b"
+checksum = "60b7607e59424a35dadbc085b0d513aa54ec28160ee640cf79ec3b634eba66d3"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -307,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "7.0.16"
+version = "7.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0cde74de18e3a00c5dd5cfa002ab6f532e1a06c2a79ee6671e2fc353b400b92"
+checksum = "34ecdaff7c9cffa3614a9f9999bf9ee4c3078fe3ce4d6a6e161736b56febf2de"
 dependencies = [
  "bytes",
  "indexmap 2.9.0",
@@ -319,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -330,7 +330,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 0.38.44",
+ "rustix",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e23419d455dc57d3ae60a2f4278cf561fc74fe866e548e14d2b0ad3e1b8ca0b2"
+checksum = "2cf0ae68ffe9ef362127a2223b42f57104edb20a50429f8c6e058912212884f7"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
+checksum = "cde3f4e40e6021d7acffc90095cbd6dc54cb593903d1de5832f435eb274b85dc"
 dependencies = [
  "async-channel",
  "async-io",
@@ -409,15 +409,15 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix 0.38.44",
+ "rustix",
  "tracing",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
+checksum = "d7605a4e50d4b06df3898d5a70bf5fde51ed9059b0434b73105193bc27acce0d"
 dependencies = [
  "async-io",
  "async-lock",
@@ -425,7 +425,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.44",
+ "rustix",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -653,9 +653,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 dependencies = [
  "serde",
 ]
@@ -790,7 +790,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-named-pipe",
- "hyper-rustls 0.27.5",
+ "hyper-rustls 0.27.6",
  "hyper-util",
  "hyperlocal",
  "log",
@@ -979,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
 dependencies = [
  "shlex",
 ]
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "chain-indexer"
-version = "2.1.2"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1239,9 +1239,21 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1255,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1487,19 +1499,6 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote 1.0.40",
- "rustc_version",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
@@ -1522,9 +1521,11 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
+ "convert_case 0.6.0",
  "proc-macro2",
  "quote 1.0.40",
  "syn 2.0.101",
+ "unicode-xid 0.2.6",
 ]
 
 [[package]]
@@ -1533,6 +1534,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
+ "convert_case 0.7.1",
  "proc-macro2",
  "quote 1.0.40",
  "syn 2.0.101",
@@ -1744,9 +1746,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -1761,6 +1763,17 @@ dependencies = [
  "cfg-if",
  "home",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1981,11 +1994,11 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cb8796f93fa038f979a014234d632e9688a120e745f936e2635123c77537f7"
+checksum = "e1276c23a1fb234d9f81b5f71c526437f2a55ab4419f29bfe1196ac4ee2f706c"
 dependencies = [
- "frame-metadata 21.0.0",
+ "frame-metadata",
  "parity-scale-codec",
  "scale-decode",
  "scale-info",
@@ -1995,25 +2008,14 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "20.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26de808fa6461f2485dc51811aefed108850064994fb4a62b3ac21ffa62ac8df"
+checksum = "d8c26fcb0454397c522c05fdad5380c4e622f8a875638af33bff5a320d1fc965"
 dependencies = [
  "cfg-if",
  "parity-scale-codec",
  "scale-info",
  "serde",
-]
-
-[[package]]
-name = "frame-metadata"
-version = "21.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20dfd1d7eae1d94e32e869e2fb272d81f52dd8db57820a373adb83ea24d7d862"
-dependencies = [
- "cfg-if",
- "parity-scale-codec",
- "scale-info",
 ]
 
 [[package]]
@@ -2421,7 +2423,6 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.12",
  "allocator-api2",
- "serde",
 ]
 
 [[package]]
@@ -2433,6 +2434,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -2464,9 +2466,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "hex"
@@ -2691,11 +2693,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
 dependencies = [
- "futures-util",
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
@@ -2704,7 +2705,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 0.26.11",
+ "webpki-roots 1.0.0",
 ]
 
 [[package]]
@@ -2722,9 +2723,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2828,9 +2829,9 @@ checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -2844,9 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -2945,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-api"
-version = "2.1.2"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3025,6 +3026,7 @@ version = "1.0.1"
 dependencies = [
  "anyhow",
  "chain-indexer",
+ "humantime-serde",
  "indexer-api",
  "indexer-common",
  "log",
@@ -3087,12 +3089,6 @@ dependencies = [
  "hashbrown 0.15.3",
  "serde",
 ]
-
-[[package]]
-name = "indexmap-nostd"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
 name = "indoc"
@@ -3180,9 +3176,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02000660d30638906021176af16b17498bd0d12813dbfe7b276d8bc7f3c0806"
+checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -3195,9 +3191,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c30758ddd7188629c6713fc45d1188af4f44c90582311d0c8d8c9907f60c48"
+checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -3418,7 +3414,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "libc",
  "redox_syscall 0.5.12",
 ]
@@ -3484,12 +3480,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
@@ -3522,9 +3512,9 @@ dependencies = [
 
 [[package]]
 name = "logforth"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d12336d4771854b6fdbf75bab8257e62d4221d1f9d7187fc254b29aa3bd23b"
+checksum = "6ab136b92556d7f0691c85ee12f2cba40f33615d2fc350f7d7504611d8df4828"
 dependencies = [
  "anyhow",
  "env_filter",
@@ -3543,6 +3533,12 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.3",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "manyhow"
@@ -3678,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "midnight-base-crypto-derive"
 version = "0.4.3-rc"
-source = "git+https://github.com/input-output-hk/midnight-ledger-prototype#00442b5e820acbd5e104011661beb88263b7dcf1"
+source = "git+https://github.com/input-output-hk/midnight-ledger-prototype#a591e61ef2b185c1fda8ae1c50d9ba8037553e4f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -3915,12 +3911,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3931,13 +3921,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3986,12 +3976,11 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -4045,17 +4034,6 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.101",
-]
 
 [[package]]
 name = "num-integer"
@@ -4122,6 +4100,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "opaque-debug"
@@ -4230,9 +4214,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.4"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
@@ -4246,9 +4230,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.7.4"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -4497,15 +4481,15 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polling"
-version = "3.7.4"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.4.0",
+ "hermit-abi 0.5.1",
  "pin-project-lite",
- "rustix 0.38.44",
+ "rustix",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -4658,7 +4642,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -4728,9 +4712,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4748,12 +4732,13 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
 dependencies = [
  "bytes",
  "getrandom 0.3.3",
+ "lru-slab",
  "rand 0.9.1",
  "ring",
  "rustc-hash",
@@ -4768,9 +4753,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
+checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -4890,7 +4875,7 @@ version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -4928,7 +4913,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -5028,7 +5013,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls 0.27.5",
+ "hyper-rustls 0.27.6",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -5190,27 +5175,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.9.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
 
@@ -5312,7 +5284,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
- "core-foundation 0.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -5366,19 +5338,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ruzstd"
-version = "0.6.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
-dependencies = [
- "byteorder",
- "derive_more 0.99.20",
-]
+checksum = "3640bec8aad418d7d03c72ea2de10d5c646a598f9883c7babc160d91e3c1b26c"
 
 [[package]]
 name = "ryu"
@@ -5610,7 +5578,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -5623,8 +5591,8 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.9.0",
- "core-foundation 0.10.0",
+ "bitflags 2.9.1",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5954,9 +5922,9 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "0.18.0"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "966e72d77a3b2171bb7461d0cb91f43670c63558c62d7cf42809cae6c8b6b818"
+checksum = "e16e5723359f0048bf64bfdfba64e5732a56847d42c4fd3fe56f18280c813413"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
@@ -5967,17 +5935,17 @@ dependencies = [
  "bs58",
  "chacha20",
  "crossbeam-queue",
- "derive_more 0.99.20",
+ "derive_more 2.0.1",
  "ed25519-zebra",
  "either",
  "event-listener",
  "fnv",
  "futures-lite",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.3",
  "hex",
  "hmac 0.12.1",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "libm",
  "libsecp256k1",
  "merlin",
@@ -6000,7 +5968,7 @@ dependencies = [
  "slab",
  "smallvec",
  "soketto",
- "twox-hash",
+ "twox-hash 2.1.0",
  "wasmi",
  "x25519-dalek",
  "zeroize",
@@ -6008,23 +5976,23 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "0.16.2"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a33b06891f687909632ce6a4e3fd7677b24df930365af3d0bcb078310129f3f"
+checksum = "bad7762a41b43cc95e5253214ca8f85a2308a048f4fe8217927888065bafd30c"
 dependencies = [
  "async-channel",
  "async-lock",
  "base64 0.22.1",
  "blake2-rfc",
  "bs58",
- "derive_more 0.99.20",
+ "derive_more 1.0.0",
  "either",
  "event-listener",
  "fnv",
  "futures-channel",
  "futures-lite",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.3",
  "hex",
  "itertools 0.13.0",
  "log",
@@ -6044,9 +6012,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -6078,7 +6046,7 @@ dependencies = [
  "digest 0.10.7",
  "sha2 0.10.9",
  "sha3 0.10.8",
- "twox-hash",
+ "twox-hash 1.6.3",
 ]
 
 [[package]]
@@ -6102,9 +6070,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c3a85280daca669cfd3bcb68a337882a8bc57ec882f72c5d13a430613a738e"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -6115,9 +6083,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f743f2a3cea30a58cd479013f75550e879009e3a02f616f18ca699335aa248c3"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6151,9 +6119,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4200e0fde19834956d4252347c12a083bdcb237d7a1a1446bffd8768417dce"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -6164,9 +6132,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ceaa29cade31beca7129b6beeb05737f44f82dbe2a9806ecea5a7093d00b7"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
 dependencies = [
  "dotenvy",
  "either",
@@ -6183,20 +6151,19 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 2.0.101",
- "tempfile",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0afdd3aa7a629683c2d750c2df343025545087081ab5942593a5288855b1b7a7"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "byteorder",
  "bytes",
  "crc",
@@ -6234,17 +6201,17 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bedbe1bbb5e2615ef347a5e9d8cd7680fb63e77d9dafc0f29be15e53f1ebe6"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "byteorder",
  "crc",
  "dotenvy",
- "etcetera",
+ "etcetera 0.8.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -6273,9 +6240,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c26083e9a520e8eb87a06b12347679b142dc2ea29e6e409f805644a7a979a5bc"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
  "flume",
@@ -6324,16 +6291,6 @@ dependencies = [
  "futures-core",
  "pin-project",
  "tokio",
-]
-
-[[package]]
-name = "string-interner"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c6a0d765f5807e98a091107bae0a56ea3799f66a5de47b2c84c94a39c09974e"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -6406,14 +6363,14 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.41.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03459d84546def5e1d0d22b162754609f18e031522b0319b53306f5829de9c09"
+checksum = "1c7533d39317bed01100b37158740dcec27c0e1933f3bca19bdf12110f242248"
 dependencies = [
  "async-trait",
  "derive-where",
  "either",
- "frame-metadata 20.0.0",
+ "frame-metadata",
  "futures",
  "hex",
  "jsonrpsee",
@@ -6443,9 +6400,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.41.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324c52c09919fec8c22a4b572a466878322e99fe14a9e3d50d6c3700a226ec25"
+checksum = "91ded0fa15fa78c58b91e2a1c6bcef8a2bc68fe165d00e1dfb9787069351511c"
 dependencies = [
  "heck 0.5.0",
  "parity-scale-codec",
@@ -6460,15 +6417,15 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.41.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ef00be9d64885ec94e478a58e4e39d222024b20013ae7df4fc6ece545391aa"
+checksum = "26c3574b60050e57cf23edf6521263b06e98a880073df330813bb04242633083"
 dependencies = [
  "base58",
  "blake2",
  "derive-where",
  "frame-decode",
- "frame-metadata 20.0.0",
+ "frame-metadata",
  "hashbrown 0.14.5",
  "hex",
  "impl-serde",
@@ -6490,9 +6447,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.41.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce07c2515b2e63b85ec3043fe4461b287af0615d4832c2fe6e81ba780b906bc0"
+checksum = "7c546d42ca103c0a6a3434cadf4ca500d2a49e60af0842b0fdee6fbfa97aa02f"
 dependencies = [
  "futures",
  "futures-util",
@@ -6507,9 +6464,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.41.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c8da275a620dd676381d72395dfea91f0a6cd849665b4f1d0919371850701"
+checksum = "d91d253492eb17c65bdb41e538d6a31508563757bd34ad6014cb03536cf31757"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -6517,18 +6474,19 @@ dependencies = [
  "quote 1.0.40",
  "scale-typegen",
  "subxt-codegen",
+ "subxt-metadata",
  "subxt-utils-fetchmetadata",
  "syn 2.0.101",
 ]
 
 [[package]]
 name = "subxt-metadata"
-version = "0.41.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff4591673600c4388e21305788282414d26c791b4dee21b7cb0b19c10076f98"
+checksum = "243990ca4e0cdb74ef7458f1d5070a1bd5144d744cc146f23a32ab56d23e1db7"
 dependencies = [
  "frame-decode",
- "frame-metadata 20.0.0",
+ "frame-metadata",
  "hashbrown 0.14.5",
  "parity-scale-codec",
  "scale-info",
@@ -6538,13 +6496,13 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.41.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba7494d250d65dc3439365ac5e8e0fbb9c3992e6e84b7aa01d69e082249b8b8"
+checksum = "55313e3652f5360b5ed878bfe1d62fe181ecb8c130c81278ab89d1580f89a7ed"
 dependencies = [
  "derive-where",
  "finito",
- "frame-metadata 20.0.0",
+ "frame-metadata",
  "futures",
  "hex",
  "impl-serde",
@@ -6564,9 +6522,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.41.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc868b55fe2303788dc7703457af390111940c3da4714b510983284501780ed5"
+checksum = "62d3a6e9cb2fd2db8bf3cb0d03da691ac949259e620c9eb8f25764b2711805ca"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -6755,15 +6713,15 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "testcontainers"
-version = "0.23.3"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a4f01f39bb10fc2a5ab23eb0d888b1e2bb168c157f61a1b98e6c501c639c74"
+checksum = "23bb7577dca13ad86a78e8271ef5d322f37229ec83b8d98da6d996c588a1ddb1"
 dependencies = [
  "async-trait",
  "bollard",
@@ -6771,7 +6729,7 @@ dependencies = [
  "bytes",
  "docker_credential",
  "either",
- "etcetera",
+ "etcetera 0.10.0",
  "futures",
  "log",
  "memchr",
@@ -6790,9 +6748,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers-modules"
-version = "0.11.6"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d43ed4e8f58424c3a2c6c56dbea6643c3c23e8666a34df13c54f0a184e6c707"
+checksum = "7f29549c522bd43086d038c421ed69cdf88bc66387acf3aa92b26f965fa95ec2"
 dependencies = [
  "testcontainers",
 ]
@@ -6923,9 +6881,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7141,7 +7099,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "bytes",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -7281,6 +7239,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7380,6 +7344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "unicode-xid"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7461,12 +7431,14 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.3",
+ "js-sys",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -7535,7 +7507,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-indexer"
-version = "2.1.2"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -7677,51 +7649,52 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.32.3"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50386c99b9c32bd2ed71a55b6dd4040af2580530fae8bdb9a6576571a80d0cca"
+checksum = "a19af97fcb96045dd1d6b4d23e2b4abdbbe81723dbc5c9f016eb52145b320063"
 dependencies = [
  "arrayvec 0.7.6",
  "multi-stash",
- "num-derive",
- "num-traits",
  "smallvec",
  "spin",
  "wasmi_collections",
  "wasmi_core",
- "wasmparser-nostd",
+ "wasmi_ir",
+ "wasmparser",
 ]
 
 [[package]]
 name = "wasmi_collections"
-version = "0.32.3"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c128c039340ffd50d4195c3f8ce31aac357f06804cfc494c8b9508d4b30dca4"
-dependencies = [
- "ahash 0.8.12",
- "hashbrown 0.14.5",
- "string-interner",
-]
+checksum = "e80d6b275b1c922021939d561574bf376613493ae2b61c6963b15db0e8813562"
 
 [[package]]
 name = "wasmi_core"
-version = "0.32.3"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23b3a7f6c8c3ceeec6b83531ee61f0013c56e51cbf2b14b0f213548b23a4b41"
+checksum = "3a8c51482cc32d31c2c7ff211cd2bedd73c5bd057ba16a2ed0110e7a96097c33"
 dependencies = [
  "downcast-rs",
  "libm",
- "num-traits",
- "paste",
 ]
 
 [[package]]
-name = "wasmparser-nostd"
-version = "0.100.2"
+name = "wasmi_ir"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a015fe95f3504a94bb1462c717aae75253e39b9dd6c3fb1062c934535c64aa"
+checksum = "6e431a14c186db59212a88516788bd68ed51f87aa1e08d1df742522867b5289a"
 dependencies = [
- "indexmap-nostd",
+ "wasmi_core",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.221.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
+dependencies = [
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -7829,15 +7802,15 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-strings 0.4.0",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -7881,9 +7854,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
@@ -7899,9 +7872,9 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]
@@ -8209,7 +8182,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -8246,7 +8219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "rustix 1.0.7",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version       = "2.1.2"
+version       = "3.0.0"
 edition       = "2024"
 license       = "Apache-2.0"
 readme        = "README.md"
@@ -24,7 +24,7 @@ anyhow                      = { version = "1.0" }
 assert_matches              = { version = "1.5" }
 async-graphql               = { version = "7.0" }
 async-graphql-axum          = { version = "7.0" }
-async-nats                  = { version = "0.40" }
+async-nats                  = { version = "0.41" }
 async-stream                = { version = "0.3" }
 axum                        = { version = "0.8" }
 bech32                      = { version = "0.11" }
@@ -46,7 +46,7 @@ humantime-serde             = { version = "1.1" }
 indoc                       = { version = "2.0" }
 itertools                   = { version = "0.14" }
 log                         = { version = "0.4" }
-logforth                    = { version = "0.24" }
+logforth                    = { version = "0.25" }
 metrics                     = { version = "0.24" }
 metrics-exporter-prometheus = { version = "0.17", default-features = false }
 midnight-ledger             = { git = "https://github.com/midnightntwrk/midnight-ledger-prototype", tag = "ledger-4.0.0" }
@@ -64,10 +64,10 @@ serde_with                  = { version = "3.12" }
 sha2                        = { version = "0.10" }
 sqlx                        = { version = "0.8" }
 stream-cancel               = { version = "0.8" }
-subxt                       = { version = "0.41" }
-tempfile                    = { version = "3.19" }
-testcontainers              = { version = "0.23" }
-testcontainers-modules      = { version = "0.11" }
+subxt                       = { version = "0.42" }
+tempfile                    = { version = "3.20" }
+testcontainers              = { version = "0.24" }
+testcontainers-modules      = { version = "0.12" }
 thiserror                   = { version = "2.0" }
 tokio                       = { version = "1" }
 tokio-stream                = { version = "0.1" }
@@ -76,4 +76,4 @@ tokio-util                  = { version = "0.7" }
 tower                       = { version = "0.5" }
 tower-http                  = { version = "0.6" }
 trait-variant               = { version = "0.1" }
-uuid                        = { version = "1.16" }
+uuid                        = { version = "1.17" }

--- a/chain-indexer/config.yaml
+++ b/chain-indexer/config.yaml
@@ -8,11 +8,6 @@ application:
   caught_up_leeway: 5
 
 infra:
-  node:
-    url: "ws://localhost:9944"
-    reconnect_max_delay: "10s" # 10ms, 100ms, 1s, 10s
-    reconnect_max_attempts: 30 # Roughly 5m
-
   storage:
     host: "localhost"
     port: 5432
@@ -20,13 +15,18 @@ infra:
     user: "indexer"
     sslmode: "prefer"
 
+  pub_sub:
+    url: "localhost:4222"
+    username: "indexer"
+
   zswap_state_storage:
     url: "localhost:4222"
     username: "indexer"
 
-  pub_sub:
-    url: "localhost:4222"
-    username: "indexer"
+  node:
+    url: "ws://localhost:9944"
+    reconnect_max_delay: "10s" # 10ms, 100ms, 1s, 10s
+    reconnect_max_attempts: 30 # Roughly 5m
 
 telemetry:
   tracing:

--- a/chain-indexer/src/domain/storage.rs
+++ b/chain-indexer/src/domain/storage.rs
@@ -34,7 +34,7 @@ where
 
     /// Get a stream of transaction chunks for all blocks starting at the given height until the
     /// given height.
-    fn get_transactions(
+    fn get_transaction_chunks(
         &self,
         from_block_height: u32,
         to_block_height: u32,

--- a/chain-indexer/src/infra.rs
+++ b/chain-indexer/src/infra.rs
@@ -20,15 +20,15 @@ use indexer_common::infra::{pool, pub_sub, zswap_state_storage};
 #[cfg(feature = "cloud")]
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct Config {
-    #[serde(rename = "node")]
-    pub node_config: node::Config,
-
     #[serde(rename = "storage")]
     pub storage_config: pool::postgres::Config,
+
+    #[serde(rename = "pub_sub")]
+    pub pub_sub_config: pub_sub::nats::Config,
 
     #[serde(rename = "zswap_state_storage")]
     pub zswap_state_storage_config: zswap_state_storage::nats::Config,
 
-    #[serde(rename = "pub_sub")]
-    pub pub_sub_config: pub_sub::nats::Config,
+    #[serde(rename = "node")]
+    pub node_config: node::Config,
 }

--- a/chain-indexer/src/infra/node.rs
+++ b/chain-indexer/src/infra/node.rs
@@ -53,7 +53,10 @@ use subxt::{
         legacy::LegacyRpcMethods,
         rpc::reconnecting_rpc_client::{ExponentialBackoff, RpcClient},
     },
-    config::substrate::{BlakeTwo256, ConsensusEngineId, DigestItem, SubstrateHeader},
+    config::{
+        Hasher,
+        substrate::{ConsensusEngineId, DigestItem, SubstrateHeader},
+    },
     ext::subxt_rpcs,
     utils::H256,
 };
@@ -494,11 +497,14 @@ async fn receive_block(
 
 /// Check an authority set against a block header's digest logs to determine the author of that
 /// block.
-fn extract_block_author(
-    header: &SubstrateHeader<u32, BlakeTwo256>,
+fn extract_block_author<H>(
+    header: &SubstrateHeader<u32, H>,
     authorities: &[[u8; 32]],
     protocol_version: ProtocolVersion,
-) -> Result<Option<BlockAuthor>, SubxtNodeError> {
+) -> Result<Option<BlockAuthor>, SubxtNodeError>
+where
+    H: Hasher,
+{
     if authorities.is_empty() {
         return Ok(None);
     }

--- a/chain-indexer/src/infra/storage/postgres.rs
+++ b/chain-indexer/src/infra/storage/postgres.rs
@@ -112,7 +112,7 @@ impl Storage for PostgresStorage {
         "from_block_height": "{from_block_height}",
         "to_block_height": "{to_block_height}"
     })]
-    fn get_transactions(
+    fn get_transaction_chunks(
         &self,
         from_block_height: u32,
         to_block_height: u32,

--- a/chain-indexer/src/infra/storage/sqlite.rs
+++ b/chain-indexer/src/infra/storage/sqlite.rs
@@ -106,7 +106,7 @@ impl Storage for SqliteStorage {
         tx.commit().await
     }
 
-    fn get_transactions(
+    fn get_transaction_chunks(
         &self,
         from_block_height: u32,
         to_block_height: u32,

--- a/chain-indexer/src/main.rs
+++ b/chain-indexer/src/main.rs
@@ -71,10 +71,10 @@ async fn run() -> anyhow::Result<()> {
     );
 
     let infra::Config {
-        node_config,
-        zswap_state_storage_config,
         storage_config,
         pub_sub_config,
+        zswap_state_storage_config,
+        node_config,
     } = infra_config;
 
     let node = SubxtNode::new(node_config)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,5 @@
+# This Docker Compose file is for local development and testing and NOT meant for production use!
+
 services:
   chain-indexer:
     depends_on:
@@ -5,7 +7,7 @@ services:
         condition: "service_healthy"
       nats:
         condition: "service_started"
-    image: "ghcr.io/midnight-ntwrk/chain-indexer:latest"
+    image: "midnightntwrk/chain-indexer:latest"
     restart: "no"
     environment:
       RUST_LOG: "chain_indexer=debug,indexer_common=debug,fastrace_opentelemetry=off,info"
@@ -29,7 +31,7 @@ services:
         condition: "service_healthy"
       nats:
         condition: "service_started"
-    image: "ghcr.io/midnight-ntwrk/wallet-indexer:latest"
+    image: "midnightntwrk/wallet-indexer:latest"
     restart: "no"
     environment:
       RUST_LOG: "wallet_indexer=debug,indexer_common=debug,fastrace_opentelemetry=off,info"
@@ -51,7 +53,7 @@ services:
         condition: "service_healthy"
       nats:
         condition: "service_started"
-    image: "ghcr.io/midnight-ntwrk/indexer-api:latest"
+    image: "midnightntwrk/indexer-api:latest"
     restart: "no"
     ports:
       - "8088:8088"
@@ -74,12 +76,12 @@ services:
   indexer-standalone:
     profiles:
       - standalone
-    image: "ghcr.io/midnight-ntwrk/indexer-standalone:latest"
+    image: "midnightntwrk/indexer-standalone:latest"
     restart: "no"
     ports:
       - "8088:8088"
     environment:
-      RUST_LOG: "indexer=debug,chain_indexer=debug,indexer_api=debug,wallet_indexer=debug,indexer_common=debug,fastrace_opentelemetry=off,info"
+      RUST_LOG: "indexer_standalone=debug,chain_indexer=debug,indexer_api=debug,wallet_indexer=debug,indexer_common=debug,fastrace_opentelemetry=off,info"
       APP__INFRA__SECRET: $APP__INFRA__SECRET
       APP__INFRA__NODE__URL: "ws://node:9944"
     healthcheck:

--- a/indexer-api/config.yaml
+++ b/indexer-api/config.yaml
@@ -1,5 +1,8 @@
 run_migrations: true
 
+application:
+  network_id: "Undeployed"
+
 infra:
   storage:
     host: "localhost"
@@ -8,11 +11,11 @@ infra:
     user: "indexer"
     sslmode: "prefer"
 
-  zswap_state_storage:
+  pub_sub:
     url: "localhost:4222"
     username: "indexer"
 
-  pub_sub:
+  zswap_state_storage:
     url: "localhost:4222"
     username: "indexer"
 
@@ -22,7 +25,6 @@ infra:
     request_body_limit: "1MiB"
     max_complexity: 200
     max_depth: 15
-    network_id: "Undeployed"
 
 telemetry:
   tracing:

--- a/indexer-api/graphql/schema-v1.graphql
+++ b/indexer-api/graphql/schema-v1.graphql
@@ -42,7 +42,6 @@ input BlockOffset @oneOf {
 	height: Int
 }
 
-
 """
 A contract action.
 """
@@ -93,10 +92,7 @@ type ContractUpdate implements ContractAction {
 	transaction: Transaction!
 }
 
-
 scalar HexEncoded
-
-
 
 type MerkleTreeCollapsedUpdate {
 	"""
@@ -177,7 +173,6 @@ type RelevantTransaction {
 	"""
 	end: Int!
 }
-
 
 type Subscription {
 	"""
@@ -268,8 +263,17 @@ union WalletSyncEvent = ViewingUpdate | ProgressUpdate
 
 union ZswapChainStateUpdate = MerkleTreeCollapsedUpdate | RelevantTransaction
 
+"""
+Directs the executor to include this field or fragment only when the `if` argument is true.
+"""
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"""
+Indicates that an Input Object is a OneOf Input Object (and thus requires exactly one of its field be provided)
+"""
 directive @oneOf on INPUT_OBJECT
+"""
+Directs the executor to skip this field or fragment when the `if` argument is true.
+"""
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 schema {
 	query: Query

--- a/indexer-api/src/application.rs
+++ b/indexer-api/src/application.rs
@@ -14,14 +14,22 @@
 use crate::domain::Api;
 use anyhow::Context as AnyhowContext;
 use futures::{TryStreamExt, future::ok};
-use indexer_common::domain::{BlockIndexed, Subscriber};
+use indexer_common::domain::{BlockIndexed, NetworkId, Subscriber};
+use serde::Deserialize;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
 };
 use tokio::{select, task};
 
-pub async fn run(api: impl Api, subscriber: impl Subscriber) -> anyhow::Result<()> {
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub struct Config {
+    pub network_id: NetworkId,
+}
+
+pub async fn run(config: Config, api: impl Api, subscriber: impl Subscriber) -> anyhow::Result<()> {
+    let Config { network_id } = config;
+
     let caught_up = Arc::new(AtomicBool::new(false));
 
     let block_indexed_task = task::spawn({
@@ -43,8 +51,13 @@ pub async fn run(api: impl Api, subscriber: impl Subscriber) -> anyhow::Result<(
         }
     });
 
-    let serve_api_task =
-        { task::spawn(async move { api.serve(caught_up).await.context("serving API") }) };
+    let serve_api_task = {
+        task::spawn(async move {
+            api.serve(network_id, caught_up)
+                .await
+                .context("serving API")
+        })
+    };
 
     select! {
         result = block_indexed_task => result,

--- a/indexer-api/src/config.rs
+++ b/indexer-api/src/config.rs
@@ -11,11 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::infra;
+use crate::{application, infra};
 
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct Config {
     pub run_migrations: bool,
+
+    #[serde(rename = "application")]
+    pub application_config: application::Config,
 
     #[serde(rename = "infra")]
     pub infra_config: infra::Config,

--- a/indexer-api/src/domain/api.rs
+++ b/indexer-api/src/domain/api.rs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use indexer_common::domain::NetworkId;
 use std::{
     error::Error as StdError,
     sync::{Arc, atomic::AtomicBool},
@@ -25,5 +26,9 @@ where
     type Error: StdError + Send + Sync + 'static;
 
     /// Serve the API.
-    async fn serve(self, caught_up: Arc<AtomicBool>) -> Result<(), Self::Error>;
+    async fn serve(
+        self,
+        network_id: NetworkId,
+        caught_up: Arc<AtomicBool>,
+    ) -> Result<(), Self::Error>;
 }

--- a/indexer-api/src/infra.rs
+++ b/indexer-api/src/infra.rs
@@ -22,17 +22,17 @@ use indexer_common::infra::{pub_sub, zswap_state_storage};
 #[cfg(feature = "cloud")]
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct Config {
-    pub secret: secrecy::SecretString,
-
-    #[serde(rename = "api")]
-    pub api_config: api::Config,
-
     #[serde(rename = "storage")]
     pub storage_config: pool::postgres::Config,
+
+    #[serde(rename = "pub_sub")]
+    pub pub_sub_config: pub_sub::nats::Config,
 
     #[serde(rename = "zswap_state_storage")]
     pub zswap_state_storage_config: zswap_state_storage::nats::Config,
 
-    #[serde(rename = "pub_sub")]
-    pub pub_sub_config: pub_sub::nats::Config,
+    #[serde(rename = "api")]
+    pub api_config: api::Config,
+
+    pub secret: secrecy::SecretString,
 }

--- a/indexer-api/src/infra/api.rs
+++ b/indexer-api/src/infra/api.rs
@@ -79,14 +79,17 @@ where
     type Error = AxumApiError;
 
     /// Serve the API.
-    async fn serve(self, caught_up: Arc<AtomicBool>) -> Result<(), Self::Error> {
+    async fn serve(
+        self,
+        network_id: NetworkId,
+        caught_up: Arc<AtomicBool>,
+    ) -> Result<(), Self::Error> {
         let Config {
             address,
             port,
             request_body_limit,
             max_complexity,
             max_depth,
-            network_id,
         } = self.config;
 
         let app = make_app(
@@ -120,7 +123,6 @@ pub struct Config {
     pub request_body_limit: u64,
     pub max_complexity: usize,
     pub max_depth: usize,
-    pub network_id: NetworkId,
 }
 
 #[derive(Debug, Error)]

--- a/indexer-api/src/main.rs
+++ b/indexer-api/src/main.rs
@@ -51,6 +51,7 @@ async fn run() -> anyhow::Result<()> {
     // Load configuration.
     let Config {
         run_migrations,
+        application_config,
         infra_config,
         telemetry_config:
             telemetry::Config {
@@ -63,7 +64,7 @@ async fn run() -> anyhow::Result<()> {
     telemetry::init_tracing(tracing_config);
     telemetry::init_metrics(metrics_config);
 
-    info!(run_migrations, infra_config:?; "starting");
+    info!(run_migrations, application_config:?, infra_config:?; "starting");
 
     let infra::Config {
         secret,
@@ -93,7 +94,7 @@ async fn run() -> anyhow::Result<()> {
 
     let api = AxumApi::new(api_config, storage, zswap_state_storage, subscriber.clone());
 
-    application::run(api, subscriber)
+    application::run(application_config, api, subscriber)
         .await
         .context("run indexer-API application")?;
 

--- a/indexer-standalone/Cargo.toml
+++ b/indexer-standalone/Cargo.toml
@@ -15,15 +15,16 @@ all-features = true
 rustdoc-args = [ "--cfg", "docsrs" ]
 
 [dependencies]
-anyhow         = { workspace = true }
-chain-indexer  = { path = "../chain-indexer", optional = true }
-indexer-api    = { path = "../indexer-api", optional = true }
-indexer-common = { path = "../indexer-common", optional = true }
-log            = { workspace = true, features = [ "kv" ], optional = true }
-secrecy        = { workspace = true, optional = true }
-serde          = { workspace = true, features = [ "derive" ] }
-tokio          = { workspace = true, features = [ "rt-multi-thread" ] }
-wallet-indexer = { path = "../wallet-indexer", optional = true }
+anyhow          = { workspace = true }
+chain-indexer   = { path = "../chain-indexer", optional = true }
+humantime-serde = { workspace = true }
+indexer-api     = { path = "../indexer-api", optional = true }
+indexer-common  = { path = "../indexer-common", optional = true }
+log             = { workspace = true, features = [ "kv" ], optional = true }
+secrecy         = { workspace = true, optional = true }
+serde           = { workspace = true, features = [ "derive" ] }
+tokio           = { workspace = true, features = [ "rt-multi-thread" ] }
+wallet-indexer  = { path = "../wallet-indexer", optional = true }
 
 [features]
 standalone = [

--- a/indexer-standalone/config.yaml
+++ b/indexer-standalone/config.yaml
@@ -1,29 +1,23 @@
 run_migrations: true
-network_id: &network_id "Undeployed"
 
-chain_indexer_application:
-  network_id: *network_id
+application:
+  network_id: "Undeployed"
   blocks_buffer: 10
   save_zswap_state_after: 1000
   caught_up_max_distance: 10
   caught_up_leeway: 5
-
-wallet_indexer_application:
-  network_id: *network_id
   active_wallets_repeat_delay: "100ms"
   active_wallets_ttl: "30m"
   transaction_batch_size: 10
-  # Number of cores by default.
-  # parallelism:
 
 infra:
+  storage:
+    cnn_url: "/data/indexer.sqlite"
+
   node:
     url: "ws://localhost:9944"
     reconnect_max_delay: "10s" # 10ms, 100ms, 1s, 10s
     reconnect_max_attempts: 30 # Roughly 5m
-
-  storage:
-    cnn_url: "/data/indexer.sqlite"
 
   api:
     address: "0.0.0.0"
@@ -31,7 +25,6 @@ infra:
     request_body_limit: "1MiB"
     max_complexity: 200
     max_depth: 15
-    network_id: *network_id
 
 telemetry:
   tracing:

--- a/indexer-standalone/src/config.rs
+++ b/indexer-standalone/src/config.rs
@@ -11,18 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use indexer_common::{infra::pool, telemetry};
+use indexer_common::{domain::NetworkId, infra::pool, telemetry};
 use serde::Deserialize;
+use std::{num::NonZeroUsize, time::Duration};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     pub run_migrations: bool,
 
-    #[serde(rename = "chain_indexer_application")]
-    pub chain_indexer_application_config: chain_indexer::application::Config,
-
-    #[serde(alias = "wallet_indexer_application")]
-    pub wallet_indexer_application_config: wallet_indexer::application::Config,
+    #[serde(rename = "application")]
+    pub application_config: ApplicationConfig,
 
     #[serde(rename = "infra")]
     pub infra_config: InfraConfig,
@@ -31,16 +29,86 @@ pub struct Config {
     pub telemetry_config: telemetry::Config,
 }
 
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub struct ApplicationConfig {
+    pub network_id: NetworkId,
+    pub blocks_buffer: usize,
+    pub save_zswap_state_after: u32,
+    pub caught_up_max_distance: u32,
+    pub caught_up_leeway: u32,
+    #[serde(with = "humantime_serde")]
+    pub active_wallets_repeat_delay: Duration,
+    #[serde(with = "humantime_serde")]
+    pub active_wallets_ttl: Duration,
+    pub transaction_batch_size: NonZeroUsize,
+    #[serde(default = "parallelism_default")]
+    pub parallelism: NonZeroUsize,
+}
+
+impl From<ApplicationConfig> for chain_indexer::application::Config {
+    fn from(config: ApplicationConfig) -> Self {
+        let ApplicationConfig {
+            network_id,
+            blocks_buffer,
+            save_zswap_state_after,
+            caught_up_max_distance,
+            caught_up_leeway,
+            ..
+        } = config;
+
+        Self {
+            network_id,
+            blocks_buffer,
+            save_zswap_state_after,
+            caught_up_max_distance,
+            caught_up_leeway,
+        }
+    }
+}
+
+impl From<ApplicationConfig> for indexer_api::application::Config {
+    fn from(config: ApplicationConfig) -> Self {
+        Self {
+            network_id: config.network_id,
+        }
+    }
+}
+
+impl From<ApplicationConfig> for wallet_indexer::application::Config {
+    fn from(config: ApplicationConfig) -> Self {
+        let ApplicationConfig {
+            network_id,
+            active_wallets_repeat_delay,
+            active_wallets_ttl,
+            transaction_batch_size,
+            parallelism,
+            ..
+        } = config;
+
+        Self {
+            network_id,
+            active_wallets_repeat_delay,
+            active_wallets_ttl,
+            transaction_batch_size,
+            parallelism,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct InfraConfig {
-    pub secret: secrecy::SecretString,
+    #[serde(rename = "storage")]
+    pub storage_config: pool::sqlite::Config,
 
     #[serde(rename = "node")]
     pub node_config: chain_indexer::infra::node::Config,
 
-    #[serde(rename = "storage")]
-    pub storage_config: pool::sqlite::Config,
-
     #[serde(rename = "api")]
     pub api_config: indexer_api::infra::api::Config,
+
+    pub secret: secrecy::SecretString,
+}
+
+fn parallelism_default() -> NonZeroUsize {
+    std::thread::available_parallelism().unwrap_or(NonZeroUsize::MIN)
 }

--- a/indexer-tests/tests/storage.rs
+++ b/indexer-tests/tests/storage.rs
@@ -169,7 +169,7 @@ async fn run_tests(
     assert_eq!(contract_action_count, (2, 2, 1));
 
     let chunks = chain_indexer_storage
-        .get_transactions(0, 1)
+        .get_transaction_chunks(0, 1)
         .try_collect::<Vec<_>>()
         .await
         .context("collect transactions 0..=1")?;

--- a/wallet-indexer/src/infra.rs
+++ b/wallet-indexer/src/infra.rs
@@ -23,12 +23,12 @@ pub mod storage;
 #[cfg(feature = "cloud")]
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct Config {
-    pub secret: SecretString,
-
     #[serde(rename = "storage")]
     pub storage_config: pool::postgres::Config,
 
     #[cfg(feature = "cloud")]
     #[serde(rename = "pub_sub")]
     pub pub_sub_config: pub_sub::nats::Config,
+
+    pub secret: SecretString,
 }


### PR DESCRIPTION
- **chore(build): kick off CI on PRs against release/* (#17)**
- **chore(build): only tag images with sha if no git tag (#19)**
- **feat: unify configuration across components (#20)**
- **chore(deps): bump parity-scale-codec from 3.7.4 to 3.7.5 (#25)**
- **docs: add "Running" section to README (#24)**
- **chore: add more and consistent tracing and logging (#27)**
- **fix(indexer-api): make viewing update stream infinite (#32)**
- **chore(deps): bump uuid from 1.16.0 to 1.17.0 (#34)**
- **chore(deps): bump sqlx from 0.8.5 to 0.8.6 (#26)**
- **chore(deps): bump various dependencies (#36)**
- **fix(chain-indexer): reset zswap state if storage is empty (#35)**
