### PR TITLE
fix(indexer-api): ensure consistent UTXO ordering by output_index in GraphQL API

### DIFF
--- a/indexer-api/src/domain/storage/unshielded_utxo.rs
+++ b/indexer-api/src/domain/storage/unshielded_utxo.rs
@@ -42,26 +42,28 @@ where
         address: &UnshieldedAddress,
     ) -> Result<Vec<UnshieldedUtxo>, sqlx::Error>;
 
-    /// Get unshielded UTXOs created by a specific transaction.
+    /// Get unshielded UTXOs created by a specific transaction, ordered by output index.
     async fn get_unshielded_utxos_created_by_transaction(
         &self,
         transaction_id: u64,
     ) -> Result<Vec<UnshieldedUtxo>, sqlx::Error>;
 
-    /// Get unshielded UTXOs spent by a specific transaction.
+    /// Get unshielded UTXOs spent by a specific transaction, ordered by output index.
     async fn get_unshielded_utxos_spent_by_transaction(
         &self,
         transaction_id: u64,
     ) -> Result<Vec<UnshieldedUtxo>, sqlx::Error>;
 
-    /// Get unshielded UTXOs created in a specific transaction for a specific address.
+    /// Get unshielded UTXOs created in a specific transaction for a specific address, ordered by
+    /// output index.
     async fn get_unshielded_utxos_created_in_transaction_for_address(
         &self,
         address: &UnshieldedAddress,
         transaction_id: u64,
     ) -> Result<Vec<UnshieldedUtxo>, sqlx::Error>;
 
