### PR TITLE
test: fixing tests failing on devnet

### DIFF
--- a/.github/workflows/qa-integration-tests-base-workflow.yml
+++ b/.github/workflows/qa-integration-tests-base-workflow.yml
@@ -40,13 +40,19 @@ concurrency:
   group: ${{github.workflow}}-${{github.head_ref || github.run_id}}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   basic-integration-tests:
+    name: Execute basic integration tests
+    permissions:
+      contents: read
+      packages: write
     env:
       TARGET_ENV: ${{ inputs.target_env }}
       GITHUB_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
       NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
-    name: Execute basic integration tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/qa-integration-tests-base-workflow.yml
+++ b/.github/workflows/qa-integration-tests-base-workflow.yml
@@ -1,4 +1,4 @@
-name: Indexer QAIntegration Tests Base workflow
+name: Indexer QA Integration Tests Base workflow
 
 # Note this is the base workflow used by the other
 # qa-integration-tests-<environment>.yml workflows

--- a/qa/tests/data/static/devnet/transactions.json
+++ b/qa/tests/data/static/devnet/transactions.json
@@ -1,4 +1,4 @@
 {
   "known-id": "00000000513469219d9077bd70336329defdd825d52a8a1da83846740d2fde91981b74e8",
-  "known-hash": "0f87c1d6d7293566fe5ed5a8aa748ba1b6a1ee8bba34dc2e9d174c28b0e6a10b"
+  "known-hash": "d3d368feb815dda0df0bcaaca4f1429bdc0a5e94f6250cfc94848013d3eab645"
 }

