### PR TITLE
chore: update upload-sarif-github-action to a0cd00c4

### DIFF
--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           repository: midnightntwrk/upload-sarif-github-action
-          ref: 8202d2182e4c0ebec293f9d9140c3378a2afe16e
+          ref: a0cd00c4e936a5c2fc10d73ef5f3371992350c05
           path: upload-sarif-github-action
           token: ${{ secrets.MIDNIGHTCI_REPO }}
 

--- a/.github/workflows/rust-security-scan.yaml
+++ b/.github/workflows/rust-security-scan.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: midnightntwrk/upload-sarif-github-action
-          ref: main
+          ref: a0cd00c4e936a5c2fc10d73ef5f3371992350c05
           path: upload-sarif-github-action
           token: ${{ secrets.MIDNIGHTCI_REPO }}
 


### PR DESCRIPTION
## Summary
Updating upload-sarif-github-action to latest main branch commit which includes Checkmarx CLI v2.3.35 upgrade.

## Context
- Checkmarx support (ticket #00254934) recommended upgrading to CLI v2.3.35
- We're experiencing intermittent race condition failures (10-20% failure rate) with CLI v2.3.29
- The upload-sarif-github-action PR upgrading CLI was merged (main branch: a0cd00c4)

## Changes
- Update checkmarx.yaml from `8202d218...` to `a0cd00c4...` (gets CLI v2.3.35)
- Pin rust-security-scan.yaml from `main` to `a0cd00c4...` (consistency and CLI v2.3.35)

## Testing Approach
Following Checkmarx support's suggestion to test v2.3.35, though release notes show no race condition fixes:
- Will monitor CI runs for "concurrent map read and map write" errors
- May need to re-run workflows multiple times due to intermittent nature (10-20% failure rate)
- Will document results as evidence for support ticket

## Note
I reviewed release notes for v2.3.30-v2.3.35 and found no mention of race condition fixes, concurrent map access fixes, or Viper configuration improvements. Testing anyway to provide concrete evidence to Checkmarx support that the issue persists and needs an actual code fix.