### PR TITLE
fix: correctly determine transaction relevance

### DIFF
--- a/generate_txs.sh
+++ b/generate_txs.sh
@@ -1,8 +1,22 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
+if [ -z "$1" ]; then
+    echo "Error: node version parameter is required" >&2
+    echo "Usage: $0 <node_version>" >&2
+    exit 1
+fi
+node_version="$1"
+
 # 1 to 2/2
-midnight-node-toolkit generate-txs \
-    --dest-file ./target/tx_1_2_2.mn \
+docker run \
+    --rm \
+    --network host \
+    -v ./target:/out \
+    ghcr.io/midnight-ntwrk/midnight-node-toolkit:$node_version \
+    generate-txs \
+    --dest-file /out/tx_1_2_2.mn \
     --to-bytes \
     single-tx \
     --shielded-amount 10 \
@@ -11,14 +25,24 @@ midnight-node-toolkit generate-txs \
     --destination-address mn_shield-addr_undeployed1tffkxdesnqz86wvds2aprwuprpvzvag5t3mkveddr33hr7xyhlhqxqzfqqxy54an7cyznaxnzs7p8tduku7fuje5mwqx9auvdn9e8x03kvvy5r6z \
     --destination-address mn_addr_undeployed1gkasr3z3vwyscy2jpp53nzr37v7n4r3lsfgj6v5g584dakjzt0xqun4d4r
 
-midnight-node-toolkit get-tx-from-context \
+docker run \
+    --rm \
+    --network host \
+    -v ./target:/out \
+    ghcr.io/midnight-ntwrk/midnight-node-toolkit:$node_version \
+    get-tx-from-context \
     --src-file ./target/tx_1_2_2.mn \
     --network undeployed \
     --dest-file ./target/tx_1_2_2.raw \
     --from-bytes
 
 # 1 to 2/3
-midnight-node-toolkit generate-txs \
+docker run \
+    --rm \
+    --network host \
+    -v ./target:/out \
+    ghcr.io/midnight-ntwrk/midnight-node-toolkit:$node_version \
+    generate-txs \
     --dest-file ./target/tx_1_2_3.mn \
     --to-bytes \
     single-tx \
@@ -28,7 +52,12 @@ midnight-node-toolkit generate-txs \
     --destination-address mn_shield-addr_undeployed1tffkxdesnqz86wvds2aprwuprpvzvag5t3mkveddr33hr7xyhlhqxqzfqqxy54an7cyznaxnzs7p8tduku7fuje5mwqx9auvdn9e8x03kvvy5r6z \
     --destination-address mn_addr_undeployed1g9nr3mvjcey7ca8shcs5d4yjndcnmczf90rhv4nju7qqqlfg4ygs0t4ngm
 
-midnight-node-toolkit get-tx-from-context \
+docker run \
+    --rm \
+    --network host \
+    -v ./target:/out \
+    ghcr.io/midnight-ntwrk/midnight-node-toolkit:$node_version \
+    get-tx-from-context \
     --src-file ./target/tx_1_2_3.mn \
     --network undeployed \
     --dest-file ./target/tx_1_2_3.raw \

--- a/generate_txs.sh
+++ b/generate_txs.sh
@@ -31,9 +31,9 @@ docker run \
     -v ./target:/out \
     ghcr.io/midnight-ntwrk/midnight-node-toolkit:$node_version \
     get-tx-from-context \
-    --src-file ./target/tx_1_2_2.mn \
+    --src-file /out/tx_1_2_2.mn \
     --network undeployed \
-    --dest-file ./target/tx_1_2_2.raw \
+    --dest-file /out/tx_1_2_2.raw \
     --from-bytes
 
 # 1 to 2/3
@@ -43,7 +43,7 @@ docker run \
     -v ./target:/out \
     ghcr.io/midnight-ntwrk/midnight-node-toolkit:$node_version \
     generate-txs \
-    --dest-file ./target/tx_1_2_3.mn \
+    --dest-file /out/tx_1_2_3.mn \
     --to-bytes \
     single-tx \
     --shielded-amount 10 \
@@ -58,7 +58,7 @@ docker run \
     -v ./target:/out \
     ghcr.io/midnight-ntwrk/midnight-node-toolkit:$node_version \
     get-tx-from-context \
-    --src-file ./target/tx_1_2_3.mn \
+    --src-file /out/tx_1_2_3.mn \
     --network undeployed \
-    --dest-file ./target/tx_1_2_3.raw \
+    --dest-file /out/tx_1_2_3.raw \
     --from-bytes

--- a/indexer-common/src/domain/ledger/transaction.rs
+++ b/indexer-common/src/domain/ledger/transaction.rs
@@ -205,13 +205,15 @@ impl Transaction {
                     let can_decrypt_guaranteed_coins = guaranteed_coins
                         .as_ref()
                         .map(|guaranteed_coins| can_decrypt_v6(&secret_key, guaranteed_coins))
-                        .unwrap_or(true);
+                        .unwrap_or_default();
 
-                    let can_decrypt_fallible_coins = fallible_coins
-                        .values()
-                        .all(|fallible_coins| can_decrypt_v6(&secret_key, &fallible_coins));
+                    let can_decrypt_fallible_coins = || {
+                        fallible_coins
+                            .values()
+                            .any(|fallible_coins| can_decrypt_v6(&secret_key, &fallible_coins))
+                    };
 
-                    can_decrypt_guaranteed_coins && can_decrypt_fallible_coins
+                    can_decrypt_guaranteed_coins || can_decrypt_fallible_coins()
                 }
 
                 TransactionV6::ClaimRewards(_) => false,

--- a/justfile
+++ b/justfile
@@ -120,6 +120,9 @@ run-indexer-standalone node="ws://localhost:9944" network_id="Undeployed":
 generate-node-data:
     ./generate_node_data.sh {{node_version}}
 
+generate-txs:
+    ./generate_txs.sh {{node_version}}
+
 run-node:
     #!/usr/bin/env bash
     node_dir=$(mktemp -d)


### PR DESCRIPTION
The logic to determine if a transaction is relevant for a (zswap) viewing key was broken: First, absence of `guaranteed_coins` was treated as `true`, but the opposite is the case. This resulted in a lot of false positives. Second, `fallible_coins` (possibly) were treated the wrong way: Instead of requiring all fallible coins to be able to be decoded it should be enough if any can be decoded.

Other changes:
- Remove some `debug` calls in wallet-indexer's code which resulted in log event tsunamis.
- Change `generate_txs.sh` to use the Dockerized toolkit (instead of a local install) which can be properly versioned.