### PR TITLE
ci: remove unnecessary Docker login from check/lint/doc jobs

### DIFF
--- a/.github/workflows/ci-cloud.yaml
+++ b/.github/workflows/ci-cloud.yaml
@@ -43,13 +43,6 @@ jobs:
           username: MidnightCI
           password: ${{ secrets.MIDNIGHTCI_REPO }}
 
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
@@ -110,13 +103,6 @@ jobs:
           machine: github.com
           username: MidnightCI
           password: ${{ secrets.MIDNIGHTCI_REPO }}
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -203,13 +189,6 @@ jobs:
           machine: github.com
           username: MidnightCI
           password: ${{ secrets.MIDNIGHTCI_REPO }}
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci-standalone.yaml
+++ b/.github/workflows/ci-standalone.yaml
@@ -43,13 +43,6 @@ jobs:
           username: MidnightCI
           password: ${{ secrets.MIDNIGHTCI_REPO }}
 
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
@@ -107,13 +100,6 @@ jobs:
           machine: github.com
           username: MidnightCI
           password: ${{ secrets.MIDNIGHTCI_REPO }}
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -194,13 +180,6 @@ jobs:
           machine: github.com
           username: MidnightCI
           password: ${{ secrets.MIDNIGHTCI_REPO }}
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
Remove GHCR Docker login from check, lint, and doc jobs in both ci-cloud and ci-standalone workflows. These jobs only run cargo commands that don't require Docker images.

Rationale:
- check: runs 'cargo check' (no Docker needed)
- lint: runs 'cargo clippy' (no Docker needed)
- doc: runs 'cargo doc' (no Docker needed)
- test: KEEPS Docker login (needs midnight-node image from GHCR)

All jobs still have 'Add github.com credentials to netrc' step, though this may also be unnecessary since midnight-ledger is public. The netrc credentials are likely historical from when repos were private.

Benefits:
- Faster job execution (skip unnecessary Docker authentication)
- Clearer intent (only test job needs Docker)
- One less failure point for check/lint/doc jobs

Fork PR impact:
- check/lint/doc jobs should work (Git repos are public)
- Only test job would fail (private Node Docker image)