### PR TITLE
test: added support to upload test results in XRay

### DIFF
--- a/.github/workflows/qa-integration-tests-base-workflow.yml
+++ b/.github/workflows/qa-integration-tests-base-workflow.yml
@@ -16,11 +16,26 @@ on:
           - qanet
           - devnet
           - testnet02
+      publish_to_xray:
+        type: boolean
+        description: Publish the test results to Xray
+        required: false
+        default: false
       ref:
         type: string
         description: Git ref
         required: false
         default: main
+      node_tag:
+        type: string
+        required: true
+        description: Node ta
+        default: latest
+      indexer_tag:
+        type: string
+        required: true
+        description: Indexer tag
+        default: latest
   workflow_call:
     inputs:
       target_env:
@@ -32,6 +47,21 @@ on:
         type: string
         description: Git ref
         required: false
+      publish_to_xray:
+        type: boolean
+        description: Publish the test results to Xray
+        required: false
+        default: false
+      node_tag:
+        type: string
+        description: Node tag
+        required: false
+        default: latest
+      indexer_tag:
+        type: string
+        description: Indexer tag
+        required: false
+        default: latest
     secrets:
       MIDNIGHTCI_PACKAGES_WRITE:
         required: true
@@ -48,11 +78,15 @@ jobs:
     name: Execute basic integration tests
     permissions:
       contents: read
-      packages: write
+      packages: read
     env:
       TARGET_ENV: ${{ inputs.target_env }}
       GITHUB_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
       NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+      XRAY_COMPONENT: "indexer"
