### PR TITLE
refactor: align UnshieldedUtxoStorage with other storage traits

### DIFF
--- a/indexer-api/src/domain/storage.rs
+++ b/indexer-api/src/domain/storage.rs
@@ -17,13 +17,9 @@ pub mod transaction;
 pub mod unshielded_utxo;
 pub mod wallet;
 
-use crate::domain::{
-    Block, ContractAction, Transaction, UnshieldedUtxo,
-    storage::{
-        block::BlockStorage, contract_action::ContractActionStorage,
-        transaction::TransactionStorage, unshielded_utxo::UnshieldedUtxoStorage,
-        wallet::WalletStorage,
-    },
+use crate::domain::storage::{
+    block::BlockStorage, contract_action::ContractActionStorage, transaction::TransactionStorage,
+    unshielded_utxo::UnshieldedUtxoStorage, wallet::WalletStorage,
 };
 use std::fmt::Debug;
 

--- a/indexer-api/src/domain/storage/transaction.rs
+++ b/indexer-api/src/domain/storage/transaction.rs
@@ -66,9 +66,6 @@ where
         &self,
         session_id: SessionId,
     ) -> Result<(Option<u64>, Option<u64>, Option<u64>), sqlx::Error>;
-
-    /// Get the highest end_index from all transactions (for progress calculation).
-    async fn get_highest_transaction_end_index(&self) -> Result<Option<u64>, sqlx::Error>;
 }
 
 #[allow(unused_variables)]

--- a/indexer-api/src/domain/storage/unshielded_utxo.rs
+++ b/indexer-api/src/domain/storage/unshielded_utxo.rs
@@ -19,6 +19,7 @@ use crate::domain::{
     },
 };
 use indexer_common::domain::{BlockHash, Identifier, TransactionHash, UnshieldedAddress};
+use sqlx::Error;
 use std::fmt::Debug;
 
 /// Storage abstraction for unshielded UTXO operations.
@@ -103,4 +104,93 @@ where
         &self,
         address: &UnshieldedAddress,
     ) -> Result<(Option<u64>, Option<u64>), sqlx::Error>;
+}
+
+#[allow(unused_variables)]
+impl UnshieldedUtxoStorage for NoopStorage {
+    #[cfg_attr(coverage, coverage(off))]
+    async fn get_unshielded_utxos_by_address(
+        &self,
+        address: &UnshieldedAddress,
+    ) -> Result<Vec<UnshieldedUtxo>, Error> {
+        unimplemented!()
+    }
+
+    #[cfg_attr(coverage, coverage(off))]
+    async fn get_unshielded_utxos_created_by_transaction(
+        &self,
+        transaction_id: u64,
+    ) -> Result<Vec<UnshieldedUtxo>, Error> {
+        unimplemented!()
+    }
+
+    #[cfg_attr(coverage, coverage(off))]
+    async fn get_unshielded_utxos_spent_by_transaction(
+        &self,
+        transaction_id: u64,
+    ) -> Result<Vec<UnshieldedUtxo>, Error> {
+        unimplemented!()
+    }
+
+    #[cfg_attr(coverage, coverage(off))]
+    async fn get_unshielded_utxos_created_in_transaction_for_address(
+        &self,
+        address: &UnshieldedAddress,
+        transaction_id: u64,
+    ) -> Result<Vec<UnshieldedUtxo>, Error> {
+        unimplemented!()
+    }
+
+    #[cfg_attr(coverage, coverage(off))]
+    async fn get_unshielded_utxos_spent_in_transaction_for_address(
+        &self,
+        address: &UnshieldedAddress,
+        transaction_id: u64,
+    ) -> Result<Vec<UnshieldedUtxo>, Error> {
+        unimplemented!()
+    }
+
+    #[cfg_attr(coverage, coverage(off))]
+    async fn get_unshielded_utxos_by_address_from_height(
+        &self,
+        address: &UnshieldedAddress,
+        height: u32,
+    ) -> Result<Vec<UnshieldedUtxo>, Error> {
+        unimplemented!()
+    }
+
+    #[cfg_attr(coverage, coverage(off))]
+    async fn get_unshielded_utxos_by_address_from_block_hash(
+        &self,
+        address: &UnshieldedAddress,
+        block_hash: &BlockHash,
+    ) -> Result<Vec<UnshieldedUtxo>, Error> {
+        unimplemented!()
+    }
+
+    #[cfg_attr(coverage, coverage(off))]
+    async fn get_unshielded_utxos_by_address_from_transaction_hash(
+        &self,
+        address: &UnshieldedAddress,
+        transaction_hash: &TransactionHash,
+    ) -> Result<Vec<UnshieldedUtxo>, Error> {
+        unimplemented!()
+    }
+
+    #[cfg_attr(coverage, coverage(off))]
+    async fn get_unshielded_utxos_by_address_from_transaction_identifier(
+        &self,
+        address: &UnshieldedAddress,
+        identifier: &Identifier,
+    ) -> Result<Vec<UnshieldedUtxo>, Error> {
+        unimplemented!()
+    }
+
+    #[cfg_attr(coverage, coverage(off))]
+    async fn get_highest_indices_for_address(
+        &self,
+        address: &UnshieldedAddress,
+    ) -> Result<(Option<u64>, Option<u64>), Error> {
+        unimplemented!()
+    }
 }

