### PR TITLE
feat: pin actions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:best-practices"
+  ],
+  "dependencyDashboard": true,
+  "enabled": true
+}


### PR DESCRIPTION
Dependabot is good but renovate is better. It's able to pin and update github actions (you'll note there's security issues raised against them bein @v4 rather than a hash.)

Think of it as belt and braces - we seem to have both running on the node and they don't seem to get in each others way so far.