### PR TITLE
feat: add DUST registration tracking to UnshieldedUtxo

### DIFF
--- a/chain-indexer/src/infra/storage.rs
+++ b/chain-indexer/src/infra/storage.rs
@@ -472,7 +472,7 @@ async fn save_unshielded_utxos(
     }
 
     if spent {
-        for utxo in utxos {
+        for &utxo in utxos {
             let query = indoc! {"
                 INSERT INTO unshielded_utxos (
                     creating_transaction_id,
@@ -483,7 +483,7 @@ async fn save_unshielded_utxos(
                     output_index,
                     intent_hash,
                     initial_nonce,
-                    is_registered_for_dust_generation
+                    registered_for_dust_generation
                 )
                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
                 ON CONFLICT (intent_hash, output_index)
@@ -498,19 +498,19 @@ async fn save_unshielded_utxos(
                 intent_hash,
                 output_index,
                 initial_nonce,
-                is_registered_for_dust_generation,
-            } = &utxo;
+                registered_for_dust_generation,
+            } = utxo;
 
             sqlx::query(query)
                 .bind(transaction_id)
                 .bind(transaction_id)
                 .bind(owner.as_ref())
                 .bind(token_type.as_ref())
-                .bind(U128BeBytes::from(*value))
-                .bind(*output_index as i32)
+                .bind(U128BeBytes::from(value))
+                .bind(output_index as i32)
                 .bind(intent_hash.as_ref())
                 .bind(initial_nonce.as_ref())
-                .bind(*is_registered_for_dust_generation)
+                .bind(registered_for_dust_generation)
                 .execute(&mut **tx)
                 .await?;
         }
@@ -524,7 +524,7 @@ async fn save_unshielded_utxos(
                 output_index,
                 intent_hash,
                 initial_nonce,
-                is_registered_for_dust_generation
+                registered_for_dust_generation
             )
         "};
 
@@ -537,17 +537,17 @@ async fn save_unshielded_utxos(
                     intent_hash,
                     output_index,
                     initial_nonce,
-                    is_registered_for_dust_generation,
+                    registered_for_dust_generation,
                 } = utxo;
 
                 q.push_bind(transaction_id)
                     .push_bind(owner.as_ref())
                     .push_bind(token_type.as_ref())
-                    .push_bind(U128BeBytes::from(*value))
+                    .push_bind(U128BeBytes::from(value))
                     .push_bind(*output_index as i32)
                     .push_bind(intent_hash.as_ref())
                     .push_bind(initial_nonce.as_ref())
-                    .push_bind(*is_registered_for_dust_generation);
+                    .push_bind(registered_for_dust_generation);
             })
             .build()
             .execute(&mut **tx)

--- a/indexer-api/graphql/schema-v1.graphql
+++ b/indexer-api/graphql/schema-v1.graphql
@@ -638,6 +638,14 @@ type UnshieldedUtxo {
 	"""
 	intentHash: HexEncoded!
 	"""
+	The hex-encoded initial nonce for DUST generation tracking.
+	"""
+	initialNonce: HexEncoded!
+	"""
+	Whether this UTXO is registered for DUST generation.
+	"""
+	isRegisteredForDustGeneration: Boolean!
+	"""
 	Transaction that created this UTXO.
 	"""
 	createdAtTransaction: Transaction!

--- a/indexer-api/graphql/schema-v1.graphql
+++ b/indexer-api/graphql/schema-v1.graphql
@@ -644,7 +644,7 @@ type UnshieldedUtxo {
 	"""
 	Whether this UTXO is registered for DUST generation.
 	"""
-	isRegisteredForDustGeneration: Boolean!
+	registeredForDustGeneration: Boolean!
 	"""
 	Transaction that created this UTXO.
 	"""

--- a/indexer-api/src/domain/unshielded.rs
+++ b/indexer-api/src/domain/unshielded.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use indexer_common::{
-    domain::{IntentHash, RawTokenType, RawUnshieldedAddress},
+    domain::{InitialNonce, IntentHash, RawTokenType, RawUnshieldedAddress},
     infra::sqlx::{SqlxOption, U128BeBytes},
 };
 use sqlx::FromRow;
@@ -44,6 +44,12 @@ pub struct UnshieldedUtxo {
 
     /// Hash of the intent that created this UTXO.
     pub intent_hash: IntentHash,
+
+    /// Initial nonce for DUST generation tracking.
+    pub initial_nonce: InitialNonce,
+
+    /// Whether this UTXO is registered for DUST generation.
+    pub is_registered_for_dust_generation: bool,
 }
 
 /// Token balance held by a contract.

--- a/indexer-api/src/domain/unshielded.rs
+++ b/indexer-api/src/domain/unshielded.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use indexer_common::{
-    domain::{InitialNonce, IntentHash, RawTokenType, RawUnshieldedAddress},
+    domain::{IntentHash, Nonce, RawTokenType, RawUnshieldedAddress},
     infra::sqlx::{SqlxOption, U128BeBytes},
 };
 use sqlx::FromRow;
@@ -46,10 +46,10 @@ pub struct UnshieldedUtxo {
     pub intent_hash: IntentHash,
 
     /// Initial nonce for DUST generation tracking.
-    pub initial_nonce: InitialNonce,
+    pub initial_nonce: Nonce,
 
     /// Whether this UTXO is registered for DUST generation.
-    pub is_registered_for_dust_generation: bool,
+    pub registered_for_dust_generation: bool,
 }
 
 /// Token balance held by a contract.

--- a/indexer-api/src/infra/api/v1/unshielded.rs
+++ b/indexer-api/src/infra/api/v1/unshielded.rs
@@ -60,7 +60,7 @@ where
     initial_nonce: HexEncoded,
 
     /// Whether this UTXO is registered for DUST generation.
-    is_registered_for_dust_generation: bool,
+    registered_for_dust_generation: bool,
 
     #[graphql(skip)]
     creating_transaction_id: u64,
@@ -122,7 +122,7 @@ where
             output_index: utxo.output_index,
             intent_hash: utxo.intent_hash.hex_encode(),
             initial_nonce: utxo.initial_nonce.hex_encode(),
-            is_registered_for_dust_generation: utxo.is_registered_for_dust_generation,
+            registered_for_dust_generation: utxo.registered_for_dust_generation,
             creating_transaction_id: utxo.creating_transaction_id,
             spending_transaction_id: utxo.spending_transaction_id,
             _s: PhantomData,

--- a/indexer-api/src/infra/api/v1/unshielded.rs
+++ b/indexer-api/src/infra/api/v1/unshielded.rs
@@ -56,6 +56,12 @@ where
     /// The hex-encoded serialized intent hash.
     intent_hash: HexEncoded,
 
+    /// The hex-encoded initial nonce for DUST generation tracking.
+    initial_nonce: HexEncoded,
+
+    /// Whether this UTXO is registered for DUST generation.
+    is_registered_for_dust_generation: bool,
+
     #[graphql(skip)]
     creating_transaction_id: u64,
 
@@ -115,6 +121,8 @@ where
             value: utxo.value.to_string(),
             output_index: utxo.output_index,
             intent_hash: utxo.intent_hash.hex_encode(),
+            initial_nonce: utxo.initial_nonce.hex_encode(),
+            is_registered_for_dust_generation: utxo.is_registered_for_dust_generation,
             creating_transaction_id: utxo.creating_transaction_id,
             spending_transaction_id: utxo.spending_transaction_id,
             _s: PhantomData,

--- a/indexer-api/src/infra/storage/unshielded.rs
+++ b/indexer-api/src/infra/storage/unshielded.rs
@@ -34,7 +34,9 @@ impl UnshieldedUtxoStorage for Storage {
                 token_type,
                 value,
                 output_index,
-                intent_hash
+                intent_hash,
+                initial_nonce,
+                is_registered_for_dust_generation
             FROM unshielded_utxos
             WHERE owner = $1
             ORDER BY id
@@ -62,7 +64,9 @@ impl UnshieldedUtxoStorage for Storage {
                 token_type,
                 value,
                 output_index,
-                intent_hash
+                intent_hash,
+                initial_nonce,
+                is_registered_for_dust_generation
             FROM unshielded_utxos
             WHERE creating_transaction_id = $1
             ORDER BY output_index
@@ -90,7 +94,9 @@ impl UnshieldedUtxoStorage for Storage {
                 token_type,
                 value,
                 output_index,
-                intent_hash
+                intent_hash,
+                initial_nonce,
+                is_registered_for_dust_generation
             FROM unshielded_utxos
             WHERE spending_transaction_id = $1
             ORDER BY output_index
@@ -119,7 +125,9 @@ impl UnshieldedUtxoStorage for Storage {
                 token_type,
                 value,
                 output_index,
-                intent_hash
+                intent_hash,
+                initial_nonce,
+                is_registered_for_dust_generation
             FROM unshielded_utxos
             WHERE creating_transaction_id = $1
             AND owner = $2
@@ -150,7 +158,9 @@ impl UnshieldedUtxoStorage for Storage {
                 token_type,
                 value,
                 output_index,
-                intent_hash
+                intent_hash,
+                initial_nonce,
+                is_registered_for_dust_generation
             FROM unshielded_utxos
             WHERE spending_transaction_id = $1
             AND owner = $2

--- a/indexer-api/src/infra/storage/unshielded.rs
+++ b/indexer-api/src/infra/storage/unshielded.rs
@@ -36,7 +36,7 @@ impl UnshieldedUtxoStorage for Storage {
                 output_index,
                 intent_hash,
                 initial_nonce,
-                is_registered_for_dust_generation
+                registered_for_dust_generation
             FROM unshielded_utxos
             WHERE owner = $1
             ORDER BY id
@@ -66,7 +66,7 @@ impl UnshieldedUtxoStorage for Storage {
                 output_index,
                 intent_hash,
                 initial_nonce,
-                is_registered_for_dust_generation
+                registered_for_dust_generation
             FROM unshielded_utxos
             WHERE creating_transaction_id = $1
             ORDER BY output_index
@@ -96,7 +96,7 @@ impl UnshieldedUtxoStorage for Storage {
                 output_index,
                 intent_hash,
                 initial_nonce,
-                is_registered_for_dust_generation
+                registered_for_dust_generation
             FROM unshielded_utxos
             WHERE spending_transaction_id = $1
             ORDER BY output_index
@@ -127,7 +127,7 @@ impl UnshieldedUtxoStorage for Storage {
                 output_index,
                 intent_hash,
                 initial_nonce,
-                is_registered_for_dust_generation
+                registered_for_dust_generation
             FROM unshielded_utxos
             WHERE creating_transaction_id = $1
             AND owner = $2
@@ -160,7 +160,7 @@ impl UnshieldedUtxoStorage for Storage {
                 output_index,
                 intent_hash,
                 initial_nonce,
-                is_registered_for_dust_generation
+                registered_for_dust_generation
             FROM unshielded_utxos
             WHERE spending_transaction_id = $1
             AND owner = $2

--- a/indexer-common/migrations/postgres/001_initial.sql
+++ b/indexer-common/migrations/postgres/001_initial.sql
@@ -83,7 +83,7 @@ CREATE TABLE unshielded_utxos (
   output_index BIGINT NOT NULL,
   intent_hash BYTEA NOT NULL,
   initial_nonce BYTEA NOT NULL,
-  is_registered_for_dust_generation BOOLEAN NOT NULL,
+  registered_for_dust_generation BOOLEAN NOT NULL,
   UNIQUE (intent_hash, output_index)
 );
 CREATE INDEX ON unshielded_utxos (creating_transaction_id);

--- a/indexer-common/migrations/postgres/001_initial.sql
+++ b/indexer-common/migrations/postgres/001_initial.sql
@@ -82,6 +82,8 @@ CREATE TABLE unshielded_utxos (
   value BYTEA NOT NULL,
   output_index BIGINT NOT NULL,
   intent_hash BYTEA NOT NULL,
+  initial_nonce BYTEA NOT NULL,
+  is_registered_for_dust_generation BOOLEAN NOT NULL,
   UNIQUE (intent_hash, output_index)
 );
 CREATE INDEX ON unshielded_utxos (creating_transaction_id);

--- a/indexer-common/migrations/sqlite/001_initial.sql
+++ b/indexer-common/migrations/sqlite/001_initial.sql
@@ -76,6 +76,8 @@ CREATE TABLE unshielded_utxos (
   value BLOB NOT NULL,
   output_index INTEGER NOT NULL,
   intent_hash BLOB NOT NULL,
+  initial_nonce BLOB NOT NULL,
+  is_registered_for_dust_generation INTEGER NOT NULL,
   UNIQUE (intent_hash, output_index)
 );
 CREATE INDEX unshielded_creating_idx ON unshielded_utxos (creating_transaction_id);

--- a/indexer-common/migrations/sqlite/001_initial.sql
+++ b/indexer-common/migrations/sqlite/001_initial.sql
@@ -77,7 +77,7 @@ CREATE TABLE unshielded_utxos (
   output_index INTEGER NOT NULL,
   intent_hash BLOB NOT NULL,
   initial_nonce BLOB NOT NULL,
-  is_registered_for_dust_generation INTEGER NOT NULL,
+  registered_for_dust_generation INTEGER NOT NULL,
   UNIQUE (intent_hash, output_index)
 );
 CREATE INDEX unshielded_creating_idx ON unshielded_utxos (creating_transaction_id);

--- a/indexer-common/src/domain.rs
+++ b/indexer-common/src/domain.rs
@@ -35,6 +35,7 @@ use sqlx::Type;
 pub type BlockAuthor = ByteArray<32>;
 pub type BlockHash = ByteArray<32>;
 pub type DustNonce = ByteArray<32>;
+pub type InitialNonce = ByteArray<32>;
 pub type IntentHash = ByteArray<32>;
 pub type RawTokenType = ByteArray<32>;
 pub type RawUnshieldedAddress = ByteArray<32>;
@@ -120,13 +121,15 @@ pub struct TransactionStructure {
 }
 
 /// An unshielded UTXO.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnshieldedUtxo {
     pub owner: RawUnshieldedAddress,
     pub token_type: RawTokenType,
     pub value: u128,
     pub intent_hash: IntentHash,
     pub output_index: u32,
+    pub initial_nonce: InitialNonce,
+    pub is_registered_for_dust_generation: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/indexer-common/src/domain.rs
+++ b/indexer-common/src/domain.rs
@@ -34,8 +34,7 @@ use sqlx::Type;
 
 pub type BlockAuthor = ByteArray<32>;
 pub type BlockHash = ByteArray<32>;
-pub type DustNonce = ByteArray<32>;
-pub type InitialNonce = ByteArray<32>;
+pub type Nonce = ByteArray<32>;
 pub type IntentHash = ByteArray<32>;
 pub type RawTokenType = ByteArray<32>;
 pub type RawUnshieldedAddress = ByteArray<32>;
@@ -121,15 +120,15 @@ pub struct TransactionStructure {
 }
 
 /// An unshielded UTXO.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UnshieldedUtxo {
     pub owner: RawUnshieldedAddress,
     pub token_type: RawTokenType,
     pub value: u128,
     pub intent_hash: IntentHash,
     pub output_index: u32,
-    pub initial_nonce: InitialNonce,
-    pub is_registered_for_dust_generation: bool,
+    pub initial_nonce: Nonce,
+    pub registered_for_dust_generation: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -206,7 +205,7 @@ pub enum LedgerEventAttributes {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DustOutput {
-    pub nonce: DustNonce,
+    pub nonce: Nonce,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -12,8 +12,8 @@
 // limitations under the License.
 
 use crate::domain::{
-    ApplyRegularTransactionResult, ByteArray, ByteVec, DustOutput, IntentHash, LedgerEvent,
-    NetworkId, PROTOCOL_VERSION_000_016_000, ProtocolVersion, RawTokenType,
+    ApplyRegularTransactionResult, ByteArray, ByteVec, DustOutput, InitialNonce, IntentHash,
+    LedgerEvent, NetworkId, PROTOCOL_VERSION_000_016_000, ProtocolVersion, RawTokenType,
     SerializedContractAddress, SerializedLedgerParameters, SerializedLedgerState,
     SerializedTransaction, SerializedZswapState, SerializedZswapStateRoot, TransactionResult,
     UnshieldedUtxo,
@@ -22,7 +22,8 @@ use crate::domain::{
 use fastrace::trace;
 use itertools::Itertools;
 use midnight_base_crypto_v6::{
-    cost_model::SyntheticCost as SyntheticCostV6, hash::HashOutput as HashOutputV6,
+    cost_model::SyntheticCost as SyntheticCostV6,
+    hash::{HashOutput as HashOutputV6, persistent_commit},
     time::Timestamp as TimestampV6,
 };
 use midnight_coin_structure_v6::{
@@ -30,6 +31,7 @@ use midnight_coin_structure_v6::{
     contract::ContractAddress as ContractAddressV6,
 };
 use midnight_ledger_v6::{
+    dust::InitialNonce as InitialNonceV6,
     events::{Event as EventV6, EventDetails as EventDetailsV6},
     semantics::{
         TransactionContext as TransactionContextV6, TransactionResult as TransactionResultV6,
@@ -161,8 +163,15 @@ impl LedgerState {
                     TransactionResultV6::Failure(_) => (TransactionResult::Failure, vec![]),
                 };
 
-                let (created_unshielded_utxos, spent_unshielded_utxos) =
-                    make_unshielded_utxos_v6(ledger_transaction, &transaction_result);
+                let ledger_state_ref = match self {
+                    Self::V6 { ledger_state, .. } => ledger_state,
+                };
+
+                let (created_unshielded_utxos, spent_unshielded_utxos) = make_unshielded_utxos_v6(
+                    ledger_transaction,
+                    &transaction_result,
+                    ledger_state_ref,
+                );
 
                 let ledger_events = make_ledger_events_v6(events)?;
 
@@ -351,9 +360,30 @@ fn timestamp_v6(block_timestamp: u64) -> TimestampV6 {
     TimestampV6::from_secs(block_timestamp / 1000)
 }
 
+fn compute_initial_nonce_v6(output_index: u32, intent_hash: IntentHash) -> InitialNonce {
+    let intent_hash_v6 = HashOutputV6(intent_hash.0);
+    let initial_nonce = InitialNonceV6(persistent_commit(&output_index, intent_hash_v6));
+    ByteArray(initial_nonce.0.0)
+}
+
+fn is_registered_for_dust_generation_v6(
+    output_index: u32,
+    intent_hash: IntentHash,
+    ledger_state: &LedgerStateV6<DefaultDBV6>,
+) -> bool {
+    let intent_hash_v6 = HashOutputV6(intent_hash.0);
+    let initial_nonce = InitialNonceV6(persistent_commit(&output_index, intent_hash_v6));
+    ledger_state
+        .dust
+        .generation
+        .night_indices
+        .contains_key(&initial_nonce)
+}
+
 fn make_unshielded_utxos_v6(
     ledger_transaction: TransactionV6,
     transaction_result: &TransactionResult,
+    ledger_state: &LedgerStateV6<DefaultDBV6>,
 ) -> (Vec<UnshieldedUtxo>, Vec<UnshieldedUtxo>) {
     match ledger_transaction {
         TransactionV6::Standard(transaction) => {
@@ -376,14 +406,28 @@ fn make_unshielded_utxos_v6(
                 // Guaranteed phase.
                 if segment == 0 {
                     for intent in transaction.intents.values() {
-                        extend_v6(&mut outputs, &mut inputs, segment, &intent, true);
+                        extend_v6(
+                            &mut outputs,
+                            &mut inputs,
+                            segment,
+                            &intent,
+                            true,
+                            ledger_state,
+                        );
                     }
 
                 // Fallible phase.
                 } else if let Some(intent) = transaction.intents.get(&segment)
                     && successful_segments.contains(&segment)
                 {
-                    extend_v6(&mut outputs, &mut inputs, segment, &intent, false);
+                    extend_v6(
+                        &mut outputs,
+                        &mut inputs,
+                        segment,
+                        &intent,
+                        false,
+                        ledger_state,
+                    );
                 }
             }
 
@@ -394,13 +438,20 @@ fn make_unshielded_utxos_v6(
             // ClaimRewards creates a single unshielded UTXO for the claimed amount.
             let owner = UserAddressV6::from(claim.owner.clone());
             let intent_hash = compute_claim_rewards_intent_hash(&owner, claim.value, &claim.nonce);
+            let output_index = 0;
+
+            let initial_nonce = compute_initial_nonce_v6(output_index, intent_hash);
+            let is_registered =
+                is_registered_for_dust_generation_v6(output_index, intent_hash, ledger_state);
 
             let utxo = UnshieldedUtxo {
                 owner: owner.0.0.into(),
                 token_type: RawTokenType::default(), // Native token (all zeros).
                 value: claim.value,
                 intent_hash,
-                output_index: 0,
+                output_index,
+                initial_nonce,
+                is_registered_for_dust_generation: is_registered,
             };
             (vec![utxo], vec![]) // Creates one UTXO, spends none.
         }
@@ -453,6 +504,7 @@ fn extend_v6(
     segment_id: u16,
     intent: &IntentV6,
     guaranteed: bool,
+    ledger_state: &LedgerStateV6<DefaultDBV6>,
 ) {
     let intent_hash = intent
         .erase_proofs()
@@ -468,12 +520,21 @@ fn extend_v6(
     let intent_outputs = intent_outputs
         .into_iter()
         .enumerate()
-        .map(|(output_index, output)| UnshieldedUtxo {
-            owner: output.owner.0.0.into(),
-            token_type: output.type_.0.0.into(),
-            value: output.value,
-            intent_hash,
-            output_index: output_index as u32,
+        .map(|(output_index, output)| {
+            let output_index_u32 = output_index as u32;
+            let initial_nonce = compute_initial_nonce_v6(output_index_u32, intent_hash);
+            let is_registered =
+                is_registered_for_dust_generation_v6(output_index_u32, intent_hash, ledger_state);
+
+            UnshieldedUtxo {
+                owner: output.owner.0.0.into(),
+                token_type: output.type_.0.0.into(),
+                value: output.value,
+                intent_hash,
+                output_index: output_index_u32,
+                initial_nonce,
+                is_registered_for_dust_generation: is_registered,
+            }
         });
     outputs.extend(intent_outputs);
 
@@ -482,12 +543,20 @@ fn extend_v6(
     } else {
         intent.fallible_inputs()
     };
-    let intent_inputs = intent_inputs.into_iter().map(|spend| UnshieldedUtxo {
-        owner: UserAddressV6::from(spend.owner).0.0.into(),
-        token_type: spend.type_.0.0.into(),
-        value: spend.value,
-        intent_hash,
-        output_index: spend.output_no,
+    let intent_inputs = intent_inputs.into_iter().map(|spend| {
+        let initial_nonce = compute_initial_nonce_v6(spend.output_no, intent_hash);
+        let is_registered =
+            is_registered_for_dust_generation_v6(spend.output_no, intent_hash, ledger_state);
+
+        UnshieldedUtxo {
+            owner: UserAddressV6::from(spend.owner).0.0.into(),
+            token_type: spend.type_.0.0.into(),
+            value: spend.value,
+            intent_hash,
+            output_index: spend.output_no,
+            initial_nonce,
+            is_registered_for_dust_generation: is_registered,
+        }
     });
     inputs.extend(intent_inputs);
 }

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -12,8 +12,8 @@
 // limitations under the License.
 
 use crate::domain::{
-    ApplyRegularTransactionResult, ByteArray, ByteVec, DustOutput, InitialNonce, IntentHash,
-    LedgerEvent, NetworkId, PROTOCOL_VERSION_000_016_000, ProtocolVersion, RawTokenType,
+    ApplyRegularTransactionResult, ByteArray, ByteVec, DustOutput, IntentHash, LedgerEvent,
+    NetworkId, Nonce, PROTOCOL_VERSION_000_016_000, ProtocolVersion, RawTokenType,
     SerializedContractAddress, SerializedLedgerParameters, SerializedLedgerState,
     SerializedTransaction, SerializedZswapState, SerializedZswapStateRoot, TransactionResult,
     UnshieldedUtxo,
@@ -23,7 +23,7 @@ use fastrace::trace;
 use itertools::Itertools;
 use midnight_base_crypto_v6::{
     cost_model::SyntheticCost as SyntheticCostV6,
-    hash::{HashOutput as HashOutputV6, persistent_commit},
+    hash::{HashOutput as HashOutputV6, persistent_commit as persistent_commit_v6},
     time::Timestamp as TimestampV6,
 };
 use midnight_coin_structure_v6::{
@@ -43,7 +43,9 @@ use midnight_ledger_v6::{
     verify::WellFormedStrictness as WellFormedStrictnessV6,
 };
 use midnight_onchain_runtime_v6::context::BlockContext as BlockContextV6;
-use midnight_serialize_v6::{Deserializable, tagged_deserialize as tagged_deserialize_v6};
+use midnight_serialize_v6::{
+    Deserializable as DeserializableV6, tagged_deserialize as tagged_deserialize_v6,
+};
 use midnight_storage_v6::DefaultDB as DefaultDBV6;
 use midnight_transient_crypto_v6::merkle_tree::{
     MerkleTreeCollapsedUpdate as MerkleTreeCollapsedUpdateV6,
@@ -144,11 +146,6 @@ impl LedgerState {
                     ledger_state.apply(&verified_ledger_transaction, &cx);
                 let block_fullness = *block_fullness + cost;
 
-                *self = Self::V6 {
-                    ledger_state,
-                    block_fullness,
-                };
-
                 let (transaction_result, events) = match transaction_result {
                     TransactionResultV6::Success(events) => (TransactionResult::Success, events),
 
@@ -163,17 +160,18 @@ impl LedgerState {
                     TransactionResultV6::Failure(_) => (TransactionResult::Failure, vec![]),
                 };
 
-                let ledger_state_ref = match self {
-                    Self::V6 { ledger_state, .. } => ledger_state,
-                };
+                let ledger_events = make_ledger_events_v6(events)?;
 
                 let (created_unshielded_utxos, spent_unshielded_utxos) = make_unshielded_utxos_v6(
                     ledger_transaction,
                     &transaction_result,
-                    ledger_state_ref,
+                    &ledger_state,
                 );
 
-                let ledger_events = make_ledger_events_v6(events)?;
+                *self = Self::V6 {
+                    ledger_state,
+                    block_fullness,
+                };
 
                 Ok(ApplyRegularTransactionResult {
                     transaction_result,
@@ -209,12 +207,12 @@ impl LedgerState {
                     .map_err(|error| Error::SystemTransaction(error.into()))?;
                 let block_fullness = *block_fullness + cost;
 
+                let ledger_events = make_ledger_events_v6(events)?;
+
                 *self = Self::V6 {
                     ledger_state,
                     block_fullness,
                 };
-
-                let ledger_events = make_ledger_events_v6(events)?;
 
                 Ok(ledger_events)
             }
@@ -360,104 +358,6 @@ fn timestamp_v6(block_timestamp: u64) -> TimestampV6 {
     TimestampV6::from_secs(block_timestamp / 1000)
 }
 
-fn compute_initial_nonce_v6(output_index: u32, intent_hash: IntentHash) -> InitialNonce {
-    let intent_hash_v6 = HashOutputV6(intent_hash.0);
-    let initial_nonce = InitialNonceV6(persistent_commit(&output_index, intent_hash_v6));
-    ByteArray(initial_nonce.0.0)
-}
-
-fn is_registered_for_dust_generation_v6(
-    output_index: u32,
-    intent_hash: IntentHash,
-    ledger_state: &LedgerStateV6<DefaultDBV6>,
-) -> bool {
-    let intent_hash_v6 = HashOutputV6(intent_hash.0);
-    let initial_nonce = InitialNonceV6(persistent_commit(&output_index, intent_hash_v6));
-    ledger_state
-        .dust
-        .generation
-        .night_indices
-        .contains_key(&initial_nonce)
-}
-
-fn make_unshielded_utxos_v6(
-    ledger_transaction: TransactionV6,
-    transaction_result: &TransactionResult,
-    ledger_state: &LedgerStateV6<DefaultDBV6>,
-) -> (Vec<UnshieldedUtxo>, Vec<UnshieldedUtxo>) {
-    match ledger_transaction {
-        TransactionV6::Standard(transaction) => {
-            let successful_segments = match &transaction_result {
-                TransactionResult::Success => transaction.segments().into_iter().collect(),
-
-                TransactionResult::PartialSuccess(segments) => segments
-                    .iter()
-                    .filter_map(|(id, success)| success.then_some(id))
-                    .copied()
-                    .collect(),
-
-                TransactionResult::Failure => HashSet::new(),
-            };
-
-            let mut outputs = vec![];
-            let mut inputs = vec![];
-
-            for segment in transaction.segments() {
-                // Guaranteed phase.
-                if segment == 0 {
-                    for intent in transaction.intents.values() {
-                        extend_v6(
-                            &mut outputs,
-                            &mut inputs,
-                            segment,
-                            &intent,
-                            true,
-                            ledger_state,
-                        );
-                    }
-
-                // Fallible phase.
-                } else if let Some(intent) = transaction.intents.get(&segment)
-                    && successful_segments.contains(&segment)
-                {
-                    extend_v6(
-                        &mut outputs,
-                        &mut inputs,
-                        segment,
-                        &intent,
-                        false,
-                        ledger_state,
-                    );
-                }
-            }
-
-            (outputs, inputs)
-        }
-
-        TransactionV6::ClaimRewards(claim) => {
-            // ClaimRewards creates a single unshielded UTXO for the claimed amount.
-            let owner = UserAddressV6::from(claim.owner.clone());
-            let intent_hash = compute_claim_rewards_intent_hash(&owner, claim.value, &claim.nonce);
-            let output_index = 0;
-
-            let initial_nonce = compute_initial_nonce_v6(output_index, intent_hash);
-            let is_registered =
-                is_registered_for_dust_generation_v6(output_index, intent_hash, ledger_state);
-
-            let utxo = UnshieldedUtxo {
-                owner: owner.0.0.into(),
-                token_type: RawTokenType::default(), // Native token (all zeros).
-                value: claim.value,
-                intent_hash,
-                output_index,
-                initial_nonce,
-                is_registered_for_dust_generation: is_registered,
-            };
-            (vec![utxo], vec![]) // Creates one UTXO, spends none.
-        }
-    }
-}
-
 fn make_ledger_events_v6(events: Vec<EventV6<DefaultDBV6>>) -> Result<Vec<LedgerEvent>, Error> {
     events
         .into_iter()
@@ -498,7 +398,87 @@ fn make_ledger_events_v6(events: Vec<EventV6<DefaultDBV6>>) -> Result<Vec<Ledger
         .collect::<Result<_, _>>()
 }
 
-fn extend_v6(
+fn make_unshielded_utxos_v6(
+    ledger_transaction: TransactionV6,
+    transaction_result: &TransactionResult,
+    ledger_state: &LedgerStateV6<DefaultDBV6>,
+) -> (Vec<UnshieldedUtxo>, Vec<UnshieldedUtxo>) {
+    match ledger_transaction {
+        TransactionV6::Standard(transaction) => {
+            let successful_segments = match &transaction_result {
+                TransactionResult::Success => transaction.segments().into_iter().collect(),
+
+                TransactionResult::PartialSuccess(segments) => segments
+                    .iter()
+                    .filter_map(|(id, success)| success.then_some(id))
+                    .copied()
+                    .collect(),
+
+                TransactionResult::Failure => HashSet::new(),
+            };
+
+            let mut outputs = vec![];
+            let mut inputs = vec![];
+
+            for segment in transaction.segments() {
+                // Guaranteed phase.
+                if segment == 0 {
+                    for intent in transaction.intents.values() {
+                        extend_unshielded_utxos_v6(
+                            &mut outputs,
+                            &mut inputs,
+                            segment,
+                            &intent,
+                            true,
+                            ledger_state,
+                        );
+                    }
+
+                // Fallible phase.
+                } else if let Some(intent) = transaction.intents.get(&segment)
+                    && successful_segments.contains(&segment)
+                {
+                    extend_unshielded_utxos_v6(
+                        &mut outputs,
+                        &mut inputs,
+                        segment,
+                        &intent,
+                        false,
+                        ledger_state,
+                    );
+                }
+            }
+
+            (outputs, inputs)
+        }
+
+        TransactionV6::ClaimRewards(claim) => {
+            // ClaimRewards creates a single unshielded UTXO for the claimed amount.
+            let owner = UserAddressV6::from(claim.owner.clone());
+            let intent_hash =
+                compute_claim_rewards_intent_hash_v6(&owner, claim.value, &claim.nonce);
+            let output_index = 0;
+
+            let initial_nonce = make_initial_nonce_v6(output_index, intent_hash);
+            let registered_for_dust_generation =
+                registered_for_dust_generation_v6(output_index, intent_hash, ledger_state);
+
+            let utxo = UnshieldedUtxo {
+                owner: owner.0.0.into(),
+                token_type: RawTokenType::default(), // Native token (all zeros).
+                value: claim.value,
+                intent_hash,
+                output_index,
+                initial_nonce,
+                registered_for_dust_generation,
+            };
+
+            (vec![utxo], vec![]) // Creates one UTXO, spends none.
+        }
+    }
+}
+
+fn extend_unshielded_utxos_v6(
     outputs: &mut Vec<UnshieldedUtxo>,
     inputs: &mut Vec<UnshieldedUtxo>,
     segment_id: u16,
@@ -521,19 +501,19 @@ fn extend_v6(
         .into_iter()
         .enumerate()
         .map(|(output_index, output)| {
-            let output_index_u32 = output_index as u32;
-            let initial_nonce = compute_initial_nonce_v6(output_index_u32, intent_hash);
-            let is_registered =
-                is_registered_for_dust_generation_v6(output_index_u32, intent_hash, ledger_state);
+            let output_index = output_index as u32;
+            let initial_nonce = make_initial_nonce_v6(output_index, intent_hash);
+            let registered_for_dust_generation =
+                registered_for_dust_generation_v6(output_index, intent_hash, ledger_state);
 
             UnshieldedUtxo {
                 owner: output.owner.0.0.into(),
                 token_type: output.type_.0.0.into(),
                 value: output.value,
                 intent_hash,
-                output_index: output_index_u32,
+                output_index,
                 initial_nonce,
-                is_registered_for_dust_generation: is_registered,
+                registered_for_dust_generation,
             }
         });
     outputs.extend(intent_outputs);
@@ -544,9 +524,9 @@ fn extend_v6(
         intent.fallible_inputs()
     };
     let intent_inputs = intent_inputs.into_iter().map(|spend| {
-        let initial_nonce = compute_initial_nonce_v6(spend.output_no, intent_hash);
-        let is_registered =
-            is_registered_for_dust_generation_v6(spend.output_no, intent_hash, ledger_state);
+        let initial_nonce = make_initial_nonce_v6(spend.output_no, intent_hash);
+        let registered_for_dust_generation =
+            registered_for_dust_generation_v6(spend.output_no, intent_hash, ledger_state);
 
         UnshieldedUtxo {
             owner: UserAddressV6::from(spend.owner).0.0.into(),
@@ -555,23 +535,45 @@ fn extend_v6(
             intent_hash,
             output_index: spend.output_no,
             initial_nonce,
-            is_registered_for_dust_generation: is_registered,
+            registered_for_dust_generation,
         }
     });
     inputs.extend(intent_inputs);
 }
 
+fn make_initial_nonce_v6(output_index: u32, intent_hash: IntentHash) -> Nonce {
+    let intent_hash_v6 = HashOutputV6(intent_hash.0);
+    let initial_nonce = InitialNonceV6(persistent_commit_v6(&output_index, intent_hash_v6));
+    ByteArray(initial_nonce.0.0)
+}
+
+fn registered_for_dust_generation_v6(
+    output_index: u32,
+    intent_hash: IntentHash,
+    ledger_state: &LedgerStateV6<DefaultDBV6>,
+) -> bool {
+    let intent_hash_v6 = HashOutputV6(intent_hash.0);
+    let initial_nonce = InitialNonceV6(persistent_commit_v6(&output_index, intent_hash_v6));
+    ledger_state
+        .dust
+        .generation
+        .night_indices
+        .contains_key(&initial_nonce)
+}
+
 /// Compute a pseudo-intent-hash for ClaimRewards transactions.
 /// ClaimRewards don't have intents, but we need a unique hash for database constraints.
 /// We use a hash of (owner || value || nonce) to ensure uniqueness.
-fn compute_claim_rewards_intent_hash(
+fn compute_claim_rewards_intent_hash_v6(
     owner: &UserAddressV6,
     value: u128,
     nonce: &NonceV6,
 ) -> IntentHash {
     let mut hasher = Sha256::new();
+
     hasher.update(owner.0.0);
     hasher.update(value.to_le_bytes());
     hasher.update(nonce.0.0);
+
     ByteArray(hasher.finalize().into())
 }

--- a/indexer-common/src/infra/sqlx.rs
+++ b/indexer-common/src/infra/sqlx.rs
@@ -40,6 +40,12 @@ impl From<u128> for U128BeBytes {
     }
 }
 
+impl From<&u128> for U128BeBytes {
+    fn from(value: &u128) -> Self {
+        Self(value.to_be_bytes())
+    }
+}
+
 impl From<U128BeBytes> for u128 {
     fn from(value: U128BeBytes) -> Self {
         u128::from_be_bytes(value.0)


### PR DESCRIPTION
### Summary
Adds DUST generation registration tracking to the `UnshieldedUtxo` type by introducing two new fields: `initial_nonce` and `is_registered_for_dust_generation`. This enables the wallet to track which Night tokens have been registered for DUST generation.

### Context
The wallet needs to identify which unshielded UTXOs are registered for DUST generation. This requires:
1. Computing the `initial_nonce` for each UTXO using the formula: `InitialNonce(persistent_commit(&output_index, intent_hash))`
2. Checking registration status against `LedgerState.dust.generation.night_indices`

This implementation became possible with ledger-6.1.0-alpha.3, which made the required cryptographic functions publicly accessible (via Jegor's wallet PR 50).

### Changes Made

**Domain Layer** (`indexer-common`):
- Added semantic type alias `InitialNonce = ByteArray<32>` to `domain.rs`
- Added `initial_nonce: InitialNonce` field to `UnshieldedUtxo` struct
- Added `is_registered_for_dust_generation: bool` field to `UnshieldedUtxo` struct
- Removed `Copy` trait from `UnshieldedUtxo` (incompatible with `ByteArray<32>`)
- Implemented `compute_initial_nonce_v6()` helper using `persistent_commit`
- Implemented `is_registered_for_dust_generation_v6()` helper that checks `ledger_state.dust.generation.night_indices`
- Updated both standard transaction and ClaimRewards transaction handling

**Storage Layer** (`chain-indexer`, `indexer-common/migrations`):
- Added `initial_nonce BYTEA NOT NULL` column to PostgreSQL schema
- Added `is_registered_for_dust_generation BOOLEAN NOT NULL` column to PostgreSQL schema
- Added corresponding columns to SQLite schema (using `INTEGER` for boolean)
- Updated all INSERT queries in `chain-indexer/src/infra/storage.rs` (both spent and unspent branches)

**API Layer** (`indexer-api`):
- Added fields to API domain `UnshieldedUtxo` struct with proper sqlx attributes
- Added fields to GraphQL schema with documentation comments
- Updated `From` trait implementation for domain-to-API conversions
- Updated all 5 SELECT queries in `indexer-api/src/infra/storage/unshielded.rs`

### Related
- Implements PM-19681
- Depends on ledger-6.1.0-alpha.3 (Jegor's wallet PR 50)
- Related to Slack discussion on 25 Sep about ClaimRewards support : https://shielded.slack.com/archives/C080DB8JBT6/p1758812411631789