--- a/qa/tests/data/static/devnet/viewing-keys.json
+++ b/qa/tests/data/static/devnet/viewing-keys.json
@@ -1,5 +1,6 @@
 {
   "pre-fund-faucet": [
+    "mn_shield-esk_dev1qvqpljf0wrewfdr5k6scfmqtertc4gvu8s2nhkpg8yrmx6n6v4t0evgc05kh2",
     "mn_shield-esk_dev1qypsq87f9ac09e95wjm2rp8vp0yd0z4pns7p2w7c9qus0vm20fj4dl93arvs7q",
     "mn_shield-esk_dev1qypsqgxmsku290j5jjqatpgpdpu88752uffh07tfujct88wkdelnxkw7pglmg82h",
     "mn_shield-esk_dev1qypsqgqmgcl2fvhg2s37dd8q6vzuad000ywm40z3wrvsmwmpq96z5rfzpv7gpr46",

--- a/qa/tests/tests/integration/basic/subscriptions/block-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/block-subscriptions.test.ts
@@ -25,6 +25,7 @@ import {
   GraphQLCompleteMessage,
 } from '@utils/indexer/websocket-client';
 import { EventCoordinator } from '@utils/event-coordinator';
+import type { TestContext } from 'vitest';
 
 /**
  * Utility function that waits for all events to be received or timeout after a given number of milliseconds
@@ -77,7 +78,7 @@ describe('block subscriptions', () => {
       const receivedBlocks: BlockSubscriptionResponse[] = [];
       const blockSubscriptionHandler: SubscriptionHandlers<BlockSubscriptionResponse> = {
         next: (payload: BlockSubscriptionResponse) => {
-          log.debug('Received data:\n', JSON.stringify(payload));
+          log.debug(`Received data:\n${JSON.stringify(payload)}`);
           receivedBlocks.push(payload);
           if (receivedBlocks.length === 2) {
             eventCoordinator.notify('twoBlocksReceived');
@@ -129,13 +130,13 @@ describe('block subscriptions', () => {
       const messagesReceived: BlockSubscriptionResponse[] = [];
       const blockSubscriptionHandler: SubscriptionHandlers<BlockSubscriptionResponse> = {
         next: (payload: BlockSubscriptionResponse) => {
-          log.debug('Received data:', JSON.stringify(payload));
+          log.debug(`Received data: ${JSON.stringify(payload)}`);
 
           messagesReceived.push(payload);
 
           if (payload.errors) {
             eventCoordinator.notify('error');
-            log.error('Error received:', JSON.stringify(payload.errors));
+            log.error(`Error received: ${JSON.stringify(payload.errors)}`);
           }
 
           if (messagesReceived.length === 10) {
@@ -187,7 +188,7 @@ describe('block subscriptions', () => {
 
       const blockSubscriptionHandler: SubscriptionHandlers<BlockSubscriptionResponse> = {
         next: (payload: BlockSubscriptionResponse) => {
-          log.debug('Received data:', JSON.stringify(payload));
+          log.debug(`Received data: ${JSON.stringify(payload)}`);
           messagesReceived.push(payload);
           if (payload.errors !== undefined) {
             log.debug('Received the expected error message');
@@ -195,7 +196,7 @@ describe('block subscriptions', () => {
           }
         },
         complete: (message) => {
-          log.debug('Complete message:', JSON.stringify(message));
+          log.debug(`Complete message: ${JSON.stringify(message)}`);
           completionMessage = message;
           eventCoordinator.notify('completion');
         },
@@ -238,7 +239,7 @@ describe('block subscriptions', () => {
 
       const blockSubscriptionHandler: SubscriptionHandlers<BlockSubscriptionResponse> = {
         next: (payload: BlockSubscriptionResponse) => {
-          log.debug('Received data:', JSON.stringify(payload));
+          log.debug(`Received data: ${JSON.stringify(payload)}`);
           messagesReceived.push(payload);
           if (payload.errors !== undefined) {
             log.debug('Received the expected error message');
@@ -246,7 +247,7 @@ describe('block subscriptions', () => {
           }
         },
         complete: (message) => {
-          log.debug('Complete message:', JSON.stringify(message));
+          log.debug(`Complete message: ${JSON.stringify(message)}`);
           completionMessage = message;
           eventCoordinator.notify('completion');
         },
@@ -283,7 +284,7 @@ describe('block subscriptions', () => {
      */
     test('should stream blocks from the block with that height, given that height exists', async ({
       skip,
-    }) => {
+    }: TestContext) => {
       const latestBlockResponse = await indexerHttpClient.getLatestBlock();
       expect(latestBlockResponse).toBeSuccess();
       const latestBlock = latestBlockResponse.data?.block;
@@ -294,7 +295,7 @@ describe('block subscriptions', () => {
       // So we need to make sure there are at least 20 blocks on chain, if not
       // we skip the test becausee the precondition is not met
       if (latestBlock?.height && latestBlock?.height < 20) {
-        skip('Skipping as we want at least 20 blocks to be produced');
+        skip?.('Skipping as we want at least 20 blocks to be produced');
       }
 
       const blockMessagesReceived: BlockSubscriptionResponse[] = [];
@@ -306,7 +307,7 @@ describe('block subscriptions', () => {
       const blockSubscriptionHandler: SubscriptionHandlers<BlockSubscriptionResponse> = {
         next: (payload) => {
           blockMessagesReceived.push(payload);
-          log.debug('Received data:', JSON.stringify(payload));
+          log.debug(`Received data: ${JSON.stringify(payload)}`);
           if (blockMessagesReceived.length === 20) {
             log.debug('Stop receiving blocks');
             eventCoordinator.notify('expectedBlocksReceived');
@@ -361,7 +362,7 @@ describe('block subscriptions', () => {
       const blockSubscriptionHandler: SubscriptionHandlers<BlockSubscriptionResponse> = {
         next: (payload) => {
           blockMessagesReceived.push(payload);
-          log.debug('Received data:', JSON.stringify(payload));
+          log.debug(`Received data: ${JSON.stringify(payload)}`);
           if (payload.errors !== undefined) {
             log.debug('Received the expected error message');
             eventCoordinator.notify('error');
@@ -400,14 +401,14 @@ describe('block subscriptions', () => {
       const blockSubscriptionHandler: SubscriptionHandlers<BlockSubscriptionResponse> = {
         next: (payload) => {
           blockMessagesReceived.push(payload);
-          log.debug('Received data:', JSON.stringify(payload));
+          log.debug(`Received data: ${JSON.stringify(payload)}`);
           if (payload.errors !== undefined) {
             log.debug('Received the expected error message');
             eventCoordinator.notify('error');
           }
         },
         complete: (message) => {
-          log.debug('Complete message:', JSON.stringify(message));
+          log.debug(`Complete message: ${JSON.stringify(message)}`);
           eventCoordinator.notify('completion');
           completionMessage = message;
         },
@@ -448,14 +449,14 @@ describe('block subscriptions', () => {
       const blockSubscriptionHandler: SubscriptionHandlers<BlockSubscriptionResponse> = {
         next: (payload) => {
           blockMessagesReceived.push(payload);
-          log.debug('Received data:', JSON.stringify(payload));
+          log.debug(`Received data: ${JSON.stringify(payload)}`);
           if (payload.errors !== undefined) {
             log.debug('Received the expected error message');
             eventCoordinator.notify('error');
           }
         },
         complete: (message) => {
-          log.debug('Complete message:', JSON.stringify(message));
+          log.debug(`Complete message: ${JSON.stringify(message)}`);
           eventCoordinator.notify('completion');
           completionMessage = message;
         },

--- a/qa/tests/tests/integration/basic/subscriptions/block-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/block-subscriptions.test.ts
@@ -122,7 +122,17 @@ describe('block subscriptions', () => {
      * @then we should receive blocks starting from the block with that hash
      */
     test('should stream blocks starting from the block with that hash, given that hash exists', async () => {
-      const knownHash = dataProvider.getKnownBlockHash();
+      // Let's get the hash of the genesis block ...
+      const genesisBlockResponse = await indexerHttpClient.getBlockByOffset({
+        height: 0,
+      });
+      expect(genesisBlockResponse).toBeSuccess();
+      const genesisBlock = genesisBlockResponse.data?.block;
+      expect(genesisBlock).toBeDefined();
+
+      //... and extract its hash
+      const knownHash = genesisBlock?.hash;
+      expect(knownHash).toBeDefined();
       const blockOffset: BlockOffset = {
         hash: knownHash,
       };

--- a/qa/tests/tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts
@@ -174,7 +174,7 @@ describe('shielded transaction subscriptions', () => {
       const receivedEvents: ShieldedTxSubscriptionResponse[] = [];
       const shieldedTxSubscriptionHandler: SubscriptionHandlers<ShieldedTxSubscriptionResponse> = {
         next: (payload) => {
-          log.debug('Received data:\n', JSON.stringify(payload));
+          log.debug(`Received data:\n${JSON.stringify(payload)}`);
           if (payload.data) {
             receivedEvents.push(payload);
           }

--- a/qa/tests/tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts
@@ -68,7 +68,7 @@ async function subscribeToUnshieldedTransactionEvents(
   const unshieldedTransactionSubscriptionHandler: SubscriptionHandlers<UnshieldedTxSubscriptionResponse> =
     {
       next: (payload) => {
-        log.debug('Received data:\n', JSON.stringify(payload, null, 2));
+        log.debug(`Received data:\n${JSON.stringify(payload, null, 2)}`);
         receivedUnshieldedTransactions.push(payload);
         if (stopCondition(receivedUnshieldedTransactions)) {
           stopListening();
@@ -129,7 +129,7 @@ describe('unshielded utxo subscriptions', async () => {
 
       expect(messages.length).toBeGreaterThanOrEqual(1);
       messages.forEach((transaction) => {
-        log.info('transaction', JSON.stringify(transaction, null, 2));
+        log.info(`transaction ${JSON.stringify(transaction, null, 2)}`);
       });
     });
 

--- a/qa/tests/tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts
@@ -95,9 +95,7 @@ async function subscribeToUnshieldedTransactionEvents(
   return receivedUnshieldedTransactions;
 }
 
-// TODO: rename to unshielded transaction subscriptions for all the occurrences
-// and update the xray tests
-describe('unshielded utxo subscriptions', async () => {
+describe('unshielded transaction subscriptions', async () => {
   beforeAll(async () => {
     indexerWsClient = new IndexerWsClient();
     await indexerWsClient.connectionInit();
@@ -107,19 +105,19 @@ describe('unshielded utxo subscriptions', async () => {
     await indexerWsClient.connectionClose();
   });
 
-  describe('a subscription to unshielded utxo events by address', async () => {
+  describe('a subscription to unshielded transaction events by address', async () => {
     let messages: UnshieldedTxSubscriptionResponse[];
 
     /**
      * Subscribing to unshielded transaction events for an existing address should
      * stream all transactions that involve that address.
      *
-     * @given an existing unshielded address that has transactions
+     * @given an unshielded wallet address that has transactions
      * @when we subscribe to unshielded transaction events by address only for that address
      * @then we should receive at least one transaction event
      * @and each transaction should involve the specified address
      */
-    test('should stream unshielded utxo events related to that address', async () => {
+    test('should stream unshielded transaction events related to that address, given that address has transactions', async () => {
       const unshieldedAddress = dataProvider.getUnshieldedAddress('existing');
       messages = await subscribeToUnshieldedTransactionEvents(
         { address: unshieldedAddress },
@@ -127,10 +125,20 @@ describe('unshielded utxo subscriptions', async () => {
         500,
       );
 
+      // we want at least one message ...
       expect(messages.length).toBeGreaterThanOrEqual(1);
+
+      // ... but also at least one message that should be a relevant unshielded transaction
+      // because progress update messages are sent regradless of the presence of transactions
+      let relevantTransactionsFound = 0;
       messages.forEach((transaction) => {
         log.info(`transaction ${JSON.stringify(transaction, null, 2)}`);
+        if (transaction.data?.unshieldedTransactions?.__typename === 'UnshieldedTransaction') {
+          relevantTransactionsFound++;
+        }
       });
+
+      expect(relevantTransactionsFound).toBeGreaterThanOrEqual(1);
     });
 
     /**
@@ -188,7 +196,7 @@ describe('unshielded utxo subscriptions', async () => {
       expect(highestFoundTransactionId).toBe(highestTransactionId);
     });
 
-    test.skip('IMPLEMENT ME: should stream unshielded utxo events that adhere to the expected schema', async () => {
+    test.skip('IMPLEMENT ME: should stream unshielded transaction events that adheres to the expected schema', async () => {
       // TODO: implement the following test that checks the schema of the unshielded transaction events
     });
 
@@ -428,7 +436,6 @@ describe('unshielded utxo subscriptions', async () => {
       const transactionEvent: UnshieldedTransactionEvent = messages[0].data
         ?.unshieldedTransactions as UnshieldedTransactionEvent;
       expect(transactionEvent.__typename).toBe('UnshieldedTransactionsProgress');
-      const transactionProgressEvent = transactionEvent as UnshieldedTransactionsProgress;
     });
 
     /**

--- a/qa/tests/tests/smoke/graphql-healthchecks.test.ts
+++ b/qa/tests/tests/smoke/graphql-healthchecks.test.ts
@@ -147,7 +147,6 @@ describe('graphql health checks', () => {
       ).client.rawRequest(query);
 
       expect(response).toBeError();
-      expect(response.errors).toBeDefined();
     });
   });
 });

--- a/qa/tests/types/vitest.d.ts
+++ b/qa/tests/types/vitest.d.ts
@@ -18,4 +18,8 @@ declare module 'vitest' {
     toBeError(): void;
     toBeSuccess(): void;
   }
+
+  interface TestContext {
+    skip?: (reason?: string) => void;
+  }
 }

--- a/qa/tests/utils/indexer/websocket-client.ts
+++ b/qa/tests/utils/indexer/websocket-client.ts
@@ -343,8 +343,8 @@ export class IndexerWsClient {
         : BLOCKS_SUBSCRIPTION_FROM_LATEST_BLOCK);
     const variables = blockOffset ? { OFFSET: blockOffset } : undefined;
 
-    log.debug('Block subscription query:\n', query);
-    log.debug('Block subscription variables:\n', variables);
+    log.debug(`Block subscription query:\n${query}`);
+    log.debug(`Block subscription variables:\n${JSON.stringify(variables, null, 2)}`);
 
     const payload: GraphQLStartMessage = {
       id,
@@ -355,7 +355,7 @@ export class IndexerWsClient {
       },
     };
 
-    log.debug('Block subscription full payload:\n', payload);
+    log.debug(`Block subscription full payload:\n${JSON.stringify(payload, null, 2)}`);
 
     // Fix type error by casting handlers to SubscriptionHandlers<unknown>
     this.handlersMap.set(id, handlers as SubscriptionHandlers<unknown>);
@@ -408,8 +408,10 @@ export class IndexerWsClient {
       ...(params.transactionId !== undefined && { TRANSACTION_ID: params.transactionId }),
     };
 
-    log.debug('Unshielded transaction subscription query:\n', query);
-    log.debug('Unshielded transaction subscription variables:\n', variables);
+    log.debug(`Unshielded transaction subscription query:\n${query}`);
+    log.debug(
+      `Unshielded transaction subscription variables:\n${JSON.stringify(variables, null, 2)}`,
+    );
 
     const payload: GraphQLStartMessage = {
       id,
@@ -420,7 +422,7 @@ export class IndexerWsClient {
       },
     };
 
-    log.debug('Unshielded transaction subscription full payload:\n', payload);
+    log.debug(`Unshielded transaction subscription full payload:\n${JSON.stringify(payload, null, 2)}`);
 
     // Type assertion to satisfy SubscriptionHandlers<unknown> requirement
     this.handlersMap.set(id, handlers as SubscriptionHandlers<unknown>);
@@ -466,8 +468,8 @@ export class IndexerWsClient {
       SESSION_ID: sessionId,
     };
 
-    log.debug('Shielded transaction subscription query:\n', query);
-    log.debug('Shielded transaction subscription variables:\n', variables);
+    log.debug(`Shielded transaction subscription query:\n${query}`);
+    log.debug(`Shielded transaction subscription variables:\n${JSON.stringify(variables, null, 2)}`);
 
     const payload: GraphQLStartMessage = {
       id,
@@ -478,7 +480,7 @@ export class IndexerWsClient {
       },
     };
 
-    log.debug('Shielded transaction subscription full payload:\n', payload);
+    log.debug(`Shielded transaction subscription full payload:\n${JSON.stringify(payload, null, 2)}`);
 
     // Type assertion to fix type error
     this.handlersMap.set(id, handlers as SubscriptionHandlers<unknown>);

--- a/qa/tests/utils/indexer/websocket-client.ts
+++ b/qa/tests/utils/indexer/websocket-client.ts
@@ -422,7 +422,9 @@ export class IndexerWsClient {
       },
     };
 
-    log.debug(`Unshielded transaction subscription full payload:\n${JSON.stringify(payload, null, 2)}`);
+    log.debug(
+      `Unshielded transaction subscription full payload:\n${JSON.stringify(payload, null, 2)}`,
+    );
 
     // Type assertion to satisfy SubscriptionHandlers<unknown> requirement
     this.handlersMap.set(id, handlers as SubscriptionHandlers<unknown>);
@@ -469,7 +471,9 @@ export class IndexerWsClient {
     };
 
     log.debug(`Shielded transaction subscription query:\n${query}`);
-    log.debug(`Shielded transaction subscription variables:\n${JSON.stringify(variables, null, 2)}`);
+    log.debug(
+      `Shielded transaction subscription variables:\n${JSON.stringify(variables, null, 2)}`,
+    );
 
     const payload: GraphQLStartMessage = {
       id,
@@ -480,7 +484,9 @@ export class IndexerWsClient {
       },
     };
 
-    log.debug(`Shielded transaction subscription full payload:\n${JSON.stringify(payload, null, 2)}`);
+    log.debug(
+      `Shielded transaction subscription full payload:\n${JSON.stringify(payload, null, 2)}`,
+    );
 
     // Type assertion to fix type error
     this.handlersMap.set(id, handlers as SubscriptionHandlers<unknown>);


### PR DESCRIPTION
Failures have been identified and fixed on a number of test cases. However there are tests related to Shielded Transactions that keep failing, this is because of the faucet being removed from the genesis block.

These tests will have to be properly updated when we have a way to mint custom shielded tokens