### PR TITLE
feat(ci): update Checkmarx action to include SCS/Scorecard support

### DIFF
--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           repository: midnightntwrk/upload-sarif-github-action
-          ref: a0cd00c4e936a5c2fc10d73ef5f3371992350c05
+          ref: 2a471c191b66c5fbd4c2ad79b4de885a919be3bd
           path: upload-sarif-github-action
           token: ${{ secrets.MIDNIGHTCI_REPO }}
 


### PR DESCRIPTION
Update upload-sarif-github-action ref to [2a471c191b66c5fbd4c2ad79b4de885a919be3bd](https://github.com/midnightntwrk/upload-sarif-github-action/commit/2a471c191b66c5fbd4c2ad79b4de885a919be3bd) to enable OSSF Scorecard scanning for repository health checks