### PR TITLE
docs: clarify currentCapacity limitations in dustGenerationStatus API

### DIFF
--- a/docs/api/v3/api-documentation.md
+++ b/docs/api/v3/api-documentation.md
@@ -326,6 +326,14 @@ query {
 - The `registered` field indicates if stake key is registered via NativeTokenObservation pallet
 - Registration data comes from Cardano mainnet via bridge
 
+**Important Note on `currentCapacity`:**
+The `currentCapacity` field represents the maximum DUST generation capacity based on the Night UTXO balance and elapsed time. This value:
+- Is accurate until the first DUST fee payment
+- May be higher than actual balance after fee payments
+- Cannot track spent DUST (fee payments are shielded transactions)
+
+For accurate DUST balance after fee payments, query the connected wallet directly via wallet SDK or DApp Connector API. Use `currentCapacity` as an approximation when wallet connection is unavailable
+
 ## Contract Action Types
 
 All ContractAction types (ContractDeploy, ContractCall, ContractUpdate) implement the ContractAction interface with these common fields:
@@ -419,7 +427,7 @@ DUST generation status for a Cardano stake key:
 - `registered`: Whether this stake key is registered (Boolean!)
 - `nightBalance`: NIGHT balance backing generation (String)
 - `generationRate`: Generation rate in Specks per second (String)
-- `currentCapacity`: Current DUST capacity (String)
+- `currentCapacity`: Current DUST generation capacity in Specks - represents maximum possible balance, may be higher than actual balance after fee payments (String)
 
 ### DustLedgerEvent
 


### PR DESCRIPTION
## Summary
Update API documentation to clarify that `currentCapacity` represents maximum DUST generation capacity, not actual balance after fee payments.

## Context
As flagged by @kapke, the `currentCapacity` field has an inherent limitation: it cannot track DUST fee payments because they are shielded transactions. The Indexer can only calculate generation capacity from Night UTXOs, making the value approximate after the first fee payment.

## Changes
- Added note explaining `currentCapacity` limitations in the dustGenerationStatus query section
- Updated field description to clarify it represents "generation capacity" not actual balance
- Added guidance to use wallet data (via SDK/DApp Connector) for accurate balance when available

## Impact
API users (particularly ProtoFire/CNGD DApp) will understand:
- `currentCapacity` is accurate until first fee payment, then becomes an approximation
- Wallet connection provides the only accurate balance after fee payments
- `currentCapacity` can be used as a fallback when wallet is unavailable

## Testing
Documentation-only change, no code modifications.

## Related Discussion
Internal Slack thread: [currentCapacity field in the dustGenerationStatus query](https://shielded.slack.com/archives/C080DB8JBT6/p1762171091029179)