### PR TITLE
feat: implement contract balance extraction for unshielded tokens

### DIFF
--- a/chain-indexer/src/domain/contract_action.rs
+++ b/chain-indexer/src/domain/contract_action.rs
@@ -32,7 +32,7 @@ impl From<indexer_common::domain::ContractAction> for ContractAction {
             state: contract_action.state,
             attributes: contract_action.attributes,
             zswap_state: Default::default(),
-            extracted_balances: Default::default(),
+            extracted_balances: contract_action.extracted_balances,
         }
     }
 }

--- a/chain-indexer/src/infra/subxt_node.rs
+++ b/chain-indexer/src/infra/subxt_node.rs
@@ -539,6 +539,7 @@ async fn make_transaction(
                     .await
             },
             network_id,
+            protocol_version,
         )
         .await?
         .into_iter()

--- a/indexer-common/src/domain.rs
+++ b/indexer-common/src/domain.rs
@@ -67,6 +67,7 @@ pub struct ContractAction {
     pub address: RawContractAddress,
     pub state: RawContractState,
     pub attributes: ContractAttributes,
+    pub extracted_balances: Vec<ContractBalance>,
 }
 
 /// Attributes for a specific contract action.

--- a/indexer-common/src/domain/ledger/transaction.rs
+++ b/indexer-common/src/domain/ledger/transaction.rs
@@ -6,7 +6,6 @@ use crate::domain::{
 };
 use fastrace::trace;
 use futures::{StreamExt, TryStreamExt};
-use std::future::Future;
 use midnight_coin_structure::{
     coin::Info as InfoV5, contract::ContractAddress as ContractAddressV5,
 };
@@ -18,7 +17,7 @@ use midnight_serialize::deserialize as deserialize_v5;
 use midnight_storage::{DefaultDB as DefaultDBV5, arena::Sp as SpV5};
 use midnight_transient_crypto::{encryption::SecretKey as SecretKeyV5, proofs::Proof as ProofV5};
 use midnight_zswap::Offer as OfferV5;
-use std::error::Error as StdError;
+use std::{error::Error as StdError, future::Future};
 
 /// Facade for `Transaction` from `midnight_ledger` across supported (protocol) versions.
 #[derive(Debug, Clone)]
@@ -98,8 +97,12 @@ impl Transaction {
                                         .map_err(|error| Error::GetContractState(error.into()))?;
 
                                     // Extract balances from contract state
-                                    let extracted_balances = ContractState::deserialize(&state, network_id, protocol_version)?
-                                        .balances(network_id)?;
+                                    let extracted_balances = ContractState::deserialize(
+                                        &state,
+                                        network_id,
+                                        protocol_version,
+                                    )?
+                                    .balances(network_id)?;
 
                                     Ok::<_, Error>(ContractAction {
                                         address,
@@ -118,8 +121,12 @@ impl Transaction {
                                     let entry_point = call.entry_point.as_ref().into();
 
                                     // Extract balances from contract state
-                                    let extracted_balances = ContractState::deserialize(&state, network_id, protocol_version)?
-                                        .balances(network_id)?;
+                                    let extracted_balances = ContractState::deserialize(
+                                        &state,
+                                        network_id,
+                                        protocol_version,
+                                    )?
+                                    .balances(network_id)?;
 
                                     Ok(ContractAction {
                                         address,
@@ -137,8 +144,12 @@ impl Transaction {
                                         .map_err(|error| Error::GetContractState(error.into()))?;
 
                                     // Extract balances from contract state
-                                    let extracted_balances = ContractState::deserialize(&state, network_id, protocol_version)?
-                                        .balances(network_id)?;
+                                    let extracted_balances = ContractState::deserialize(
+                                        &state,
+                                        network_id,
+                                        protocol_version,
+                                    )?
+                                    .balances(network_id)?;
 
                                     Ok(ContractAction {
                                         address,


### PR DESCRIPTION
- Adds missing balance extraction logic in ledger transaction processing

## Changes Made
  - **Domain model**: Added `extracted_balances` field to `ContractAction` struct
  - **Balance extraction**: Implemented contract state deserialization and balance extraction in `contract_actions()` method
  - **Error handling**: Used `?` operator for critical parsing operations to fail fast on blockchain data errors
  - **API compatibility**: Updated method signature to include `protocol_version` parameter
  - **Conversion logic**: Fixed chain-indexer to properly map extracted balances

Let me know how you think about this @hseeberger 