### PR TITLE
fix: correct node version extraction in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-indexer-images.yaml
+++ b/.github/workflows/build-indexer-images.yaml
@@ -184,14 +184,14 @@ jobs:
 
       - name: Set up Node Tag to target
         run: |
-          # Use workflow dispatch input if provided, otherwise read from justfile
+          # Use workflow dispatch input if provided, otherwise read from NODE_VERSION file
           if [ -n "${{ github.event.inputs.node_tag }}" ]; then
             echo "Using node tag from workflow dispatch: ${{ github.event.inputs.node_tag }}"
             echo "NODE_TAG=${{ github.event.inputs.node_tag }}" >> $GITHUB_ENV
           else
-            echo "Reading node tag from justfile..."
-            node_tag=$(grep '^node_version :=' justfile | sed -E 's/node_version := "(.*)"/\1/')
-            echo "Using node tag from justfile: $node_tag"
+            echo "Reading node tag from NODE_VERSION file..."
+            node_tag=$(cat NODE_VERSION)
+            echo "Using node tag: $node_tag"
             echo "NODE_TAG=$node_tag" >> $GITHUB_ENV
           fi
 


### PR DESCRIPTION
## Summary
Fixes the Docker Compose validation job in the GitHub Actions workflow that was failing to pull the correct node image due to incorrect node version extraction.

## Problem
The workflow was trying to parse the justfile to extract the node version using grep and sed, but the justfile uses shell command substitution (`cat NODE_VERSION`) which doesn't get evaluated by the regex. This caused the workflow to try pulling an image with the literal tag `node_version := \`cat NODE_VERSION\`` instead of the actual version.

## Solution
Changed the workflow to read the node version directly from the `NODE_VERSION` file, matching how it's done elsewhere in the codebase.

## Changes
- Updated `.github/workflows/build-indexer-images.yaml` line 193 to use `cat NODE_VERSION` instead of parsing the justfile