### PR TITLE
refactor: clean up DUST event types and align with existing patterns

### DIFF
--- a/chain-indexer/src/domain/dust.rs
+++ b/chain-indexer/src/domain/dust.rs
@@ -50,7 +50,7 @@ pub enum DustRegistrationEvent {
     },
 }
 
-/// Processed DUST events ready for persistence.
+/// DUST event projections ready for persistence.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DustEventProjections {
     pub generations: Vec<DustGeneration>,

--- a/chain-indexer/src/domain/dust.rs
+++ b/chain-indexer/src/domain/dust.rs
@@ -12,14 +12,13 @@
 // limitations under the License.
 
 pub use indexer_common::domain::dust::{
-    DustEvent, DustEventDetails, DustEventType, DustGenerationInfo, DustMerklePathEntry,
+    DustEvent, DustEventAttributes, DustEventVariant, DustGenerationInfo, DustMerklePathEntry,
     DustParameters, QualifiedDustOutput,
 };
 
 use indexer_common::domain::{
     CardanoStakeKey, DustAddress, DustCommitment, DustNullifier, DustUtxoId,
 };
-use thiserror::Error;
 
 /// Domain representation of DUST registration events from the NativeTokenObservation pallet.
 #[derive(Debug, Clone, PartialEq)]
@@ -51,21 +50,9 @@ pub enum DustRegistrationEvent {
     },
 }
 
