### PR TITLE
fix(indexer-api): correctly determine highest relevant index for standalone

### DIFF
--- a/indexer-api/graphql/schema-v1.graphql
+++ b/indexer-api/graphql/schema-v1.graphql
@@ -132,7 +132,7 @@ type ProgressUpdate {
 	highestIndex: Int!
 	"""
 	The highest end index into the zswap state of all currently known relevant transactions,
-	i.e. such that belong to any wallet. Less or equal `highest_index`.
+	i.e. those that belong to any known wallet. Less or equal `highest_index`.
 	"""
 	highestRelevantIndex: Int!
 	"""

--- a/indexer-api/src/domain/storage/transaction.rs
+++ b/indexer-api/src/domain/storage/transaction.rs
@@ -58,10 +58,10 @@ where
 
     /// Get a tuple of end indices:
     /// - the highest end index into the zswap state of all currently known transactions,
-    /// - the highest end index into the zswap state of all currently known relevant
-    ///   transactions,i.e. such that belong to any wallet,
+    /// - the highest end index into the zswap state of all currently known relevant transactions,
+    ///   i.e. those that belong to any known wallet,
     /// - the highest end index into the zswap state of all currently known relevant transactions
-    ///   for a particular wallet identified by the given [SessionId].
+    ///   for a particular wallet identified by the given session ID.
     async fn get_highest_indices(
         &self,
         session_id: SessionId,

--- a/indexer-api/src/infra/api/v1.rs
+++ b/indexer-api/src/infra/api/v1.rs
@@ -781,7 +781,7 @@ struct ProgressUpdate {
     highest_index: u64,
 
     /// The highest end index into the zswap state of all currently known relevant transactions,
-    /// i.e. such that belong to any wallet. Less or equal `highest_index`.
+    /// i.e. those that belong to any known wallet. Less or equal `highest_index`.
     highest_relevant_index: u64,
 
     /// The highest end index into the zswap state of all currently known relevant transactions for

--- a/indexer-api/src/infra/storage/sqlite/transaction.rs
+++ b/indexer-api/src/infra/storage/sqlite/transaction.rs
@@ -294,9 +294,12 @@ impl TransactionStorage for SqliteStorage {
                 SELECT MAX(end_index) FROM transactions
             ) AS highest_end_index,
             (
-                SELECT MAX(end_index)
+                SELECT end_index
                 FROM transactions
-                INNER JOIN relevant_transactions ON transactions.id = relevant_transactions.transaction_id
+                WHERE id = (
+                    SELECT MAX(last_indexed_transaction_id)
+                    FROM wallets
+                )
             ) AS highest_relevant_end_index,
             (
                 SELECT end_index

--- a/indexer-common/migrations/sqlite/001_initial.sql
+++ b/indexer-common/migrations/sqlite/001_initial.sql
@@ -72,6 +72,8 @@ CREATE TABLE wallets(
 
 CREATE INDEX wallets_session_id ON wallets(session_id);
 
+CREATE INDEX wallets_last_indexed_transaction_id ON wallets(last_indexed_transaction_id DESC);
+
 CREATE TABLE relevant_transactions(
     id INTEGER PRIMARY KEY,
     wallet_id BLOB NOT NULL,
@@ -106,3 +108,4 @@ CREATE TABLE zswap_state(
     value BLOB NOT NULL,
     last_index INTEGER
 );
+


### PR DESCRIPTION
Fix #93. Was partially fixed by #94, but standalone was forgotten there.