### PR TITLE
test: pinned QA github actions to SHA-1

### DIFF
--- a/.github/workflows/qa-integration-tests-base-workflow.yml
+++ b/.github/workflows/qa-integration-tests-base-workflow.yml
@@ -88,17 +88,17 @@ jobs:
       XRAY_REPORT_TESTS_MISSING_METADATA: "false"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v 5.0.0
         with:
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup Node.js v22.x
-        uses: actions/setup-node@0b2533296d2e4fd807934a1b8c9f2c2e2c1cec88 # v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22.x
 
       - name: Restore Yarn cache
-        uses: actions/cache@68815abbfec7aafc14e5cac4153c2a9b3a7e2f3e # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3
         with:
           path: |
             qa/tests/.yarn/cache
@@ -108,7 +108,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Add github.com credentials to netrc
-        uses: extractions/netrc@1d9c24356fa3206b60a5f517c33771e3ff9701d4 # v2
+        uses: extractions/netrc@f6f1722d05ce2890aa86fd9654565b1214ac53a4 # v2
         with:
           machine: github.com
           username: MidnightCI
@@ -157,7 +157,7 @@ jobs:
           xray_client_secret: ${{ secrets.XRAY_CLIENT_SECRET }}
 
       - name: Upload Integration Test Reports
-        uses: actions/upload-artifact@26f2637149b6b4a9707a7e054202490f356e7021 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: junit-integration-test-reports
@@ -165,7 +165,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload XRay Test Reports
-        uses: actions/upload-artifact@26f2637149b6b4a9707a7e054202490f356e7021 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: xray-integration-test-reports
@@ -173,7 +173,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload logs
-        uses: actions/upload-artifact@26f2637149b6b4a9707a7e054202490f356e7021 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: qa-integration-tests-${{ inputs.target_env }}-logs


### PR DESCRIPTION
updated a few github actions to SHA-1 rather than release tags