### PR TITLE
feat: enhance unshielded token subscription with sync progress data (PM-17159)

### DIFF
--- a/indexer-api/graphql/schema-v1.graphql
+++ b/indexer-api/graphql/schema-v1.graphql
@@ -311,7 +311,7 @@ input UnshieldedOffset @oneOf {
 }
 
 """
-Progress tracking information for unshielded token synchronization
+Progress tracking information for unshielded token synchronization.
 """
 type UnshieldedProgress {
 	"""

--- a/indexer-api/src/domain/storage/transaction.rs
+++ b/indexer-api/src/domain/storage/transaction.rs
@@ -66,9 +66,6 @@ where
         &self,
         session_id: SessionId,
     ) -> Result<(Option<u64>, Option<u64>, Option<u64>), sqlx::Error>;
-
-    /// Get the highest end_index from all transactions (for progress calculation).
-    async fn get_highest_transaction_end_index(&self) -> Result<Option<u64>, sqlx::Error>;
 }
 
 #[allow(unused_variables)]

--- a/indexer-api/src/domain/storage/unshielded_utxo.rs
+++ b/indexer-api/src/domain/storage/unshielded_utxo.rs
@@ -43,11 +43,14 @@ where
         filter: UnshieldedUtxoFilter<'_>,
     ) -> Result<Vec<UnshieldedUtxo>, sqlx::Error>;
 
-    /// Get the highest end_index for transactions involving the given unshielded address.
-    async fn get_highest_end_index_for_address(
+    /// Get the highest end indices for unshielded address progress calculation.
+    /// Returns a tuple of:
+    /// - the highest end index from all transactions
+    /// - the highest end index for transactions involving the given unshielded address
+    async fn get_highest_indices_for_address(
         &self,
         address: &UnshieldedAddress,
-    ) -> Result<Option<u64>, sqlx::Error>;
+    ) -> Result<(Option<u64>, Option<u64>), sqlx::Error>;
 }
 
 /// Filter criteria for unshielded UTXOs queries.
@@ -81,6 +84,14 @@ impl UnshieldedUtxoStorage for NoopStorage {
         address: Option<&UnshieldedAddress>,
         filter: UnshieldedUtxoFilter<'_>,
     ) -> Result<Vec<UnshieldedUtxo>, sqlx::Error> {
+        unimplemented!()
+    }
+
+    #[cfg_attr(coverage, coverage(off))]
+    async fn get_highest_indices_for_address(
+        &self,
+        address: &UnshieldedAddress,
+    ) -> Result<(Option<u64>, Option<u64>), sqlx::Error> {
         unimplemented!()
     }
 }

--- a/indexer-api/src/infra/api/v1.rs
+++ b/indexer-api/src/infra/api/v1.rs
@@ -684,7 +684,7 @@ pub enum UnshieldedAddressFormatError {
     UnexpectedNetworkId(NetworkId, NetworkId),
 }
 
-/// Progress tracking information for unshielded token synchronization
+/// Progress tracking information for unshielded token synchronization.
 #[derive(SimpleObject, Clone, Debug)]
 pub struct UnshieldedProgress {
     /// The highest end index of all currently known transactions

--- a/indexer-api/src/infra/storage/postgres/transaction.rs
+++ b/indexer-api/src/infra/storage/postgres/transaction.rs
@@ -264,14 +264,4 @@ impl TransactionStorage for PostgresStorage {
             highest_relevant_wallet_index.map(|n| n as u64),
         ))
     }
-
-    async fn get_highest_transaction_end_index(&self) -> Result<Option<u64>, sqlx::Error> {
-        let query = indoc! {"
-            SELECT MAX(end_index) FROM transactions
-        "};
-
-        let highest_index: Option<i64> = sqlx::query_scalar(query).fetch_one(&*self.pool).await?;
-
-        Ok(highest_index.map(|n| n as u64))
-    }
 }

--- a/indexer-api/src/infra/storage/postgres/unshielded_utxo.rs
+++ b/indexer-api/src/infra/storage/postgres/unshielded_utxo.rs
@@ -210,24 +210,33 @@ impl UnshieldedUtxoStorage for PostgresStorage {
         Ok(utxos)
     }
 
-    async fn get_highest_end_index_for_address(
+    async fn get_highest_indices_for_address(
         &self,
         address: &UnshieldedAddress,
-    ) -> Result<Option<u64>, sqlx::Error> {
+    ) -> Result<(Option<u64>, Option<u64>), sqlx::Error> {
         let query = indoc! {"
-            SELECT MAX(transactions.end_index)
-            FROM transactions
-            INNER JOIN unshielded_utxos ON 
-                unshielded_utxos.creating_transaction_id = transactions.id OR
-                unshielded_utxos.spending_transaction_id = transactions.id
-            WHERE unshielded_utxos.owner_address = $1
+            SELECT (
+                SELECT MAX(end_index) FROM transactions
+            ) AS highest_end_index,
+            (
+                SELECT MAX(transactions.end_index)
+                FROM transactions
+                INNER JOIN unshielded_utxos ON 
+                    unshielded_utxos.creating_transaction_id = transactions.id OR
+                    unshielded_utxos.spending_transaction_id = transactions.id
+                WHERE unshielded_utxos.owner_address = $1
+            ) AS highest_end_index_for_address
         "};
 
-        let highest_index: Option<i64> = sqlx::query_scalar(query)
-            .bind(address.as_ref())
-            .fetch_one(&*self.pool)
-            .await?;
+        let (highest_index, highest_index_for_address) =
+            sqlx::query_as::<_, (Option<i64>, Option<i64>)>(query)
+                .bind(address.as_ref())
+                .fetch_one(&*self.pool)
+                .await?;
 
-        Ok(highest_index.map(|n| n as u64))
+        Ok((
+            highest_index.map(|n| n as u64),
+            highest_index_for_address.map(|n| n as u64),
+        ))
     }
 }

--- a/indexer-api/src/infra/storage/sqlite/transaction.rs
+++ b/indexer-api/src/infra/storage/sqlite/transaction.rs
@@ -313,14 +313,4 @@ impl TransactionStorage for SqliteStorage {
             highest_relevant_wallet_index.map(|n| n as u64),
         ))
     }
-
-    async fn get_highest_transaction_end_index(&self) -> Result<Option<u64>, sqlx::Error> {
-        let query = indoc! {"
-            SELECT MAX(end_index) FROM transactions
-        "};
-
-        let highest_index: Option<i64> = sqlx::query_scalar(query).fetch_one(&*self.pool).await?;
-
-        Ok(highest_index.map(|n| n as u64))
-    }
 }

--- a/indexer-api/src/infra/storage/sqlite/unshielded_utxo.rs
+++ b/indexer-api/src/infra/storage/sqlite/unshielded_utxo.rs
@@ -167,25 +167,34 @@ impl UnshieldedUtxoStorage for SqliteStorage {
         Ok(utxos)
     }
 
-    async fn get_highest_end_index_for_address(
+    async fn get_highest_indices_for_address(
         &self,
         address: &UnshieldedAddress,
-    ) -> Result<Option<u64>, sqlx::Error> {
+    ) -> Result<(Option<u64>, Option<u64>), sqlx::Error> {
         let query = indoc! {"
-            SELECT MAX(transactions.end_index)
-            FROM transactions
-            INNER JOIN unshielded_utxos ON 
-                unshielded_utxos.creating_transaction_id = transactions.id OR
-                unshielded_utxos.spending_transaction_id = transactions.id
-            WHERE unshielded_utxos.owner_address = ?
+            SELECT (
+                SELECT MAX(end_index) FROM transactions
+            ) AS highest_end_index,
+            (
+                SELECT MAX(transactions.end_index)
+                FROM transactions
+                INNER JOIN unshielded_utxos ON 
+                    unshielded_utxos.creating_transaction_id = transactions.id OR
+                    unshielded_utxos.spending_transaction_id = transactions.id
+                WHERE unshielded_utxos.owner_address = ?
+            ) AS highest_end_index_for_address
         "};
 
-        let highest_index: Option<i64> = sqlx::query_scalar(query)
-            .bind(address.as_ref())
-            .fetch_one(&*self.pool)
-            .await?;
+        let (highest_index, highest_index_for_address) =
+            sqlx::query_as::<_, (Option<i64>, Option<i64>)>(query)
+                .bind(address.as_ref())
+                .fetch_one(&*self.pool)
+                .await?;
 
-        Ok(highest_index.map(|n| n as u64))
+        Ok((
+            highest_index.map(|n| n as u64),
+            highest_index_for_address.map(|n| n as u64),
+        ))
     }
 }
 


### PR DESCRIPTION
Implements https://github.com/midnightntwrk/midnight-indexer/issues/86

## Summary
- Adds real-time synchronisation progress tracking to the unshielded token GraphQL subscription
- Enables wallets to display sync percentage for improved user experience

## Motivation
Wallets need to show users their synchronisation status when subscribing to unshielded token events. This PR implements the progress tracking feature specified in PM-17159, following the same pattern as the existing shielded wallet subscription.

 ```graphql
  # Old
  subscription {
    unshieldedUtxos(address: "...") {
      eventType  # REMOVED
      transaction  # Now optional
      createdUtxos  # Now optional
      spentUtxos  # Now optional
    }
  }

  # New
  subscription {
    unshieldedUtxos(address: "...") {
      progress {  # Always present
        highestIndex
        currentIndex
      }
      transaction  # Present for updates, null for progress-only
      createdUtxos  # Present for updates, null for progress-only
      spentUtxos  # Present for updates, null for progress-only
    }
  }
