### PR TITLE
chore: improve node update process robustness

### DIFF
--- a/docs/updating-node-version.md
+++ b/docs/updating-node-version.md
@@ -15,7 +15,7 @@ When updating from an old version (e.g., `0.13.2-rc.2`) to a new version (e.g., 
 # First, update the NODE_VERSION file to the new version
 echo "0.13.5-79c649d7" > NODE_VERSION
 
-# Then generate node data for the new version
+# Then generate node data for the new version (will verify image exists first)
 just update-node
 ```
 
@@ -60,10 +60,29 @@ Before creating PR, verify:
 
 ## Breaking Changes
 
-If the new node version includes breaking changes (e.g., removed fields like `new_registrations`):
-1. Check node release notes for breaking changes
-2. Update domain types if needed
-3. Consider backward compatibility requirements
+If the new node version includes breaking changes, follow these steps:
+
+### Common Breaking Change Scenarios
+
+#### Field Removal
+Example: Node removes `new_registrations` field
+1. **Compilation error**: `error[E0560]: struct has no field named 'new_registrations'`
+2. **Fix**: Update domain types in `indexer-common/src/domain/`
+3. **GraphQL**: Update schema if the field was exposed
+4. **Database**: Consider migration if the field was stored
+
+#### Transaction Format Change
+Example: Node changes from hex-encoded to binary transactions
+1. **Runtime error**: `cannot hex-decode transaction: odd number of digits`
+2. **Fix**: Update parsing in `chain-indexer/src/infra/subxt_node/`
+3. **Test**: Verify with real transactions from the new node
+
+#### Event Structure Change
+Example: Event adds/removes fields
+1. **Compilation error**: Missing or extra fields in event destructuring
+2. **Fix**: Update event handling in `chain-indexer/src/domain/`
+3. **Storage**: Update database schema if events are stored
+
 
 ## CI Considerations
 
@@ -79,7 +98,3 @@ If issues are discovered after deployment:
 2. Keep the new metadata file (doesn't hurt)
 3. Ensure all references point back to working version
 4. Investigate and fix before re-attempting
-
----
-
-*Last updated: August 2025*

--- a/generate_node_data.sh
+++ b/generate_node_data.sh
@@ -2,6 +2,14 @@
 
 set -euxo pipefail
 
+# Cleanup function to ensure node container is removed
+cleanup() {
+    docker rm -f node >/dev/null 2>&1 || true
+}
+
+# Set up trap to cleanup on exit
+trap cleanup EXIT
+
 if [ -z "$1" ]; then
     echo "Error: node version parameter is required" >&2
     echo "Usage: $0 <node_version>" >&2
@@ -9,12 +17,93 @@ if [ -z "$1" ]; then
 fi
 node_version="$1"
 
+# Configurable delays for PM-19168 workaround
+DELAY_BEFORE_SEND=${DELAY_BEFORE_SEND:-6}
+DELAY_BEFORE_MAINTENANCE=${DELAY_BEFORE_MAINTENANCE:-6}
+
+# Function to run all toolkit commands
+run_toolkit_commands() {
+    # Generate batches
+    # Note: Reduced from -n 3 -b 2 to -n 1 -b 1 to minimize DUST requirements
+    # after fees were enabled in node 0.16.0-da0b6c69. Larger batch sizes fail with:
+    # "Balancing TX failed: Insufficient DUST (trying to spend X, need Y more)"
+    # This matches the approach used in midnight-node's toolkit-e2e.sh CI tests.
+    docker run \
+        --rm \
+        --network host \
+        -v /tmp:/out \
+        ghcr.io/midnight-ntwrk/midnight-node-toolkit:$node_version \
+        generate-txs batches -n 1 -b 1
+    
+    docker run \
+        --rm \
+        --network host \
+        -v /tmp:/out \
+        ghcr.io/midnight-ntwrk/midnight-node-toolkit:$node_version \
+        generate-txs --dest-file /out/contract_tx_1_deploy.mn --to-bytes \
+        contract-calls deploy \
+        --rng-seed '0000000000000000000000000000000000000000000000000000000000000037'
+    
+    docker run \
+        --rm \
+        --network host \
+        -v /tmp:/out \
+        ghcr.io/midnight-ntwrk/midnight-node-toolkit:$node_version \
+        contract-address --network undeployed \
+        --src-file /out/contract_tx_1_deploy.mn --dest-file /out/contract_address.mn
+    
+    # Add delay to work around PM-19168 (ctime > tblock validation issue).
+    sleep $DELAY_BEFORE_SEND
+    
+    docker run \
+        --rm \
+        --network host \
+        -v /tmp:/out \
+        ghcr.io/midnight-ntwrk/midnight-node-toolkit:$node_version \
+        generate-txs --src-files /out/contract_tx_1_deploy.mn --dest-url ws://127.0.0.1:9944 \
+        send
+    
+    # Add delay to work around PM-19168.
+    sleep $DELAY_BEFORE_SEND
+    
+    # The 'store' function inserts data into a Merkle tree in the test contract
+    # (see midnight-node MerkleTreeContract). We need this to generate contract
+    # action events in the test data so the indexer can verify it properly tracks
+    # and indexes contract state changes.
+    docker run \
+        --rm \
+        --network host \
+        -v /tmp:/out \
+        ghcr.io/midnight-ntwrk/midnight-node-toolkit:$node_version \
+        generate-txs contract-calls call \
+        --call-key store \
+        --rng-seed '0000000000000000000000000000000000000000000000000000000000000037' \
+        --contract-address /out/contract_address.mn
+    
+    # Wait for the contract call to be finalized before running maintenance.
+    sleep 15
+    
+    # Add longer delay for maintenance to work around PM-19168.
+    sleep $DELAY_BEFORE_MAINTENANCE
+    
+    docker run \
+        --rm \
+        --network host \
+        -v /tmp:/out \
+        ghcr.io/midnight-ntwrk/midnight-node-toolkit:$node_version \
+        generate-txs contract-calls maintenance \
+        --rng-seed '0000000000000000000000000000000000000000000000000000000000000037' \
+        --contract-address /out/contract_address.mn
+}
+
+# Clean up any existing data
 if [ -d ./.node/$node_version ]; then
     rm -r ./.node/$node_version;
 fi
 
 mkdir -p ./.node/$node_version
 
+# Start the node container
 # SIDECHAIN_BLOCK_BENEFICIARY specifies the wallet that receives block rewards and transaction fees (DUST).
 # Required after fees were enabled in 0.16.0-da0b6c69.
 # This hex value is a public key that matches the one used in toolkit-e2e.sh.
@@ -28,78 +117,49 @@ docker run \
     -v ./.node/$node_version:/node \
     ghcr.io/midnight-ntwrk/midnight-node:$node_version
 
-sleep 10
+# Wait for node to be ready (max 30 seconds)
+echo "Waiting for node to be ready..."
+for i in {1..30}; do
+    if nc -z localhost 9944 2>/dev/null; then
+        echo "Node is ready"
+        sleep 2  # Give it a moment to fully initialize
+        break
+    fi
+    if [ $i -eq 30 ]; then
+        echo "Error: Node failed to start after 30 seconds" >&2
+        docker logs node 2>&1 | tail -20
+        exit 1
+    fi
+    sleep 1
+done
 
-# Generate batches
-# Note: Reduced from -n 3 -b 2 to -n 1 -b 1 to minimize DUST requirements
-# after fees were enabled in node 0.16.0-da0b6c69. Larger batch sizes fail with:
-# "Balancing TX failed: Insufficient DUST (trying to spend X, need Y more)"
-# This matches the approach used in midnight-node's toolkit-e2e.sh CI tests.
-docker run \
-    --rm \
-    --network host \
-    -v /tmp:/out \
-    ghcr.io/midnight-ntwrk/midnight-node-toolkit:$node_version \
-    generate-txs batches -n 1 -b 1
+# Retry the entire toolkit command sequence up to 3 times
+max_attempts=3
+attempt=1
 
-docker run \
-    --rm \
-    --network host \
-    -v /tmp:/out \
-    ghcr.io/midnight-ntwrk/midnight-node-toolkit:$node_version \
-    generate-txs --dest-file /out/contract_tx_1_deploy.mn --to-bytes \
-    contract-calls deploy \
-    --rng-seed '0000000000000000000000000000000000000000000000000000000000000037'
+while [ $attempt -le $max_attempts ]; do
+    echo "Running toolkit commands (attempt $attempt of $max_attempts)..."
+    
+    # Try to run all toolkit commands
+    if run_toolkit_commands; then
+        echo "Successfully generated node data"
+        exit 0
+    fi
+    
+    echo "Toolkit commands failed on attempt $attempt" >&2
+    
+    # If this wasn't the last attempt, clean up and retry
+    if [ $attempt -lt $max_attempts ]; then
+        echo "Cleaning up node data folder for retry..." >&2
+        rm -rf ./.node/$node_version/*
+        echo "Waiting before retry..." >&2
+        sleep $((attempt * 5))
+    fi
+    
+    attempt=$((attempt + 1))
+done
 
-docker run \
-    --rm \
-    --network host \
-    -v /tmp:/out \
-    ghcr.io/midnight-ntwrk/midnight-node-toolkit:$node_version \
-    contract-address --network undeployed \
-    --src-file /out/contract_tx_1_deploy.mn --dest-file /out/contract_address.mn
-
-# Add delay to work around PM-19168 (ctime > tblock validation issue).
-sleep 6
-
-docker run \
-    --rm \
-    --network host \
-    -v /tmp:/out \
-    ghcr.io/midnight-ntwrk/midnight-node-toolkit:$node_version \
-    generate-txs --src-files /out/contract_tx_1_deploy.mn --dest-url ws://127.0.0.1:9944 \
-    send
-
-# Add delay to work around PM-19168.
-sleep 6
-
-# The 'store' function inserts data into a Merkle tree in the test contract
-# (see midnight-node MerkleTreeContract). We need this to generate contract
-# action events in the test data so the indexer can verify it properly tracks
-# and indexes contract state changes.
-docker run \
-    --rm \
-    --network host \
-    -v /tmp:/out \
-    ghcr.io/midnight-ntwrk/midnight-node-toolkit:$node_version \
-    generate-txs contract-calls call \
-    --call-key store \
-    --rng-seed '0000000000000000000000000000000000000000000000000000000000000037' \
-    --contract-address /out/contract_address.mn
-
-# Wait for the contract call to be finalized before running maintenance.
-sleep 15
-
-# Add longer delay for maintenance to work around PM-19168.
-sleep 6
-
-docker run \
-    --rm \
-    --network host \
-    -v /tmp:/out \
-    ghcr.io/midnight-ntwrk/midnight-node-toolkit:$node_version \
-    generate-txs contract-calls maintenance \
-    --rng-seed '0000000000000000000000000000000000000000000000000000000000000037' \
-    --contract-address /out/contract_address.mn
-
-docker rm -f node
+echo "Failed to generate node data after $max_attempts attempts" >&2
+# Clean up the folder on final failure
+rm -rf ./.node/$node_version
+exit 1

--- a/get_node_metadata.sh
+++ b/get_node_metadata.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
-set -euxo pipefail
+set -euo pipefail
+
+# Cleanup function to ensure node container is removed
+cleanup() {
+    docker rm -f node >/dev/null 2>&1 || true
+}
+
+# Set up trap to cleanup on exit
+trap cleanup EXIT
 
 if [ -z "$1" ]; then
     echo "Error: node version parameter is required" >&2
@@ -8,6 +16,25 @@ if [ -z "$1" ]; then
     exit 1
 fi
 node_version="$1"
+
+# Check if subxt is installed and verify version
+if ! command -v subxt &> /dev/null; then
+    echo "Error: subxt is not installed. Install it with: cargo install subxt-cli" >&2
+    exit 1
+fi
+
+# Extract expected version from Cargo.toml
+expected_version=$(grep 'subxt.*version' Cargo.toml | sed -E 's/.*version = "([^"]+)".*/\1/')
+# Get installed version (subxt outputs version like "subxt-cli 0.44.0-unknown")
+installed_version=$(subxt version | sed -E 's/subxt-cli ([0-9]+\.[0-9]+).*/\1/')
+
+if [ "$installed_version" != "$expected_version" ]; then
+    echo "Error: subxt version mismatch" >&2
+    echo "  Expected: $expected_version (from Cargo.toml)" >&2
+    echo "  Installed: $installed_version" >&2
+    echo "  Install correct version with: cargo install subxt-cli --version ${expected_version}" >&2
+    exit 1
+fi
 
 mkdir -p ./.node/$node_version
 
@@ -23,11 +50,23 @@ docker run \
     -e SIDECHAIN_BLOCK_BENEFICIARY="04bcf7ad3be7a5c790460be82a713af570f22e0f801f6659ab8e84a52be6969e" \
     ghcr.io/midnight-ntwrk/midnight-node:$node_version
 
-sleep 10
+# Wait for port to be available (max 30 seconds)
+echo "Waiting for node to be ready..."
+for i in {1..30}; do
+    if nc -z localhost 9944 2>/dev/null; then
+        echo "Node is ready"
+        sleep 2  # Give it a moment to fully initialize
+        break
+    fi
+    if [ $i -eq 30 ]; then
+        echo "Error: Node failed to start after 30 seconds" >&2
+        docker logs node 2>&1 | tail -20
+        exit 1
+    fi
+    sleep 1
+done
 
 subxt metadata \
     -f bytes \
     --url ws://localhost:9944 > \
     ./.node/$node_version/metadata.scale
-
-docker rm -f node


### PR DESCRIPTION
## Summary
  This PR builds on Oscar's recent improvements (#322) to make the node update process more reliable by addressing race conditions and intermittent failures we've observed in CI/CD.

  ## What Changed
  ### `get_node_metadata.sh`
  - Replace fixed 10s sleep with proper port readiness check (max 30s)
  - Add cleanup trap to ensure Docker container removal on exit
  - Add subxt version verification to match Cargo.toml requirement

  ### `generate_node_data.sh`
  - Refactor to retry entire toolkit sequence as a unit (not individual commands)
  - Keep Docker container running across retry attempts for efficiency
  - Clean up node data folder between retries and on final failure
  - Make PM-19168 workaround delays configurable via environment variables

  ### Documentation
  - Add concrete examples of breaking changes with solutions
  - Improve troubleshooting guidance

  ## Why These Changes
  - **Race condition fix**: Fixed sleep was causing intermittent failures when node took longer to start
  - **Retry reliability**: Toolkit commands sometimes fail due to timing issues; retrying the full sequence is more robust
  - **Version mismatch prevention**: Ensures subxt CLI version matches what the codebase expects
  - **Clean state on failure**: Prevents corrupted test data from persisting

  ## Testing
  Tested with node version `0.16.1-969433ad`
  - Metadata generation works correctly with port check
  - Test data generation handles retries properly
  - Build system correctly picks up new metadata

  ## Related
  - Complements #322 (Oscar's simplification of node update process)
  - Addresses issues discovered during recent CI failures