### PR TITLE
fix: use correct intent hash for spent UTXOs

### DIFF
--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -524,6 +524,7 @@ fn extend_unshielded_utxos_v6(
         intent.fallible_inputs()
     };
     let intent_inputs = intent_inputs.into_iter().map(|spend| {
+        let intent_hash = spend.intent_hash.0.0.into();
         let initial_nonce = make_initial_nonce_v6(spend.output_no, intent_hash);
         let registered_for_dust_generation =
             registered_for_dust_generation_v6(spend.output_no, intent_hash, ledger_state);


### PR DESCRIPTION
We were using the wrong intent hash when fetching spent UTXOs. Specifically we were using the hash of the intent where they were spent, rather than the hash of the intent where they were created.

This meant the indexer never considered existing UTXOs to be spent, and considered new UTXOs to be immediately spent in the TX where they were created.