### PR TITLE
test: removed not required interactive-tools plugin

### DIFF
--- a/qa/tests/.yarnrc.yml
+++ b/qa/tests/.yarnrc.yml
@@ -1,7 +1,3 @@
 nodeLinker: node-modules
 
-plugins:
-  - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
-    spec: "@yarnpkg/plugin-interactive-tools"
-
 yarnPath: .yarn/releases/yarn-3.6.4.cjs


### PR DESCRIPTION
This plugin is good for local interactive admin work but has a blob of 1MB that I feel it's not really needed.