### PR TITLE
chore(ci): correct commit hash for upload-sarif action

### DIFF
--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -30,7 +30,7 @@ jobs:
       # This is what makes it safe with pull_request_target
 
       - name: Checkmarx Full Scan
-        uses: midnightntwrk/upload-sarif-github-action/checkmarx-scan-public@e44b6107cd89fd42b662dbfa94c1e35b9766a2ab
+        uses: midnightntwrk/upload-sarif-github-action/checkmarx-scan-public@e44b61098d7ad94aac342bb40920d41fb7154cfc
         with:
           cx-client-id: ${{ secrets.CX_CLIENT_ID }}
           cx-client-secret: ${{ secrets.CX_CLIENT_SECRET_EU }}


### PR DESCRIPTION
Wrong hash: e44b6107cd89fd42b662dbfa94c1e35b9766a2ab (doesn't exist)
Correct hash: e44b61098d7ad94aac342bb40920d41fb7154cfc (main)

Fixes GitHub Actions tarball download error.