### PR TITLE
fix: resolve panic when querying transaction field on ContractAction interface

### DIFF
--- a/indexer-api/src/infra/api/v1/transaction.rs
+++ b/indexer-api/src/infra/api/v1/transaction.rs
@@ -69,13 +69,26 @@ where
     _s: PhantomData<S>,
 }
 
-// Needed to derive `Interface` for `ContractAction`. Weird!
+// Required by async-graphql's Interface derive macro for `ContractAction`.
+// This should never be called in practice as the concrete types (ContractDeploy,
+// ContractCall, ContractUpdate) implement their own transaction resolvers.
+// However, the trait is still required for the interface to compile.
+// Since From trait cannot return Result, we must panic on error.
 impl<S> From<Result<Transaction<S>, ApiError>> for Transaction<S>
 where
     S: Storage,
 {
-    fn from(_value: Result<Transaction<S>, ApiError>) -> Self {
-        unimplemented!()
+    fn from(value: Result<Transaction<S>, ApiError>) -> Self {
+        match value {
+            Ok(transaction) => transaction,
+            Err(err) => {
+                // This panic indicates a bug in async-graphql's interface resolution
+                // or a missing implementation in one of the concrete types
+                panic!(
+                    "Unexpected error resolving transaction for ContractAction interface: {err}. This trait should not be called directly - concrete types should handle their own transaction resolution."
+                )
+            }
+        }
     }
 }
 

--- a/indexer-api/src/infra/api/v1/transaction.rs
+++ b/indexer-api/src/infra/api/v1/transaction.rs
@@ -70,10 +70,6 @@ where
 }
 
 // Required by async-graphql's Interface derive macro for `ContractAction`.
-// This should never be called in practice as the concrete types (ContractDeploy,
-// ContractCall, ContractUpdate) implement their own transaction resolvers.
-// However, the trait is still required for the interface to compile.
-// Since From trait cannot return Result, we must panic on error.
 impl<S> From<Result<Transaction<S>, ApiError>> for Transaction<S>
 where
     S: Storage,
@@ -81,11 +77,11 @@ where
     fn from(value: Result<Transaction<S>, ApiError>) -> Self {
         match value {
             Ok(transaction) => transaction,
-            Err(err) => {
+            Err(error) => {
                 // This panic indicates a bug in async-graphql's interface resolution
-                // or a missing implementation in one of the concrete types
+                // or a missing implementation in one of the concrete types.
                 panic!(
-                    "Unexpected error resolving transaction for ContractAction interface: {err}. This trait should not be called directly - concrete types should handle their own transaction resolution."
+                    "Unexpected error resolving transaction for ContractAction interface: {error}"
                 )
             }
         }


### PR DESCRIPTION
### Summary
Fixes PM-18643 where querying the `transaction` field on any `ContractAction` (Deploy/Call/Update) caused the API to panic and forcibly close the socket connection.

### Problem
The `ContractAction` GraphQL interface requires a `From<Result<Transaction<S>, ApiError>>` trait implementation for async-graphql to properly resolve the transaction field. The previous implementation had `unimplemented!()` which caused a panic whenever the transaction field was queried.

### Solution
Implemented proper error handling in the `From` trait:
- Returns the transaction on success
- Panics with descriptive error message on failure (required since From trait cannot return Result)

### Testing
✅ Tested with Giuseppe's exact query that was causing the issue:
```graphql
query {
  contractAction(
    address: "000200e99d4445695a6244a01ab00d592825e2703c3f9a928f01429561585ce2db1e78"
    offset: { transactionOffset: { hash: "2e62a162e23231d816fb7b6a8e722fd4f5f0a5157f7a9f2542c47d7a73671527" } }
  ) {
    transaction { hash }
  }
}
```

**Before**: `curl: (52) Empty reply from server` + panic in logs  
**After**: Query returns data successfully

### Checklist
- [x] Code compiles without warnings
- [x] Manually tested the fix with the problematic query
- [x] Verified no regression in existing functionality
- [x] Added explanatory comments for the unusual panic requirement