--- a/indexer-api/src/infra/api/v1/subscription/unshielded.rs
+++ b/indexer-api/src/infra/api/v1/subscription/unshielded.rs
@@ -23,7 +23,6 @@ use fastrace::trace;
 use futures::{Stream, StreamExt, stream::TryStreamExt};
 use indexer_common::domain::{ByteVec, NetworkId, Subscriber, UnshieldedUtxoIndexed};
 use log::{debug, warn};
-use scopeguard;
 use std::{future::ready, marker::PhantomData, pin::pin, time::Duration};
 use tokio::time::interval;
 use tokio_stream::wrappers::IntervalStream;
@@ -122,10 +121,6 @@ where
         .try_filter(move |event| ready(event.address == address_for_filter));
 
     let updates = try_stream! {
-        // Create a drop guard that logs when the subscription ends.
-        let _guard = scopeguard::guard((), |_| {
-            debug!(address:?; "unshielded UTXO subscription dropped");
-        });
         let mut utxo_indexed_events = pin!(utxo_indexed_events);
         while let Some(UnshieldedUtxoIndexed { address: _, transaction_id }) = utxo_indexed_events
             .try_next()

--- a/indexer-api/src/infra/storage/postgres/transaction.rs
+++ b/indexer-api/src/infra/storage/postgres/transaction.rs
@@ -264,14 +264,4 @@ impl TransactionStorage for PostgresStorage {
             highest_relevant_wallet_index.map(|n| n as u64),
         ))
     }
-
-    async fn get_highest_transaction_end_index(&self) -> Result<Option<u64>, sqlx::Error> {
-        let query = indoc! {"
-            SELECT MAX(end_index) FROM transactions
-        "};
-
-        let highest_index: Option<i64> = sqlx::query_scalar(query).fetch_one(&*self.pool).await?;
-
-        Ok(highest_index.map(|n| n as u64))
-    }
 }

--- a/indexer-api/src/infra/storage/sqlite/transaction.rs
+++ b/indexer-api/src/infra/storage/sqlite/transaction.rs
@@ -313,14 +313,4 @@ impl TransactionStorage for SqliteStorage {
             highest_relevant_wallet_index.map(|n| n as u64),
         ))
     }
-
-    async fn get_highest_transaction_end_index(&self) -> Result<Option<u64>, sqlx::Error> {
-        let query = indoc! {"
-            SELECT MAX(end_index) FROM transactions
-        "};
-
-        let highest_index: Option<i64> = sqlx::query_scalar(query).fetch_one(&*self.pool).await?;
-
-        Ok(highest_index.map(|n| n as u64))
-    }
 }


### PR DESCRIPTION
I am not intending to merge this into the currently ongoing pr 'feat: enhance unshielded token subscription with sync progress data (PM-17159)'. I have made the base branch of this PR to be not main, it's just to show the changes easily. I will change the base branch of this PR to be main after the PM-17159 PR gets merged.

- Remove `UnshieldedUtxoFilter` enum entirely
- Add dedicated methods like `get_unshielded_utxos_by_address()`, `get_unshielded_utxos_created_by_transaction()`, etc.
- Follow same pattern as other storage traits in codebase