### PR TITLE
feat: no more netrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,8 +3,6 @@
 git config --local commit.gpgSign true
 git config --local tag.gpgSign true
 
-export NETRC="${NETRC:=$HOME/.netrc}"
-
 if [[ -f ~/.midnight-indexer.envrc ]]; then
     echo direnv: using ~/.midnight-indexer.envrc
     source ~/.midnight-indexer.envrc

--- a/.github/workflows/build-indexer-images.yaml
+++ b/.github/workflows/build-indexer-images.yaml
@@ -48,13 +48,6 @@ jobs:
           version=$(grep '^version.*=' Cargo.toml | sed -E 's/version.*=.*"(.*)"/\1/')
           echo "version=$version" | tee -a $GITHUB_ENV
 
-      - name: Add github.com credentials to netrc
-        uses: extractions/netrc@v2
-        with:
-          machine: github.com
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_REPO }}
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -103,7 +96,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          secret-files: netrc=/home/runner/.netrc
           cache-from: type=registry,ref=ghcr.io/midnight-ntwrk/${{ matrix.name }}:buildcache
           cache-to: type=registry,ref=ghcr.io/midnight-ntwrk/${{ matrix.name }}:buildcache,mode=max
 
@@ -141,13 +133,6 @@ jobs:
         run: |
           version=$(grep '^version.*=' Cargo.toml | sed -E 's/version.*=.*"(.*)"/\1/')
           echo "version=$version" | tee -a $GITHUB_ENV
-
-      - name: Add github.com credentials to netrc
-        uses: extractions/netrc@v2
-        with:
-          machine: github.com
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_REPO }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/build-indexer-tests.yaml
+++ b/.github/workflows/build-indexer-tests.yaml
@@ -31,13 +31,6 @@ jobs:
           version=$(grep '^version.*=' Cargo.toml | sed -E 's/version.*=.*"(.*)"/\1/')
           echo "version=$version" | tee -a $GITHUB_ENV
 
-      - name: Add github.com credentials to netrc
-        uses: extractions/netrc@v2
-        with:
-          machine: github.com
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_REPO }}
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -86,6 +79,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          secret-files: netrc=/home/runner/.netrc
           cache-from: type=registry,ref=ghcr.io/midnight-ntwrk/indexer-tests:buildcache
           cache-to: type=registry,ref=ghcr.io/midnight-ntwrk/indexer-tests:buildcache,mode=max

--- a/.github/workflows/ci-cloud.yaml
+++ b/.github/workflows/ci-cloud.yaml
@@ -36,13 +36,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
-      - name: Add github.com credentials to netrc
-        uses: extractions/netrc@v2
-        with:
-          machine: github.com
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_REPO }}
-
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -104,13 +97,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
-      - name: Add github.com credentials to netrc
-        uses: extractions/netrc@v2
-        with:
-          machine: github.com
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_REPO }}
-
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -149,13 +135,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-
-      - name: Add github.com credentials to netrc
-        uses: extractions/netrc@v2
-        with:
-          machine: github.com
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_REPO }}
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -196,13 +175,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-
-      - name: Add github.com credentials to netrc
-        uses: extractions/netrc@v2
-        with:
-          machine: github.com
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_REPO }}
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/ci-standalone.yaml
+++ b/.github/workflows/ci-standalone.yaml
@@ -36,13 +36,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
-      - name: Add github.com credentials to netrc
-        uses: extractions/netrc@v2
-        with:
-          machine: github.com
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_REPO }}
-
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -101,13 +94,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
-      - name: Add github.com credentials to netrc
-        uses: extractions/netrc@v2
-        with:
-          machine: github.com
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_REPO }}
-
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -143,13 +129,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-
-      - name: Add github.com credentials to netrc
-        uses: extractions/netrc@v2
-        with:
-          machine: github.com
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_REPO }}
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -187,13 +166,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-
-      - name: Add github.com credentials to netrc
-        uses: extractions/netrc@v2
-        with:
-          machine: github.com
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_REPO }}
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -37,13 +37,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
-      - name: Add github.com credentials to netrc
-        uses: extractions/netrc@v2
-        with:
-          machine: github.com
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_REPO }}
-
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/rust-security-scan.yaml
+++ b/.github/workflows/rust-security-scan.yaml
@@ -32,13 +32,6 @@ jobs:
       - name: Install Deny
         run: cargo install cargo-deny
 
