### PR TITLE
chore(ci): add docker image pre-pull with retry to test workflows

### DIFF
--- a/.github/workflows/ci-cloud.yaml
+++ b/.github/workflows/ci-cloud.yaml
@@ -129,6 +129,14 @@ jobs:
           username: MidnightCI
           password: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
 
+      - name: Pre-pull Docker images
+        run: |
+          NODE_VERSION=$(tr -d '\n' < NODE_VERSION)
+          echo "Pre-pulling midnight-node:$NODE_VERSION..."
+          docker pull "ghcr.io/midnight-ntwrk/midnight-node:$NODE_VERSION" || \
+          docker pull "ghcr.io/midnight-ntwrk/midnight-node:$NODE_VERSION" || \
+          docker pull "ghcr.io/midnight-ntwrk/midnight-node:$NODE_VERSION"
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/ci-standalone.yaml
+++ b/.github/workflows/ci-standalone.yaml
@@ -123,6 +123,14 @@ jobs:
           username: MidnightCI
           password: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
 
+      - name: Pre-pull Docker images
+        run: |
+          NODE_VERSION=$(tr -d '\n' < NODE_VERSION)
+          echo "Pre-pulling midnight-node:$NODE_VERSION..."
+          docker pull "ghcr.io/midnight-ntwrk/midnight-node:$NODE_VERSION" || \
+          docker pull "ghcr.io/midnight-ntwrk/midnight-node:$NODE_VERSION" || \
+          docker pull "ghcr.io/midnight-ntwrk/midnight-node:$NODE_VERSION"
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:


### PR DESCRIPTION
## Description

### Summary
Adds a pre-pull step with retry logic to CI workflows (ci-cloud and ci-standalone) to mitigate intermittent testcontainers image pull failures.

### Problem
CI test runs intermittently fail with `"failed to pull the image, error: bytes remaining on stream"` when testcontainers attempts to pull the midnight-node Docker image during test execution. This is a transient network/registry issue that occurs when the HTTP stream from ghcr.io is interrupted.

### Solution
Pre-pull the midnight-node Docker image before running tests, with 3 retry attempts using shell `||` operators. This approach:
- Separates image pull from test execution (faster failure feedback if image truly unavailable)
- Provides automatic retry for transient network issues
- Uses existing GHCR authentication from the workflow
- Adds minimal overhead (~5-10 seconds for cached images)

### Changes
- **ci-cloud.yaml**: Added pre-pull step in test job after GHCR login
- **ci-standalone.yaml**: Added pre-pull step in test job after GHCR login

The pre-pull step reads `NODE_VERSION` and attempts to pull the image up to 3 times, failing the workflow only if all attempts fail.

### Testing
- Verified workflow syntax
- Confirmed `NODE_VERSION` file exists and contains valid version
- Local testing shows retry mechanism works for transient failures

### Related
- Similar patterns used across testcontainers implementations (Java, .NET)