### PR TITLE
chore: add a Nix package definition for `midnight-indexer`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 .vscode
 .zed
 target
+
+# Nix
+result
+result-*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3738,7 +3738,7 @@ dependencies = [
 [[package]]
 name = "midnight-base-crypto"
 version = "1.0.0-alpha.4"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-6.1.0-alpha.4#5ff23902cda440781ac3c8cac55c2ff69866e1b8"
+source = "git+https://github.com/blockfrost/midnight-ledger?branch=fix%2Fcargo-vendor--ledger-6.1.0-alpha.4#9a3c0218405d137f098348e2a79c4cfcfa54fe48"
 dependencies = [
  "anyhow",
  "atomic-write-file",
@@ -3768,7 +3768,7 @@ dependencies = [
 [[package]]
 name = "midnight-base-crypto-derive"
 version = "1.0.0-alpha.4"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-6.1.0-alpha.4#5ff23902cda440781ac3c8cac55c2ff69866e1b8"
+source = "git+https://github.com/blockfrost/midnight-ledger?branch=fix%2Fcargo-vendor--ledger-6.1.0-alpha.4#9a3c0218405d137f098348e2a79c4cfcfa54fe48"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
@@ -3804,7 +3804,7 @@ dependencies = [
 [[package]]
 name = "midnight-coin-structure"
 version = "1.0.0-alpha.4"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-6.1.0-alpha.4#5ff23902cda440781ac3c8cac55c2ff69866e1b8"
+source = "git+https://github.com/blockfrost/midnight-ledger?branch=fix%2Fcargo-vendor--ledger-6.1.0-alpha.4#9a3c0218405d137f098348e2a79c4cfcfa54fe48"
 dependencies = [
  "fake",
  "lazy_static",
@@ -3839,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "midnight-ledger"
 version = "6.1.0-alpha.4"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-6.1.0-alpha.4#5ff23902cda440781ac3c8cac55c2ff69866e1b8"
+source = "git+https://github.com/blockfrost/midnight-ledger?branch=fix%2Fcargo-vendor--ledger-6.1.0-alpha.4#9a3c0218405d137f098348e2a79c4cfcfa54fe48"
 dependencies = [
  "anyhow",
  "derive-where",
@@ -3854,6 +3854,7 @@ dependencies = [
  "midnight-coin-structure",
  "midnight-onchain-runtime",
  "midnight-serialize",
+ "midnight-static",
  "midnight-storage",
  "midnight-transient-crypto",
  "midnight-zswap",
@@ -3870,7 +3871,7 @@ dependencies = [
 [[package]]
 name = "midnight-onchain-runtime"
 version = "1.0.0-alpha.4"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-6.1.0-alpha.4#5ff23902cda440781ac3c8cac55c2ff69866e1b8"
+source = "git+https://github.com/blockfrost/midnight-ledger?branch=fix%2Fcargo-vendor--ledger-6.1.0-alpha.4#9a3c0218405d137f098348e2a79c4cfcfa54fe48"
 dependencies = [
  "derive-where",
  "enum_index",
@@ -3895,7 +3896,7 @@ dependencies = [
 [[package]]
 name = "midnight-onchain-state"
 version = "1.0.0-alpha.4"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-6.1.0-alpha.4#5ff23902cda440781ac3c8cac55c2ff69866e1b8"
+source = "git+https://github.com/blockfrost/midnight-ledger?branch=fix%2Fcargo-vendor--ledger-6.1.0-alpha.4#9a3c0218405d137f098348e2a79c4cfcfa54fe48"
 dependencies = [
  "derive-where",
  "fake",
@@ -3913,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "midnight-onchain-vm"
 version = "1.0.0-alpha.4"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-6.1.0-alpha.4#5ff23902cda440781ac3c8cac55c2ff69866e1b8"
+source = "git+https://github.com/blockfrost/midnight-ledger?branch=fix%2Fcargo-vendor--ledger-6.1.0-alpha.4#9a3c0218405d137f098348e2a79c4cfcfa54fe48"
 dependencies = [
  "derive-where",
  "fake",
@@ -3955,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "midnight-serialize"
 version = "1.0.0-alpha.4"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-6.1.0-alpha.4#5ff23902cda440781ac3c8cac55c2ff69866e1b8"
+source = "git+https://github.com/blockfrost/midnight-ledger?branch=fix%2Fcargo-vendor--ledger-6.1.0-alpha.4#9a3c0218405d137f098348e2a79c4cfcfa54fe48"
 dependencies = [
  "crypto",
  "konst",
@@ -3968,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "midnight-serialize-macros"
 version = "1.0.0-alpha.4"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-6.1.0-alpha.4#5ff23902cda440781ac3c8cac55c2ff69866e1b8"
+source = "git+https://github.com/blockfrost/midnight-ledger?branch=fix%2Fcargo-vendor--ledger-6.1.0-alpha.4#9a3c0218405d137f098348e2a79c4cfcfa54fe48"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",
@@ -3976,9 +3977,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "midnight-static"
+version = "1.0.0-alpha.4"
+source = "git+https://github.com/blockfrost/midnight-ledger?branch=fix%2Fcargo-vendor--ledger-6.1.0-alpha.4#9a3c0218405d137f098348e2a79c4cfcfa54fe48"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.41",
+]
+
+[[package]]
 name = "midnight-storage"
 version = "1.0.0-alpha.4"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-6.1.0-alpha.4#5ff23902cda440781ac3c8cac55c2ff69866e1b8"
+source = "git+https://github.com/blockfrost/midnight-ledger?branch=fix%2Fcargo-vendor--ledger-6.1.0-alpha.4#9a3c0218405d137f098348e2a79c4cfcfa54fe48"
 dependencies = [
  "archery",
  "crypto",
@@ -4002,7 +4012,7 @@ dependencies = [
 [[package]]
 name = "midnight-storage-macros"
 version = "1.0.0-alpha.4"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-6.1.0-alpha.4#5ff23902cda440781ac3c8cac55c2ff69866e1b8"
+source = "git+https://github.com/blockfrost/midnight-ledger?branch=fix%2Fcargo-vendor--ledger-6.1.0-alpha.4#9a3c0218405d137f098348e2a79c4cfcfa54fe48"
 dependencies = [
  "midnight-serialize-macros",
  "proc-macro2",
@@ -4013,7 +4023,7 @@ dependencies = [
 [[package]]
 name = "midnight-transient-crypto"
 version = "1.0.0-alpha.4"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-6.1.0-alpha.4#5ff23902cda440781ac3c8cac55c2ff69866e1b8"
+source = "git+https://github.com/blockfrost/midnight-ledger?branch=fix%2Fcargo-vendor--ledger-6.1.0-alpha.4#9a3c0218405d137f098348e2a79c4cfcfa54fe48"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -4048,7 +4058,7 @@ dependencies = [
 [[package]]
 name = "midnight-zswap"
 version = "6.1.0-alpha.4"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=ledger-6.1.0-alpha.4#5ff23902cda440781ac3c8cac55c2ff69866e1b8"
+source = "git+https://github.com/blockfrost/midnight-ledger?branch=fix%2Fcargo-vendor--ledger-6.1.0-alpha.4#9a3c0218405d137f098348e2a79c4cfcfa54fe48"
 dependencies = [
  "derive-where",
  "fake",
@@ -4060,6 +4070,7 @@ dependencies = [
  "midnight-coin-structure",
  "midnight-onchain-runtime",
  "midnight-serialize",
+ "midnight-static",
  "midnight-storage",
  "midnight-transient-crypto",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,14 +51,14 @@ log                          = { version = "0.4" }
 logforth                     = { version = "0.28" }
 metrics                      = { version = "0.24" }
 metrics-exporter-prometheus  = { version = "0.17", default-features = false }
-midnight-base-crypto_v6      = { git = "https://github.com/midnightntwrk/midnight-ledger", package = "midnight-base-crypto", tag = "ledger-6.1.0-alpha.4" }
-midnight-coin-structure_v6   = { git = "https://github.com/midnightntwrk/midnight-ledger", package = "midnight-coin-structure", tag = "ledger-6.1.0-alpha.4" }
-midnight-ledger_v6           = { git = "https://github.com/midnightntwrk/midnight-ledger", package = "midnight-ledger", tag = "ledger-6.1.0-alpha.4" }
-midnight-onchain-runtime_v6  = { git = "https://github.com/midnightntwrk/midnight-ledger", package = "midnight-onchain-runtime", tag = "ledger-6.1.0-alpha.4" }
-midnight-serialize_v6        = { git = "https://github.com/midnightntwrk/midnight-ledger", package = "midnight-serialize", tag = "ledger-6.1.0-alpha.4" }
-midnight-storage_v6          = { git = "https://github.com/midnightntwrk/midnight-ledger", package = "midnight-storage", tag = "ledger-6.1.0-alpha.4" }
-midnight-transient-crypto_v6 = { git = "https://github.com/midnightntwrk/midnight-ledger", package = "midnight-transient-crypto", tag = "ledger-6.1.0-alpha.4" }
-midnight-zswap_v6            = { git = "https://github.com/midnightntwrk/midnight-ledger", package = "midnight-zswap", tag = "ledger-6.1.0-alpha.4" }
+midnight-base-crypto_v6      = { git = "https://github.com/blockfrost/midnight-ledger", package = "midnight-base-crypto", branch = "fix/cargo-vendor--ledger-6.1.0-alpha.4" }
+midnight-coin-structure_v6   = { git = "https://github.com/blockfrost/midnight-ledger", package = "midnight-coin-structure", branch = "fix/cargo-vendor--ledger-6.1.0-alpha.4" }
+midnight-ledger_v6           = { git = "https://github.com/blockfrost/midnight-ledger", package = "midnight-ledger", branch = "fix/cargo-vendor--ledger-6.1.0-alpha.4" }
+midnight-onchain-runtime_v6  = { git = "https://github.com/blockfrost/midnight-ledger", package = "midnight-onchain-runtime", branch = "fix/cargo-vendor--ledger-6.1.0-alpha.4" }
+midnight-serialize_v6        = { git = "https://github.com/blockfrost/midnight-ledger", package = "midnight-serialize", branch = "fix/cargo-vendor--ledger-6.1.0-alpha.4" }
+midnight-storage_v6          = { git = "https://github.com/blockfrost/midnight-ledger", package = "midnight-storage", branch = "fix/cargo-vendor--ledger-6.1.0-alpha.4" }
+midnight-transient-crypto_v6 = { git = "https://github.com/blockfrost/midnight-ledger", package = "midnight-transient-crypto", branch = "fix/cargo-vendor--ledger-6.1.0-alpha.4" }
+midnight-zswap_v6            = { git = "https://github.com/blockfrost/midnight-ledger", package = "midnight-zswap", branch = "fix/cargo-vendor--ledger-6.1.0-alpha.4" }
 nix                          = { version = "0.30" }
 opentelemetry                = { version = "0.31" }
 opentelemetry-otlp           = { version = "0.31" }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,116 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1758215636,
+        "narHash": "sha256-8nkzkPbdxze8CxWhKWlcLbJEU1vfLM/nVqRlTy17V54=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "a669fe77a8b0cd6f11419d89ea45a16691ca5121",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1758264155,
+        "narHash": "sha256-sgg1sd/pYO9C7ccY9tAvR392CDscx8sqXrHkxspjIH0=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "a7d9df0179fcc48259a68b358768024f8e5a6372",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751211869,
+        "narHash": "sha256-1Cu92i1KSPbhPCKxoiVG5qnoRiKTgR5CcGSRyLpOd7Y=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b43c397f6c213918d6cfe6e3550abfe79b5d1c51",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758224093,
+        "narHash": "sha256-buZMH6NgzSLowTda+aArct5ISsMR/S888EdFaqUvbog=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "958a8d06e3e5ba7dca7cc23b0639335071d65f2a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,19 @@
+{
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    crane.url = "github:ipetkov/crane";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = inputs:
+    inputs.flake-utils.lib.eachDefaultSystem (system: {
+      packages.default = import ./nix/packages.nix {
+        inherit inputs;
+        targetSystem = system;
+      };
+    });
+}

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,0 +1,85 @@
+{
+  inputs,
+  targetSystem,
+}: let
+  pkgs = inputs.nixpkgs.legacyPackages.${targetSystem};
+  inherit (pkgs) lib;
+
+  rustPackages = inputs.fenix.packages.${pkgs.system}.stable;
+
+  craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustPackages.toolchain;
+
+  src = lib.cleanSourceWith {
+    src = lib.cleanSource ../.;
+    filter = path: type:
+      craneLib.filterCargoSources path type
+      || lib.hasSuffix ".scale" path
+      || lib.hasSuffix ".graphql" path
+      || lib.hasSuffix "NODE_VERSION" path;
+    name = "source";
+  };
+
+  commonArgs =
+    {
+      pname = "midnight-indexer";
+      inherit src;
+      strictDeps = true;
+
+      nativeBuildInputs =
+        [
+          pkgs.gnum4
+          pkgs.protobuf
+        ]
+        ++ lib.optionals pkgs.stdenv.isLinux [
+          pkgs.pkg-config
+        ];
+      buildInputs =
+        lib.optionals pkgs.stdenv.isLinux [
+          pkgs.openssl
+        ]
+        ++ lib.optionals pkgs.stdenv.isDarwin [
+          pkgs.libiconv
+          pkgs.darwin.apple_sdk_12_3.frameworks.SystemConfiguration
+          pkgs.darwin.apple_sdk_12_3.frameworks.Security
+          pkgs.darwin.apple_sdk_12_3.frameworks.CoreFoundation
+        ];
+    }
+    // lib.optionalAttrs pkgs.stdenv.isLinux {
+      # The linker bundled with Fenix has wrong interpreter path, and it fails with ENOENT, so:
+      RUSTFLAGS = "-Clink-arg=-fuse-ld=bfd";
+    }
+    // lib.optionalAttrs pkgs.stdenv.isDarwin {
+      # for bindgen
+      LIBCLANG_PATH = "${lib.getLib pkgs.llvmPackages.libclang}/lib";
+    };
+
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+  packagesCloud = craneLib.buildPackage (commonArgs
+    // {
+      inherit cargoArtifacts;
+      pname = commonArgs.pname + "-cloud";
+      doCheck = false; # we run tests elsewhere
+      cargoExtraArgs = "--features cloud";
+    });
+
+  packagesStandalone = craneLib.buildPackage (commonArgs
+    // {
+      inherit cargoArtifacts;
+      pname = commonArgs.pname + "-standalone";
+      doCheck = false; # we run tests elsewhere
+      cargoExtraArgs = "-p indexer-standalone --features standalone";
+    });
+
+  packages = pkgs.stdenv.mkDerivation {
+    inherit (packagesCloud) pname version;
+    buildCommand = ''
+      mkdir -p $out
+      cp -vr ${packagesCloud}/bin $out/
+      chmod -R +w $out
+      cp -vf ${packagesStandalone}/bin/indexer-standalone $out/bin/
+    '';
+    meta.mainProgram = "indexer-standalone";
+  };
+in
+  packages


### PR DESCRIPTION
Part of [blockfrost-ops/issues/2057](https://github.com/blockfrost/blockfrost-ops/issues/2057).

## Context

At Blockfrost, we’d rather use a source-based build definition, instead of depending on binary blobs in container registries (DockerHub, GHCR). A build definition inside a restrictive Nix sandbox is close to ideal for this purpose.

This requires small changes in `midnight-ledger` to make it work with `cargo-vendor`. The changes against `main` can be seen in <https://github.com/midnightntwrk/midnight-ledger/pull/81> there.

Since `midnight-indexer` depends on a tag of the ledger repository:
* `ledger-6.1.0-alpha.4`,

I have created a branch there:

* [fix/cargo-vendor--ledger-6.1.0-alpha.4](https://github.com/blockfrost/midnight-ledger/tree/fix/cargo-vendor--ledger-6.1.0-alpha.4),

against which this repository can be built, just to show it’s possible:

```
❯ nix build -L
[…]

❯ ll ./result/bin/
total 154M
-r-xr-xr-x 4 root root  44M Jan  1  1970 chain-indexer
-r-xr-xr-x 4 root root  29M Jan  1  1970 indexer-api
-r-xr-xr-x 4 root root 2.3M Jan  1  1970 indexer-api-cli
-r-xr-xr-x 4 root root  51M Jan  1  1970 indexer-standalone
-r-xr-xr-x 4 root root  11M Jan  1  1970 indexer-tests
-r-xr-xr-x 4 root root  18M Jan  1  1970 wallet-indexer

❯ ./result/bin/indexer-api-cli --help | head -1
Usage: indexer-api-cli <COMMAND>
```

The next release, `ledger-6.1.0-alpha.5`, will probably contain this ledger patch, if it gets merged to their `main` in the meantime.