### PR TITLE
test: ramp up contractActions subscription tests 

### DIFF
--- a/qa/tests/tests/integration/basic/subscriptions/contract-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/contract-subscriptions.test.ts
@@ -604,7 +604,7 @@ describe('contract action subscriptions', () => {
     test('should receive error message when both height and hash are provided in block offset', async () => {
       const contractAddress = dataProvider.getKnownContractAddress();
 
-      const knownBlockHash = dataProvider.getKnownBlockHash();
+      const knownBlockHash = await dataProvider.getKnownBlockHash();
       const knownBlockHeight = await dataProvider.getContractDeployBlockHeight();
 
       const receivedMessages: ContractActionSubscriptionResponse[] = [];

--- a/qa/tests/utils/testdata-provider.ts
+++ b/qa/tests/utils/testdata-provider.ts
@@ -187,12 +187,17 @@ class TestDataProvider {
   getBlockHashFromBlocks() {
     const envName = env.getCurrentEnvironmentName();
     const baseDir = `data/static/${envName}`;
-    
+
     if (!this.blocks) {
       this.blocks = importJsoncData(`${baseDir}/blocks.jsonc`) as JsonObject;
     }
-    
-    if (this.blocks && this.blocks['other-blocks'] && Array.isArray(this.blocks['other-blocks']) && this.blocks['other-blocks'].length > 0) {
+
+    if (
+      this.blocks &&
+      this.blocks['other-blocks'] &&
+      Array.isArray(this.blocks['other-blocks']) &&
+      this.blocks['other-blocks'].length > 0
+    ) {
       return this.blocks['other-blocks'][0] as string; // Return the first block hash from the array
     }
     throw new Error('No block hashes available in blocks.jsonc');


### PR DESCRIPTION
…test cases

- Add 7 new test cases for contract action subscriptions covering edge cases and error scenarios
- Add getBlockHashFromBlocks() method to testdata-provider to load block hashes from blocks.jsonc
- Update contract-subscriptions.test.ts with comprehensive test coverage:
  * Stream contract actions from latest block
  * Stream with block hash offset (historical data)
  * Stream with block height offset (historical data)
  * Handle non-existent contract address
  * Handle malformed contract address errors
  * Handle non-existent block hash offset errors
  * Handle invalid block hash format errors
  * Handle invalid block height format errors
  * Handle both height and hash provided errors
- Load blocks.jsonc data in testdata-provider init method