### PR TITLE
chore: update checkmarx-scan-public to use default scanners

### DIFF
--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -30,7 +30,7 @@ jobs:
       # This is what makes it safe with pull_request_target
 
       - name: Checkmarx Full Scan
-        uses: midnightntwrk/upload-sarif-github-action/checkmarx-scan@3b9a00b556853664122fd72ad61d15d94cacecfa
+        uses: midnightntwrk/upload-sarif-github-action/checkmarx-scan-public@3b9a00b556853664122fd72ad61d15d94cacecfa
         with:
           cx-client-id: ${{ secrets.CX_CLIENT_ID }}
           cx-client-secret: ${{ secrets.CX_CLIENT_SECRET_EU }}


### PR DESCRIPTION
Updates upload-sarif-github-action ref to 3b9a00b which removes explicit --scan-types flag, allowing Checkmarx CLI to run all licensed scanners including SCS (Supply Chain Security).

Previous ref: fdfe002 (explicit scan types, excluded SCS)
New ref: 3b9a00b (uses CLI defaults, includes all licensed scanners)