### PR TITLE
refactor: Rename GraphQL field from parameters to ledgerParameters

### DIFF
--- a/indexer-api/graphql/schema-v1.graphql
+++ b/indexer-api/graphql/schema-v1.graphql
@@ -33,7 +33,7 @@ type Block {
 	"""
 	The hex-encoded ledger parameters after this block.
 	"""
-	parameters: HexEncoded
+	ledgerParameters: HexEncoded
 }
 
 """

--- a/indexer-api/src/infra/api/v1/block.rs
+++ b/indexer-api/src/infra/api/v1/block.rs
@@ -83,7 +83,7 @@ where
     }
 
     /// The hex-encoded ledger parameters after this block.
-    async fn parameters(&self, cx: &Context<'_>) -> ApiResult<Option<HexEncoded>> {
+    async fn ledger_parameters(&self, cx: &Context<'_>) -> ApiResult<Option<HexEncoded>> {
         let parameters = cx
             .get_storage::<S>()
             .get_block_parameters(self.id)


### PR DESCRIPTION
As suggested by Simon in PM-19761, 'ledgerParameters' is more explicit than the generic 'parameters' field name. This makes it clear that these are specifically the ledger's parameters, not block parameters or something else.

jira comment : https://shielded.atlassian.net/browse/PM-19761?focusedCommentId=37230