### PR TITLE
test: improve node example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,6 +1021,7 @@ dependencies = [
  "assert_matches",
  "async-stream",
  "byte-unit",
+ "clap",
  "const-hex",
  "derive_more 2.0.1",
  "fake",

--- a/chain-indexer/Cargo.toml
+++ b/chain-indexer/Cargo.toml
@@ -40,6 +40,7 @@ trait-variant      = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+clap           = { workspace = true, features = [ "derive" ] }
 fs_extra       = { workspace = true }
 fake           = { workspace = true }
 tempfile       = { workspace = true }

--- a/chain-indexer/examples/node.rs
+++ b/chain-indexer/examples/node.rs
@@ -1,34 +1,65 @@
 use anyhow::Context;
 use chain_indexer::{
-    domain::Node,
+    domain::{Block, Node},
     infra::subxt_node::{Config, SubxtNode},
 };
-use futures::{StreamExt, TryStreamExt};
+use clap::Parser;
+use futures::{Stream, StreamExt, TryStreamExt};
 use indexer_common::domain::{NetworkId, PROTOCOL_VERSION_000_013_000};
-use std::{pin::pin, time::Duration};
+use std::{pin::Pin, time::Duration};
 
-/// This program connects to a local node and prints some first blocks and their transactions.
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let config = Config {
-        url: "ws://localhost:9944".to_string(),
-        genesis_protocol_version: PROTOCOL_VERSION_000_013_000,
-        reconnect_max_delay: Duration::from_secs(1),
-        reconnect_max_attempts: 3,
-    };
-    let mut node = SubxtNode::new(config).await.context("create SubxtNode")?;
+    Cli::parse().run().await
+}
 
-    let blocks = node.finalized_blocks(None, NetworkId::Undeployed).take(60);
-    let mut blocks = pin!(blocks);
-    while let Some(block) = blocks.try_next().await.context("get next block")? {
-        println!("## BLOCK: height={}, \thash={}", block.height, block.hash);
-        for transaction in block.transactions {
-            println!(
-                "    ## TRANSACTION: hash={}, \t{transaction:?}",
-                transaction.hash
-            );
+/// This program connects to a node and prints blocks and their transactions.
+#[derive(Debug, Parser)]
+#[command()]
+struct Cli {
+    /// The node URL; defaults to "ws://localhost:9944".
+    #[arg(long, default_value = "ws://localhost:9944")]
+    node: String,
+
+    /// How many blocks to skip; none if omitted.
+    #[arg(long)]
+    skip: Option<usize>,
+
+    /// How many blocks to take; unlimited if omitted.
+    #[arg(long)]
+    take: Option<usize>,
+}
+
+impl Cli {
+    async fn run(self) -> anyhow::Result<()> {
+        let config = Config {
+            url: self.node,
+            genesis_protocol_version: PROTOCOL_VERSION_000_013_000,
+            reconnect_max_delay: Duration::from_secs(1),
+            reconnect_max_attempts: 1,
+        };
+        let mut node = SubxtNode::new(config).await.context("create SubxtNode")?;
+
+        let blocks = node.finalized_blocks(None, NetworkId::Undeployed);
+        let mut blocks: Pin<Box<dyn Stream<Item = Result<Block, _>> + Send>> = Box::pin(blocks);
+
+        if let Some(n) = self.skip {
+            blocks = Box::pin(blocks.skip(n));
         }
-    }
 
-    Ok(())
+        if let Some(n) = self.take {
+            blocks = Box::pin(blocks.take(n));
+        }
+
+        while let Some(block) = blocks.try_next().await.context("get next block")? {
+            println!("## BLOCK: height={}, \thash={}", block.height, block.hash);
+            for transaction in block.transactions {
+                println!(
+                    "    ## TRANSACTION: hash={}, \t{transaction:?}",
+                    transaction.hash
+                );
+            }
+        }
+        Ok(())
+    }
 }


### PR DESCRIPTION
This extends the capabilities of the `node` example: 
- `--node` argument
- `--skip` argument to optionally skip blocks; else from beginning
- `--take` argument to optionally take blocks; else take all