### PR TITLE
feat: improve error handling for network ID mismatches in unshielded address queries

### DIFF
--- a/indexer-api/src/infra/api.rs
+++ b/indexer-api/src/infra/api.rs
@@ -15,7 +15,7 @@ pub mod v1;
 
 use crate::domain::{Api, ZswapStateCache, storage::Storage};
 use anyhow::Context as _;
-use async_graphql::Context;
+use async_graphql::{Context, ErrorExtensions};
 use axum::{
     Router,
     body::Body,
@@ -297,6 +297,37 @@ where
         self.context(context)
             .inspect_err(|error| error!(error = format!("{error:#}"); "API error"))
             .map_err(|_| async_graphql::Error::new("Internal Error"))
+    }
+}
+
+pub(crate) trait UnshieldedAddressResultExt<T> {
+    /// Handle UnshieldedAddressFormatError specifically for network mismatch validation.
+    /// Network mismatch errors are exposed to users, other errors become "Internal Error".
+    fn address_validation<C>(self, context: C) -> async_graphql::Result<T>
+    where
+        C: Display + Send + Sync + 'static;
+}
+
+impl<T> UnshieldedAddressResultExt<T> for Result<T, v1::UnshieldedAddressFormatError> {
+    fn address_validation<C>(self, context: C) -> async_graphql::Result<T>
+    where
+        C: Display + Send + Sync + 'static,
+    {
+        self.map_err(|e| match e {
+            v1::UnshieldedAddressFormatError::UnexpectedNetworkId(got, expected) => {
+                async_graphql::Error::new(format!(
+                    "Invalid address: address is for {} network but indexer is configured for {}",
+                    got, expected
+                ))
+                .extend_with(|_, e| e.set("code", "NETWORK_MISMATCH"))
+            }
+
+            _ => {
+                let error = anyhow::Error::new(e).context(context);
+                error!(error = format!("{error:#}"); "API error");
+                async_graphql::Error::new("Internal Error")
+            }
+        })
     }
 }
 

--- a/indexer-api/src/infra/api/v1/query.rs
+++ b/indexer-api/src/infra/api/v1/query.rs
@@ -14,10 +14,10 @@
 use crate::{
     domain::{HexEncoded, storage::Storage},
     infra::api::{
-        ContextExt, ResultExt, UnshieldedAddressResultExt,
+        ContextExt, ResultExt,
         v1::{
             self, Block, BlockOffset, ContractAction, ContractActionOffset, Transaction,
-            TransactionOffset, UnshieldedAddress, UnshieldedOffset,
+            TransactionOffset, UnshieldedAddress, UnshieldedAddressResultExt, UnshieldedOffset,
         },
     },
 };

--- a/indexer-api/src/infra/api/v1/query.rs
+++ b/indexer-api/src/infra/api/v1/query.rs
@@ -14,7 +14,7 @@
 use crate::{
     domain::{HexEncoded, storage::Storage},
     infra::api::{
-        ContextExt, ResultExt,
+        ContextExt, ResultExt, UnshieldedAddressResultExt,
         v1::{
             self, Block, BlockOffset, ContractAction, ContractActionOffset, Transaction,
             TransactionOffset, UnshieldedAddress, UnshieldedOffset,
@@ -107,7 +107,7 @@ where
 
             let address = address
                 .try_into_domain(network_id)
-                .internal("convert address into domain address")?;
+                .address_validation("convert address into domain address")?;
             let txs = storage
                 .get_transactions_involving_unshielded(&address, 0)
                 .await
@@ -230,7 +230,7 @@ where
 
         let address = address
             .try_into_domain(network_id)
-            .internal("convert address into domain address")?;
+            .address_validation("convert address into domain address")?;
         let utxos = match offset {
             Some(UnshieldedOffset::BlockOffset(BlockOffset::Height(start))) => storage
                 .get_unshielded_utxos_by_address_from_height(&address, start)

--- a/indexer-api/src/infra/api/v1/subscription/unshielded.rs
+++ b/indexer-api/src/infra/api/v1/subscription/unshielded.rs
@@ -14,7 +14,7 @@
 use crate::{
     domain::storage::Storage,
     infra::api::{
-        ContextExt, ResultExt,
+        ContextExt, ResultExt, UnshieldedAddressResultExt,
         v1::{UnshieldedAddress, UnshieldedProgress, UnshieldedUtxo, UnshieldedUtxoEvent},
     },
 };
@@ -81,7 +81,7 @@ where
         let network_id = cx.get_network_id();
         let address = address
             .try_into_domain(network_id)
-            .internal("convert address into domain address")?;
+            .address_validation("convert address into domain address")?;
 
         // Use 0 as default to include all transactions from genesis.
         // Since transaction IDs start from 1 (BIGSERIAL/AUTOINCREMENT), using >= 0

--- a/indexer-api/src/infra/api/v1/subscription/unshielded.rs
+++ b/indexer-api/src/infra/api/v1/subscription/unshielded.rs
@@ -14,8 +14,11 @@
 use crate::{
     domain::storage::Storage,
     infra::api::{
-        ContextExt, ResultExt, UnshieldedAddressResultExt,
-        v1::{UnshieldedAddress, UnshieldedProgress, UnshieldedUtxo, UnshieldedUtxoEvent},
+        ContextExt, ResultExt,
+        v1::{
+            UnshieldedAddress, UnshieldedAddressResultExt, UnshieldedProgress, UnshieldedUtxo,
+            UnshieldedUtxoEvent,
+        },
     },
 };
 use async_graphql::{Context, Subscription, async_stream::try_stream};


### PR DESCRIPTION
Closes #135

## Summary
  • Enhance user experience by replacing generic "Internal Error" with clear validation messages for network mismatches
  • Add extension trait `UnshieldedAddressResultExt` following team's established error handling patterns
  • Return actionable error with code "NETWORK_MISMATCH" when address is from wrong network
  • Apply pattern consistently across all UnshieldedAddress endpoints (queries and subscriptions)

## Technical Details
  • Follow ViewingKey validation approach suggested by @hseeberger
  • Only expose network mismatch errors; other format errors remain as "Internal Error" for security
  • Centralised error handling logic in extension trait for maintainability

## Manual Test
- ✅ If I test with an unshielded address from a different environment (expected behaviour from the change here) :
![Screenshot 2025-06-26 at 12 50 09](https://github.com/user-attachments/assets/236a1e64-c889-470b-a65d-28a3f81f14d8)

- ❓If I change the network id part from a valid unshielded address:
![Screenshot 2025-06-26 at 12 57 27](https://github.com/user-attachments/assets/c552745a-e926-495d-a4ad-b7979ab8944f)
server log : `......"midnight-indexer/indexer-api/src/infra/api.rs","line":327,"message":"API error","kvs":{
"error":"convert address into domain address: cannot bech32m-decode unshielded address: no valid bech32 or bech32m checksum: the checksum residue is not valid for the data"
......}}`