### PR TITLE
chore: remove obsolete TryFrom byte slice impl for ViewingKey

### DIFF
--- a/indexer-api/src/domain/viewing_key.rs
+++ b/indexer-api/src/domain/viewing_key.rs
@@ -13,9 +13,7 @@
 
 use async_graphql::scalar;
 use derive_more::derive::From;
-use indexer_common::domain::{
-    NetworkId, TryFromBytesForViewingKey, UnknownNetworkIdError, ViewingKey as CommonViewingKey,
-};
+use indexer_common::domain::{NetworkId, UnknownNetworkIdError, ViewingKey as CommonViewingKey};
 use midnight_serialize::Deserializable;
 use midnight_transient_crypto::encryption::SecretKey;
 use serde::{Deserialize, Serialize};
@@ -52,11 +50,9 @@ impl ViewingKey {
             return Err(ViewingKeyFormatError::UnexpectedNetworkId(n, network_id));
         }
 
-        SecretKey::deserialize(&mut bytes.as_slice(), 0)?
-            .repr()
-            .as_slice()
-            .try_into()
-            .map_err(ViewingKeyFormatError::Array)
+        let secret_key = SecretKey::deserialize(&mut bytes.as_slice(), 0)?;
+
+        Ok(secret_key.into())
     }
 }
 
@@ -76,9 +72,6 @@ pub enum ViewingKeyFormatError {
 
     #[error("cannot deserialize viewing key")]
     Deserialize(#[from] io::Error),
-
-    #[error(transparent)]
-    Array(TryFromBytesForViewingKey),
 }
 
 #[cfg(test)]

--- a/indexer-common/src/domain/viewing_key.rs
+++ b/indexer-common/src/domain/viewing_key.rs
@@ -106,18 +106,6 @@ impl Display for ViewingKey {
     }
 }
 
-impl TryFrom<&[u8]> for ViewingKey {
-    type Error = TryFromBytesForViewingKey;
-
-    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        let bytes = bytes
-            .try_into()
-            .map_err(|_| TryFromBytesForViewingKey(SecretKey::BYTES, bytes.len()))?;
-
-        Ok(Self(bytes))
-    }
-}
-
 impl From<SecretKey> for ViewingKey {
     fn from(secret_key: SecretKey) -> Self {
         Self(secret_key.repr())
@@ -129,10 +117,6 @@ impl From<ViewingKey> for SecretKey {
         SecretKey::from_repr(&viewing_key.0).expect("SecretKey can be created from repr")
     }
 }
-
-#[derive(Debug, Error)]
-#[error("cannot create viewing key of len {0} from slice of len {1}")]
-pub struct TryFromBytesForViewingKey(usize, usize);
 
 #[derive(Debug, Error)]
 pub enum DecryptViewingKeyError {


### PR DESCRIPTION
Fix #125.