### PR TITLE
chore(ci): update checkmarx action to latest version

### DIFF
--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -30,7 +30,7 @@ jobs:
       # This is what makes it safe with pull_request_target
 
       - name: Checkmarx Full Scan
-        uses: midnightntwrk/upload-sarif-github-action/checkmarx-scan-public@e44b61098d7ad94aac342bb40920d41fb7154cfc
+        uses: midnightntwrk/upload-sarif-github-action/checkmarx-scan-public@32b96caabd2472b3d142ed0a278d619d6bd82bf8
         with:
           cx-client-id: ${{ secrets.CX_CLIENT_ID }}
           cx-client-secret: ${{ secrets.CX_CLIENT_SECRET_EU }}


### PR DESCRIPTION
Updates upload-sarif-github-action to commit 32b96ca which includes:
- Fix for SCS token configuration (CLI doesn't support scs_repo_token property)
- Fix for file-filter regex validation (hyphen position in character class)

These fixes resolve CI failures when using file-filter with hyphens and SCS scanning.