### PR TITLE
fix: skip UTXO creation for failed transactions

### DIFF
--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -403,6 +403,12 @@ fn make_unshielded_utxos_v6(
     transaction_result: &TransactionResult,
     ledger_state: &LedgerStateV6<DefaultDBV6>,
 ) -> (Vec<UnshieldedUtxo>, Vec<UnshieldedUtxo>) {
+    // Skip UTXO creation entirely for failed transactions
+    // TransactionResult::Failure means no state changes occurred on the ledger
+    if matches!(transaction_result, TransactionResult::Failure) {
+        return (vec![], vec![]);
+    }
+
     match ledger_transaction {
         TransactionV6::Standard(transaction) => {
             let successful_segments = match &transaction_result {

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -586,14 +586,17 @@ fn compute_claim_rewards_intent_hash_v6(
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::{NetworkId, TransactionResult, ledger::{TransactionV6, ledger_state::make_unshielded_utxos_v6}};
+    use crate::domain::{
+        NetworkId, TransactionResult,
+        ledger::{TransactionV6, ledger_state::make_unshielded_utxos_v6},
+    };
     use midnight_ledger_v6::structure::LedgerState as LedgerStateV6;
 
     #[test]
     fn test_make_unshielded_utxos_skips_failed_transactions() {
-        use midnight_transient_crypto_v6::curve::EmbeddedFr;
         use midnight_ledger_v6::structure::StandardTransaction as StandardTransactionV6;
         use midnight_storage_v6::storage::HashMap;
+        use midnight_transient_crypto_v6::curve::EmbeddedFr;
 
         let network_id = NetworkId::Undeployed;
         let intents = HashMap::new();
@@ -609,20 +612,14 @@ mod tests {
         let ledger_state = LedgerStateV6::new(network_id);
 
         let failure_result = TransactionResult::Failure;
-        let (created, spent) = make_unshielded_utxos_v6(
-            ledger_transaction.clone(),
-            &failure_result,
-            &ledger_state,
-        );
+        let (created, spent) =
+            make_unshielded_utxos_v6(ledger_transaction.clone(), &failure_result, &ledger_state);
         assert_eq!(created.len(), 0);
         assert_eq!(spent.len(), 0);
 
         let success_result = TransactionResult::Success;
-        let (created, spent) = make_unshielded_utxos_v6(
-            ledger_transaction.clone(),
-            &success_result,
-            &ledger_state,
-        );
+        let (created, spent) =
+            make_unshielded_utxos_v6(ledger_transaction.clone(), &success_result, &ledger_state);
         assert_eq!(created.len(), 0);
         assert_eq!(spent.len(), 0);
     }

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -403,7 +403,8 @@ fn make_unshielded_utxos_v6(
     transaction_result: &TransactionResult,
     ledger_state: &LedgerStateV6<DefaultDBV6>,
 ) -> (Vec<UnshieldedUtxo>, Vec<UnshieldedUtxo>) {
-    // Skip UTXO creation entirely for failed transactions, because no state changes occurred on the ledger.
+    // Skip UTXO creation entirely for failed transactions, because no state changes occurred on the
+    // ledger.
     if matches!(transaction_result, TransactionResult::Failure) {
         return (vec![], vec![]);
     }

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -589,15 +589,17 @@ fn compute_claim_rewards_intent_hash_v6(
 mod tests {
     use crate::domain::{
         ByteArray, NetworkId, TransactionResult,
-        ledger::{TransactionV6, ledger_state::{compute_claim_rewards_intent_hash_v6, make_unshielded_utxos_v6}},
+        ledger::{
+            TransactionV6,
+            ledger_state::{compute_claim_rewards_intent_hash_v6, make_unshielded_utxos_v6},
+        },
     };
     use midnight_base_crypto_v6::hash::HashOutput as HashOutputV6;
     use midnight_coin_structure_v6::coin::{
         NIGHT as NIGHTV6, Nonce as NonceV6, UserAddress as UserAddressV6,
     };
     use midnight_ledger_v6::structure::{
-        LedgerState as LedgerStateV6,
-        OutputInstructionUnshielded as OutputInstructionUnshieldedV6,
+        LedgerState as LedgerStateV6, OutputInstructionUnshielded as OutputInstructionUnshieldedV6,
         StandardTransaction as StandardTransactionV6,
     };
     use midnight_transient_crypto_v6::curve::EmbeddedFr;

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -587,12 +587,20 @@ fn compute_claim_rewards_intent_hash_v6(
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::{ByteArray, ledger::ledger_state::compute_claim_rewards_intent_hash_v6};
+    use crate::domain::{
+        ByteArray, NetworkId, TransactionResult,
+        ledger::{TransactionV6, ledger_state::{compute_claim_rewards_intent_hash_v6, make_unshielded_utxos_v6}},
+    };
     use midnight_base_crypto_v6::hash::HashOutput as HashOutputV6;
     use midnight_coin_structure_v6::coin::{
         NIGHT as NIGHTV6, Nonce as NonceV6, UserAddress as UserAddressV6,
     };
-    use midnight_ledger_v6::structure::OutputInstructionUnshielded as OutputInstructionUnshieldedV6;
+    use midnight_ledger_v6::structure::{
+        LedgerState as LedgerStateV6,
+        OutputInstructionUnshielded as OutputInstructionUnshieldedV6,
+        StandardTransaction as StandardTransactionV6,
+    };
+    use midnight_transient_crypto_v6::curve::EmbeddedFr;
 
     #[test]
     fn test_claim_rewards_intent_hash_computation() {
@@ -616,21 +624,9 @@ mod tests {
         let intent_hash2 = compute_claim_rewards_intent_hash_v6(&owner, value, &nonce);
         assert_eq!(intent_hash, intent_hash2);
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::domain::{
-        NetworkId, TransactionResult,
-        ledger::{TransactionV6, ledger_state::make_unshielded_utxos_v6},
-    };
-    use midnight_ledger_v6::structure::LedgerState as LedgerStateV6;
 
     #[test]
     fn test_make_unshielded_utxos_v6() {
-        use midnight_ledger_v6::structure::StandardTransaction as StandardTransactionV6;
-        use midnight_transient_crypto_v6::curve::EmbeddedFr;
-
         let network_id = NetworkId::Undeployed;
 
         let transaction = StandardTransactionV6 {

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -403,8 +403,7 @@ fn make_unshielded_utxos_v6(
     transaction_result: &TransactionResult,
     ledger_state: &LedgerStateV6<DefaultDBV6>,
 ) -> (Vec<UnshieldedUtxo>, Vec<UnshieldedUtxo>) {
-    // Skip UTXO creation entirely for failed transactions
-    // TransactionResult::Failure means no state changes occurred on the ledger
+    // Skip UTXO creation entirely for failed transactions, because no state changes occurred on the ledger.
     if matches!(transaction_result, TransactionResult::Failure) {
         return (vec![], vec![]);
     }
@@ -593,34 +592,37 @@ mod tests {
     use midnight_ledger_v6::structure::LedgerState as LedgerStateV6;
 
     #[test]
-    fn test_make_unshielded_utxos_skips_failed_transactions() {
+    fn test_make_unshielded_utxos_v6() {
         use midnight_ledger_v6::structure::StandardTransaction as StandardTransactionV6;
-        use midnight_storage_v6::storage::HashMap;
         use midnight_transient_crypto_v6::curve::EmbeddedFr;
 
         let network_id = NetworkId::Undeployed;
-        let intents = HashMap::new();
-        let test_transaction = StandardTransactionV6 {
+
+        let transaction = StandardTransactionV6 {
             network_id: network_id.to_string(),
-            intents,
-            guaranteed_coins: None,
-            fallible_coins: HashMap::new(),
+            intents: Default::default(),
+            guaranteed_coins: Default::default(),
+            fallible_coins: Default::default(),
             binding_randomness: EmbeddedFr::from_le_bytes(&[0u8; 32]).unwrap(),
         };
-        let ledger_transaction = TransactionV6::Standard(test_transaction);
+        let ledger_transaction = TransactionV6::Standard(transaction);
 
         let ledger_state = LedgerStateV6::new(network_id);
 
-        let failure_result = TransactionResult::Failure;
-        let (created, spent) =
-            make_unshielded_utxos_v6(ledger_transaction.clone(), &failure_result, &ledger_state);
-        assert_eq!(created.len(), 0);
-        assert_eq!(spent.len(), 0);
+        let (created, spent) = make_unshielded_utxos_v6(
+            ledger_transaction.clone(),
+            &TransactionResult::Failure,
+            &ledger_state,
+        );
+        assert!(created.is_empty());
+        assert!(spent.is_empty());
 
-        let success_result = TransactionResult::Success;
-        let (created, spent) =
-            make_unshielded_utxos_v6(ledger_transaction.clone(), &success_result, &ledger_state);
-        assert_eq!(created.len(), 0);
-        assert_eq!(spent.len(), 0);
+        let (created, spent) = make_unshielded_utxos_v6(
+            ledger_transaction,
+            &TransactionResult::Success,
+            &ledger_state,
+        );
+        assert!(created.is_empty());
+        assert!(spent.is_empty());
     }
 }


### PR DESCRIPTION
Closes : [PM-19840](https://shielded.atlassian.net/browse/PM-19840)

### Summary
The indexer was incorrectly creating UTXOs for transactions with `TransactionResult::Failure`. These UTXOs don't exist on the ledger since failed transactions make no state changes.

### Problem
- When a transaction completely fails (`TransactionResult::Failure`), the ledger returns unchanged state
- The indexer was still processing segment 0 and creating UTXOs for these failed transactions
- This caused the indexer state to diverge from the actual ledger state
- Users would see phantom UTXOs that don't actually exist

### Solution
Added an early return in `make_unshielded_utxos_v6` to skip UTXO creation entirely when `TransactionResult::Failure` is encountered.

### Context
- Discovered by @simongellis when investigating invalid transactions on devnet
- Thomas Kerber confirmed that `TransactionResult::Failure` means NO state changes should occur
- See ledger code: `midnight-ledger/ledger/src/semantics.rs:1131` - returns unchanged state on failure

### Changes
- Added early return for failed transactions in `indexer-common/src/domain/ledger/ledger_state.rs`
- Added unit test to verify the fix

### Testing
- Unit test verifies no UTXOs are created for `TransactionResult::Failure`
- Existing tests pass unchanged

### Related
- Fixes part of the issue reported in #topic-node channel
- Separate from PR #400 which fixes ClaimRewards intent hash calculation

[PM-19840]: https://shielded.atlassian.net/browse/PM-19840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