### PR TITLE
fix: remove incorrect assertion on stream ordering in chain-indexer

### DIFF
--- a/chain-indexer/src/application.rs
+++ b/chain-indexer/src/application.rs
@@ -360,8 +360,9 @@ async fn index_block(
 
     // Use saturating subtraction to handle the case where streams are temporarily out of order.
     // The two subscriptions (highest_blocks and finalized_blocks) are independent with no
-    // ordering guarantee, so node_block_height < block.height may happen under certain rare conditions.
-    // This will produce 0 when node_block_height < block.height, treating it as caught up.
+    // ordering guarantee, so node_block_height < block.height may happen under certain rare
+    // conditions. This will produce 0 when node_block_height < block.height, treating it as
+    // caught up.
     let distance = node_block_height.saturating_sub(block.height);
     let max_distance = if *caught_up {
         caught_up_max_distance + caught_up_leeway

--- a/chain-indexer/src/application.rs
+++ b/chain-indexer/src/application.rs
@@ -360,7 +360,7 @@ async fn index_block(
 
     // Use saturating subtraction to handle the case where streams are temporarily out of order.
     // The two subscriptions (highest_blocks and finalized_blocks) are independent with no
-    // ordering guarantee, so node_block_height < block.height is expected behavior.
+    // ordering guarantee, so node_block_height < block.height may happen under certain rare conditions.
     // This will produce 0 when node_block_height < block.height, treating it as caught up.
     let distance = node_block_height.saturating_sub(block.height);
     let max_distance = if *caught_up {


### PR DESCRIPTION
Fixes #367

## Summary
Removes an incorrect assertion that was causing panics when two independent subscription streams were temporarily out of order. This is normal async behavior, not a bug.

## Context
Simon Gellis reported assertion failures on EC2 instances (issue #367). His analysis was correct: the assertion incorrectly enforced ordering between two independent WebSocket subscriptions that have no ordering guarantee.

## The Problem
The code had two independent async tasks:
1. `highest_block_on_node_task` - subscribes to highest finalized blocks
2. `index_blocks_task` - processes blocks

The assertion `assert!(node_block_height >= block.height)` incorrectly assumed the first stream would always be ahead. This is false - they're independent subscriptions with no synchronization.

## The Fix
```diff
- assert!(node_block_height >= block.height);
- let distance = node_block_height - block.height;

+ // Use saturating subtraction - streams have no ordering guarantee
+ let distance = node_block_height.saturating_sub(block.height);
```

## Why This Is Correct
- **Industry standard**: No major blockchain indexer (Blockscout, The Graph, Subsquid) asserts ordering between independent streams
- **Expected behavior**: Streams being temporarily out of order is normal in async systems
- **Not a safety check**: The assertion wasn't protecting against invalid state
- **Graceful handling**: Saturating subtraction treats negative distances as 0 (caught up)