### PR TITLE
fix: add --wait flag to docker compose commands to prevent race condition

### DIFF
--- a/justfile
+++ b/justfile
@@ -87,7 +87,7 @@ build-docker-image package profile="dev":
         .
 
 run-chain-indexer node="ws://localhost:9944" network_id="Undeployed":
-    docker compose up -d postgres nats
+    docker compose up -d --wait postgres nats
     RUST_LOG=chain_indexer=debug,indexer_common=debug,fastrace_opentelemetry=off,info \
         CONFIG_FILE=chain-indexer/config.yaml \
         APP__APPLICATION__NETWORK_ID={{network_id}} \
@@ -95,14 +95,14 @@ run-chain-indexer node="ws://localhost:9944" network_id="Undeployed":
         cargo run -p chain-indexer --features {{feature}}
 
 run-wallet-indexer network_id="Undeployed":
-    docker compose up -d postgres nats
+    docker compose up -d --wait postgres nats
     RUST_LOG=wallet_indexer=debug,indexer_common=debug,fastrace_opentelemetry=off,info \
         CONFIG_FILE=wallet-indexer/config.yaml \
         APP__APPLICATION__NETWORK_ID={{network_id}} \
         cargo run -p wallet-indexer --features {{feature}}
 
 run-indexer-api network_id="Undeployed":
-    docker compose up -d postgres nats
+    docker compose up -d --wait postgres nats
     RUST_LOG=indexer_api=debug,indexer_common=debug,info \
         CONFIG_FILE=indexer-api/config.yaml \
         APP__APPLICATION__NETWORK_ID={{network_id}} \


### PR DESCRIPTION
## Summary
Fixes race condition where indexer services attempt to connect to Postgres before it's fully ready.

## Problem
The `run-indexer-api`, `run-chain-indexer`, and `run-wallet-indexer` recipes start Postgres and NATS containers with `docker compose up -d` and immediately try to connect. On first run, Postgres may not be ready, causing connection errors:
  - `Connection reset by peer (os error 54)`

## Solution
Added `--wait` flag to `docker compose up -d` commands. This makes Docker Compose wait for the Postgres healthcheck to pass before returning, ensuring the database is ready before the application attempts to connect.

## Changes
 - Updated `justfile` recipes to use `docker compose up -d --wait` for:
   - `run-chain-indexer`
   - `run-wallet-indexer`
   - `run-indexer-api`

## Testing
Run `just run-indexer-api` - it should connect successfully on the first attempt without requiring a retry.