### PR TITLE
fix: return client error for unknown block hash in subscriptions

### DIFF
--- a/indexer-api/src/infra/api.rs
+++ b/indexer-api/src/infra/api.rs
@@ -407,6 +407,10 @@ trait OptionExt<T> {
     fn ok_or_server_error<S>(self, message: impl Fn() -> S) -> Result<T, ApiError>
     where
         S: ToString;
+    
+    fn ok_or_client_error<S>(self, message: impl Fn() -> S) -> Result<T, ApiError>
+    where
+        S: ToString;
 }
 
 impl<T> OptionExt<T> for Option<T> {
@@ -415,6 +419,13 @@ impl<T> OptionExt<T> for Option<T> {
         S: ToString,
     {
         self.ok_or_else(|| ApiError::Server(InnerApiError(message().to_string(), None)))
+    }
+    
+    fn ok_or_client_error<S>(self, message: impl Fn() -> S) -> Result<T, ApiError>
+    where
+        S: ToString,
+    {
+        self.ok_or_else(|| ApiError::Client(InnerApiError(message().to_string(), None)))
     }
 }
 

--- a/indexer-api/src/infra/api.rs
+++ b/indexer-api/src/infra/api.rs
@@ -407,7 +407,7 @@ trait OptionExt<T> {
     fn ok_or_server_error<S>(self, message: impl Fn() -> S) -> Result<T, ApiError>
     where
         S: ToString;
-    
+
     fn ok_or_client_error<S>(self, message: impl Fn() -> S) -> Result<T, ApiError>
     where
         S: ToString;
@@ -420,7 +420,7 @@ impl<T> OptionExt<T> for Option<T> {
     {
         self.ok_or_else(|| ApiError::Server(InnerApiError(message().to_string(), None)))
     }
-    
+
     fn ok_or_client_error<S>(self, message: impl Fn() -> S) -> Result<T, ApiError>
     where
         S: ToString,

--- a/indexer-api/src/infra/api/v1.rs
+++ b/indexer-api/src/infra/api/v1.rs
@@ -125,7 +125,7 @@ async fn resolve_height(offset: Option<BlockOffset>, storage: &impl Storage) -> 
                     .get_block_by_hash(hash)
                     .await
                     .map_err_into_server_error(|| format!("get block by hash {hash}"))?
-                    .ok_or_server_error(|| format!("block with hash {hash} not found"))?;
+                    .ok_or_client_error(|| format!("block with hash {hash} not found"))?;
 
                 Ok(block.height)
             }
@@ -135,7 +135,7 @@ async fn resolve_height(offset: Option<BlockOffset>, storage: &impl Storage) -> 
                     .get_block_by_height(height)
                     .await
                     .map_err_into_server_error(|| "get block by height")?
-                    .ok_or_server_error(|| format!("block with height {height} not found"))?;
+                    .ok_or_client_error(|| format!("block with height {height} not found"))?;
 
                 Ok(height)
             }


### PR DESCRIPTION
Fixes https://github.com/midnightntwrk/midnight-indexer/issues/173

Fixes an issue where block subscriptions with unknown hash return "Internal Server Error" instead of the actual error message.

## Problem
When subscribing to blocks with an invalid/unknown hash, the API was returning:
  - Status: 500 (Internal Server Error)
  - Message: "Internal Server Error"
  - Logs showed: `"block with hash ... not found"`

## Solution
Updated error handling to properly distinguish between client and server errors:
  - Missing blocks are now treated as client errors (400) since they're caused by invalid input
  - The actual error message is returned to the client