### PR TITLE
chore(deps): bump Rust to 1.90.0

### DIFF
--- a/.github/workflows/ci-cloud.yaml
+++ b/.github/workflows/ci-cloud.yaml
@@ -84,7 +84,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
-          toolchain: nightly-2025-08-07
+          toolchain: nightly-2025-09-19
 
       - name: Install just
         uses: taiki-e/install-action@v2
@@ -215,7 +215,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           components: rust-docs
-          toolchain: nightly-2025-08-07
+          toolchain: nightly-2025-09-19
 
       - name: Install just
         uses: taiki-e/install-action@v2

--- a/.github/workflows/ci-standalone.yaml
+++ b/.github/workflows/ci-standalone.yaml
@@ -81,7 +81,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
-          toolchain: nightly-2025-08-07
+          toolchain: nightly-2025-09-19
 
       - name: Install just
         uses: taiki-e/install-action@v2
@@ -206,7 +206,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           components: rust-docs
-          toolchain: nightly-2025-08-07
+          toolchain: nightly-2025-09-19
 
       - name: Install just
         uses: taiki-e/install-action@v2

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ set shell := ["bash", "-uc"]
 feature := "cloud"
 packages := "indexer-common chain-indexer wallet-indexer indexer-api indexer-standalone indexer-tests"
 rust_version := `grep channel rust-toolchain.toml | sed -r 's/channel = "(.*)"/\1/'`
-nightly := "nightly-2025-09-18"
+nightly := "nightly-2025-09-19"
 node_version := `cat NODE_VERSION`
 
 check:

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ set shell := ["bash", "-uc"]
 feature := "cloud"
 packages := "indexer-common chain-indexer wallet-indexer indexer-api indexer-standalone indexer-tests"
 rust_version := `grep channel rust-toolchain.toml | sed -r 's/channel = "(.*)"/\1/'`
-nightly := "nightly-2025-08-07"
+nightly := "nightly-2025-09-18"
 node_version := `cat NODE_VERSION`
 
 check:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.90.0"


### PR DESCRIPTION
Rust 1.90 includes a new default faster linker on linux: https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/