-#[derive(Error, Debug)]
-pub enum DustProcessingError {
-    #[error("Database error during DUST processing")]
-    Database(#[from] sqlx::Error),
-
-    #[error("Invalid DUST event data: {0}")]
-    InvalidEventData(String),
-
-    #[error("DUST generation info not found for index {0}")]
-    GenerationInfoNotFound(u64),
-}
-
 /// Processed DUST events ready for persistence.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ProcessedDustEvents {
+pub struct DustEventProjections {
     pub generations: Vec<DustGeneration>,
     pub utxos: Vec<DustUtxo>,
     pub merkle_tree_updates: Vec<DustMerkleTreeUpdate>,
@@ -105,8 +92,8 @@ pub struct DustDtimeUpdate {
 
 /// Extract operations from DUST events.
 /// This processing happens in the domain layer.
-pub fn extract_dust_operations(dust_events: &[DustEvent]) -> ProcessedDustEvents {
-    let mut result = ProcessedDustEvents {
+pub fn extract_dust_operations(dust_events: &[DustEvent]) -> DustEventProjections {
+    let mut result = DustEventProjections {
         generations: Vec::new(),
         utxos: Vec::new(),
         merkle_tree_updates: Vec::new(),
@@ -118,7 +105,7 @@ pub fn extract_dust_operations(dust_events: &[DustEvent]) -> ProcessedDustEvents
 
     for dust_event in dust_events {
         match &dust_event.event_details {
-            DustEventDetails::DustInitialUtxo {
+            DustEventAttributes::DustInitialUtxo {
                 output,
                 generation_info,
                 generation_index,
@@ -133,7 +120,7 @@ pub fn extract_dust_operations(dust_events: &[DustEvent]) -> ProcessedDustEvents
                 });
             }
 
-            DustEventDetails::DustGenerationDtimeUpdate {
+            DustEventAttributes::DustGenerationDtimeUpdate {
                 generation_info,
                 generation_index,
                 merkle_path,
@@ -145,7 +132,7 @@ pub fn extract_dust_operations(dust_events: &[DustEvent]) -> ProcessedDustEvents
                 });
             }
 
-            DustEventDetails::DustSpendProcessed {
+            DustEventAttributes::DustSpendProcessed {
                 commitment,
                 nullifier,
                 ..
@@ -154,14 +141,6 @@ pub fn extract_dust_operations(dust_events: &[DustEvent]) -> ProcessedDustEvents
                     commitment: *commitment,
                     nullifier: *nullifier,
                 });
-            }
-
-            // Registration events are handled at block level.
-            DustEventDetails::DustRegistration { .. }
-            | DustEventDetails::DustDeregistration { .. }
-            | DustEventDetails::DustMappingAdded { .. }
-            | DustEventDetails::DustMappingRemoved { .. } => {
-                // Intentionally empty - already handled at block level.
             }
         }
     }

--- a/chain-indexer/src/domain/ledger_state.rs
+++ b/chain-indexer/src/domain/ledger_state.rs
@@ -143,7 +143,7 @@ impl LedgerState {
         transaction.spent_unshielded_utxos = result.spent_unshielded_utxos;
 
         // Extract operations from DUST events (dust.rs::extract_dust_operations).
-        transaction.processed_dust_events = extract_dust_operations(&transaction.dust_events);
+        transaction.dust_event_projections = extract_dust_operations(&transaction.dust_events);
         if transaction.end_index > transaction.start_index {
             for contract_action in transaction.contract_actions.iter_mut() {
                 let zswap_state = self.extract_contract_zswap_state(&contract_action.address)?;
@@ -183,7 +183,7 @@ impl LedgerState {
         transaction.dust_events = dust_events;
 
         // Extract operations from DUST events (dust.rs::extract_dust_operations).
-        transaction.processed_dust_events = extract_dust_operations(&transaction.dust_events);
+        transaction.dust_event_projections = extract_dust_operations(&transaction.dust_events);
 
         Ok(Transaction::System(Box::new(transaction)))
     }

--- a/chain-indexer/src/domain/transaction.rs
+++ b/chain-indexer/src/domain/transaction.rs
@@ -99,7 +99,7 @@ pub struct RegularTransaction {
     pub created_unshielded_utxos: Vec<UnshieldedUtxo>,
     pub spent_unshielded_utxos: Vec<UnshieldedUtxo>,
     pub dust_events: Vec<DustEvent>,
-    pub processed_dust_events: DustEventProjections,
+    pub dust_event_projections: DustEventProjections,
 }
 
 impl From<node::RegularTransaction> for RegularTransaction {
@@ -119,7 +119,7 @@ impl From<node::RegularTransaction> for RegularTransaction {
             created_unshielded_utxos: Default::default(),
             spent_unshielded_utxos: Default::default(),
             dust_events: Default::default(),
-            processed_dust_events: Default::default(),
+            dust_event_projections: Default::default(),
         }
     }
 }
@@ -141,7 +141,7 @@ pub struct SystemTransaction {
 
     // These fields come from applying the node transactions to the ledger state.
     pub dust_events: Vec<DustEvent>,
-    pub processed_dust_events: DustEventProjections,
+    pub dust_event_projections: DustEventProjections,
 }
 
 impl TryFrom<node::SystemTransaction> for SystemTransaction {
@@ -165,7 +165,7 @@ impl TryFrom<node::SystemTransaction> for SystemTransaction {
             treasury_payment_shielded: metadata.treasury_payment_shielded,
             treasury_payment_unshielded: metadata.treasury_payment_unshielded,
             dust_events: Default::default(),
-            processed_dust_events: Default::default(),
+            dust_event_projections: Default::default(),
         })
     }
 }

--- a/chain-indexer/src/domain/transaction.rs
+++ b/chain-indexer/src/domain/transaction.rs
@@ -13,7 +13,7 @@
 
 use crate::domain::{
     ContractAction,
-    dust::{DustEvent, ProcessedDustEvents},
+    dust::{DustEvent, DustEventProjections},
     node,
 };
 use indexer_common::domain::{
@@ -99,7 +99,7 @@ pub struct RegularTransaction {
     pub created_unshielded_utxos: Vec<UnshieldedUtxo>,
     pub spent_unshielded_utxos: Vec<UnshieldedUtxo>,
     pub dust_events: Vec<DustEvent>,
-    pub processed_dust_events: ProcessedDustEvents,
+    pub processed_dust_events: DustEventProjections,
 }
 
 impl From<node::RegularTransaction> for RegularTransaction {
@@ -141,7 +141,7 @@ pub struct SystemTransaction {
 
     // These fields come from applying the node transactions to the ledger state.
     pub dust_events: Vec<DustEvent>,
-    pub processed_dust_events: ProcessedDustEvents,
+    pub processed_dust_events: DustEventProjections,
 }
 
 impl TryFrom<node::SystemTransaction> for SystemTransaction {

--- a/chain-indexer/src/infra/storage.rs
+++ b/chain-indexer/src/infra/storage.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use crate::domain::{
-    self, Block, BlockTransactions, ContractAction, DustRegistrationEvent, ProcessedDustEvents,
+    self, Block, BlockTransactions, ContractAction, DustEventProjections, DustRegistrationEvent,
     RegularTransaction, SystemTransaction, Transaction, TransactionVariant, node::BlockInfo,
 };
 use fastrace::trace;
@@ -21,7 +21,7 @@ use indexer_common::{
     domain::{
         BlockHash, ByteVec, DustNullifier,
         dust::{
-            DustCommitment, DustEvent, DustEventType, DustGenerationInfo, DustMerklePathEntry,
+            DustCommitment, DustEvent, DustEventVariant, DustGenerationInfo, DustMerklePathEntry,
             QualifiedDustOutput,
         },
         ledger::{
@@ -642,7 +642,7 @@ async fn save_identifiers(
 
 #[trace(properties = { "transaction_id": "{transaction_id}" })]
 async fn save_processed_dust_events(
-    processed_dust_events: &ProcessedDustEvents,
+    processed_dust_events: &DustEventProjections,
     transaction_id: i64,
     block_height: u32,
     tx: &mut SqlxTransaction,
@@ -702,7 +702,7 @@ async fn save_dust_events(
 
     QueryBuilder::new(query)
         .push_values(dust_events.iter(), |mut q, event| {
-            let event_type = DustEventType::from(&event.event_details);
+            let event_type = DustEventVariant::from(&event.event_details);
             q.push_bind(transaction_id)
                 .push_bind(event.transaction_hash.as_ref())
                 .push_bind(event.logical_segment as i32)
@@ -870,7 +870,7 @@ async fn save_parameter_update(
         "};
 
         let parameter_update =
-            to_value(&parameter_update).map_err(|error| sqlx::Error::Encode(error.into()))?;
+            to_value(parameter_update).map_err(|error| sqlx::Error::Encode(error.into()))?;
 
         sqlx::query(query)
             .bind(transaction_id)
@@ -900,7 +900,7 @@ async fn save_night_distribution(
         "};
 
         let json_value =
-            to_value(&night_distribution).map_err(|error| sqlx::Error::Encode(error.into()))?;
+            to_value(night_distribution).map_err(|error| sqlx::Error::Encode(error.into()))?;
 
         sqlx::query(query)
             .bind(transaction_id)
@@ -960,7 +960,7 @@ async fn save_shielded_treasury_payment(
         "};
 
         let treasury_payment_json =
-            to_value(&treasury_payment).map_err(|error| sqlx::Error::Encode(error.into()))?;
+            to_value(treasury_payment).map_err(|error| sqlx::Error::Encode(error.into()))?;
 
         sqlx::query(query)
             .bind(transaction_id)
@@ -994,7 +994,7 @@ async fn save_unshielded_treasury_payment(
         "};
 
         let treasury_payment_json =
-            to_value(&treasury_payment).map_err(|error| sqlx::Error::Encode(error.into()))?;
+            to_value(treasury_payment).map_err(|error| sqlx::Error::Encode(error.into()))?;
 
         sqlx::query(query)
             .bind(transaction_id)

--- a/indexer-api/graphql/schema-v1.graphql
+++ b/indexer-api/graphql/schema-v1.graphql
@@ -255,20 +255,6 @@ type DustCommitmentProgress {
 }
 
 """
-Details for DUST deregistration event.
-"""
-type DustDeregistrationDetails {
-	"""
-	Cardano stake key address.
-	"""
-	cardanoAddress: HexEncoded!
-	"""
-	DUST address.
-	"""
-	dustAddress: HexEncoded!
-}
-
-"""
 DUST event from chain processing.
 """
 type DustEvent {
@@ -287,22 +273,22 @@ type DustEvent {
 	"""
 	Event type.
 	"""
-	eventType: DustEventType!
+	eventType: DustEventVariant!
 	"""
 	Event details.
 	"""
-	eventDetails: DustEventDetails!
+	eventDetails: DustEventAttributes!
 }
 
 """
 DUST event details union.
 """
-union DustEventDetails = DustInitialUtxoDetails | DustGenerationDtimeUpdateDetails | DustSpendProcessedDetails | DustRegistrationDetails | DustDeregistrationDetails | DustMappingAddedDetails | DustMappingRemovedDetails
+union DustEventAttributes = DustInitialUtxoDetails | DustGenerationDtimeUpdateDetails | DustSpendProcessedDetails
 
 """
 Type of DUST event.
 """
-enum DustEventType {
+enum DustEventVariant {
 	"""
 	Initial DUST UTXO creation.
 	"""
@@ -315,22 +301,6 @@ enum DustEventType {
 	DUST spend processed.
 	"""
 	DUST_SPEND_PROCESSED
-	"""
-	Registration event.
-	"""
-	DUST_REGISTRATION
-	"""
-	Deregistration event.
-	"""
-	DUST_DEREGISTRATION
-	"""
-	Mapping added event.
-	"""
-	DUST_MAPPING_ADDED
-	"""
-	Mapping removed event.
-	"""
-	DUST_MAPPING_REMOVED
 }
 
 """
@@ -499,42 +469,6 @@ type DustInitialUtxoDetails {
 }
 
 """
-Details for DUST mapping added event.
-"""
-type DustMappingAddedDetails {
-	"""
-	Cardano stake key address.
-	"""
-	cardanoAddress: HexEncoded!
-	"""
-	DUST address.
-	"""
-	dustAddress: HexEncoded!
-	"""
-	UTXO identifier.
-	"""
-	utxoId: HexEncoded!
-}
-
-"""
-Details for DUST mapping removed event.
-"""
-type DustMappingRemovedDetails {
-	"""
-	Cardano stake key address.
-	"""
-	cardanoAddress: HexEncoded!
-	"""
-	DUST address.
-	"""
-	dustAddress: HexEncoded!
-	"""
-	UTXO identifier.
-	"""
-	utxoId: HexEncoded!
-}
-
-"""
 Merkle tree path entry for DUST trees.
 """
 type DustMerklePathEntry {
@@ -615,20 +549,6 @@ type DustParametersInfo {
 	DUST grace period in seconds.
 	"""
 	dustGracePeriod: Int!
-}
-
-"""
-Details for DUST registration event.
-"""
-type DustRegistrationDetails {
-	"""
-	Cardano stake key address.
-	"""
-	cardanoAddress: HexEncoded!
-	"""
-	DUST address.
-	"""
-	dustAddress: HexEncoded!
 }
 
 """
@@ -751,7 +671,7 @@ type Query {
 	"""
 	Get recent DUST events with optional filtering.
 	"""
-	recentDustEvents(limit: Int, eventType: DustEventType): [DustEvent!]!
+	recentDustEvents(limit: Int, eventType: DustEventVariant): [DustEvent!]!
 }
 
 """

--- a/indexer-api/graphql/schema-v1.graphql
+++ b/indexer-api/graphql/schema-v1.graphql
@@ -271,13 +271,13 @@ type DustEvent {
 	"""
 	physicalSegment: Int!
 	"""
-	Event type.
+	Event variant.
 	"""
-	eventType: DustEventVariant!
+	eventVariant: DustEventVariant!
 	"""
-	Event details.
+	Event attributes.
 	"""
-	eventDetails: DustEventAttributes!
+	eventAttributes: DustEventAttributes!
 }
 
 """
@@ -286,7 +286,7 @@ DUST event details union.
 union DustEventAttributes = DustInitialUtxoDetails | DustGenerationDtimeUpdateDetails | DustSpendProcessedDetails
 
 """
-Type of DUST event.
+Variant of DUST event.
 """
 enum DustEventVariant {
 	"""
@@ -671,7 +671,7 @@ type Query {
 	"""
 	Get recent DUST events with optional filtering.
 	"""
-	recentDustEvents(limit: Int, eventType: DustEventVariant): [DustEvent!]!
+	recentDustEvents(limit: Int, eventVariant: DustEventVariant): [DustEvent!]!
 }
 
 """

--- a/indexer-api/src/domain/storage/dust.rs
+++ b/indexer-api/src/domain/storage/dust.rs
@@ -98,7 +98,7 @@ pub trait DustStorage: BlockStorage {
     async fn get_recent_dust_events(
         &self,
         limit: u32,
-        event_type: Option<indexer_common::domain::dust::DustEventType>,
+        event_type: Option<indexer_common::domain::dust::DustEventVariant>,
     ) -> Result<Vec<indexer_common::domain::dust::DustEvent>, sqlx::Error>;
 
     /// Get progress information for DUST nullifier transactions.
@@ -208,7 +208,7 @@ impl DustStorage for NoopStorage {
     async fn get_recent_dust_events(
         &self,
         limit: u32,
-        event_type: Option<indexer_common::domain::dust::DustEventType>,
+        event_type: Option<indexer_common::domain::dust::DustEventVariant>,
     ) -> Result<Vec<indexer_common::domain::dust::DustEvent>, sqlx::Error> {
         unimplemented!("NoopStorage")
     }

--- a/indexer-api/src/domain/storage/dust.rs
+++ b/indexer-api/src/domain/storage/dust.rs
@@ -98,7 +98,7 @@ pub trait DustStorage: BlockStorage {
     async fn get_recent_dust_events(
         &self,
         limit: u32,
-        event_type: Option<indexer_common::domain::dust::DustEventVariant>,
+        event_variant: Option<indexer_common::domain::dust::DustEventVariant>,
     ) -> Result<Vec<indexer_common::domain::dust::DustEvent>, sqlx::Error>;
 
     /// Get progress information for DUST nullifier transactions.
@@ -208,7 +208,7 @@ impl DustStorage for NoopStorage {
     async fn get_recent_dust_events(
         &self,
         limit: u32,
-        event_type: Option<indexer_common::domain::dust::DustEventVariant>,
+        event_variant: Option<indexer_common::domain::dust::DustEventVariant>,
     ) -> Result<Vec<indexer_common::domain::dust::DustEvent>, sqlx::Error> {
         unimplemented!("NoopStorage")
     }

--- a/indexer-api/src/infra/api/v1/dust.rs
+++ b/indexer-api/src/infra/api/v1/dust.rs
@@ -529,14 +529,14 @@ pub struct DustEvent {
     /// Physical segment within transaction.
     pub physical_segment: u16,
 
-    /// Event type.
-    pub event_type: DustEventVariant,
+    /// Event variant.
+    pub event_variant: DustEventVariant,
 
-    /// Event details.
-    pub event_details: DustEventAttributes,
+    /// Event attributes.
+    pub event_attributes: DustEventAttributes,
 }
 
-/// Type of DUST event.
+/// Variant of DUST event.
 #[derive(Debug, Clone, Copy, Enum, Serialize, Deserialize, PartialEq, Eq)]
 pub enum DustEventVariant {
     /// Initial DUST UTXO creation.
@@ -550,8 +550,8 @@ pub enum DustEventVariant {
 }
 
 impl From<DustEventVariant> for indexer_common::domain::dust::DustEventVariant {
-    fn from(event_type: DustEventVariant) -> Self {
-        match event_type {
+    fn from(event_variant: DustEventVariant) -> Self {
+        match event_variant {
             DustEventVariant::DustInitialUtxo => Self::DustInitialUtxo,
             DustEventVariant::DustGenerationDtimeUpdate => Self::DustGenerationDtimeUpdate,
             DustEventVariant::DustSpendProcessed => Self::DustSpendProcessed,
@@ -701,7 +701,7 @@ impl From<indexer_common::domain::dust::DustEvent> for DustEvent {
     fn from(event: indexer_common::domain::dust::DustEvent) -> Self {
         use indexer_common::domain::dust::DustEventAttributes as DomainDetails;
 
-        let event_type = match &event.event_details {
+        let event_variant = match &event.event_details {
             DomainDetails::DustInitialUtxo { .. } => DustEventVariant::DustInitialUtxo,
             DomainDetails::DustGenerationDtimeUpdate { .. } => {
                 DustEventVariant::DustGenerationDtimeUpdate
@@ -709,7 +709,7 @@ impl From<indexer_common::domain::dust::DustEvent> for DustEvent {
             DomainDetails::DustSpendProcessed { .. } => DustEventVariant::DustSpendProcessed,
         };
 
-        let event_details = match event.event_details {
+        let event_attributes = match event.event_details {
             DomainDetails::DustInitialUtxo {
                 output,
                 generation_info,
@@ -781,8 +781,8 @@ impl From<indexer_common::domain::dust::DustEvent> for DustEvent {
             transaction_hash: event.transaction_hash.hex_encode(),
             logical_segment: event.logical_segment,
             physical_segment: event.physical_segment,
-            event_type,
-            event_details,
+            event_variant,
+            event_attributes,
         }
     }
 }

--- a/indexer-api/src/infra/api/v1/query.rs
+++ b/indexer-api/src/infra/api/v1/query.rs
@@ -20,7 +20,8 @@ use crate::{
             block::{Block, BlockOffset},
             contract_action::{ContractAction, ContractActionOffset},
             dust::{
-                DustEvent, DustEventType, DustGenerationStatus, DustMerkleTreeType, DustSystemState,
+                DustEvent, DustEventVariant, DustGenerationStatus, DustMerkleTreeType,
+                DustSystemState,
             },
             transaction::{Transaction, TransactionOffset},
         },
@@ -290,7 +291,7 @@ where
         &self,
         cx: &Context<'_>,
         limit: Option<u32>,
-        event_type: Option<DustEventType>,
+        event_type: Option<DustEventVariant>,
     ) -> ApiResult<Vec<DustEvent>> {
         let storage = cx.get_storage::<S>();
 

--- a/indexer-api/src/infra/api/v1/query.rs
+++ b/indexer-api/src/infra/api/v1/query.rs
@@ -286,12 +286,12 @@ where
     }
 
     /// Get recent DUST events with optional filtering.
-    #[trace(properties = { "limit": "{limit:?}", "event_type": "{event_type:?}" })]
+    #[trace(properties = { "limit": "{limit:?}", "event_variant": "{event_variant:?}" })]
     async fn recent_dust_events(
         &self,
         cx: &Context<'_>,
         limit: Option<u32>,
-        event_type: Option<DustEventVariant>,
+        event_variant: Option<DustEventVariant>,
     ) -> ApiResult<Vec<DustEvent>> {
         let storage = cx.get_storage::<S>();
 
@@ -299,7 +299,7 @@ where
         let limit = limit.unwrap_or(10).min(100);
 
         let events = storage
-            .get_recent_dust_events(limit, event_type.map(Into::into))
+            .get_recent_dust_events(limit, event_variant.map(Into::into))
             .await
             .map_err_into_server_error(|| "get recent DUST events")?;
 

--- a/indexer-api/src/infra/storage/dust.rs
+++ b/indexer-api/src/infra/storage/dust.rs
@@ -741,7 +741,7 @@ impl DustStorage for Storage {
     async fn get_recent_dust_events(
         &self,
         limit: u32,
-        event_type: Option<DustEventVariant>,
+        event_variant: Option<DustEventVariant>,
     ) -> Result<Vec<DustEvent>, sqlx::Error> {
         #[derive(FromRow)]
         struct DustEventRow {
@@ -751,7 +751,7 @@ impl DustStorage for Storage {
             event_data: Json<DustEventAttributes>,
         }
 
-        let query = if event_type.is_some() {
+        let query = if event_variant.is_some() {
             // Filter by event type.
             indoc! {"
                 SELECT de.transaction_hash, de.logical_segment, de.physical_segment, de.event_data
@@ -772,9 +772,9 @@ impl DustStorage for Storage {
             "}
         };
 
-        let rows = if let Some(event_type) = event_type {
+        let rows = if let Some(event_variant) = event_variant {
             sqlx::query_as::<_, DustEventRow>(query)
-                .bind(event_type)
+                .bind(event_variant)
                 .bind(limit as i64)
                 .fetch_all(&*self.pool)
                 .await?

--- a/indexer-api/src/infra/storage/dust.rs
+++ b/indexer-api/src/infra/storage/dust.rs
@@ -33,7 +33,7 @@ use indexer_common::{
     domain::{
         CardanoStakeKey, DustAddress, DustCommitment, DustMerkleRoot, DustMerkleUpdate, DustNonce,
         DustNullifier, DustOwner, DustPrefix, NightUtxoHash,
-        dust::{DustEvent, DustEventDetails, DustEventType, DustMerklePathEntry},
+        dust::{DustEvent, DustEventAttributes, DustEventVariant, DustMerklePathEntry},
         ledger::TransactionHash,
     },
     infra::sqlx::{SqlxOption, U128BeBytes},
@@ -711,7 +711,7 @@ impl DustStorage for Storage {
             transaction_hash: TransactionHash,
             logical_segment: i32,
             physical_segment: i32,
-            event_data: Json<DustEventDetails>,
+            event_data: Json<DustEventAttributes>,
         }
 
         let query = indoc! {"
@@ -741,14 +741,14 @@ impl DustStorage for Storage {
     async fn get_recent_dust_events(
         &self,
         limit: u32,
-        event_type: Option<DustEventType>,
+        event_type: Option<DustEventVariant>,
     ) -> Result<Vec<DustEvent>, sqlx::Error> {
         #[derive(FromRow)]
         struct DustEventRow {
             transaction_hash: TransactionHash,
             logical_segment: i32,
             physical_segment: i32,
-            event_data: Json<DustEventDetails>,
+            event_data: Json<DustEventAttributes>,
         }
 
         let query = if event_type.is_some() {

--- a/indexer-common/src/domain/dust.rs
+++ b/indexer-common/src/domain/dust.rs
@@ -13,10 +13,7 @@
 
 pub use crate::domain::{DustCommitment, DustNullifier};
 
-use crate::domain::{
-    ByteVec, CardanoStakeKey, DustAddress, DustNonce, DustOwner, NightUtxoHash, NightUtxoNonce,
-    ledger::TransactionHash,
-};
+use crate::domain::{DustNonce, DustOwner, NightUtxoHash, NightUtxoNonce, ledger::TransactionHash};
 use serde::{Deserialize, Serialize};
 
 /// DUST event for the indexer domain.
@@ -25,12 +22,12 @@ pub struct DustEvent {
     pub transaction_hash: TransactionHash,
     pub logical_segment: u16,
     pub physical_segment: u16,
-    pub event_details: DustEventDetails,
+    pub event_details: DustEventAttributes,
 }
 
 /// DUST event details.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum DustEventDetails {
+pub enum DustEventAttributes {
     /// Initial DUST UTXO creation.
     DustInitialUtxo {
         /// Qualified DUST output.
@@ -65,42 +62,6 @@ pub enum DustEventDetails {
         time: u64,
         /// DUST parameters.
         params: DustParameters,
-    },
-
-    /// Registration event - Cardano address registered with DUST address.
-    DustRegistration {
-        /// Cardano stake key address.
-        cardano_address: CardanoStakeKey,
-        /// DUST address (32 bytes).
-        dust_address: DustAddress,
-    },
-
-    /// Deregistration event - Cardano address deregistered from DUST address.
-    DustDeregistration {
-        /// Cardano stake key address.
-        cardano_address: CardanoStakeKey,
-        /// DUST address (32 bytes).
-        dust_address: DustAddress,
-    },
-
-    /// Mapping added - UTXO mapping added for registration.
-    DustMappingAdded {
-        /// Cardano stake key address.
-        cardano_address: CardanoStakeKey,
-        /// DUST address.
-        dust_address: ByteVec,
-        /// UTXO identifier.
-        utxo_id: ByteVec,
-    },
-
-    /// Mapping removed - UTXO mapping removed for registration.
-    DustMappingRemoved {
-        /// Cardano stake key address.
-        cardano_address: CardanoStakeKey,
-        /// DUST address.
-        dust_address: ByteVec,
-        /// UTXO identifier.
-        utxo_id: ByteVec,
     },
 }
 
@@ -190,7 +151,7 @@ impl Default for DustParameters {
 /// DUST event type for database storage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "DUST_EVENT_TYPE", rename_all = "PascalCase")]
-pub enum DustEventType {
+pub enum DustEventVariant {
     /// Initial DUST UTXO creation.
     DustInitialUtxo,
 
@@ -199,30 +160,16 @@ pub enum DustEventType {
 
     /// DUST spend processed.
     DustSpendProcessed,
-
-    /// Registration event.
-    DustRegistration,
-
-    /// Deregistration event.
-    DustDeregistration,
-
-    /// Mapping added event.
-    DustMappingAdded,
-
-    /// Mapping removed event.
-    DustMappingRemoved,
 }
 
-impl From<&DustEventDetails> for DustEventType {
-    fn from(details: &DustEventDetails) -> Self {
+impl From<&DustEventAttributes> for DustEventVariant {
+    fn from(details: &DustEventAttributes) -> Self {
         match details {
-            DustEventDetails::DustInitialUtxo { .. } => Self::DustInitialUtxo,
-            DustEventDetails::DustGenerationDtimeUpdate { .. } => Self::DustGenerationDtimeUpdate,
-            DustEventDetails::DustSpendProcessed { .. } => Self::DustSpendProcessed,
-            DustEventDetails::DustRegistration { .. } => Self::DustRegistration,
-            DustEventDetails::DustDeregistration { .. } => Self::DustDeregistration,
-            DustEventDetails::DustMappingAdded { .. } => Self::DustMappingAdded,
-            DustEventDetails::DustMappingRemoved { .. } => Self::DustMappingRemoved,
+            DustEventAttributes::DustInitialUtxo { .. } => Self::DustInitialUtxo,
+            DustEventAttributes::DustGenerationDtimeUpdate { .. } => {
+                Self::DustGenerationDtimeUpdate
+            }
+            DustEventAttributes::DustSpendProcessed { .. } => Self::DustSpendProcessed,
         }
     }
 }

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -14,7 +14,7 @@
 use crate::domain::{
     ByteArray, ByteVec, NetworkId, PROTOCOL_VERSION_000_016_000, ProtocolVersion,
     dust::{
-        DustEvent, DustEventDetails, DustGenerationInfo, DustMerklePathEntry, DustParameters,
+        DustEvent, DustEventAttributes, DustGenerationInfo, DustMerklePathEntry, DustParameters,
         QualifiedDustOutput,
     },
     ledger::{
@@ -470,7 +470,7 @@ where
                     generation,
                     generation_index,
                     ..
-                } => Some(DustEventDetails::DustInitialUtxo {
+                } => Some(DustEventAttributes::DustInitialUtxo {
                     output: QualifiedDustOutput {
                         initial_value: output.initial_value,
                         owner: output.owner.0.0.to_bytes_le().into(),
@@ -518,7 +518,7 @@ where
                         })
                         .collect();
 
-                    Some(DustEventDetails::DustGenerationDtimeUpdate {
+                    Some(DustEventAttributes::DustGenerationDtimeUpdate {
                         generation_info: DustGenerationInfo {
                             night_utxo_hash: generation.nonce.0.0.into(),
                             value: generation.value,
@@ -539,7 +539,7 @@ where
                     v_fee,
                     declared_time,
                     ..
-                } => Some(DustEventDetails::DustSpendProcessed {
+                } => Some(DustEventAttributes::DustSpendProcessed {
                     commitment: commitment.0.0.to_bytes_le().into(),
                     commitment_index: *commitment_index,
                     nullifier: nullifier.0.0.to_bytes_le().into(),

--- a/indexer-tests/e2e.graphql
+++ b/indexer-tests/e2e.graphql
@@ -519,7 +519,7 @@ query DustEventsByTransactionQuery($transactionHash: HexEncoded!) {
     }
 }
 
-query RecentDustEventsQuery($limit: Int, $eventType: DustEventType) {
+query RecentDustEventsQuery($limit: Int, $eventType: DustEventVariant) {
     recentDustEvents(limit: $limit, eventType: $eventType) {
         transactionHash
         logicalSegment

--- a/indexer-tests/e2e.graphql
+++ b/indexer-tests/e2e.graphql
@@ -470,8 +470,8 @@ query DustEventsByTransactionQuery($transactionHash: HexEncoded!) {
         transactionHash
         logicalSegment
         physicalSegment
-        eventType
-        eventDetails {
+        eventVariant
+        eventAttributes {
             __typename
             ... on DustInitialUtxoDetails {
                 initialValue
@@ -519,13 +519,13 @@ query DustEventsByTransactionQuery($transactionHash: HexEncoded!) {
     }
 }
 
-query RecentDustEventsQuery($limit: Int, $eventType: DustEventVariant) {
-    recentDustEvents(limit: $limit, eventType: $eventType) {
+query RecentDustEventsQuery($limit: Int, $eventVariant: DustEventVariant) {
+    recentDustEvents(limit: $limit, eventVariant: $eventVariant) {
         transactionHash
         logicalSegment
         physicalSegment
-        eventType
-        eventDetails {
+        eventVariant
+        eventAttributes {
             __typename
             ... on DustInitialUtxoDetails {
                 initialValue

--- a/indexer-tests/src/e2e.rs
+++ b/indexer-tests/src/e2e.rs
@@ -1163,13 +1163,13 @@ async fn test_dust_events_queries(
 
                 // Validate and count event types.
                 match event.event_type {
-                    dust_events_by_transaction_query::DustEventType::DUST_INITIAL_UTXO => {
+                    dust_events_by_transaction_query::DustEventVariant::DUST_INITIAL_UTXO => {
                         dust_initial_utxo_count += 1;
                     }
-                    dust_events_by_transaction_query::DustEventType::DUST_GENERATION_DTIME_UPDATE => {
+                    dust_events_by_transaction_query::DustEventVariant::DUST_GENERATION_DTIME_UPDATE => {
                         dust_generation_update_count += 1;
                     }
-                    dust_events_by_transaction_query::DustEventType::DUST_SPEND_PROCESSED => {
+                    dust_events_by_transaction_query::DustEventVariant::DUST_SPEND_PROCESSED => {
                         dust_spend_processed_count += 1;
                     }
                     _ => {
@@ -1300,9 +1300,9 @@ async fn test_dust_comprehensive_coverage(
     // Even with no events, the queries should execute without errors.
     println!("Testing DUST event type filters...");
     let event_types = [
-        recent_dust_events_query::DustEventType::DUST_INITIAL_UTXO,
-        recent_dust_events_query::DustEventType::DUST_GENERATION_DTIME_UPDATE,
-        recent_dust_events_query::DustEventType::DUST_SPEND_PROCESSED,
+        recent_dust_events_query::DustEventVariant::DUST_INITIAL_UTXO,
+        recent_dust_events_query::DustEventVariant::DUST_GENERATION_DTIME_UPDATE,
+        recent_dust_events_query::DustEventVariant::DUST_SPEND_PROCESSED,
     ];
 
     for (i, event_type) in event_types.iter().enumerate() {
@@ -1329,7 +1329,7 @@ async fn test_dust_comprehensive_coverage(
         // Note: block_height is not available in DustEvent type
 
         // Type-specific validation through event_details field
-        if let recent_dust_events_query::DustEventType::DUST_INITIAL_UTXO = event.event_type {
+        if let recent_dust_events_query::DustEventVariant::DUST_INITIAL_UTXO = event.event_type {
             // Event details validation would go here if needed
         }
     }
@@ -1375,10 +1375,10 @@ async fn test_dust_comprehensive_coverage(
         let has_reward_events = recent_events.iter().any(|e| {
             matches!(
                 e.event_type,
-                recent_dust_events_query::DustEventType::DUST_INITIAL_UTXO
+                recent_dust_events_query::DustEventVariant::DUST_INITIAL_UTXO
             ) || matches!(
                 e.event_type,
-                recent_dust_events_query::DustEventType::DUST_SPEND_PROCESSED
+                recent_dust_events_query::DustEventVariant::DUST_SPEND_PROCESSED
             )
         });
         assert!(

--- a/indexer-tests/src/e2e.rs
+++ b/indexer-tests/src/e2e.rs
@@ -1162,7 +1162,7 @@ async fn test_dust_events_queries(
                 assert_eq!(event.transaction_hash, transaction.hash);
 
                 // Validate and count event types.
-                match event.event_type {
+                match event.event_variant {
                     dust_events_by_transaction_query::DustEventVariant::DUST_INITIAL_UTXO => {
                         dust_initial_utxo_count += 1;
                     }
@@ -1173,7 +1173,7 @@ async fn test_dust_events_queries(
                         dust_spend_processed_count += 1;
                     }
                     _ => {
-                        panic!("Invalid DUST event type: {:?}", event.event_type);
+                        panic!("Invalid DUST event type: {:?}", event.event_variant);
                     }
                 }
             }
@@ -1235,7 +1235,7 @@ async fn test_dust_events_queries(
     println!("Testing recentDustEvents query...");
     let variables = recent_dust_events_query::Variables {
         limit: Some(10),
-        event_type: None, // Get all event types.
+        event_variant: None, // Get all event types.
     };
     let recent_events = send_query::<RecentDustEventsQuery>(api_client, api_url, variables)
         .await?
@@ -1250,8 +1250,8 @@ async fn test_dust_events_queries(
         // Each event should have these fields (validation done by type system).
         // Just access them to ensure they exist.
         let _ = &event.transaction_hash;
-        let _ = &event.event_type;
-        let _ = &event.event_details;
+        let _ = &event.event_variant;
+        let _ = &event.event_attributes;
     }
 
     // Verify consistency: events should exist only if we found DUST-generating transactions.
@@ -1299,17 +1299,17 @@ async fn test_dust_comprehensive_coverage(
     // 1. Test all DUST event type filters.
     // Even with no events, the queries should execute without errors.
     println!("Testing DUST event type filters...");
-    let event_types = [
+    let event_variants = [
         recent_dust_events_query::DustEventVariant::DUST_INITIAL_UTXO,
         recent_dust_events_query::DustEventVariant::DUST_GENERATION_DTIME_UPDATE,
         recent_dust_events_query::DustEventVariant::DUST_SPEND_PROCESSED,
     ];
 
-    for (i, event_type) in event_types.iter().enumerate() {
-        println!("  Testing filter {}/{}...", i + 1, event_types.len());
+    for (i, event_variant) in event_variants.iter().enumerate() {
+        println!("  Testing filter {}/{}...", i + 1, event_variants.len());
         let variables = recent_dust_events_query::Variables {
             limit: Some(5),
-            event_type: Some(event_type.clone()),
+            event_variant: Some(event_variant.clone()),
         };
         let filtered_events = send_query::<RecentDustEventsQuery>(api_client, api_url, variables)
             .await?
@@ -1328,8 +1328,8 @@ async fn test_dust_comprehensive_coverage(
         // Cannot access private field, assume transaction_hash is valid
         // Note: block_height is not available in DustEvent type
 
-        // Type-specific validation through event_details field
-        if let recent_dust_events_query::DustEventVariant::DUST_INITIAL_UTXO = event.event_type {
+        // Type-specific validation through event_attributes field
+        if let recent_dust_events_query::DustEventVariant::DUST_INITIAL_UTXO = event.event_variant {
             // Event details validation would go here if needed
         }
     }
@@ -1338,7 +1338,7 @@ async fn test_dust_comprehensive_coverage(
     println!("Testing pagination with limit parameter...");
     let variables = recent_dust_events_query::Variables {
         limit: Some(1),
-        event_type: None,
+        event_variant: None,
     };
     let limited_events = send_query::<RecentDustEventsQuery>(api_client, api_url, variables)
         .await?
@@ -1374,10 +1374,10 @@ async fn test_dust_comprehensive_coverage(
         // At least some DUST events should be for block rewards.
         let has_reward_events = recent_events.iter().any(|e| {
             matches!(
-                e.event_type,
+                e.event_variant,
                 recent_dust_events_query::DustEventVariant::DUST_INITIAL_UTXO
             ) || matches!(
-                e.event_type,
+                e.event_variant,
                 recent_dust_events_query::DustEventVariant::DUST_SPEND_PROCESSED
             )
         });


### PR DESCRIPTION
Closes #353

## Summary
This PR addresses confusion around DUST event types identified during code review. It cleans up the type hierarchy and aligns naming with existing patterns in the codebase (e.g., ContractAction types).

## Changes
- **Remove unused registration variants**: Removed 4 registration event variants (`DustRegistration`, `DustDeregistration`, `DustMappingAdded`, `DustMappingRemoved`) from `DustEventAttributes` that were never used as DUST events - these go directly to `cnight_registrations` table
  - **Align naming with existing patterns**:
    - `DustEventType` → `DustEventVariant` (consistent with `ContractActionVariant`)
    - `DustEventDetails` → `DustEventAttributes` (consistent with `ContractActionAttributes`)
    - `ProcessedDustEvents` → `DustEventProjections` (clearer intent as event projections)
  - **Remove unused types**: Deleted `DustProcessingError` which was never used
  - **Fix clippy warnings**: Removed unnecessary borrows in `to_value()` calls
  - **Update GraphQL schema**: Regenerated schema and updated test queries to reflect new type names

## Context
The indexer stores DUST events in two forms:
  1. **Raw events** (`DustEvent`): Immutable audit log preserving blockchain events exactly as received
  2. **Projections** (`DustEventProjections`): Normalized, query-optimized views of the events

The confusion arose because registration events from the NativeTokenObservation pallet were included in the event enum but handled separately. This PR clarifies the separation between ledger DUST events (3 types) and node registration events (4 types).

  ## Testing
  - [x] All tests pass (`just test`)
  - [x] Code compiles without warnings (`just check`)
  - [x] Clippy passes (`just lint`)