### PR TITLE
feat: rename ApplyStage to TransactionResult and add segment results

### DIFF
--- a/chain-indexer/src/domain/transaction.rs
+++ b/chain-indexer/src/domain/transaction.rs
@@ -13,8 +13,8 @@
 
 use crate::domain::ContractAction;
 use indexer_common::domain::{
-    ApplyStage, ByteArray, Identifier, MerkleTreeRoot, ProtocolVersion, RawTransaction,
-    TransactionHash,
+    ByteArray, Identifier, MerkleTreeRoot, ProtocolVersion, RawTransaction, TransactionHash,
+    TransactionResult,
 };
 use sqlx::FromRow;
 use std::fmt::Debug;
@@ -24,7 +24,7 @@ use std::fmt::Debug;
 pub struct Transaction {
     pub hash: TransactionHash,
     pub protocol_version: ProtocolVersion,
-    pub apply_stage: ApplyStage,
+    pub transaction_result: TransactionResult,
     pub identifiers: Vec<Identifier>,
     pub raw: RawTransaction,
     pub contract_actions: Vec<ContractAction>,

--- a/chain-indexer/src/domain/zswap.rs
+++ b/chain-indexer/src/domain/zswap.rs
@@ -17,13 +17,15 @@ use fastrace::trace;
 use indexer_common::{
     LedgerTransaction,
     domain::{
-        ApplyStage, ByteArray, ContractAddress, MerkleTreeRoot, NetworkId, RawLedgerState,
-        RawTransaction,
+        ByteArray, ContractAddress, MerkleTreeRoot, NetworkId, RawLedgerState, RawTransaction,
+        TransactionResult,
     },
     serialize::SerializableExt,
 };
 use midnight_base_crypto::{hash::HashOutput, time::Timestamp};
-use midnight_ledger::semantics::{TransactionContext, TransactionResult};
+use midnight_ledger::semantics::{
+    TransactionContext, TransactionResult as LedgerTransactionResult,
+};
 use midnight_onchain_runtime::context::BlockContext;
 use midnight_serialize::deserialize;
 use midnight_storage::DefaultDB;
@@ -97,7 +99,7 @@ impl LedgerState {
         block_parent_hash: ByteArray<32>,
         block_timestamp: u64,
         network_id: NetworkId,
-    ) -> Result<TransactionResult<DefaultDB>, Error> {
+    ) -> Result<TransactionResult, Error> {
         let ledger_transaction =
             deserialize::<LedgerTransaction, _>(&mut transaction.as_ref(), network_id.into())
                 .map_err(|error| Error::Io("cannot deserialize ledger transaction", error))?;
@@ -114,6 +116,17 @@ impl LedgerState {
         };
         let (state, transaction_result) = self.apply(&ledger_transaction, &cx);
         *self = LedgerState(state.into());
+
+        let transaction_result = match transaction_result {
+            LedgerTransactionResult::Success => TransactionResult::Success,
+
+            LedgerTransactionResult::PartialSuccess(segments) => {
+                let _segments = segments.into_iter().collect::<Vec<_>>();
+                TransactionResult::PartialSuccess
+            }
+
+            LedgerTransactionResult::Failure(_) => TransactionResult::Failure,
+        };
 
         Ok(transaction_result)
     }
@@ -144,11 +157,7 @@ impl LedgerState {
         }
 
         // Update transaction.
-        transaction.apply_stage = match transaction_result {
-            TransactionResult::Success => ApplyStage::Success,
-            TransactionResult::PartialSuccess(_) => ApplyStage::PartialSuccess,
-            TransactionResult::Failure(_) => ApplyStage::Failure,
-        };
+        transaction.transaction_result = transaction_result;
         transaction.merkle_tree_root = extract_merkle_tree_root(zswap, network_id)?;
         transaction.start_index = start_index;
         transaction.end_index = end_index;

--- a/chain-indexer/src/domain/zswap.rs
+++ b/chain-indexer/src/domain/zswap.rs
@@ -121,8 +121,11 @@ impl LedgerState {
             LedgerTransactionResult::Success => TransactionResult::Success,
 
             LedgerTransactionResult::PartialSuccess(segments) => {
-                let _segments = segments.into_iter().collect::<Vec<_>>();
-                TransactionResult::PartialSuccess
+                let segments = segments
+                    .into_iter()
+                    .map(|(id, result)| (id, result.is_ok()))
+                    .collect::<Vec<_>>();
+                TransactionResult::PartialSuccess(segments)
             }
 
             LedgerTransactionResult::Failure(_) => TransactionResult::Failure,

--- a/chain-indexer/src/infra/node.rs
+++ b/chain-indexer/src/infra/node.rs
@@ -587,7 +587,7 @@ async fn make_transaction(
 
     let transaction = Transaction {
         hash,
-        apply_stage: Default::default(),
+        transaction_result: Default::default(),
         protocol_version,
         identifiers,
         contract_actions,

--- a/chain-indexer/src/infra/storage/postgres.rs
+++ b/chain-indexer/src/infra/storage/postgres.rs
@@ -232,7 +232,7 @@ async fn save_transactions(
             q.push_bind(block_id)
                 .push_bind(hash.as_ref())
                 .push_bind(protocol_version.0 as i64)
-                .push_bind(transaction_result)
+                .push_bind(Json(transaction_result))
                 .push_bind(identifiers)
                 .push_bind(raw)
                 .push_bind(merkle_tree_root)

--- a/chain-indexer/src/infra/storage/postgres.rs
+++ b/chain-indexer/src/infra/storage/postgres.rs
@@ -207,7 +207,7 @@ async fn save_transactions(
                 block_id,
                 hash,
                 protocol_version,
-                apply_stage,
+                transaction_result,
                 identifiers,
                 raw,
                 merkle_tree_root,
@@ -221,7 +221,7 @@ async fn save_transactions(
             let Transaction {
                 hash,
                 protocol_version,
-                apply_stage,
+                transaction_result,
                 identifiers,
                 raw,
                 merkle_tree_root,
@@ -232,7 +232,7 @@ async fn save_transactions(
             q.push_bind(block_id)
                 .push_bind(hash.as_ref())
                 .push_bind(protocol_version.0 as i64)
-                .push_bind(apply_stage)
+                .push_bind(transaction_result)
                 .push_bind(identifiers)
                 .push_bind(raw)
                 .push_bind(merkle_tree_root)

--- a/chain-indexer/src/infra/storage/sqlite.rs
+++ b/chain-indexer/src/infra/storage/sqlite.rs
@@ -224,7 +224,7 @@ async fn save_transactions(
             q.push_bind(block_id)
                 .push_bind(hash.as_ref())
                 .push_bind(protocol_version.0 as i64)
-                .push_bind(transaction_result)
+                .push_bind(Json(transaction_result))
                 .push_bind(raw)
                 .push_bind(merkle_tree_root)
                 .push_bind(*start_index as i64)

--- a/chain-indexer/src/infra/storage/sqlite.rs
+++ b/chain-indexer/src/infra/storage/sqlite.rs
@@ -201,7 +201,7 @@ async fn save_transactions(
                         block_id,
                         hash,
                         protocol_version,
-                        apply_stage,
+                        transaction_result,
                         raw,
                         merkle_tree_root,
                         start_index,
@@ -214,7 +214,7 @@ async fn save_transactions(
             let Transaction {
                 hash,
                 protocol_version,
-                apply_stage,
+                transaction_result,
                 raw,
                 merkle_tree_root,
                 start_index,
@@ -224,7 +224,7 @@ async fn save_transactions(
             q.push_bind(block_id)
                 .push_bind(hash.as_ref())
                 .push_bind(protocol_version.0 as i64)
-                .push_bind(apply_stage)
+                .push_bind(transaction_result)
                 .push_bind(raw)
                 .push_bind(merkle_tree_root)
                 .push_bind(*start_index as i64)

--- a/docs/api/v1/api-documentation.md
+++ b/docs/api/v1/api-documentation.md
@@ -44,7 +44,6 @@ Sec-WebSocket-Protocol: graphql-transport-ws
 
 - `HexEncoded`: Hex-encoded bytes (for hashes, addresses, session IDs).
 - `ViewingKey`: A viewing key in hex or Bech32 format for wallet sessions.
-- `ApplyStage`: Enumerated stages of transaction application. This scalar represents the outcome of transaction processing on the chain ("Success", "PartialSuccess" or "Failure").
 - `Unit`: An empty return type for mutations that do not return data.
 
 ## Example Queries and Mutations
@@ -75,7 +74,7 @@ query {
     }
     transactions {
       hash
-      applyStage
+      transactionResult
     }
   }
 }

--- a/indexer-api/graphql/schema-v1.graphql
+++ b/indexer-api/graphql/schema-v1.graphql
@@ -1,5 +1,3 @@
-scalar ApplyStage
-
 """
 A block with its relevant data.
 """
@@ -205,9 +203,9 @@ type Transaction {
 	"""
 	protocolVersion: Int!
 	"""
-	The transaction apply stage.
+	The result of applying a transaction to the ledger state.
 	"""
-	applyStage: ApplyStage!
+	transactionResult: TransactionResult!
 	"""
 	The transaction identifiers.
 	"""
@@ -237,6 +235,8 @@ input TransactionOffset @oneOf {
 	hash: HexEncoded
 	identifier: HexEncoded
 }
+
+scalar TransactionResult
 
 scalar Unit
 

--- a/indexer-api/graphql/schema-v1.graphql
+++ b/indexer-api/graphql/schema-v1.graphql
@@ -172,6 +172,20 @@ type RelevantTransaction {
 	end: Int!
 }
 
+"""
+One of many segments for a partially successful transaction result.
+"""
+type Segment {
+	"""
+	Segment ID.
+	"""
+	id: Int!
+	"""
+	Successful or not.
+	"""
+	success: Boolean!
+}
+
 type Subscription {
 	"""
 	Subscribe to blocks starting at the given offset or at the latest block if the offset is
@@ -236,7 +250,23 @@ input TransactionOffset @oneOf {
 	identifier: HexEncoded
 }
 
-scalar TransactionResult
+"""
+The result of applying a transaction to the ledger state.
+In case of a partial success (status), there will be segments.
+"""
+type TransactionResult {
+	status: TransactionResultStatus!
+	segments: [Segment!]
+}
+
+"""
+The status of the transaction result: success, partial success or failure.
+"""
+enum TransactionResultStatus {
+	SUCCESS
+	PARTIAL_SUCCESS
+	FAILURE
+}
 
 scalar Unit
 

--- a/indexer-api/graphql/schema-v1.graphql
+++ b/indexer-api/graphql/schema-v1.graphql
@@ -173,7 +173,8 @@ type RelevantTransaction {
 }
 
 """
-One of many segments for a partially successful transaction result.
+One of many segments for a partially successful transaction result showing success for some
+segment.
 """
 type Segment {
 	"""

--- a/indexer-api/src/domain/transaction.rs
+++ b/indexer-api/src/domain/transaction.rs
@@ -14,7 +14,7 @@
 use crate::domain::BlockHash;
 use derive_more::Debug;
 use indexer_common::domain::{
-    ApplyStage, Identifier, MerkleTreeRoot, ProtocolVersion, RawTransaction, TransactionHash,
+    Identifier, MerkleTreeRoot, ProtocolVersion, RawTransaction, TransactionHash, TransactionResult,
 };
 use sqlx::FromRow;
 
@@ -33,7 +33,7 @@ pub struct Transaction {
     #[sqlx(try_from = "i64")]
     pub protocol_version: ProtocolVersion,
 
-    pub apply_stage: ApplyStage,
+    pub transaction_result: TransactionResult,
 
     #[debug(skip)]
     #[cfg_attr(feature = "standalone", sqlx(skip))]

--- a/indexer-api/src/domain/transaction.rs
+++ b/indexer-api/src/domain/transaction.rs
@@ -33,6 +33,7 @@ pub struct Transaction {
     #[sqlx(try_from = "i64")]
     pub protocol_version: ProtocolVersion,
 
+    #[sqlx(json)]
     pub transaction_result: TransactionResult,
 
     #[debug(skip)]

--- a/indexer-api/src/infra/api/v1.rs
+++ b/indexer-api/src/infra/api/v1.rs
@@ -274,7 +274,8 @@ pub enum TransactionResultStatus {
     Failure,
 }
 
-/// One of many segments for a partially successful transaction result.
+/// One of many segments for a partially successful transaction result showing success for some
+/// segment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, SimpleObject)]
 pub struct Segment {
     /// Segment ID.

--- a/indexer-api/src/infra/api/v1.rs
+++ b/indexer-api/src/infra/api/v1.rs
@@ -148,8 +148,8 @@ where
     /// The protocol version.
     protocol_version: u32,
 
-    /// The transaction apply stage.
-    apply_stage: ApplyStage,
+    /// The result of applying a transaction to the ledger state.
+    transaction_result: TransactionResult,
 
     /// The transaction identifiers.
     #[debug(skip)]
@@ -218,7 +218,7 @@ where
             hash,
             block_hash,
             protocol_version: ProtocolVersion(protocol_version),
-            apply_stage,
+            transaction_result,
             identifiers,
             raw,
             merkle_tree_root,
@@ -228,7 +228,7 @@ where
         Self {
             hash: hash.hex_encode(),
             protocol_version,
-            apply_stage: apply_stage.into(),
+            transaction_result: transaction_result.into(),
             identifiers: identifiers
                 .into_iter()
                 .map(|identifier| identifier.hex_encode())
@@ -258,22 +258,22 @@ enum TransactionOffset {
     Identifier(HexEncoded),
 }
 
-/// The apply stage of a transaction.
+/// The result of applying a transaction to the ledger state.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ApplyStage {
-    SucceedEntirely,
-    FailFallible,
-    FailEntirely,
+pub enum TransactionResult {
+    Success,
+    PartialSuccess,
+    Failure,
 }
 
-scalar!(ApplyStage);
+scalar!(TransactionResult);
 
-impl From<indexer_common::domain::ApplyStage> for ApplyStage {
-    fn from(apply_stage: indexer_common::domain::ApplyStage) -> Self {
-        match apply_stage {
-            indexer_common::domain::ApplyStage::Success => Self::SucceedEntirely,
-            indexer_common::domain::ApplyStage::PartialSuccess => Self::FailFallible,
-            indexer_common::domain::ApplyStage::Failure => Self::FailEntirely,
+impl From<indexer_common::domain::TransactionResult> for TransactionResult {
+    fn from(transaction_result: indexer_common::domain::TransactionResult) -> Self {
+        match transaction_result {
+            indexer_common::domain::TransactionResult::Success => Self::Success,
+            indexer_common::domain::TransactionResult::PartialSuccess => Self::PartialSuccess,
+            indexer_common::domain::TransactionResult::Failure => Self::Failure,
         }
     }
 }

--- a/indexer-api/src/infra/api/v1/subscription/wallet.rs
+++ b/indexer-api/src/infra/api/v1/subscription/wallet.rs
@@ -29,7 +29,7 @@ use futures::{
     stream::{self, TryStreamExt},
 };
 use indexer_common::domain::{
-    ApplyStage, LedgerStateStorage, NetworkId, SessionId, Subscriber, WalletIndexed,
+    LedgerStateStorage, NetworkId, SessionId, Subscriber, TransactionResult, WalletIndexed,
 };
 use log::{debug, warn};
 use metrics::{Counter, counter};
@@ -235,7 +235,7 @@ where
     // For failures, don't increment the index, because no changes were applied to the zswap state.
     // Put another way: the next transaction will have the same start_index like this end index.
     // This avoids "update with end before start" errors when calling `collapsed_update`.
-    let index = if transaction.apply_stage == ApplyStage::Failure {
+    let index = if transaction.transaction_result == TransactionResult::Failure {
         transaction.end_index
     } else {
         transaction.end_index + 1

--- a/indexer-api/src/infra/storage/postgres.rs
+++ b/indexer-api/src/infra/storage/postgres.rs
@@ -129,7 +129,7 @@ impl Storage for PostgresStorage {
                 transactions.hash,
                 blocks.hash AS block_hash,
                 transactions.protocol_version,
-                transactions.apply_stage,
+                transactions.transaction_result,
                 transactions.identifiers,
                 transactions.raw,
                 transactions.merkle_tree_root,
@@ -154,7 +154,7 @@ impl Storage for PostgresStorage {
                 transactions.hash,
                 blocks.hash AS block_hash,
                 transactions.protocol_version,
-                transactions.apply_stage,
+                transactions.transaction_result,
                 transactions.identifiers,
                 transactions.raw,
                 transactions.merkle_tree_root,
@@ -182,7 +182,7 @@ impl Storage for PostgresStorage {
                 transactions.hash,
                 blocks.hash AS block_hash,
                 transactions.protocol_version,
-                transactions.apply_stage,
+                transactions.transaction_result,
                 transactions.identifiers,
                 transactions.raw,
                 transactions.merkle_tree_root,
@@ -210,7 +210,7 @@ impl Storage for PostgresStorage {
                 transactions.hash,
                 blocks.hash AS block_hash,
                 transactions.protocol_version,
-                transactions.apply_stage,
+                transactions.transaction_result,
                 transactions.identifiers,
                 transactions.raw,
                 transactions.merkle_tree_root,
@@ -301,7 +301,7 @@ impl Storage for PostgresStorage {
             INNER JOIN transactions ON transactions.id = contract_actions.transaction_id
             WHERE contract_actions.address = $1
             AND transactions.block_id = (SELECT id FROM blocks WHERE hash = $2)
-            AND transactions.apply_stage != 'Failure'
+            AND transactions.transaction_result != 'Failure'
             ORDER BY id DESC
             LIMIT 1
         "};
@@ -332,7 +332,7 @@ impl Storage for PostgresStorage {
             INNER JOIN blocks ON blocks.id = transactions.block_id
             WHERE contract_actions.address = $1
             AND blocks.height = $2
-            AND transactions.apply_stage != 'Failure'
+            AND transactions.transaction_result != 'Failure'
             ORDER BY id DESC
             LIMIT 1
         "};
@@ -363,7 +363,7 @@ impl Storage for PostgresStorage {
             AND contract_actions.transaction_id = (
                 SELECT id FROM transactions
                 WHERE hash = $2
-                AND apply_stage != 'Failure'
+                AND transaction_result != 'Failure'
                 LIMIT 1
             )
             ORDER BY id DESC
@@ -395,7 +395,7 @@ impl Storage for PostgresStorage {
             INNER JOIN transactions ON transactions.id = contract_actions.transaction_id
             WHERE contract_actions.address = $1
             AND $2 = ANY(transactions.identifiers)
-            AND transactions.apply_stage != 'Failure'
+            AND transactions.transaction_result != 'Failure'
             ORDER BY id DESC
             LIMIT 1
         "};
@@ -451,7 +451,7 @@ impl Storage for PostgresStorage {
                     FROM contract_actions
                     INNER JOIN transactions ON transactions.id = contract_actions.transaction_id
                     INNER JOIN blocks ON blocks.id = transactions.block_id
-                    WHERE transactions.apply_stage != 'Failure'
+                    WHERE transactions.transaction_result != 'Failure'
                     AND contract_actions.address = $1
                     AND blocks.height >= $2
                     AND contract_actions.id >= $3
@@ -535,7 +535,7 @@ impl Storage for PostgresStorage {
                         transactions.hash,
                         blocks.hash AS block_hash,
                         transactions.protocol_version,
-                        transactions.apply_stage,
+                        transactions.transaction_result,
                         transactions.identifiers,
                         transactions.raw,
                         transactions.merkle_tree_root,

--- a/indexer-api/src/infra/storage/sqlite.rs
+++ b/indexer-api/src/infra/storage/sqlite.rs
@@ -126,7 +126,7 @@ impl Storage for SqliteStorage {
                 transactions.hash,
                 blocks.hash AS block_hash,
                 transactions.protocol_version,
-                transactions.apply_stage,
+                transactions.transaction_result,
                 transactions.raw,
                 transactions.merkle_tree_root,
                 transactions.start_index,
@@ -156,7 +156,7 @@ impl Storage for SqliteStorage {
                 transactions.hash,
                 blocks.hash AS block_hash,
                 transactions.protocol_version,
-                transactions.apply_stage,
+                transactions.transaction_result,
                 transactions.raw,
                 transactions.merkle_tree_root,
                 transactions.start_index,
@@ -191,7 +191,7 @@ impl Storage for SqliteStorage {
                 transactions.hash,
                 blocks.hash AS block_hash,
                 transactions.protocol_version,
-                transactions.apply_stage,
+                transactions.transaction_result,
                 transactions.raw,
                 transactions.merkle_tree_root,
                 transactions.start_index,
@@ -227,7 +227,7 @@ impl Storage for SqliteStorage {
                 transactions.hash,
                 blocks.hash AS block_hash,
                 transactions.protocol_version,
-                transactions.apply_stage,
+                transactions.transaction_result,
                 transactions.raw,
                 transactions.merkle_tree_root,
                 transactions.start_index,
@@ -324,7 +324,7 @@ impl Storage for SqliteStorage {
             INNER JOIN transactions ON transactions.id = contract_actions.transaction_id
             WHERE contract_actions.address = $1
             AND transactions.block_id = (SELECT id FROM blocks WHERE hash = $2)
-            AND transactions.apply_stage != 'Failure'
+            AND transactions.transaction_result != 'Failure'
             ORDER BY id DESC
             LIMIT 1
         "};
@@ -354,7 +354,7 @@ impl Storage for SqliteStorage {
             INNER JOIN blocks ON blocks.id = transactions.block_id
             WHERE contract_actions.address = $1
             AND blocks.height = $2
-            AND transactions.apply_stage != 'Failure'
+            AND transactions.transaction_result != 'Failure'
             ORDER BY id DESC
             LIMIT 1
         "};
@@ -384,7 +384,7 @@ impl Storage for SqliteStorage {
             AND contract_actions.transaction_id = (
                 SELECT id FROM transactions
                 WHERE hash = $2
-                AND apply_stage != 'Failure'
+                AND transaction_result != 'Failure'
                 ORDER BY id DESC
                 LIMIT 1
             )
@@ -417,7 +417,7 @@ impl Storage for SqliteStorage {
             INNER JOIN transaction_identifiers ON transactions.id = transaction_identifiers.transaction_id
             WHERE contract_actions.address = $1
             AND transaction_identifiers.identifier = $2
-            AND transactions.apply_stage != 'Failure'
+            AND transactions.transaction_result != 'Failure'
             ORDER BY id DESC
             LIMIT 1
         "};
@@ -471,7 +471,7 @@ impl Storage for SqliteStorage {
                     FROM contract_actions
                     INNER JOIN transactions ON transactions.id = contract_actions.transaction_id
                     INNER JOIN blocks ON blocks.id = transactions.block_id
-                    WHERE transactions.apply_stage != 'Failure'
+                    WHERE transactions.transaction_result != 'Failure'
                     AND contract_actions.address = $1
                     AND blocks.height >= $2
                     AND contract_actions.id >= $3
@@ -553,7 +553,7 @@ impl Storage for SqliteStorage {
                         transactions.hash,
                         blocks.hash AS block_hash,
                         transactions.protocol_version,
-                        transactions.apply_stage,
+                        transactions.transaction_result,
                         transactions.raw,
                         transactions.merkle_tree_root,
                         transactions.start_index,

--- a/indexer-api/src/infra/storage/sqlite.rs
+++ b/indexer-api/src/infra/storage/sqlite.rs
@@ -324,7 +324,7 @@ impl Storage for SqliteStorage {
             INNER JOIN transactions ON transactions.id = contract_actions.transaction_id
             WHERE contract_actions.address = $1
             AND transactions.block_id = (SELECT id FROM blocks WHERE hash = $2)
-            AND transactions.transaction_result != 'Failure'
+            AND json_extract(transactions.transaction_result, '$') != 'Failure'
             ORDER BY id DESC
             LIMIT 1
         "};
@@ -354,7 +354,7 @@ impl Storage for SqliteStorage {
             INNER JOIN blocks ON blocks.id = transactions.block_id
             WHERE contract_actions.address = $1
             AND blocks.height = $2
-            AND transactions.transaction_result != 'Failure'
+            AND json_extract(transactions.transaction_result, '$') != 'Failure'
             ORDER BY id DESC
             LIMIT 1
         "};
@@ -384,7 +384,7 @@ impl Storage for SqliteStorage {
             AND contract_actions.transaction_id = (
                 SELECT id FROM transactions
                 WHERE hash = $2
-                AND transaction_result != 'Failure'
+                AND json_extract(transaction_result, '$') != 'Failure'
                 ORDER BY id DESC
                 LIMIT 1
             )
@@ -417,7 +417,7 @@ impl Storage for SqliteStorage {
             INNER JOIN transaction_identifiers ON transactions.id = transaction_identifiers.transaction_id
             WHERE contract_actions.address = $1
             AND transaction_identifiers.identifier = $2
-            AND transactions.transaction_result != 'Failure'
+            AND json_extract(transactions.transaction_result, '$') != 'Failure'
             ORDER BY id DESC
             LIMIT 1
         "};
@@ -471,10 +471,10 @@ impl Storage for SqliteStorage {
                     FROM contract_actions
                     INNER JOIN transactions ON transactions.id = contract_actions.transaction_id
                     INNER JOIN blocks ON blocks.id = transactions.block_id
-                    WHERE transactions.transaction_result != 'Failure'
-                    AND contract_actions.address = $1
+                    WHERE contract_actions.address = $1
                     AND blocks.height >= $2
                     AND contract_actions.id >= $3
+                    AND json_extract(transactions.transaction_result, '$') != 'Failure'
                     ORDER BY id ASC
                     LIMIT $4
                 "};

--- a/indexer-common/migrations/postgres/001_initial.sql
+++ b/indexer-common/migrations/postgres/001_initial.sql
@@ -1,9 +1,3 @@
-CREATE TYPE TRANSACTION_RESULT AS ENUM(
-    'Success',
-    'PartialSuccess',
-    'Failure'
-);
-
 CREATE TYPE CONTRACT_ACTION_VARIANT AS ENUM(
     'Deploy',
     'Call',
@@ -25,7 +19,7 @@ CREATE TABLE transactions(
     block_id BIGINT NOT NULL REFERENCES blocks(id),
     hash BYTEA NOT NULL,
     protocol_version BIGINT NOT NULL,
-    transaction_result TRANSACTION_RESULT NOT NULL,
+    transaction_result JSONB NOT NULL,
     identifiers BYTEA[] NOT NULL,
     raw BYTEA NOT NULL,
     merkle_tree_root BYTEA NOT NULL,

--- a/indexer-common/migrations/postgres/001_initial.sql
+++ b/indexer-common/migrations/postgres/001_initial.sql
@@ -33,7 +33,11 @@ CREATE INDEX ON transactions(hash);
 
 CREATE INDEX ON transactions(transaction_result);
 
+CREATE INDEX ON transactions(start_index);
+
 CREATE INDEX ON transactions(end_index);
+
+CREATE INDEX ON transactions USING GIN(transaction_result);
 
 CREATE TABLE contract_actions(
     id BIGSERIAL PRIMARY KEY,

--- a/indexer-common/migrations/postgres/001_initial.sql
+++ b/indexer-common/migrations/postgres/001_initial.sql
@@ -1,4 +1,4 @@
-CREATE TYPE APPLY_STAGE AS ENUM(
+CREATE TYPE TRANSACTION_RESULT AS ENUM(
     'Success',
     'PartialSuccess',
     'Failure'
@@ -25,7 +25,7 @@ CREATE TABLE transactions(
     block_id BIGINT NOT NULL REFERENCES blocks(id),
     hash BYTEA NOT NULL,
     protocol_version BIGINT NOT NULL,
-    apply_stage APPLY_STAGE NOT NULL,
+    transaction_result TRANSACTION_RESULT NOT NULL,
     identifiers BYTEA[] NOT NULL,
     raw BYTEA NOT NULL,
     merkle_tree_root BYTEA NOT NULL,
@@ -37,7 +37,7 @@ CREATE INDEX ON transactions(block_id);
 
 CREATE INDEX ON transactions(hash);
 
-CREATE INDEX ON transactions(apply_stage);
+CREATE INDEX ON transactions(transaction_result);
 
 CREATE INDEX ON transactions(end_index);
 

--- a/indexer-common/migrations/sqlite/001_initial.sql
+++ b/indexer-common/migrations/sqlite/001_initial.sql
@@ -13,7 +13,7 @@ CREATE TABLE transactions(
     block_id INTEGER NOT NULL,
     hash BLOB NOT NULL,
     protocol_version INTEGER NOT NULL,
-    transaction_result TEXT CHECK (transaction_result IN ('Success', 'PartialSuccess', 'Failure')) NOT NULL,
+    transaction_result TEXT NOT NULL,
     raw BLOB NOT NULL,
     merkle_tree_root BLOB NOT NULL,
     start_index INTEGER NOT NULL,

--- a/indexer-common/migrations/sqlite/001_initial.sql
+++ b/indexer-common/migrations/sqlite/001_initial.sql
@@ -13,7 +13,7 @@ CREATE TABLE transactions(
     block_id INTEGER NOT NULL,
     hash BLOB NOT NULL,
     protocol_version INTEGER NOT NULL,
-    apply_stage TEXT CHECK (apply_stage IN ('Success', 'PartialSuccess', 'Failure')) NOT NULL,
+    transaction_result TEXT CHECK (transaction_result IN ('Success', 'PartialSuccess', 'Failure')) NOT NULL,
     raw BLOB NOT NULL,
     merkle_tree_root BLOB NOT NULL,
     start_index INTEGER NOT NULL,
@@ -25,7 +25,7 @@ CREATE INDEX transactions_block_id ON transactions(block_id);
 
 CREATE INDEX transactions_hash ON transactions(hash);
 
-CREATE INDEX transactions_apply_stage ON transactions(apply_stage);
+CREATE INDEX transactions_transaction_result ON transactions(transaction_result);
 
 CREATE INDEX transactions_end_index ON transactions(end_index);
 

--- a/indexer-common/migrations/sqlite/001_initial.sql
+++ b/indexer-common/migrations/sqlite/001_initial.sql
@@ -27,6 +27,8 @@ CREATE INDEX transactions_hash ON transactions(hash);
 
 CREATE INDEX transactions_transaction_result ON transactions(transaction_result);
 
+CREATE INDEX transactions_start_index ON transactions(start_index);
+
 CREATE INDEX transactions_end_index ON transactions(end_index);
 
 CREATE TABLE transaction_identifiers(

--- a/indexer-common/src/domain.rs
+++ b/indexer-common/src/domain.rs
@@ -43,14 +43,13 @@ pub type RawTransaction = ByteVec;
 pub type SessionId = ByteArray<32>;
 
 /// The result of applying a transaction to the ledger state.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
-#[cfg_attr(feature = "cloud", sqlx(type_name = "TRANSACTION_RESULT"))]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TransactionResult {
     /// All guaranteed and fallible coins succeeded.
     Success,
 
     /// Not all fallible coins succeeded.
-    PartialSuccess,
+    PartialSuccess(Vec<(u16, bool)>),
 
     /// Guaranteed coins failed.
     #[default]

--- a/indexer-common/src/domain.rs
+++ b/indexer-common/src/domain.rs
@@ -42,17 +42,17 @@ pub type MerkleTreeRoot = ByteVec;
 pub type RawTransaction = ByteVec;
 pub type SessionId = ByteArray<32>;
 
-/// The apply stage of a transaction.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
-#[cfg_attr(feature = "cloud", sqlx(type_name = "APPLY_STAGE"))]
-pub enum ApplyStage {
-    /// Guaranteed and fallible coins succeeded.
+/// The result of applying a transaction to the ledger state.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[cfg_attr(feature = "cloud", sqlx(type_name = "TRANSACTION_RESULT"))]
+pub enum TransactionResult {
+    /// All guaranteed and fallible coins succeeded.
     Success,
 
-    /// Only guaranteed coins succeeded.
+    /// Not all fallible coins succeeded.
     PartialSuccess,
 
-    /// Both guaranteed and fallible coins failed.
+    /// Guaranteed coins failed.
     #[default]
     Failure,
 }

--- a/indexer-common/src/domain.rs
+++ b/indexer-common/src/domain.rs
@@ -48,7 +48,7 @@ pub enum TransactionResult {
     /// All guaranteed and fallible coins succeeded.
     Success,
 
-    /// Not all fallible coins succeeded.
+    /// Not all fallible coins succeeded; the value maps segemt ID to success.
     PartialSuccess(Vec<(u16, bool)>),
 
     /// Guaranteed coins failed.

--- a/indexer-tests/e2e.graphql
+++ b/indexer-tests/e2e.graphql
@@ -12,7 +12,7 @@ query BlockQuery($block_offset: BlockOffset) {
         transactions {
             hash
             protocolVersion
-            applyStage
+            transactionResult
             identifiers
             block {
                 hash
@@ -23,7 +23,7 @@ query BlockQuery($block_offset: BlockOffset) {
                     address
                     transaction {
                         hash
-                        applyStage
+                        transactionResult
                         identifiers
                         block {
                             hash
@@ -36,7 +36,7 @@ query BlockQuery($block_offset: BlockOffset) {
                     address
                     transaction {
                         hash
-                        applyStage
+                        transactionResult
                         identifiers
                         block {
                             hash
@@ -51,7 +51,7 @@ query BlockQuery($block_offset: BlockOffset) {
                 ... on ContractUpdate {
                     address
                     transaction {
-                        applyStage
+                        transactionResult
                         hash
                         identifiers
                         block {
@@ -69,7 +69,7 @@ query TransactionsQuery($transaction_offset: TransactionOffset!) {
     transactions(offset: $transaction_offset) {
         hash
         protocolVersion
-        applyStage
+        transactionResult
         identifiers
         block {
             hash
@@ -80,7 +80,7 @@ query TransactionsQuery($transaction_offset: TransactionOffset!) {
                 address
                 transaction {
                     hash
-                    applyStage
+                    transactionResult
                     identifiers
                     block {
                         hash
@@ -93,7 +93,7 @@ query TransactionsQuery($transaction_offset: TransactionOffset!) {
                 address
                 transaction {
                     hash
-                    applyStage
+                    transactionResult
                     identifiers
                     block {
                         hash
@@ -109,7 +109,7 @@ query TransactionsQuery($transaction_offset: TransactionOffset!) {
                 address
                 transaction {
                     hash
-                    applyStage
+                    transactionResult
                     identifiers
                     block {
                         hash
@@ -128,7 +128,7 @@ query ContractActionQuery($address: HexEncoded!, $contract_action_offset: Contra
             address
             transaction {
                 hash
-                applyStage
+                transactionResult
                 identifiers
                 block {
                     hash
@@ -141,7 +141,7 @@ query ContractActionQuery($address: HexEncoded!, $contract_action_offset: Contra
             address
             transaction {
                 hash
-                applyStage
+                transactionResult
                 identifiers
                 block {
                     hash
@@ -157,7 +157,7 @@ query ContractActionQuery($address: HexEncoded!, $contract_action_offset: Contra
             address
             transaction {
                 hash
-                applyStage
+                transactionResult
                 identifiers
                 block {
                     hash
@@ -190,7 +190,7 @@ subscription BlockSubscription($block_offset: BlockOffset) {
         transactions {
             hash
             protocolVersion
-            applyStage
+            transactionResult
             identifiers
             block {
                 hash
@@ -201,7 +201,7 @@ subscription BlockSubscription($block_offset: BlockOffset) {
                     address
                     transaction {
                         hash
-                        applyStage
+                        transactionResult
                         identifiers
                         block {
                             hash
@@ -214,7 +214,7 @@ subscription BlockSubscription($block_offset: BlockOffset) {
                     address
                     transaction {
                         hash
-                        applyStage
+                        transactionResult
                         identifiers
                         block {
                             hash
@@ -230,7 +230,7 @@ subscription BlockSubscription($block_offset: BlockOffset) {
                     address
                     transaction {
                         hash
-                        applyStage
+                        transactionResult
                         identifiers
                         block {
                             hash
@@ -253,7 +253,7 @@ subscription ContractActionSubscription(
             address
             transaction {
                 hash
-                applyStage
+                transactionResult
                 identifiers
                 block {
                     hash
@@ -266,7 +266,7 @@ subscription ContractActionSubscription(
             address
             transaction {
                 hash
-                applyStage
+                transactionResult
                 identifiers
                 block {
                     hash
@@ -282,7 +282,7 @@ subscription ContractActionSubscription(
             address
             transaction {
                 hash
-                applyStage
+                transactionResult
                 identifiers
                 block {
                     hash

--- a/indexer-tests/e2e.graphql
+++ b/indexer-tests/e2e.graphql
@@ -12,7 +12,9 @@ query BlockQuery($block_offset: BlockOffset) {
         transactions {
             hash
             protocolVersion
-            transactionResult
+            transactionResult {
+                status
+            }
             identifiers
             block {
                 hash
@@ -23,7 +25,9 @@ query BlockQuery($block_offset: BlockOffset) {
                     address
                     transaction {
                         hash
-                        transactionResult
+                        transactionResult {
+                            status
+                        }
                         identifiers
                         block {
                             hash
@@ -36,7 +40,9 @@ query BlockQuery($block_offset: BlockOffset) {
                     address
                     transaction {
                         hash
-                        transactionResult
+                        transactionResult {
+                            status
+                        }
                         identifiers
                         block {
                             hash
@@ -51,7 +57,9 @@ query BlockQuery($block_offset: BlockOffset) {
                 ... on ContractUpdate {
                     address
                     transaction {
-                        transactionResult
+                        transactionResult {
+                            status
+                        }
                         hash
                         identifiers
                         block {
@@ -69,7 +77,9 @@ query TransactionsQuery($transaction_offset: TransactionOffset!) {
     transactions(offset: $transaction_offset) {
         hash
         protocolVersion
-        transactionResult
+        transactionResult {
+                status
+            }
         identifiers
         block {
             hash
@@ -80,7 +90,9 @@ query TransactionsQuery($transaction_offset: TransactionOffset!) {
                 address
                 transaction {
                     hash
-                    transactionResult
+                    transactionResult {
+                        status
+                    }
                     identifiers
                     block {
                         hash
@@ -93,7 +105,9 @@ query TransactionsQuery($transaction_offset: TransactionOffset!) {
                 address
                 transaction {
                     hash
-                    transactionResult
+                    transactionResult {
+                        status
+                    }
                     identifiers
                     block {
                         hash
@@ -109,7 +123,9 @@ query TransactionsQuery($transaction_offset: TransactionOffset!) {
                 address
                 transaction {
                     hash
-                    transactionResult
+                    transactionResult {
+                        status
+                    }
                     identifiers
                     block {
                         hash
@@ -128,7 +144,9 @@ query ContractActionQuery($address: HexEncoded!, $contract_action_offset: Contra
             address
             transaction {
                 hash
-                transactionResult
+                transactionResult {
+                    status
+                }
                 identifiers
                 block {
                     hash
@@ -141,7 +159,9 @@ query ContractActionQuery($address: HexEncoded!, $contract_action_offset: Contra
             address
             transaction {
                 hash
-                transactionResult
+                transactionResult {
+                    status
+                }
                 identifiers
                 block {
                     hash
@@ -157,7 +177,9 @@ query ContractActionQuery($address: HexEncoded!, $contract_action_offset: Contra
             address
             transaction {
                 hash
-                transactionResult
+                transactionResult {
+                    status
+                }
                 identifiers
                 block {
                     hash
@@ -190,7 +212,9 @@ subscription BlockSubscription($block_offset: BlockOffset) {
         transactions {
             hash
             protocolVersion
-            transactionResult
+            transactionResult {
+                status
+            }
             identifiers
             block {
                 hash
@@ -201,7 +225,9 @@ subscription BlockSubscription($block_offset: BlockOffset) {
                     address
                     transaction {
                         hash
-                        transactionResult
+                        transactionResult {
+                            status
+                        }
                         identifiers
                         block {
                             hash
@@ -214,7 +240,9 @@ subscription BlockSubscription($block_offset: BlockOffset) {
                     address
                     transaction {
                         hash
-                        transactionResult
+                        transactionResult {
+                            status
+                        }
                         identifiers
                         block {
                             hash
@@ -230,7 +258,9 @@ subscription BlockSubscription($block_offset: BlockOffset) {
                     address
                     transaction {
                         hash
-                        transactionResult
+                        transactionResult {
+                            status
+                        }
                         identifiers
                         block {
                             hash
@@ -253,7 +283,9 @@ subscription ContractActionSubscription(
             address
             transaction {
                 hash
-                transactionResult
+                transactionResult {
+                    status
+                }
                 identifiers
                 block {
                     hash
@@ -266,7 +298,9 @@ subscription ContractActionSubscription(
             address
             transaction {
                 hash
-                transactionResult
+                transactionResult {
+                    status
+                }
                 identifiers
                 block {
                     hash
@@ -282,7 +316,9 @@ subscription ContractActionSubscription(
             address
             transaction {
                 hash
-                transactionResult
+                transactionResult {
+                    status
+                }
                 identifiers
                 block {
                     hash

--- a/indexer-tests/src/e2e.rs
+++ b/indexer-tests/src/e2e.rs
@@ -14,13 +14,22 @@
 //! e2e testing library
 
 use crate::{
-    e2e::{
+    e2e::graphql::{
+        BlockQuery, BlockSubscription, ConnectMutation, ContractActionQuery,
+        ContractActionSubscription, DisconnectMutation, TransactionsQuery, WalletSubscription,
+        block_query,
         block_subscription::{
-            BlockSubscriptionBlocks as BlockSubscriptionBlock,
+            self, BlockSubscriptionBlocks as BlockSubscriptionBlock,
             BlockSubscriptionBlocksTransactions as BlockSubscriptionTransaction,
             BlockSubscriptionBlocksTransactionsContractActions as BlockSubscriptionContractAction,
+            TransactionResultStatus as BlockSubscriptionTransactionResultStatus,
         },
-        contract_action_query::ContractActionQueryContractAction,
+        connect_mutation,
+        contract_action_query::{
+            self, ContractActionQueryContractAction,
+            TransactionResultStatus as ContractActionQueryTransactionResultStatus,
+        },
+        contract_action_subscription, disconnect_mutation, transactions_query, wallet_subscription,
     },
     graphql_ws_client,
 };
@@ -30,7 +39,7 @@ use futures::{StreamExt, TryStreamExt, future::ok};
 use graphql_client::{GraphQLQuery, Response};
 use indexer_api::{
     domain::{AsBytesExt, HexEncoded, ViewingKey},
-    infra::api::v1::{TransactionResult, Unit},
+    infra::api::v1::TransactionResultStatus,
 };
 use indexer_common::domain::NetworkId;
 use itertools::Itertools;
@@ -331,7 +340,7 @@ async fn test_contract_action_query(
     for expected_contract_action in indexer_data
         .contract_actions
         .iter()
-        .filter(|c| c.transaction_transaction_result() != TransactionResult::Failure)
+        .filter(|c| c.transaction_transaction_result_status() != TransactionResultStatus::Failure)
     {
         // Existing block hash.
         let variables = contract_action_query::Variables {
@@ -675,7 +684,7 @@ trait ContractActionExt {
     fn block_hash(&self) -> HexEncoded;
     fn block_height(&self) -> i64;
     fn transaction_hash(&self) -> HexEncoded;
-    fn transaction_transaction_result(&self) -> TransactionResult;
+    fn transaction_transaction_result_status(&self) -> TransactionResultStatus;
     fn identifiers(&self) -> Vec<HexEncoded>;
 }
 
@@ -718,14 +727,27 @@ impl ContractActionExt for BlockSubscriptionContractAction {
         transaction_hash.to_owned()
     }
 
-    fn transaction_transaction_result(&self) -> TransactionResult {
-        let transaction_result = match self {
-            BlockSubscriptionContractAction::ContractCall(c) => &c.transaction.transaction_result,
-            BlockSubscriptionContractAction::ContractDeploy(c) => &c.transaction.transaction_result,
-            BlockSubscriptionContractAction::ContractUpdate(c) => &c.transaction.transaction_result,
+    fn transaction_transaction_result_status(&self) -> TransactionResultStatus {
+        let status = match self {
+            BlockSubscriptionContractAction::ContractCall(c) => {
+                &c.transaction.transaction_result.status
+            }
+            BlockSubscriptionContractAction::ContractDeploy(c) => {
+                &c.transaction.transaction_result.status
+            }
+            BlockSubscriptionContractAction::ContractUpdate(c) => {
+                &c.transaction.transaction_result.status
+            }
         };
 
-        transaction_result.to_owned()
+        match status {
+            BlockSubscriptionTransactionResultStatus::SUCCESS => TransactionResultStatus::Success,
+            BlockSubscriptionTransactionResultStatus::PARTIAL_SUCCESS => {
+                TransactionResultStatus::PartialSuccess
+            }
+            BlockSubscriptionTransactionResultStatus::FAILURE => TransactionResultStatus::Failure,
+            other => panic!("unexpected variant: {other:?}"),
+        }
     }
 
     fn identifiers(&self) -> Vec<HexEncoded> {
@@ -778,18 +800,27 @@ impl ContractActionExt for ContractActionQueryContractAction {
         transaction_hash.to_owned()
     }
 
-    fn transaction_transaction_result(&self) -> TransactionResult {
-        let transaction_result = match self {
-            ContractActionQueryContractAction::ContractCall(c) => &c.transaction.transaction_result,
+    fn transaction_transaction_result_status(&self) -> TransactionResultStatus {
+        let status = match self {
+            ContractActionQueryContractAction::ContractCall(c) => {
+                &c.transaction.transaction_result.status
+            }
             ContractActionQueryContractAction::ContractDeploy(c) => {
-                &c.transaction.transaction_result
+                &c.transaction.transaction_result.status
             }
             ContractActionQueryContractAction::ContractUpdate(c) => {
-                &c.transaction.transaction_result
+                &c.transaction.transaction_result.status
             }
         };
 
-        transaction_result.to_owned()
+        match status {
+            ContractActionQueryTransactionResultStatus::SUCCESS => TransactionResultStatus::Success,
+            ContractActionQueryTransactionResultStatus::PARTIAL_SUCCESS => {
+                TransactionResultStatus::PartialSuccess
+            }
+            ContractActionQueryTransactionResultStatus::FAILURE => TransactionResultStatus::Failure,
+            other => panic!("unexpected variant: {other:?}"),
+        }
     }
 
     fn identifiers(&self) -> Vec<HexEncoded> {
@@ -843,66 +874,74 @@ fn seed_to_secret_key(seed: &str) -> SecretKey {
     SecretKeys::from(Seed::from(seed_bytes)).encryption_secret_key
 }
 
-#[derive(GraphQLQuery)]
-#[graphql(
-    schema_path = "../indexer-api/graphql/schema-v1.graphql",
-    query_path = "./e2e.graphql",
-    response_derives = "Debug, Clone, Serialize"
-)]
-struct BlockQuery;
+mod graphql {
+    use graphql_client::GraphQLQuery;
+    use indexer_api::{
+        domain::{HexEncoded, ViewingKey},
+        infra::api::v1::Unit,
+    };
 
-#[derive(GraphQLQuery)]
-#[graphql(
-    schema_path = "../indexer-api/graphql/schema-v1.graphql",
-    query_path = "./e2e.graphql",
-    response_derives = "Debug, Clone, Serialize"
-)]
-struct TransactionsQuery;
+    #[derive(GraphQLQuery)]
+    #[graphql(
+        schema_path = "../indexer-api/graphql/schema-v1.graphql",
+        query_path = "./e2e.graphql",
+        response_derives = "Debug, Clone, Serialize"
+    )]
+    pub struct BlockQuery;
 
-#[derive(GraphQLQuery)]
-#[graphql(
-    schema_path = "../indexer-api/graphql/schema-v1.graphql",
-    query_path = "./e2e.graphql",
-    response_derives = "Debug, Clone, Serialize"
-)]
-struct ContractActionQuery;
+    #[derive(GraphQLQuery)]
+    #[graphql(
+        schema_path = "../indexer-api/graphql/schema-v1.graphql",
+        query_path = "./e2e.graphql",
+        response_derives = "Debug, Clone, Serialize"
+    )]
+    pub struct TransactionsQuery;
 
-#[derive(GraphQLQuery)]
-#[graphql(
-    schema_path = "../indexer-api/graphql/schema-v1.graphql",
-    query_path = "./e2e.graphql",
-    response_derives = "Debug, Clone, Serialize"
-)]
-struct ConnectMutation;
+    #[derive(GraphQLQuery)]
+    #[graphql(
+        schema_path = "../indexer-api/graphql/schema-v1.graphql",
+        query_path = "./e2e.graphql",
+        response_derives = "Debug, Clone, Serialize"
+    )]
+    pub struct ContractActionQuery;
 
-#[derive(GraphQLQuery)]
-#[graphql(
-    schema_path = "../indexer-api/graphql/schema-v1.graphql",
-    query_path = "./e2e.graphql",
-    response_derives = "Debug, Clone, Serialize"
-)]
-struct DisconnectMutation;
+    #[derive(GraphQLQuery)]
+    #[graphql(
+        schema_path = "../indexer-api/graphql/schema-v1.graphql",
+        query_path = "./e2e.graphql",
+        response_derives = "Debug, Clone, Serialize"
+    )]
+    pub struct ConnectMutation;
 
-#[derive(GraphQLQuery)]
-#[graphql(
-    schema_path = "../indexer-api/graphql/schema-v1.graphql",
-    query_path = "./e2e.graphql",
-    response_derives = "Debug, Clone, Serialize"
-)]
-struct BlockSubscription;
+    #[derive(GraphQLQuery)]
+    #[graphql(
+        schema_path = "../indexer-api/graphql/schema-v1.graphql",
+        query_path = "./e2e.graphql",
+        response_derives = "Debug, Clone, Serialize"
+    )]
+    pub struct DisconnectMutation;
 
-#[derive(GraphQLQuery)]
-#[graphql(
-    schema_path = "../indexer-api/graphql/schema-v1.graphql",
-    query_path = "./e2e.graphql",
-    response_derives = "Debug, Clone, Serialize"
-)]
-struct ContractActionSubscription;
+    #[derive(GraphQLQuery)]
+    #[graphql(
+        schema_path = "../indexer-api/graphql/schema-v1.graphql",
+        query_path = "./e2e.graphql",
+        response_derives = "Debug, Clone, Serialize"
+    )]
+    pub struct BlockSubscription;
 
-#[derive(GraphQLQuery)]
-#[graphql(
-    schema_path = "../indexer-api/graphql/schema-v1.graphql",
-    query_path = "./e2e.graphql",
-    response_derives = "Debug, Clone, Serialize"
-)]
-struct WalletSubscription;
+    #[derive(GraphQLQuery)]
+    #[graphql(
+        schema_path = "../indexer-api/graphql/schema-v1.graphql",
+        query_path = "./e2e.graphql",
+        response_derives = "Debug, Clone, Serialize"
+    )]
+    pub struct ContractActionSubscription;
+
+    #[derive(GraphQLQuery)]
+    #[graphql(
+        schema_path = "../indexer-api/graphql/schema-v1.graphql",
+        query_path = "./e2e.graphql",
+        response_derives = "Debug, Clone, Serialize"
+    )]
+    pub struct WalletSubscription;
+}

--- a/indexer-tests/tests/local_e2e.rs
+++ b/indexer-tests/tests/local_e2e.rs
@@ -251,6 +251,7 @@ async fn start_indexer_api(
             format!("{}/../indexer-api/config.yaml", env!("CARGO_MANIFEST_DIR")),
         ),
         ("APP__INFRA__API__PORT", api_port.to_string()),
+        ("APP__INFRA__API__MAX_COMPLEXITY", "500".to_string()),
         ("APP__INFRA__PUB_SUB__URL", nats_url.to_owned()),
         ("APP__INFRA__STORAGE__PORT", postgres_port.to_string()),
         ("APP__INFRA__LEDGER_STATE_STORAGE__URL", nats_url.to_owned()),
@@ -311,6 +312,7 @@ fn start_indexer_standalone(node_url: &str) -> anyhow::Result<(Child, u16, TempD
             ),
         ),
         ("APP__INFRA__API__PORT", api_port.to_string()),
+        ("APP__INFRA__API__MAX_COMPLEXITY", "500".to_string()),
         ("APP__INFRA__NODE__URL", node_url.to_owned()),
         ("APP__INFRA__STORAGE__CNN_URL", sqlite_file),
     ];

--- a/indexer-tests/tests/storage.rs
+++ b/indexer-tests/tests/storage.rs
@@ -23,8 +23,8 @@ use indexer_common::{
     self,
     cipher::make_cipher,
     domain::{
-        ApplyStage, BlockAuthor, BlockHash, ByteArray, ByteVec, ContractAddress, Identifier,
-        NetworkId, ProtocolVersion, RawTransaction, TransactionHash,
+        BlockAuthor, BlockHash, ByteArray, ByteVec, ContractAddress, Identifier, NetworkId,
+        ProtocolVersion, RawTransaction, TransactionHash, TransactionResult,
     },
     error::BoxError,
     infra::{migrations, pool},
@@ -238,7 +238,7 @@ async fn run_tests(
     assert_eq!(transaction.hash, TRANSACTION_1_HASH);
     assert_eq!(transaction.block_hash, BLOCK_1_HASH);
     assert_eq!(transaction.protocol_version, PROTOCOL_VERSION_0_1);
-    assert_eq!(transaction.apply_stage, ApplyStage::Failure);
+    assert_eq!(transaction.transaction_result, TransactionResult::Failure);
     assert_eq!(transaction.identifiers, vec![IDENTIFIER_1.to_owned()]);
     assert_eq!(&transaction.raw, &*RAW_TRANSACTION_1);
     let contract_actions = indexer_api_storage
@@ -256,7 +256,7 @@ async fn run_tests(
     );
     let transaction = &transactions[1];
     assert_eq!(transaction.hash, TRANSACTION_1_HASH);
-    assert_eq!(transaction.apply_stage, ApplyStage::Success);
+    assert_eq!(transaction.transaction_result, TransactionResult::Success);
 
     let block = indexer_api_storage
         .get_latest_block()
@@ -278,7 +278,7 @@ async fn run_tests(
     assert_eq!(transaction.hash, TRANSACTION_2_HASH);
     assert_eq!(transaction.block_hash, BLOCK_2_HASH);
     assert_eq!(transaction.protocol_version, PROTOCOL_VERSION_0_1);
-    assert_eq!(transaction.apply_stage, ApplyStage::Success);
+    assert_eq!(transaction.transaction_result, TransactionResult::Success);
     assert_eq!(transaction.identifiers, vec![IDENTIFIER_2.to_owned()]);
     assert_eq!(&transaction.raw, &*RAW_TRANSACTION_2);
     let contract_actions = indexer_api_storage
@@ -510,7 +510,7 @@ static BLOCK_1: LazyLock<Block> = LazyLock::new(|| Block {
         Transaction {
             hash: TRANSACTION_1_HASH,
             protocol_version: PROTOCOL_VERSION_0_1,
-            apply_stage: ApplyStage::Failure,
+            transaction_result: TransactionResult::Failure,
             identifiers: vec![IDENTIFIER_1.to_owned()],
             raw: RAW_TRANSACTION_1.to_owned(),
             contract_actions: vec![chain_indexer::domain::ContractAction {
@@ -526,7 +526,7 @@ static BLOCK_1: LazyLock<Block> = LazyLock::new(|| Block {
         Transaction {
             hash: TRANSACTION_1_HASH,
             protocol_version: PROTOCOL_VERSION_0_1,
-            apply_stage: ApplyStage::Success,
+            transaction_result: TransactionResult::Success,
             identifiers: vec![IDENTIFIER_1.to_owned()],
             raw: RAW_TRANSACTION_1.to_owned(),
             contract_actions: vec![chain_indexer::domain::ContractAction {
@@ -553,7 +553,7 @@ static BLOCK_2: LazyLock<Block> = LazyLock::new(|| Block {
     transactions: vec![Transaction {
         hash: TRANSACTION_2_HASH,
         protocol_version: PROTOCOL_VERSION_0_1,
-        apply_stage: ApplyStage::Success,
+        transaction_result: TransactionResult::Success,
         identifiers: vec![IDENTIFIER_2.to_owned()],
         raw: RAW_TRANSACTION_2.to_owned(),
         contract_actions: vec![

--- a/indexer-tests/tests/storage.rs
+++ b/indexer-tests/tests/storage.rs
@@ -160,7 +160,7 @@ async fn run_tests(
         .get_contract_action_count()
         .await
         .context("get contract action count")?;
-    assert_eq!(contract_action_count, (2, 2, 1));
+    assert_eq!(contract_action_count, (1, 3, 1));
 
     let block_transactions = chain_indexer_storage
         .get_block_transactions(0)
@@ -238,7 +238,7 @@ async fn run_tests(
     assert_eq!(transaction.hash, TRANSACTION_1_HASH);
     assert_eq!(transaction.block_hash, BLOCK_1_HASH);
     assert_eq!(transaction.protocol_version, PROTOCOL_VERSION_0_1);
-    assert_eq!(transaction.transaction_result, TransactionResult::Failure);
+    assert_eq!(transaction.transaction_result, TransactionResult::Success);
     assert_eq!(transaction.identifiers, vec![IDENTIFIER_1.to_owned()]);
     assert_eq!(&transaction.raw, &*RAW_TRANSACTION_1);
     let contract_actions = indexer_api_storage
@@ -256,7 +256,7 @@ async fn run_tests(
     );
     let transaction = &transactions[1];
     assert_eq!(transaction.hash, TRANSACTION_1_HASH);
-    assert_eq!(transaction.transaction_result, TransactionResult::Success);
+    assert_eq!(transaction.transaction_result, TransactionResult::Failure);
 
     let block = indexer_api_storage
         .get_latest_block()
@@ -510,7 +510,7 @@ static BLOCK_1: LazyLock<Block> = LazyLock::new(|| Block {
         Transaction {
             hash: TRANSACTION_1_HASH,
             protocol_version: PROTOCOL_VERSION_0_1,
-            transaction_result: TransactionResult::Failure,
+            transaction_result: TransactionResult::Success,
             identifiers: vec![IDENTIFIER_1.to_owned()],
             raw: RAW_TRANSACTION_1.to_owned(),
             contract_actions: vec![chain_indexer::domain::ContractAction {
@@ -526,14 +526,16 @@ static BLOCK_1: LazyLock<Block> = LazyLock::new(|| Block {
         Transaction {
             hash: TRANSACTION_1_HASH,
             protocol_version: PROTOCOL_VERSION_0_1,
-            transaction_result: TransactionResult::Success,
+            transaction_result: TransactionResult::Failure,
             identifiers: vec![IDENTIFIER_1.to_owned()],
             raw: RAW_TRANSACTION_1.to_owned(),
             contract_actions: vec![chain_indexer::domain::ContractAction {
                 address: ADDRESS.to_owned(),
                 state: b"state".as_slice().into(),
                 zswap_state: b"zswap_state".as_slice().into(),
-                attributes: chain_indexer::domain::ContractAttributes::Deploy,
+                attributes: chain_indexer::domain::ContractAttributes::Call {
+                    entry_point: b"entry_point".as_slice().into(),
+                },
             }],
             merkle_tree_root: b"merkle_tree_root".as_slice().into(),
             start_index: 0,

--- a/wallet-indexer/src/infra/storage/postgres.rs
+++ b/wallet-indexer/src/infra/storage/postgres.rs
@@ -206,7 +206,11 @@ mod tests {
         },
     };
     use indoc::indoc;
-    use sqlx::{QueryBuilder, postgres::PgSslMode, types::time::OffsetDateTime};
+    use sqlx::{
+        QueryBuilder,
+        postgres::PgSslMode,
+        types::{Json, time::OffsetDateTime},
+    };
     use std::{error::Error as StdError, iter, time::Duration};
     use testcontainers::{ImageExt, runners::AsyncRunner};
     use testcontainers_modules::postgres::Postgres;
@@ -284,7 +288,7 @@ mod tests {
                 q.push_bind(1)
                     .push_bind(id.to_string().into_bytes())
                     .push_bind(1_000)
-                    .push_bind(TransactionResult::Success)
+                    .push_bind(Json(TransactionResult::Success))
                     .push_bind([b"identifier"])
                     .push_bind(b"raw")
                     .push_bind(b"merkle_tree_root")

--- a/wallet-indexer/src/infra/storage/postgres.rs
+++ b/wallet-indexer/src/infra/storage/postgres.rs
@@ -199,7 +199,7 @@ mod tests {
     use anyhow::Context;
     use chacha20poly1305::{ChaCha20Poly1305, Key, KeyInit};
     use indexer_common::{
-        domain::{ApplyStage, ViewingKey},
+        domain::{TransactionResult, ViewingKey},
         infra::{
             migrations,
             pool::{self, postgres::PostgresPool},
@@ -271,7 +271,7 @@ mod tests {
                 block_id,
                 hash,
                 protocol_version,
-                apply_stage,
+                transaction_result,
                 identifiers,
                 raw,
                 merkle_tree_root,
@@ -284,7 +284,7 @@ mod tests {
                 q.push_bind(1)
                     .push_bind(id.to_string().into_bytes())
                     .push_bind(1_000)
-                    .push_bind(ApplyStage::Success)
+                    .push_bind(TransactionResult::Success)
                     .push_bind([b"identifier"])
                     .push_bind(b"raw")
                     .push_bind(b"merkle_tree_root")

--- a/wallet-indexer/src/infra/storage/sqlite.rs
+++ b/wallet-indexer/src/infra/storage/sqlite.rs
@@ -180,7 +180,7 @@ mod tests {
     use chacha20poly1305::{ChaCha20Poly1305, Key, KeyInit};
     use futures::{StreamExt, TryStreamExt};
     use indexer_common::{
-        domain::{ApplyStage, ViewingKey},
+        domain::{TransactionResult, ViewingKey},
         infra::{
             migrations,
             pool::{self, sqlite::SqlitePool},
@@ -228,7 +228,7 @@ mod tests {
                 block_id,
                 hash,
                 protocol_version,
-                apply_stage,
+                transaction_result,
                 raw,
                 merkle_tree_root,
                 start_index,
@@ -240,7 +240,7 @@ mod tests {
                 q.push_bind(block_id)
                     .push_bind(id.to_string())
                     .push_bind(1_000)
-                    .push_bind(ApplyStage::Success)
+                    .push_bind(TransactionResult::Success)
                     .push_bind("raw")
                     .push_bind("merkle_tree_root")
                     .push_bind(0)

--- a/wallet-indexer/src/infra/storage/sqlite.rs
+++ b/wallet-indexer/src/infra/storage/sqlite.rs
@@ -187,7 +187,10 @@ mod tests {
         },
     };
     use indoc::indoc;
-    use sqlx::{QueryBuilder, Row, types::time::OffsetDateTime};
+    use sqlx::{
+        QueryBuilder, Row,
+        types::{Json, time::OffsetDateTime},
+    };
     use std::{error::Error as StdError, iter, time::Duration};
     use uuid::Uuid;
 
@@ -240,7 +243,7 @@ mod tests {
                 q.push_bind(block_id)
                     .push_bind(id.to_string())
                     .push_bind(1_000)
-                    .push_bind(TransactionResult::Success)
+                    .push_bind(Json(TransactionResult::Success))
                     .push_bind("raw")
                     .push_bind("merkle_tree_root")
                     .push_bind(0)


### PR DESCRIPTION
Ledger v5 introduces a richer `TransactionResult` which conveys segment results (a segment ID to success mapping) for the partial failure. This information needs to be indexed and served via the API, too. Therefore a breaking change is needed, because the transaction result is no longer a simple tag/enum-variant, but a structured object. As the change is breaking, we also rename `ApplyStage` to `TransactionResult` to no longer invent fancy names for well known ledger terms.