### PR TITLE
test: added GH workflow to test compose file

### DIFF
--- a/.github/workflows/test-docker-compose.yaml
+++ b/.github/workflows/test-docker-compose.yaml
@@ -1,0 +1,167 @@
+name: Docker Compose Validation
+
+# Purpose of this workflow is to execute once the docker images have been built
+# to check if the compose file can spin up the indexer containers as well as they
+# are healthy. It depends on the indexer images workflows, so the first job is just
+# to make sure the "upstream" workflows have completed successfully
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  wait-for-builds:
+    name: Wait for Indexer images to be built
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for all build workflows to succeed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+
+          owner=$(echo "${{ github.repository }}" | cut -d/ -f1)
+          repo=$(echo "${{ github.repository }}" | cut -d/ -f2)
+          sha=${{ github.sha }}
+
+          workflows=(
+            "build-indexer-api"
+            "build-chain-indexer"
+            "build-wallet-indexer"
+            "build-indexer-standalone"
+          )
+
+          echo "Waiting for all build workflows to succeed for $sha..."
+
+          for wf in "${workflows[@]}"; do
+            echo "Checking $wf..."
+
+            # Poll every 10s until the workflow completes (max 10 mins)
+            for attempt in $(seq 1 60); do
+              wf_id=$(gh api /repos/$owner/$repo/actions/workflows | jq -r ".workflows[] | select(.name == \"$wf\") | .id")
+
+              run_json=$(gh api "/repos/$owner/$repo/actions/workflows/$wf_id/runs?head_sha=$sha&per_page=1")
+              status=$(echo "$run_json" | jq -r '.workflow_runs[0].status')
+              conclusion=$(echo "$run_json" | jq -r '.workflow_runs[0].conclusion')
+
+              echo "Status: $status, Conclusion: $conclusion"
+
+              if [[ "$status" == "completed" ]]; then
+                if [[ "$conclusion" != "success" ]]; then
+                  echo "$wf failed or was cancelled."
+                  exit 1
+                fi
+                break
+              fi
+
+              echo "Waiting for $wf to complete... (attempt $attempt)"
+              sleep 10
+            done
+          done
+
+          echo "All workflows completed successfully, proceeding with docker-compose-test"
+
+  docker-compose-test:
+    name: Docker Compose Validation
+    needs: wait-for-builds
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        profile: [ cloud, standalone ]
+    env:
+      NODE_TAG: 0.13.0-alpha.3
+      APP__INFRA__STORAGE__PASSWORD: ${{ secrets.APP__INFRA__STORAGE__PASSWORD }}
+      APP__INFRA__PUB_SUB__PASSWORD: ${{ secrets.APP__INFRA__PUB_SUB__PASSWORD }}
+      APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD: ${{ secrets.APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD }}
+      APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Docker versions
+        run: |
+          docker version
+          docker compose version
+
+      - name: Store indexer version
+        env:
+          toolchain_toml: "rust-toolchain.toml"
+        run: |
+          version=$(grep '^version.*=' Cargo.toml | sed -E 's/version.*=.*"(.*)"/\1/')
+          echo "version=$version" | tee -a $GITHUB_ENV
+
+      - name: Add github.com credentials to netrc
+        uses: extractions/netrc@v2
+        with:
+          machine: github.com
+          username: MidnightCI
+          password: ${{ secrets.MIDNIGHTCI_REPO }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: MidnightCI
+          password: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+
+      - name: Prepare metadata (tag) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        env:
+          DOCKER_METADATA_SHORT_SHA_LENGTH: 8
+        with:
+          # Note version is set above in Set up environment
+          tags: |
+            type=semver,pattern={{version}}
+            ${{ github.ref_type != 'tag' && format('type=sha,prefix={0}-,format=short', env.version) || '' }}
+
+      - name: Validating docker image tag used (must be one)
+        run: |
+          echo "Raw tags output: ${{ steps.meta.outputs.tags }}"
+          tag_count=$(echo "${{ steps.meta.outputs.tags }}" | grep -c .)
+
+          if [ "$tag_count" -ne 1 ]; then
+            echo "Expected exactly one Docker tag, but got $tag_count:"
+            exit 1
+          fi
+
+          # Extract the single tag
+          INDEXER_TAG=$(echo "${{ steps.meta.outputs.tags }}" | cut -d ':' -f2)
+          echo "Using INDEXER_TAG=$INDEXER_TAG"
+          echo "INDEXER_TAG=$INDEXER_TAG" >> $GITHUB_ENV
+
+      - name: Docker Compose Up
+        run: |
+          echo "Compose up with:"
+          echo "- Indexer tag: $INDEXER_TAG"
+          echo "- Node tag   : $NODE_TAG"
+          docker compose --profile "${{ matrix.profile }}" up -d
+
+      - name: Show running containers
+        run: docker compose ps
+
+      - name: Wait for services to be healthy
+        run: |
+          # Wait for up to 60 seconds for all healthchecks to pass
+          for i in $(seq 1 12); do
+            echo "Check for services to be healthy... attempt $i"
+            unhealthy=$(docker compose ps |grep -E 'unhealthy|starting' || true)
+            if [ -z "$unhealthy" ]; then
+              echo "All services healthy!"
+              exit 0
+            else
+              echo "Unhealthy services: $unhealthy"
+            fi
+            sleep 5
+          done
+          echo "Some services failed to become healthy:"
+          exit 1
+
+      - name: Show logs (on failure)
+        if: failure()
+        run: docker compose logs
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,12 +2,14 @@
 
 services:
   chain-indexer:
+    profiles:
+      - cloud
     depends_on:
       postgres:
         condition: "service_healthy"
       nats:
         condition: "service_started"
-    image: "midnightntwrk/chain-indexer:latest"
+    image: "ghcr.io/midnight-ntwrk/chain-indexer:${INDEXER_TAG:-latest}"
     restart: "no"
     environment:
       RUST_LOG: "chain_indexer=debug,indexer_common=debug,fastrace_opentelemetry=off,info"
@@ -19,19 +21,22 @@ services:
       APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD: $APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD
       APP__INFRA__LEDGER_STATE_STORAGE__URL: "nats:4222"
     healthcheck:
-      test: ["CMD-SHELL", "cat /var/run/chain-indexer/running"]
-      start_interval: "5s"
+      test: [ "CMD-SHELL", "cat /var/run/chain-indexer/running" ]
+      start_interval: "2s"
+      start_period: "30s"
       interval: "5s"
       timeout: "2s"
       retries: 2
 
   wallet-indexer:
+    profiles:
+      - cloud
     depends_on:
       postgres:
         condition: "service_healthy"
       nats:
         condition: "service_started"
-    image: "midnightntwrk/wallet-indexer:latest"
+    image: "ghcr.io/midnight-ntwrk/wallet-indexer:${INDEXER_TAG:-latest}"
     restart: "no"
     environment:
       RUST_LOG: "wallet_indexer=debug,indexer_common=debug,fastrace_opentelemetry=off,info"
@@ -41,19 +46,22 @@ services:
       APP__INFRA__PUB_SUB__URL: "nats:4222"
       APP__INFRA__PUB_SUB__PASSWORD: $APP__INFRA__PUB_SUB__PASSWORD
     healthcheck:
-      test: ["CMD-SHELL", "cat /var/run/wallet-indexer/running"]
-      start_interval: "5s"
+      test: [ "CMD-SHELL", "cat /var/run/wallet-indexer/running" ]
+      start_interval: "2s"
+      start_period: "30s"
       interval: "5s"
       timeout: "2s"
       retries: 2
 
   indexer-api:
+    profiles:
+      - cloud
     depends_on:
       postgres:
         condition: "service_healthy"
       nats:
         condition: "service_started"
-    image: "midnightntwrk/indexer-api:latest"
+    image: "ghcr.io/midnight-ntwrk/indexer-api:${INDEXER_TAG:-latest}"
     restart: "no"
     ports:
       - "8088:8088"
@@ -67,16 +75,19 @@ services:
       APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD: $APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD
       APP__INFRA__LEDGER_STATE_STORAGE__URL: "nats:4222"
     healthcheck:
-      test: ["CMD-SHELL", "cat /var/run/indexer-api/running"]
-      start_interval: "5s"
+      test: [ "CMD-SHELL", "cat /var/run/indexer-api/running" ]
+      start_interval: "2s"
+      start_period: "30s"
       interval: "5s"
       timeout: "2s"
       retries: 2
 
   indexer-standalone:
+    depends_on:
+      - node
     profiles:
       - standalone
-    image: "midnightntwrk/indexer-standalone:latest"
+    image: "ghcr.io/midnight-ntwrk/indexer-standalone:${INDEXER_TAG:-latest}"
     restart: "no"
     ports:
       - "8088:8088"
@@ -85,13 +96,16 @@ services:
       APP__INFRA__SECRET: $APP__INFRA__SECRET
       APP__INFRA__NODE__URL: "ws://node:9944"
     healthcheck:
-      test: ["CMD-SHELL", "cat /var/run/indexer-standalone/running"]
-      start_interval: "5s"
+      test: [ "CMD-SHELL", "cat /var/run/indexer-standalone/running" ]
+      start_interval: "2s"
+      start_period: "30s"
       interval: "5s"
       timeout: "2s"
       retries: 2
 
   postgres:
+    profiles:
+      - cloud
     image: "postgres:17.1-alpine"
     restart: "always"
     ports:
@@ -103,7 +117,7 @@ services:
       POSTGRES_DB: "indexer"
       POSTGRES_PASSWORD: $APP__INFRA__STORAGE__PASSWORD
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U indexer"]
+      test: [ "CMD-SHELL", "pg_isready -U indexer" ]
       interval: "5s"
       timeout: "2s"
       retries: 2
@@ -111,9 +125,11 @@ services:
       - no-new-privileges:true
 
   nats:
+    profiles:
+      - cloud
     image: "nats:2.11.1"
     restart: "always"
-    command: ["--user", "indexer", "--pass", $APP__INFRA__PUB_SUB__PASSWORD, "-js"]
+    command: [ "--user", "indexer", "--pass", $APP__INFRA__PUB_SUB__PASSWORD, "-js" ]
     ports:
       - "4222:4222"
     volumes:
@@ -122,7 +138,8 @@ services:
       - no-new-privileges:true
 
   node:
-    image: "ghcr.io/midnight-ntwrk/midnight-node:0.13.0-alpha.3"
+    profiles: [ cloud, standalone ]
+    image: "ghcr.io/midnight-ntwrk/midnight-node:${NODE_TAG:-latest}"
     restart: "always"
     ports:
       - "9944:9944"


### PR DESCRIPTION
The indexer comes with the ability to build docker images and to bundle up a local environment that can be started with docker compose.

It enables and speeds up local development and testing, giving a quick and easy way to test latest changes, plus the indexer images are published on Docker Hub on major releases to Testnet

This change provides:
- a GitHub workflow file that starts docker compose and checks for problems on health of the containers
- a fix for PM-17587 that is causing more recent docker compose versions (>= v2.36.0) requiring healthcheck.start_interval together with healthcheck.start_period
- an update of the images used in the docker compose file with an option to provide the image tags by environment variable
- added explicit cloud profile on docker compose file as the behaviour of docker compose up command was odd, it was creating also non-standalone images (fixes PM-18090)