### PR TITLE
chore(build): renovate use semantic commits

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices"
+    "config:best-practices",
+    "security:openssf-scorecard",
+    ":semanticCommits"
   ],
   "dependencyDashboard": true,
   "enabled": true


### PR DESCRIPTION
Otherwise renovate will attempt to detect semantic commits, this forces it to do so all the time.

Also shows open scorecard of updated dependencies in PRs (information only change).