+      XRAY_PROJECT_KEY: "PM"
+      XRAY_TEST_PLAN_KEY: "PM-19197"
+      XRAY_REPORT_TESTS_MISSING_METADATA: "false"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -74,20 +108,69 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - name: Add github.com credentials to netrc
+        uses: extractions/netrc@v2
+        with:
+          machine: github.com
+          username: MidnightCI
+          password: ${{ secrets.MIDNIGHTCI_REPO }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: MidnightCI
+          password: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
+
+      - name: Startup local environment
+        if: inputs.target_env == 'undeployed'
+        env:
+          NODE_TAG: ${{ inputs.node_tag }}
+          INDEXER_TAG: ${{ inputs.indexer_tag }}
+          APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
+          APP__INFRA__STORAGE__PASSWORD: ${{ secrets.APP__INFRA__STORAGE__PASSWORD }}
+          APP__INFRA__PUB_SUB__PASSWORD: ${{ secrets.APP__INFRA__PUB_SUB__PASSWORD }}
+          APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD: ${{ secrets.APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD }}
+        run: |
+          . ./.envrc
+          echo "NODE_TAG: $NODE_TAG"
+          echo "INDEXER_TAG: $INDEXER_TAG"
+          bash ./qa/scripts/startup-localenv-with-data.sh
+
       - name: Install dependencies
         working-directory: qa/tests
         run: yarn install --immutable
+
+      - name: Run smoke tests
+        working-directory: qa/tests
+        run: yarn test smoke
 
       - name: Run integration tests
         working-directory: qa/tests
         run: yarn test
 
+      - name: Publish to Xray
+        if: always() && inputs.publish_to_xray == true
+        uses: GiuseppeSalvatoreShielded/TestActions/xray-upload@e5cf0c100e61b96f5bc73963312fc8064d7b2d2d
+        with:
+          test_results_path: ./qa/tests/reports/xray/test-results.json
+          xray_client_id: ${{ secrets.XRAY_CLIENT_ID }}
+          xray_client_secret: ${{ secrets.XRAY_CLIENT_SECRET }}
+
       - name: Upload Integration Test Reports
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: integration-test-reports
+          name: junit-integration-test-reports
           path: ./qa/tests/reports/custom-junit-report.xml
+          if-no-files-found: warn
+
+      - name: Upload XRay Test Reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: xray-integration-test-reports
+          path: ./qa/tests/reports/xray/test-results.json
           if-no-files-found: warn
 
       - name: Upload logs
@@ -97,4 +180,3 @@ jobs:
           name: qa-integration-tests-${{ inputs.target_env }}-logs
           path: |
             ./qa/tests/logs
-

--- a/.github/workflows/qa-integration-tests-base-workflow.yml
+++ b/.github/workflows/qa-integration-tests-base-workflow.yml
@@ -80,8 +80,8 @@ jobs:
       packages: read
     env:
       TARGET_ENV: ${{ inputs.target_env }}
-      GITHUB_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
-      NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+      GITHUB_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
+      NODE_AUTH_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
       XRAY_COMPONENT: "indexer"
       XRAY_PROJECT_KEY: "PM"
       XRAY_TEST_PLAN_KEY: "PM-19197"

--- a/.github/workflows/qa-integration-tests-base-workflow.yml
+++ b/.github/workflows/qa-integration-tests-base-workflow.yml
@@ -77,7 +77,6 @@ jobs:
   basic-integration-tests:
     name: Execute basic integration tests
     permissions:
-      contents: read
       packages: read
     env:
       TARGET_ENV: ${{ inputs.target_env }}
@@ -94,12 +93,12 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup Node.js v22.x
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@0b2533296d2e4fd807934a1b8c9f2c2e2c1cec88 # v5
         with:
           node-version: 22.x
 
       - name: Restore Yarn cache
-        uses: actions/cache@v4
+        uses: actions/cache@68815abbfec7aafc14e5cac4153c2a9b3a7e2f3e # v4
         with:
           path: |
             qa/tests/.yarn/cache
@@ -109,14 +108,14 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Add github.com credentials to netrc
-        uses: extractions/netrc@v2
+        uses: extractions/netrc@1d9c24356fa3206b60a5f517c33771e3ff9701d4 # v2
         with:
           machine: github.com
           username: MidnightCI
           password: ${{ secrets.MIDNIGHTCI_REPO }}
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef #v3.6.0
         with:
           registry: ghcr.io
           username: MidnightCI
@@ -158,7 +157,7 @@ jobs:
           xray_client_secret: ${{ secrets.XRAY_CLIENT_SECRET }}
 
       - name: Upload Integration Test Reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@26f2637149b6b4a9707a7e054202490f356e7021 # v4
         if: always()
         with:
           name: junit-integration-test-reports
@@ -166,7 +165,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload XRay Test Reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@26f2637149b6b4a9707a7e054202490f356e7021 # v4
         if: always()
         with:
           name: xray-integration-test-reports
@@ -174,7 +173,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@26f2637149b6b4a9707a7e054202490f356e7021 # v4
         if: always()
         with:
           name: qa-integration-tests-${{ inputs.target_env }}-logs

--- a/.github/workflows/qa-integration-tests-devnet.yml
+++ b/.github/workflows/qa-integration-tests-devnet.yml
@@ -2,6 +2,12 @@ name: Indexer QA Integration Tests - devnet
 
 on:
   workflow_dispatch:
+    inputs:
+      publish_to_xray:
+        type: boolean
+        description: Publish the test results to Xray
+        required: false
+        default: false
 
 jobs:
   test:
@@ -10,4 +16,5 @@ jobs:
     with:
       target_env: devnet
       ref: main
+      publish_to_xray: ${{ inputs.publish_to_xray }}
     secrets: inherit

--- a/.github/workflows/qa-integration-tests-undeployed.yml
+++ b/.github/workflows/qa-integration-tests-undeployed.yml
@@ -1,0 +1,32 @@
+name: Indexer QA Integration Tests - undeployed
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish_to_xray:
+        type: boolean
+        description: Publish the test results to Xray
+        required: false
+        default: false
+      node_tag:
+        type: string
+        description: Node tag
+        required: false
+        default: latest
+      indexer_tag:
+        type: string
+        description: Indexer tag
+        required: false
+        default: latest
+
+jobs:
+  test:
+    name: Indexer QA Integration Tests on undeployed
+    uses: ./.github/workflows/qa-integration-tests-base-workflow.yml
+    with:
+      target_env: undeployed
+      ref: main
+      publish_to_xray: ${{ inputs.publish_to_xray }}
+      node_tag: ${{ inputs.node_tag }}
+      indexer_tag: ${{ inputs.indexer_tag }}
+    secrets: inherit

--- a/qa/tests/tests/e2e/shielded-transactions.test.ts
+++ b/qa/tests/tests/e2e/shielded-transactions.test.ts
@@ -75,6 +75,11 @@ describe('shielded transactions', () => {
      * @then the block should contain the expected transaction
      */
     test('should be reported by the indexer through a block query by hash', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Block', 'ByHash', 'ShieldedTokens'],
+        testKey: 'PM-17709',
+      };
+
       context.skip?.(
         transactionResult.status !== 'confirmed',
         "Toolkit transaction hasn't been confirmed",
@@ -98,6 +103,11 @@ describe('shielded transactions', () => {
      * @then the indexer should return the expected transaction
      */
     test('should be reported by the indexer through a transaction query by hash', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Transaction', 'ByHash', 'ShieldedTokens'],
+        testKey: 'PM-17710',
+      };
+
       context.skip?.(
         transactionResult.status !== 'confirmed',
         "Toolkit transaction hasn't been confirmed",

--- a/qa/tests/tests/e2e/unshielded-transactions.test.ts
+++ b/qa/tests/tests/e2e/unshielded-transactions.test.ts
@@ -148,6 +148,11 @@ describe('unshielded transactions', () => {
      * @then the block should contain the transaction with outputs for both addresses
      */
     test('should be reported by the indexer through a block query by hash', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Block', 'ByHash', 'UnshieldedToken'],
+        testKey: 'PM-17711',
+      };
+
       context.skip?.(
         transactionResult.status !== 'confirmed',
         "Toolkit transaction hasn't been confirmed",
@@ -182,6 +187,11 @@ describe('unshielded transactions', () => {
      * @then the returned transactions should include outputs for both addresses involved
      */
     test('should be reported by the indexer through a transaction query by hash', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Transaction', 'ByHash', 'UnshieldedToken'],
+        testKey: 'PM-17712',
+      };
+
       context.skip?.(
         transactionResult.status !== 'confirmed',
         "Toolkit transaction hasn't been confirmed",
@@ -221,6 +231,11 @@ describe('unshielded transactions', () => {
      * @then we should receive a transaction event that includes created and spent UTXOs for the source address
      */
     test('should be reported by the indexer through an unshielded transaction event for the source address', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Subscription', 'Transaction', 'UnshieldedToken'],
+        testKey: 'PM-177113',
+      };
+
       context.skip?.(
         transactionResult.status !== 'confirmed',
         "Toolkit transaction hasn't been confirmed",
@@ -255,6 +270,11 @@ describe('unshielded transactions', () => {
      * @then we should receive a transaction event that includes a created UTXO for the destination
      */
     test('should be reported by the indexer through an unshielded transaction event for the destination address', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Subscription', 'Transaction', 'UnshieldedToken'],
+        testKey: 'PM-177114',
+      };
+
       context.skip?.(
         transactionResult.status !== 'confirmed',
         "Toolkit transaction hasn't been confirmed",
@@ -288,6 +308,11 @@ describe('unshielded transactions', () => {
      * @then there should be two created outputs and one spent output reflecting the transfer of 1 NIGHT
      */
     test('should have transferred 1 NIGHT from the source to the destination address', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['UnshieldedTokens'],
+        testKey: 'PM-177115',
+      };
+
       context.skip?.(
         transactionResult.status !== 'confirmed',
         "Toolkit transaction hasn't been confirmed",

--- a/qa/tests/tests/integration/basic/queries/block-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/block-queries.test.ts
@@ -25,6 +25,7 @@ import type {
   UnshieldedUtxo,
 } from '@utils/indexer/indexer-types';
 import dataProvider from '@utils/testdata-provider';
+import { TestContext } from 'vitest';
 
 const indexerHttpClient = new IndexerHttpClient();
 
@@ -82,7 +83,12 @@ describe('block queries', () => {
      * @when we send a block query without parameters
      * @then Indexer should return the latest known block
      */
-    test('should return the latest known block', async () => {
+    test('should return the latest known block', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Block', 'Latest'],
+        testKey: 'PM-17677',
+      };
+
       log.debug('Requesting latest block from indexer');
       const response: BlockResponse = await indexerHttpClient.getLatestBlock();
 
@@ -100,7 +106,12 @@ describe('block queries', () => {
      * @when we send a block query without parameters
      * @then Indexer should respond with a block according to the requested schema
      */
-    test('should respond with a block according to the requested schema', async () => {
+    test('should respond with a block according to the requested schema', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Block', 'Latest', 'SchemaValidation'],
+        testKey: 'PM-17678',
+      };
+
       log.debug('Requesting latest block from indexer');
       const response: BlockResponse = await indexerHttpClient.getLatestBlock();
 
@@ -125,7 +136,12 @@ describe('block queries', () => {
      * @when we send a block query by hash using that hash
      * @then Indexer should respond with the block with that hash
      */
-    test('should return the block with that hash, given that block exists', async () => {
+    test('should return the block with that hash, given that block exists', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Block', 'ByHash'],
+        testKey: 'PM-17679',
+      };
+
       // Everything is already checked in getLatestBlockByHash function
       // If the promise resolves, we know that the block exists and the test passes
       const blockByHash = await getLatestBlockByHash();
@@ -137,7 +153,12 @@ describe('block queries', () => {
      * @when we send a block query by hash
      * @then Indexer should respond with a block according to the requested schema
      */
-    test('should return blocks according to the requested schema', async () => {
+    test('should return blocks according to the requested schema', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Block', 'ByHash', 'SchemaValidation'],
+        testKey: 'PM-17680',
+      };
+
       const blockByHash = await getLatestBlockByHash();
 
       log.debug('Validating block schema');
@@ -155,7 +176,12 @@ describe('block queries', () => {
      * @when we send a block query by hash using that hash
      * @then Indexer should respond with a null block section
      */
-    test("should return a null block, given a block with that hash doesn't exist", async () => {
+    test("should return a null block, given a block with that hash doesn't exist", async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Block', 'ByHash', 'Negative'],
+        testKey: 'PM-17681',
+      };
+
       const allZeroHash = '0000000000000000000000000000000000000000000000000000000000000000';
       log.debug(`Requesting a block with hash ${allZeroHash}`);
 
@@ -173,7 +199,12 @@ describe('block queries', () => {
      * @when we send a block query by hash using them
      * @then Indexer should respond with an error
      */
-    test('should return an error, when the hash is invalid (malformed)', async () => {
+    test('should return an error, when the hash is invalid (malformed)', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Block', 'ByHash', 'Negative'],
+        testKey: 'PM-17683',
+      };
+
       const fabricatedMalformedHashes = dataProvider.getFabricatedMalformedHashes();
 
       for (const targetHash of fabricatedMalformedHashes) {
@@ -194,7 +225,12 @@ describe('block queries', () => {
      * @when we send a block query by height using that height
      * @then Indexer should respond with the block with that height
      */
-    test('should return the block with that height, given a valid height', async () => {
+    test('should return the block with that height, given a valid height', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Block', 'ByHeight'],
+        testKey: 'PM-17339',
+      };
+
       // Everything is already checked in getLatestBlockByHeight function
       // If the promise resolves, we know that the block exists and the test passes
       const blockByHeight = await getLatestBlockByHeight();
@@ -206,7 +242,12 @@ describe('block queries', () => {
      * @when we send a block query by height
      * @then Indexer should respond with a block according to the requested schema
      */
-    test('should return a blocks according to the requested schema', async () => {
+    test('should return a blocks according to the requested schema', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Block', 'ByHeight', 'SchemaValidation'],
+        testKey: 'PM-17684',
+      };
+
       // Everything is already checked in getLatestBlockByHeight function
       // If the promise resolves, we know that the block exists and the test passes
       const blockByHeight = await getLatestBlockByHeight();
@@ -226,7 +267,12 @@ describe('block queries', () => {
      * @when we send a block query by height using that height
      * @then Indexer should respond with the genesis block
      */
-    test('should return the genesis block, given height=0 is requested', async () => {
+    test('should return the genesis block, given height=0 is requested', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Block', 'ByHeight', 'Genesis'],
+        testKey: 'PM-17685',
+      };
+
       log.debug(`Requesting genesis block (height = 0)`);
 
       const queryResponse = await indexerHttpClient.getBlockByOffset({ height: 0 });
@@ -248,7 +294,12 @@ describe('block queries', () => {
      * @when we send a block query by height using that height
      * @then Indexer should respond with an empty block
      */
-    test('should return an empty body answer, given that block height request is the maximum available height', async () => {
+    test('should return an empty body answer, given that block height request is the maximum available height', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Block', 'ByHeight', 'Negative'],
+        testKey: 'PM-17686',
+      };
+
       const maxAllowedBlockHeight = 2 ** 32 - 1; // Note this is the maximum allowed height and will take 800+ years to reach
       log.debug(`Requesting block with max height = ${maxAllowedBlockHeight}`);
 
@@ -268,7 +319,12 @@ describe('block queries', () => {
      * @when we send a block query by height using them
      * @then Indexer should respond with an error
      */
-    test('should return an error, given an invalid height', async () => {
+    test('should return an error, given an invalid height', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Block', 'ByHeight', 'Negative'],
+        testKey: 'PM-17687',
+      };
+
       const invalidHeights = dataProvider.getFabricatedMalformedHeights();
 
       for (const targetHeight of invalidHeights) {
@@ -292,7 +348,12 @@ describe('block queries', () => {
      * @when we send a block query with both parameters
      * @then Indexer should respond with an error
      */
-    test('should return an error, as only one parameter at a time can be used', async () => {
+    test('should return an error, as only one parameter at a time can be used', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Block', 'ByHeightAndHash', 'Negative'],
+        testKey: 'PM-17688',
+      };
+
       // Here we cover the 4 combinations of valid and invalid parameters (hash and height)
       const hashes = [dataProvider.getKnownBlockHash(), 'invalid-hash'];
       const heights = [1, 2 ** 32];
@@ -343,7 +404,12 @@ describe(`genesis block`, () => {
      * @when we inspect its transactions
      * @then it should contain transactions with pre-fund wallet utxos
      */
-    test('should contain transactions with pre-fund wallet utxos', async () => {
+    test('should contain transactions with pre-fund wallet utxos', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Block', 'ByHeight', 'Genesis', 'PreFundWallets'],
+        testKey: 'PM-17689',
+      };
+
       const genesisTransactions = await extractGenesisTransactions(genesisBlock);
       expect(genesisTransactions).toBeDefined();
       expect(genesisTransactions.length).toBeGreaterThanOrEqual(1);
@@ -369,7 +435,12 @@ describe(`genesis block`, () => {
      * @when we inspect the utxos in its transaction
      * @then there should be utxos related to exactly 4 pre-fund wallets
      */
-    test('should contain utxos related to exactly 4 pre-fund wallets', async () => {
+    test('should contain utxos related to exactly 4 pre-fund wallets', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Block', 'ByHeight', 'Genesis', 'PreFundWallets'],
+        testKey: 'PM-17690',
+      };
+
       const expectedPreFundWallets = 4;
       const genesisTransactions = await extractGenesisTransactions(genesisBlock);
 
@@ -399,7 +470,12 @@ describe(`genesis block`, () => {
      * @when we inspect the utxos in its transaction
      * @then there should be utxos with exactly 1 token type
      */
-    test('should contain utxos with exactly 1 token', async () => {
+    test('should contain utxos with exactly 1 token', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Block', 'ByHeight', 'Genesis', 'PreFundWallets'],
+        testKey: 'PM-17691',
+      };
+
       const expectedTokenTypes = 1;
       const genesisTransactions = await extractGenesisTransactions(genesisBlock);
 
@@ -430,7 +506,12 @@ describe(`genesis block`, () => {
      * @then the utxos should be sorted by outputIndex in ascending order
      */
     // https://shielded.atlassian.net/browse/PM-17665
-    test('should contain utxos sorted by outputIndex in ascending order', async () => {
+    test('should contain utxos sorted by outputIndex in ascending order', async (context: TestContext) => {
+      context.task!.meta.custom = {
+        labels: ['Query', 'Block', 'ByHeight', 'Genesis', 'PreFundWallets'],
+        testKey: 'PM-17692',
+      };
+
       const genesisTransactions = await extractGenesisTransactions(genesisBlock);
 
       // Loop through all the utxos in the transactions that have them and gather all

--- a/qa/tests/tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts
@@ -31,6 +31,7 @@ import type {
   UnshieldedTransactionsProgress,
   UnshieldedUtxo,
 } from '@utils/indexer/indexer-types';
+import { TestContext } from 'vitest';
 
 let indexerWsClient: IndexerWsClient;
 
@@ -196,9 +197,12 @@ describe('unshielded transaction subscriptions', async () => {
       expect(highestFoundTransactionId).toBe(highestTransactionId);
     });
 
-    test.skip('IMPLEMENT ME: should stream unshielded transaction events that adheres to the expected schema', async () => {
-      // TODO: implement the following test that checks the schema of the unshielded transaction events
-    });
+    test.todo(
+      'IMPLEMENT ME: should stream unshielded transaction events that adheres to the expected schema',
+      async () => {
+        // TODO: implement the following test that checks the schema of the unshielded transaction events
+      },
+    );
 
     /**
      * Subscribing to unshielded transaction events for an address without transactions
@@ -333,7 +337,13 @@ describe('unshielded transaction subscriptions', async () => {
      * @and we should receive a progress message with the highest transaction ID
      * @and the highest transaction ID in events should match the progress message
      */
-    test('should return a stream of transactions containing that address, starting from transaction id = 0', async () => {
+    test('should return a stream of transactions containing that address, starting from transaction id = 0', async ({
+      task,
+    }: TestContext) => {
+      task!.meta.custom = {
+        labels: ['UnshieldedTokens', 'Subscription', 'Transaction'],
+      };
+
       const targetTransactionId = 0;
       const targetAddress = dataProvider.getUnshieldedAddress('existing');
 

--- a/qa/tests/upload-to-xray.sh
+++ b/qa/tests/upload-to-xray.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Good to perform some checks and the below vars and report in case of missing
+XRAY_BASE_URL="https://eu.xray.cloud.getxray.app/api/v2"
+AUTH_URL="${XRAY_BASE_URL}/authenticate"
+REPORT_PATH=$XRAY_REPORT_PATH
+
+# Check if XRAY_CLIENT_ID and XRAY_CLIENT_SECRET are defined as environment variables
+if [ -z "$XRAY_CLIENT_ID" ]; then
+    echo "[ERROR] - XRAY_CLIENT_ID environment variable is not set"
+    echo "[INFO] - Please set XRAY_CLIENT_ID environment variable before running this script"
+    exit 1
+fi
+
+if [ -z "$XRAY_CLIENT_SECRET" ]; then
+    echo "[ERROR] - XRAY_CLIENT_SECRET environment variable is not set"
+    echo "[INFO] - Please set XRAY_CLIENT_SECRET environment variable before running this script"
+    exit 1
+fi
+
+echo "[INFO] - Authenticating in Xray..."
+
+AUTH_DATA="{\"client_id\": \"${XRAY_CLIENT_ID}\", \"client_secret\": \"${XRAY_CLIENT_SECRET}\"}"
+
+XRAY_SESSION_TOKEN=$(curl -X POST $AUTH_URL \
+  -H "Content-Type: application/json" \
+  -d "${AUTH_DATA}" --silent)
+
+if [ -z "$XRAY_SESSION_TOKEN" ]; then
+  echo "[ERROR] - Authentication failed. Exiting..."
+  exit 1
+fi
+
+XRAY_SESSION_TOKEN=${XRAY_SESSION_TOKEN//\"/}
+
+echo "[INFO] - Authentication successful! Token received"
+
+
+# Also this maybe good to be a parameter or env variable
+TEST_RESULT_FILE="./reports/xray/test-results.json"
+
+echo "[INFO] - Uploading test results to XRay..."
+
+# JUnit Format
+# RESPONSE=$(curl -X POST "${XRAY_BASE_URL}/import/execution/junit?projectKey=PM&testExecKey=PM-17151" \
+#  -H "Authorization: Bearer ${XRAY_SESSION_TOKEN}" \
+#  -H "Content-Type: text/xml" \
+#  --data @"${TEST_RESULT_FILE}" )
+
+# XRay JSON Format
+RESPONSE=$(curl -X POST "${XRAY_BASE_URL}/import/execution" \
+ -H "Authorization: Bearer ${XRAY_SESSION_TOKEN}" \
+ -H "Content-Type: application/json" \
+ --data @"${TEST_RESULT_FILE}" )
+
+echo "XRAY API responded with: ${RESPONSE}"
+EXECUTION_ID=$(echo $RESPONSE | grep -o '"key":"[^"]*"' | sed 's/"key":"\([^"]*\)"/\1/')
+echo $EXECUTION_ID > xray_id.txt
+
+echo "✅ Upload completed."

--- a/qa/tests/utils/reporters/custom-xray-json/README.md
+++ b/qa/tests/utils/reporters/custom-xray-json/README.md
@@ -1,0 +1,104 @@
+# Custom XRay JSON reporter
+
+This reporter is customised to be used in conjunction with XRay. It will produce a JSON report with a format that is compatible with XRay JSON results (explained in details here https://docs.getxray.app/space/XRAYCLOUD/44577176/Import+Execution+Results+-+REST+v2#Xray-JSON-Results)
+
+# Usage 
+
+## Add to the reporters
+
+From an usage point of view, you will need to enable it in Vitest configuration file. Just import it
+
+``` typescript
+import XRayJsonReporter from './utils/reporters/custom-xray-json/xray-json-reporter';
+```
+
+and add it to the list of reporters, as simple as adding one line on the below section
+
+``` Typescript
+reporters: [
+      'verbose',
+      new XRayJsonReporter(), // Add this entry
+      new CustomJUnitReporter(),
+      [
+        'junit',
+        {
+          outputFile: './reports/junit/test-results.xml',
+        },
+      ],
+      [
+        'json',
+        {
+          outputFile: './reports/json/test-results.json',
+        },
+      ],
+    ],
+```
+
+## In your tests
+
+By default, the XRay reporter will pick up the test case result and some basic information for the test results. That can be populated with additional information, such as labels/tags like in the example below.
+
+NOTE 1: labels and key (Jira ID of a XRay test case) are the only fields supported. They are both optional. 
+
+NOTE 2: If you don't provide a Jira Key it likely means you don't have already a XRay test case, in which case XRay will create one for you and match it by the test name (in the example below 'this is a test', prefixed by a test suite name if defined). So try not to change the test name, or if you have to, add a key to keep the mapping consistent
+
+``` Typescript
+test('this is a test', async ({task}) => {
+
+      // Use the task metadata like in the below example
+      // to export custom fields
+      // So far labels and Jira key are the only supporterd fields
+      // ... this can be extended
+      task.meta.custom = {
+        labels: ['UnshieldedTokens', 'Subscription', 'Transaction'],
+        testKey: 'PM-1234'
+      };
+
+      // ... rest of your test here
+});
+
+```
+
+## Useful variables
+The reporter uses environment variables to define some parts of the report that will be interpreted accordingly by XRay.
+
+- __TARGET_ENV__: this is a mandatory field needed to understand what environment the test execution is targetting. If not specified 'undeployed' will be used, which might be what you want, so setting up explicitly every time is best
+
+- __XRAY_COMPONENT__: this is a mandatory field needed to define what component the test execution is for
+
+- __XRAY_TEST_EXEC_KEY__: This is the test execution key (a Jira ID for the TestExecution type). At least one of XRAY_TEST_EXEC_KEY or XRAY_TEST_PLAN_KEY must be provided.
+
+- __XRAY_TEST_PLAN_KEY__: This is the test plan key (a Jira ID for the TestPlan type). At least one of XRAY_TEST_EXEC_KEY or XRAY_TEST_PLAN_KEY must be provided.
+
+- __XRAY_PROJECT_KEY__: This is the optional project Key. If not provided the default is 'PM' for Porject Midnight
+
+- __XRAY_REPORT_TESTS_MISSING_METADATA__: This controls whether tests without custom metadata should be included in the XRay report. When set to 'true', tests that don't define custom metadata will be excluded from the report. When set to 'false' (default) or not set, all tests will be included regardless of metadata. This is useful when you only want to report specific tests that have been properly configured with XRay metadata.
+
+_NOTE: Please don't confuse test key, test plan key and test execution key as they are identifying different entities_
+
+# Upload the results
+
+Once you have executed your tests (either locally or in CI), a JSON test result file should be produced in `reports/xray/test-results.json`. You can use that to upload the test execution report either from your local environment through a script or setup GitHub workflow to do it for you. In both cases you will need the following environment variables set
+
+- __XRAY_CLIENT_ID__ and __XRAY_CLIENT_SECRET__
+
+## Locally through a script
+
+You can invoke the `upload-to-xray.sh` script, bearing in mind it will expect to have the report file in `reports/xray/test-results.json`
+
+## Through CI execution in GitHub
+
+For now the GitHub workflow will need to use the same script as above, in future we will create a GitHub Action
+
+# Be aware of ...
+
+## Providing a test key
+As we already said, if you don't provide a test key, XRay will try to match an existing test case using the `definition` field. If it finds one it will use that test case, otherwise it will create one. 
+
+## Fields to update
+
+- __summary__: This is the title of the XRay test case that appears on top of the Jira issue. This is created using [test suite name], [test case name] format (comma-separated) 
+
+- __labels__: When providing the labels remember that they will be added to the exsising ones. If labels already exist, the ones you are providing will be added. Because of this behavirou, the labels you provide might not be the ones that you actually see, just because of what we said. 
+
+- __definition__: The definition field of a test case will be set based the [test suite name].[test case name]. So basically test suite and test case names joined together by a dot

--- a/qa/tests/utils/reporters/custom-xray-json/xray-json-reporter.ts
+++ b/qa/tests/utils/reporters/custom-xray-json/xray-json-reporter.ts
@@ -1,0 +1,292 @@
+// This file is part of midnightntwrk/midnight-indexer.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import fs from 'fs';
+import path from 'path';
+import { Reporter } from 'vitest/reporters';
+import { RunnerTestSuite, RunnerTaskResult } from 'vitest';
+
+// XRay JSON format interfaces based on the schema
+// TODOs:
+// - Add support for additional metadata to be added to the test results (with explicit types)
+// - Add support test retries so that only the latest test result is used, not all
+// - Check the exact expectations for the testKey presence
+// - Check the exact expectations for the testPlanKey and/or testExecutionKey presence
+
+interface XRayExecInfo {
+  summary: string;
+  description?: string;
+  testPlanKey?: string;
+  testEnvironments?: string[];
+  startDate: string;
+  finishDate: string;
+  testExecutionKey?: string;
+}
+
+interface XRayTest {
+  testKey?: string;
+  start: string;
+  finish: string;
+  status: 'PASSED' | 'FAILED' | 'TODO' | 'EXECUTING' | 'ABORTED' | 'SKIPPED';
+  assignee?: string;
+  testInfo?: XRayTestInfo;
+  evidences?: Array<{
+    data: string;
+    filename: string;
+    contentType: string;
+  }>;
+  comment?: string;
+  defects?: string[];
+  examples?: Array<{
+    status: 'PASSED' | 'FAILED' | 'TODO' | 'EXECUTING' | 'ABORTED' | 'SKIPPED';
+    duration?: number;
+    defects?: string[];
+    comment?: string;
+  }>;
+}
+
+interface XRayTestInfo {
+  projectKey: string;
+  type: string;
+  summary: string;
+  definition: string;
+  labels?: string[];
+}
+
+interface XRayReport {
+  testExecutionKey?: string;
+  info: XRayExecInfo;
+  tests: XRayTest[];
+}
+
+function flattenTests(
+  suite: RunnerTestSuite,
+  parentNames: string[] = [],
+): {
+  suiteName: string;
+  className: string;
+  testName: string;
+  time: number;
+  failureMessage?: string;
+  startTime?: number;
+  metadata?: Record<string, any>;
+}[] {
+  const results: {
+    suiteName: string;
+    className: string;
+    testName: string;
+    time: number;
+    failureMessage?: string;
+    startTime?: number;
+    metadata?: Record<string, any>;
+  }[] = [];
+
+  const currentNames = [...parentNames, suite.name];
+
+  for (const task of suite.tasks) {
+    if (task.type === 'suite') {
+      results.push(...flattenTests(task, currentNames));
+    } else if (task.type === 'test') {
+      const result = task.result as RunnerTaskResult;
+
+      // Extract timing information
+      const startTime = result?.startTime || Date.now();
+      const duration = result?.duration || 0;
+      const endTime = startTime + duration;
+
+      // You can use the following information but note that not everything
+      // might be available, especially the "describe()" strings
+      // currentNames[0] -> This is the test file path
+      // currentNames[1] -> This is the top level describe string
+      // suite.name      -> This is the lower level describe string, just wrapping the test/it
+      // task.name       -> This is the test/it string
+
+      const testFileName = currentNames[0];
+      const testSuiteName = suite.name;
+      const testTaskName = task.name;
+
+      // console.debug('suiteName: ', suite.name);
+      // console.debug('currentNames[0]: ', currentNames[0]);
+      // console.debug('currentNames[1]: ', currentNames[1]);
+      // console.debug('suite.name: ', suite.name);
+      // console.debug('task.name: ', task.name);
+      // console.debug('--------------------------------');
+      results.push({
+        suiteName: testFileName,
+        className: testSuiteName,
+        testName: testTaskName,
+        time: duration / 1000, // Convert to seconds
+        failureMessage: result?.errors?.[0]?.message,
+        startTime: startTime,
+        metadata: (task as any).meta, // Extract task metadata
+      });
+
+      // console.debug('results.at(-1).suiteName: ', results.at(-1)?.suiteName);
+      // console.debug('results.at(-1).className: ', results.at(-1)?.className);
+      // console.debug('results.at(-1).testName: ', results.at(-1)?.testName);
+    }
+  }
+
+  return results;
+}
+
+export default class XRayJsonReporter implements Reporter {
+  private startTime: number = Date.now();
+
+  onFinished(files: RunnerTestSuite[]) {
+    const testcases = files.flatMap((file) => flattenTests(file));
+    const endTime = Date.now();
+
+    if (!process.env.XRAY_COMPONENT) {
+      console.error(
+        'ERROR: XRay JSON Reporter Error: XRAY_COMPONENT environment variable must be defined',
+      );
+      console.error(
+        '       Please set the XRAY_COMPONENT environment variable to specify the component being tested',
+      );
+      console.error('ERROR: Failed to create a Custom XRay JSON report');
+      return;
+    }
+
+    if (!process.env.XRAY_PROJECT_KEY) {
+      console.debug('WARNING: XRAY_PROJECT_KEY env variable not set, PM will be used as default');
+    }
+
+    const targetEnv = process.env.TARGET_ENV || 'undeployed';
+    const xrayComponent = process.env.XRAY_COMPONENT || 'unknown component';
+    const xrayReportEmptyMeta = process.env.XRAY_REPORT_TESTS_MISSING_METADATA || 'false';
+    const xrayTestExecKey = process.env.XRAY_TEST_EXEC_KEY;
+    const xrayTestPlanKey = process.env.XRAY_TEST_PLAN_KEY;
+    const xrayProjectKey = process.env.XRAY_PROJECT_KEY || 'PM';
+
+    console.debug('XRay JSON Reporter info: ');
+    console.debug(` TARGET_ENV: ${targetEnv}`);
+    console.debug(` XRAY_COMPONENT: ${xrayComponent}`);
+    console.debug(` XRAY_REPORT_TESTS_MISSING_METADATA: ${xrayReportEmptyMeta}`);
+    console.debug(` XRAY_TEST_EXEC_KEY: ${xrayTestExecKey}`);
+    console.debug(` XRAY_TEST_PLAN_KEY: ${xrayTestPlanKey}`);
+    console.debug(` XRAY_PROJECT_KEY: ${xrayProjectKey}`);
+
+    // Group tests by suite for better organization
+    const grouped = testcases.reduce(
+      (acc, tc) => {
+        if (!acc[tc.suiteName]) acc[tc.suiteName] = [];
+        acc[tc.suiteName].push(tc);
+        return acc;
+      },
+      {} as Record<string, typeof testcases>,
+    );
+
+    // Convert test cases to XRay format
+    const xrayTests: XRayTest[] = testcases.flatMap((test) => {
+      const status: XRayTest['status'] = test.failureMessage ? 'FAILED' : 'PASSED';
+
+      const testData: XRayTest = {
+        start: new Date(test.startTime || this.startTime).toISOString(),
+        finish: new Date((test.startTime || this.startTime) + test.time * 1000).toISOString(),
+        status,
+      };
+
+      // Skip the test entirely if the metadata is not defined
+      if (xrayReportEmptyMeta === 'false' && test.metadata?.custom === undefined) {
+        return [];
+      }
+
+      // Details about the schema here https://docs.getxray.app/space/XRAYCLOUD/44565311/Using+Xray+JSON+format+to+import+execution+results
+      // Minimum required fields when testInfo is provided: ["summary", "projectKey", "type"],
+      testData.testInfo = {
+        projectKey: xrayProjectKey,
+        type: 'Automated',
+        summary: `${test.className}, ${test.testName}`,
+        definition: `${test.className}.${test.testName}`,
+      };
+
+      // Managing labels as metadata
+      testData.testInfo.labels = ['Xray']; // Default label
+      if (test.metadata?.custom?.labels) {
+        testData.testInfo.labels.push(...test.metadata.custom?.labels);
+      }
+
+      // Managing the test key if available
+      if (test.testName) {
+        if (test.metadata?.custom?.testKey) {
+          testData.testKey = test.metadata.custom.testKey;
+        }
+      }
+
+      // Add failure evidence if test failed
+      if (test.failureMessage) {
+        testData.evidences = [
+          {
+            data: test.failureMessage,
+            contentType: 'text/plain',
+            filename: test.suiteName,
+          },
+        ];
+        testData.comment = `Test failed: ${test.failureMessage}`;
+      }
+
+      return testData;
+    });
+
+    const now = new Date();
+    const currentDate = now.toLocaleDateString('en-GB'); // DD/MM/YYYY format
+    const currentTime = now.toLocaleTimeString('en-GB', {
+      timeZoneName: 'short',
+    }); // HH:MM:SS with timezone
+
+    // Create XRay report
+    const xrayReport: XRayReport = {
+      info: {
+        summary: `Test execution for ${xrayComponent} tests targeting ${targetEnv} env ran on ${currentDate} at ${currentTime}`,
+        description:
+          `Automated test execution results for ${xrayComponent} tests. ` +
+          `This XRay issue has been automatically created by XRay`,
+        startDate: new Date(this.startTime).toISOString(),
+        finishDate: new Date(endTime).toISOString(),
+        testEnvironments: [targetEnv],
+      },
+      tests: xrayTests,
+    };
+
+    // Validate that at least one of the required XRay keys is provided
+    if (!xrayTestExecKey && !xrayTestPlanKey) {
+      console.error(
+        'ERROR: XRay JSON Reporter Error: At least one of XRAY_TEST_EXEC_KEY or XRAY_TEST_PLAN_KEY must be defined',
+      );
+      console.error('       Please set one of these environment variables:');
+      console.error('        - XRAY_TEST_EXEC_KEY: For linking to an existing test execution');
+      console.error('        - XRAY_TEST_PLAN_KEY: For linking to a test plan');
+      console.error('ERROR: Failed to create a Custom XRay JSON report');
+      return;
+      //throw new Error('Missing required XRay configuration: XRAY_TEST_EXEC_KEY or XRAY_TEST_PLAN_KEY must be defined');
+    }
+
+    if (xrayTestExecKey) {
+      xrayReport.testExecutionKey = xrayTestExecKey;
+    }
+
+    if (xrayTestPlanKey) {
+      xrayReport.info.testPlanKey = xrayTestPlanKey;
+    }
+
+    // Write XRay JSON report
+    const outputPath = path.resolve('./reports/xray/test-results.json');
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, JSON.stringify(xrayReport, null, 2), 'utf-8');
+
+    console.log(`Custom XRay JSON report written to ${outputPath}`);
+  }
+}

--- a/qa/tests/utils/reporters/custom-xray-json/xray-json-reporter.ts
+++ b/qa/tests/utils/reporters/custom-xray-json/xray-json-reporter.ts
@@ -165,7 +165,7 @@ export default class XRayJsonReporter implements Reporter {
     }
 
     const targetEnv = process.env.TARGET_ENV || 'undeployed';
-    const xrayComponent = process.env.XRAY_COMPONENT || 'unknown component';
+    const xrayComponent = process.env.XRAY_COMPONENT;
     const xrayReportEmptyMeta = process.env.XRAY_REPORT_TESTS_MISSING_METADATA || 'false';
     const xrayTestExecKey = process.env.XRAY_TEST_EXEC_KEY;
     const xrayTestPlanKey = process.env.XRAY_TEST_PLAN_KEY;

--- a/qa/tests/utils/reporters/index.ts
+++ b/qa/tests/utils/reporters/index.ts
@@ -1,4 +1,4 @@
-// This file is part of midnightntwrk/midnight-indexer
+// This file is part of midnightntwrk/midnight-indexer.
 // Copyright (C) 2025 Midnight Foundation
 // SPDX-License-Identifier: Apache-2.0
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,19 +13,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-declare module 'vitest' {
-  interface Assertion<T> {
-    toBeError(): void;
-    toBeSuccess(): void;
-  }
-
-  interface TestContext {
-    skip?: (condition: boolean, reason?: string) => void;
-    task?: {
-      meta: {
-        done?: boolean;
-        custom?: Record<string, any>;
-      };
-    };
-  }
-}
+export { default as CustomJUnitReporter } from './custom-junit/custom-junit-reporter';
+export { default as XRayJsonReporter } from './custom-xray-json/xray-json-reporter';

--- a/qa/tests/vitest.config.ts
+++ b/qa/tests/vitest.config.ts
@@ -1,3 +1,18 @@
+// This file is part of midnightntwrk/midnight-indexer.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import path from 'path';
 import { defineConfig } from 'vitest/config';
 import XRayJsonReporter from './utils/reporters/custom-xray-json/xray-json-reporter';

--- a/qa/tests/vitest.config.ts
+++ b/qa/tests/vitest.config.ts
@@ -1,7 +1,6 @@
-import { suite } from '@vitest/runner';
 import path from 'path';
 import { defineConfig } from 'vitest/config';
-import { JUnitReporter } from 'vitest/reporters';
+import XRayJsonReporter from './utils/reporters/custom-xray-json/xray-json-reporter';
 import CustomJUnitReporter from './utils/reporters/custom-junit/custom-junit-reporter';
 
 export default defineConfig({
@@ -18,6 +17,7 @@ export default defineConfig({
     retry: 1, // Retry failed tests one extra time just for random glitches
     reporters: [
       'verbose',
+      new XRayJsonReporter(),
       new CustomJUnitReporter(),
       [
         'junit',


### PR DESCRIPTION
This change enables the test results (generated with an additional custom 
reporter that uses XRay JSON format) to be uploaded to XRay

It adds:
- A README with instructions on how it can be used
- Custom reporter that uses XRay JSON format
- Changes to Vitest configuration file
- A script to upload the test report
- An example on what to do on the test cases