-    /// Get unshielded UTXOs spent in a specific transaction for a specific address.
+    /// Get unshielded UTXOs spent in a specific transaction for a specific address, ordered by
+    /// output index.
     async fn get_unshielded_utxos_spent_in_transaction_for_address(
         &self,
         address: &UnshieldedAddress,

--- a/indexer-api/src/infra/storage/postgres/unshielded_utxo.rs
+++ b/indexer-api/src/infra/storage/postgres/unshielded_utxo.rs
@@ -50,7 +50,7 @@ impl UnshieldedUtxoStorage for PostgresStorage {
                 creating_transaction_id, spending_transaction_id
             FROM unshielded_utxos
             WHERE creating_transaction_id = $1
-            ORDER BY output_index ASC
+            ORDER BY output_index
         "};
 
         let utxos = sqlx::query_as::<_, UnshieldedUtxo>(query)
@@ -71,7 +71,7 @@ impl UnshieldedUtxoStorage for PostgresStorage {
                 creating_transaction_id, spending_transaction_id
             FROM unshielded_utxos
             WHERE spending_transaction_id = $1
-            ORDER BY output_index ASC
+            ORDER BY output_index
         "};
 
         let utxos = sqlx::query_as::<_, UnshieldedUtxo>(query)
@@ -94,7 +94,7 @@ impl UnshieldedUtxoStorage for PostgresStorage {
             FROM unshielded_utxos
             WHERE creating_transaction_id = $1
             AND owner_address = $2
-            ORDER BY output_index ASC
+            ORDER BY output_index
         "};
 
         let utxos = sqlx::query_as::<_, UnshieldedUtxo>(query)
@@ -118,7 +118,7 @@ impl UnshieldedUtxoStorage for PostgresStorage {
             FROM unshielded_utxos
             WHERE spending_transaction_id = $1
             AND owner_address = $2
-            ORDER BY output_index ASC
+            ORDER BY output_index
         "};
 
         let utxos = sqlx::query_as::<_, UnshieldedUtxo>(query)

--- a/indexer-api/src/infra/storage/postgres/unshielded_utxo.rs
+++ b/indexer-api/src/infra/storage/postgres/unshielded_utxo.rs
@@ -50,6 +50,7 @@ impl UnshieldedUtxoStorage for PostgresStorage {
                 creating_transaction_id, spending_transaction_id
             FROM unshielded_utxos
             WHERE creating_transaction_id = $1
+            ORDER BY output_index ASC
         "};
 
         let utxos = sqlx::query_as::<_, UnshieldedUtxo>(query)
@@ -70,6 +71,7 @@ impl UnshieldedUtxoStorage for PostgresStorage {
                 creating_transaction_id, spending_transaction_id
             FROM unshielded_utxos
             WHERE spending_transaction_id = $1
+            ORDER BY output_index ASC
         "};
 
         let utxos = sqlx::query_as::<_, UnshieldedUtxo>(query)
@@ -92,6 +94,7 @@ impl UnshieldedUtxoStorage for PostgresStorage {
             FROM unshielded_utxos
             WHERE creating_transaction_id = $1
             AND owner_address = $2
+            ORDER BY output_index ASC
         "};
 
         let utxos = sqlx::query_as::<_, UnshieldedUtxo>(query)
@@ -115,6 +118,7 @@ impl UnshieldedUtxoStorage for PostgresStorage {
             FROM unshielded_utxos
             WHERE spending_transaction_id = $1
             AND owner_address = $2
+            ORDER BY output_index ASC
         "};
 
         let utxos = sqlx::query_as::<_, UnshieldedUtxo>(query)

--- a/indexer-api/src/infra/storage/sqlite/unshielded_utxo.rs
+++ b/indexer-api/src/infra/storage/sqlite/unshielded_utxo.rs
@@ -48,7 +48,7 @@ impl UnshieldedUtxoStorage for SqliteStorage {
             SELECT *
             FROM unshielded_utxos
             WHERE creating_transaction_id = ?
-            ORDER BY output_index ASC
+            ORDER BY output_index
         "};
 
         let utxos = sqlx::query_as::<_, UnshieldedUtxo>(query)
@@ -67,7 +67,7 @@ impl UnshieldedUtxoStorage for SqliteStorage {
             SELECT *
             FROM unshielded_utxos
             WHERE spending_transaction_id = ?
-            ORDER BY output_index ASC
+            ORDER BY output_index
         "};
 
         let utxos = sqlx::query_as::<_, UnshieldedUtxo>(query)
@@ -88,7 +88,7 @@ impl UnshieldedUtxoStorage for SqliteStorage {
             FROM unshielded_utxos
             WHERE creating_transaction_id = ?
             AND owner_address = ?
-            ORDER BY output_index ASC
+            ORDER BY output_index
         "};
 
         let utxos = sqlx::query_as::<_, UnshieldedUtxo>(query)
@@ -110,7 +110,7 @@ impl UnshieldedUtxoStorage for SqliteStorage {
             FROM unshielded_utxos
             WHERE spending_transaction_id = ?
             AND owner_address = ?
-            ORDER BY output_index ASC
+            ORDER BY output_index
         "};
 
         let utxos = sqlx::query_as::<_, UnshieldedUtxo>(query)

--- a/indexer-api/src/infra/storage/sqlite/unshielded_utxo.rs
+++ b/indexer-api/src/infra/storage/sqlite/unshielded_utxo.rs
@@ -48,6 +48,7 @@ impl UnshieldedUtxoStorage for SqliteStorage {
             SELECT *
             FROM unshielded_utxos
             WHERE creating_transaction_id = ?
+            ORDER BY output_index ASC
         "};
 
         let utxos = sqlx::query_as::<_, UnshieldedUtxo>(query)
@@ -66,6 +67,7 @@ impl UnshieldedUtxoStorage for SqliteStorage {
             SELECT *
             FROM unshielded_utxos
             WHERE spending_transaction_id = ?
+            ORDER BY output_index ASC
         "};
 
         let utxos = sqlx::query_as::<_, UnshieldedUtxo>(query)
@@ -86,6 +88,7 @@ impl UnshieldedUtxoStorage for SqliteStorage {
             FROM unshielded_utxos
             WHERE creating_transaction_id = ?
             AND owner_address = ?
+            ORDER BY output_index ASC
         "};
 
         let utxos = sqlx::query_as::<_, UnshieldedUtxo>(query)
@@ -107,6 +110,7 @@ impl UnshieldedUtxoStorage for SqliteStorage {
             FROM unshielded_utxos
             WHERE spending_transaction_id = ?
             AND owner_address = ?
+            ORDER BY output_index ASC
         "};
 
         let utxos = sqlx::query_as::<_, UnshieldedUtxo>(query)


### PR DESCRIPTION
Fixes #99

## Summary

Fixes UTXO output ordering in GraphQL API to return UTXOs in consistent ascending order by `output_index` instead of random database insertion order.

## Problem

The `unshieldedCreatedOutputs` and `unshieldedSpentOutputs` fields in GraphQL transaction queries were returning UTXOs in inconsistent order:

**Before:**
```json
"unshieldedCreatedOutputs": [
  { "outputIndex": 15, "owner": "...", "value": "5000000000000000" },
  { "outputIndex": 4, "owner": "...", "value": "5000000000000000" },
  { "outputIndex": 24, "owner": "...", "value": "5000000000000000" },
  { "outputIndex": 1, "owner": "...", "value": "5000000000000000" }
]
```

**After:**
```json
"unshieldedCreatedOutputs": [
  { "outputIndex": 1, "owner": "...", "value": "5000000000000000" },
  { "outputIndex": 4, "owner": "...", "value": "5000000000000000" },
  { "outputIndex": 15, "owner": "...", "value": "5000000000000000" },
  { "outputIndex": 24, "owner": "...", "value": "5000000000000000" }
]
```

## Changes

**Storage Layer (PostgreSQL & SQLite):**
- Added `ORDER BY output_index ASC` to `get_unshielded_utxos_created_by_transaction`
- Added `ORDER BY output_index ASC` to `get_unshielded_utxos_spent_by_transaction` 
- Added `ORDER BY output_index ASC` to `get_unshielded_utxos_created_in_transaction_for_address`
- Added `ORDER BY output_index ASC` to `get_unshielded_utxos_spent_in_transaction_for_address`

**Documentation:**
- Updated trait documentation to specify ordering behavior

## Testing

- ✅ All tests pass for both cloud (PostgreSQL) and standalone (SQLite) features
- ✅ Compilation and linting checks pass
- ✅ Genesis block UTXOs and regular transaction UTXOs both affected

## Impact

- **API Consistency**: Predictable UTXO ordering across all queries
- **Client Applications**: Reliable data presentation for wallets and explorers  
- **Testing**: Deterministic results for test assertions
- **User Experience**: Logical sequential ordering in transaction details