### PR TITLE
fix: use same intent hash for ClaimRewards as ledger

### DIFF
--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -27,7 +27,7 @@ use midnight_base_crypto_v6::{
     time::Timestamp as TimestampV6,
 };
 use midnight_coin_structure_v6::{
-    coin::{Nonce as NonceV6, UserAddress as UserAddressV6},
+    coin::{NIGHT as NIGHTV6, Nonce as NonceV6, UserAddress as UserAddressV6},
     contract::ContractAddress as ContractAddressV6,
 };
 use midnight_ledger_v6::{
@@ -38,6 +38,7 @@ use midnight_ledger_v6::{
     },
     structure::{
         LedgerParameters as LedgerParametersV6, LedgerState as LedgerStateV6,
+        OutputInstructionUnshielded as OutputInstructionUnshieldedV6,
         SystemTransaction as LedgerSystemTransactionV6,
     },
     verify::WellFormedStrictness as WellFormedStrictnessV6,
@@ -52,7 +53,6 @@ use midnight_transient_crypto_v6::merkle_tree::{
     MerkleTreeDigest as MerkleTreeDigestV6,
 };
 use midnight_zswap_v6::ledger::State as ZswapStateV6;
-use sha2::{Digest, Sha256};
 use std::{collections::HashSet, ops::Deref, sync::LazyLock};
 
 static STRICTNESS_V6: LazyLock<WellFormedStrictnessV6> = LazyLock::new(|| {
@@ -569,11 +569,11 @@ fn compute_claim_rewards_intent_hash_v6(
     value: u128,
     nonce: &NonceV6,
 ) -> IntentHash {
-    let mut hasher = Sha256::new();
+    let output = OutputInstructionUnshieldedV6 {
+        amount: value,
+        target_address: *owner,
+        nonce: *nonce,
+    };
 
-    hasher.update(owner.0.0);
-    hasher.update(value.to_le_bytes());
-    hasher.update(nonce.0.0);
-
-    ByteArray(hasher.finalize().into())
+    ByteArray(output.mk_intent_hash(NIGHTV6).0.0)
 }

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -561,9 +561,9 @@ fn registered_for_dust_generation_v6(
         .contains_key(&initial_nonce)
 }
 
-/// Compute a pseudo-intent-hash for ClaimRewards transactions.
-/// ClaimRewards don't have intents, but we need a unique hash for database constraints.
-/// We use a hash of (owner || value || nonce) to ensure uniqueness.
+/// Compute the intent hash for ClaimRewards transactions.
+/// ClaimRewards don't have intents, but UTXOs need an intent hash.
+/// We compute this hash the same way that the ledger does internally.
 fn compute_claim_rewards_intent_hash_v6(
     owner: &UserAddressV6,
     value: u128,

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -577,3 +577,36 @@ fn compute_claim_rewards_intent_hash_v6(
 
     ByteArray(output.mk_intent_hash(NIGHTV6).0.0)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::domain::{ByteArray, ledger::ledger_state::compute_claim_rewards_intent_hash_v6};
+    use midnight_base_crypto_v6::hash::HashOutput as HashOutputV6;
+    use midnight_coin_structure_v6::coin::{
+        NIGHT as NIGHTV6, Nonce as NonceV6, UserAddress as UserAddressV6,
+    };
+    use midnight_ledger_v6::structure::OutputInstructionUnshielded as OutputInstructionUnshieldedV6;
+
+    #[test]
+    fn test_claim_rewards_intent_hash_computation() {
+        let owner_bytes = [1u8; 32];
+        let owner = UserAddressV6(HashOutputV6(owner_bytes));
+        let value = 1000000u128;
+        let nonce_bytes = [2u8; 32];
+        let nonce = NonceV6(HashOutputV6(nonce_bytes));
+
+        let intent_hash = compute_claim_rewards_intent_hash_v6(&owner, value, &nonce);
+
+        let output = OutputInstructionUnshieldedV6 {
+            amount: value,
+            target_address: owner,
+            nonce,
+        };
+        let expected_hash = ByteArray(output.mk_intent_hash(NIGHTV6).0.0);
+
+        assert_eq!(intent_hash, expected_hash);
+
+        let intent_hash2 = compute_claim_rewards_intent_hash_v6(&owner, value, &nonce);
+        assert_eq!(intent_hash, intent_hash2);
+    }
+}


### PR DESCRIPTION
The indexer is "making up" an intent hash for UTXOs created by ClaimRewards transactions. The ledger has its own process for computing this intent hash, which is different from the indexer. This means that the indexer has a different list of UTXOs than the ledger (and therefore the node), making it impossible to build a valid transaction using just the indexer's API.

Update the indexer to use the same intent hashes as the ledger. For reference, the ledger's logic can be found at https://github.com/midnightntwrk/midnight-ledger/blob/815ba76f7a38d85c290bb93e152a5feca35022fd/ledger/src/semantics.rs#L1438-L1444.