### PR TITLE
ci(checkmarx): update action to include BYOR upload fix

### DIFF
--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -30,7 +30,7 @@ jobs:
       # This is what makes it safe with pull_request_target
 
       - name: Checkmarx Full Scan
-        uses: midnightntwrk/upload-sarif-github-action/checkmarx-scan-public@3b9a00b556853664122fd72ad61d15d94cacecfa
+        uses: midnightntwrk/upload-sarif-github-action/checkmarx-scan-public@d96d3ffc1c42f5769d972413da59dc1b438d7761
         with:
           cx-client-id: ${{ secrets.CX_CLIENT_ID }}
           cx-client-secret: ${{ secrets.CX_CLIENT_SECRET_EU }}


### PR DESCRIPTION
Updates to commit d96d3ff which includes the fix for BYOR upload reference path (./upload-sarif-github-action -> ./)
This should fix the BYOR upload failure seen in [a ci checkmarx build](https://github.com/midnightntwrk/midnight-indexer/actions/runs/18534182639/job/52824709673?pr=435.).