-      - name: Add github.com credentials to netrc
-        uses: extractions/netrc@f6f1722d05ce2890aa86fd9654565b1214ac53a4  # v2.0.1
-        with:
-          machine: github.com
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_REPO }}
-
       - name: Run deny
         run: cargo deny check -Aduplicate -Aunmaintained -Alicense-not-encountered -Aparse-error -Asource-not-allowed -Aunlicensed
         # TODO: once everything's open sourced remove -Aunlicensed

--- a/README.md
+++ b/README.md
@@ -201,14 +201,6 @@ Create a classic PAT with:
 - `read:packages`
 - `read:org`
 
-#### ~/.netrc Setup
-
-```bash
-machine github.com
-login <YOUR_GITHUB_ID>
-password <YOUR_GITHUB_PAT>
-```
-
 #### Docker Authentication
 
 ```bash
@@ -237,7 +229,7 @@ The Midnight Foundation appreciates contributions, and like many other open sour
 
 ### Dependabot
 
-The Midnight Foundation uses GitHub Dependabot feature to keep our projects dependencies up-to-date and address potential security vulnerabilities. 
+The Midnight Foundation uses GitHub Dependabot feature to keep our projects dependencies up-to-date and address potential security vulnerabilities.
 
 ### Checkmarx
 
@@ -245,4 +237,4 @@ The Midnight Foundation uses Checkmarx for application security (AppSec) to iden
 
 ### Unito
 
-Facilitates two-way data synchronization, automated workflows and streamline processes between: Jira, GitHub issues and Github project Kanban board. 
+Facilitates two-way data synchronization, automated workflows and streamline processes between: Jira, GitHub issues and Github project Kanban board.

--- a/chain-indexer/Dockerfile
+++ b/chain-indexer/Dockerfile
@@ -11,11 +11,9 @@ SHELL ["/bin/bash", "-c"]
 ARG PROFILE=release
 RUN git config --global url."https://@github.com".insteadOf "ssh://git@github.com"
 COPY --from=planner /build/recipe.json recipe.json
-RUN --mount=type=secret,id=netrc,target=/root/.netrc \
-    cargo chef cook --profile $PROFILE --recipe-path recipe.json
+RUN cargo chef cook --profile $PROFILE --recipe-path recipe.json
 COPY . .
-RUN --mount=type=secret,id=netrc,target=/root/.netrc \
-    cargo build -p chain-indexer --locked --features cloud --profile $PROFILE && \
+RUN cargo build -p chain-indexer --locked --features cloud --profile $PROFILE && \
     mkdir -p /runtime/usr/local/bin && \
     mv "./target/${PROFILE/dev/debug}/chain-indexer" /runtime/usr/local/bin && \
     mv /build/chain-indexer/bin/entrypoint.sh /runtime/usr/local/bin && \

--- a/indexer-api/Dockerfile
+++ b/indexer-api/Dockerfile
@@ -11,11 +11,9 @@ SHELL ["/bin/bash", "-c"]
 ARG PROFILE=release
 RUN git config --global url."https://@github.com".insteadOf "ssh://git@github.com"
 COPY --from=planner /build/recipe.json recipe.json
-RUN --mount=type=secret,id=netrc,target=/root/.netrc \
-    cargo chef cook --profile $PROFILE --recipe-path recipe.json
+RUN cargo chef cook --profile $PROFILE --recipe-path recipe.json
 COPY . .
-RUN --mount=type=secret,id=netrc,target=/root/.netrc \
-    cargo build -p indexer-api --locked --features cloud --profile $PROFILE && \
+RUN cargo build -p indexer-api --locked --features cloud --profile $PROFILE && \
     mkdir -p /runtime/usr/local/bin && \
     mv "./target/${PROFILE/dev/debug}/indexer-api" /runtime/usr/local/bin && \
     mv /build/indexer-api/bin/entrypoint.sh /runtime/usr/local/bin && \

--- a/indexer-standalone/Dockerfile
+++ b/indexer-standalone/Dockerfile
@@ -11,11 +11,9 @@ SHELL ["/bin/bash", "-c"]
 ARG PROFILE=release
 RUN git config --global url."https://@github.com".insteadOf "ssh://git@github.com"
 COPY --from=planner /build/recipe.json recipe.json
-RUN --mount=type=secret,id=netrc,target=/root/.netrc \
-    cargo chef cook --profile $PROFILE --recipe-path recipe.json
+RUN cargo chef cook --profile $PROFILE --recipe-path recipe.json
 COPY . .
-RUN --mount=type=secret,id=netrc,target=/root/.netrc \
-    cargo build -p indexer-standalone --locked --features standalone --profile $PROFILE && \
+RUN cargo build -p indexer-standalone --locked --features standalone --profile $PROFILE && \
     mkdir -p /runtime/usr/local/bin && \
     mv "./target/${PROFILE/dev/debug}/indexer-standalone" /runtime/usr/local/bin && \
     mv /build/indexer-standalone/bin/entrypoint.sh /runtime/usr/local/bin && \

--- a/indexer-tests/Dockerfile
+++ b/indexer-tests/Dockerfile
@@ -26,15 +26,13 @@ RUN mkdir ./indexer-common/src && \
     sed -i "/\"wallet-indexer\"/s/^/# /" Cargo.toml && \
     sed -i "/\"indexer-standalone\"/s/^/# /" Cargo.toml && \
     find . -path '*/src/*' | xargs touch -t 197001010000 -m
-RUN --mount=type=secret,id=netrc,target=/root/.netrc \
-    cargo build -p indexer-tests --profile $PROFILE && \
+RUN cargo build -p indexer-tests --profile $PROFILE && \
     find ./target | xargs touch -t 197001020000 -m
 
 COPY ./indexer-common/ ./indexer-common/
 COPY ./indexer-api/ ./indexer-api/
 COPY ./indexer-tests/ ./indexer-tests/
-RUN --mount=type=secret,id=netrc,target=/root/.netrc \
-    cargo build -p indexer-tests --locked --profile $PROFILE && \
+RUN cargo build -p indexer-tests --locked --profile $PROFILE && \
     mv ./target/$([ "$PROFILE" = "release" ] && echo "release" || echo "debug")/indexer-tests /
 
 # ---------- IMAGE STAGE ---------- #

--- a/justfile
+++ b/justfile
@@ -80,7 +80,6 @@ build-docker-image package profile="dev":
     docker build \
         --build-arg "RUST_VERSION={{rust_version}}" \
         --build-arg "PROFILE={{profile}}" \
-        --secret id=netrc,src=$NETRC \
         -t ghcr.io/midnight-ntwrk/{{package}}:${tag} \
         -t ghcr.io/midnight-ntwrk/{{package}}:latest \
         -f {{package}}/Dockerfile \

--- a/wallet-indexer/Dockerfile
+++ b/wallet-indexer/Dockerfile
@@ -11,11 +11,9 @@ SHELL ["/bin/bash", "-c"]
 ARG PROFILE=release
 RUN git config --global url."https://@github.com".insteadOf "ssh://git@github.com"
 COPY --from=planner /build/recipe.json recipe.json
-RUN --mount=type=secret,id=netrc,target=/root/.netrc \
-    cargo chef cook --profile $PROFILE --recipe-path recipe.json
+RUN cargo chef cook --profile $PROFILE --recipe-path recipe.json
 COPY . .
-RUN --mount=type=secret,id=netrc,target=/root/.netrc \
-    cargo build -p wallet-indexer --locked --features cloud --profile $PROFILE && \
+RUN cargo build -p wallet-indexer --locked --features cloud --profile $PROFILE && \
     mkdir -p /runtime/usr/local/bin && \
     mv "./target/${PROFILE/dev/debug}/wallet-indexer" /runtime/usr/local/bin && \
     mv /build/wallet-indexer/bin/entrypoint.sh /runtime/usr/local/bin && \


### PR DESCRIPTION
With the open sourcing of the ledger, we don't need .netrc files. Everything we need should be public.


BLOCKER: This needs to wait till we can point to new ledger repo (which means using new ledger).
BLOCKER: Need to wait till an image from midnight-node is done.