### PR TITLE
test: default toolkit to latest-main 

### DIFF
--- a/qa/scripts/startup-localenv-from-genesis.sh
+++ b/qa/scripts/startup-localenv-from-genesis.sh
@@ -113,6 +113,8 @@ for i in {1..30}; do
   sleep 2
 done
 
+docker compose --profile cloud logs | grep "Highest known block" 
+
 
 docker ps --format "table {{.Image}}\t{{.Names}}\t{{.Status}}"
 

--- a/qa/scripts/startup-localenv-with-data.sh
+++ b/qa/scripts/startup-localenv-with-data.sh
@@ -39,7 +39,12 @@ docker run --rm \
     alpine sh -c "mkdir -p /project/target/data /project/target/postgres /project/target/nats"
 
 export NODE_TAG=${NODE_TAG:-`cat NODE_VERSION`}
-export NODE_TOOLKIT_TAG=${NODE_TOOLKIT_TAG:-`echo $NODE_TAG`}
+if [ -n "$NODE_TOOLKIT_TAG" ]; then
+  echo "Using explicit NODE_TOOLKIT_TAG: $NODE_TOOLKIT_TAG"
+else
+  export NODE_TOOLKIT_TAG=latest-main
+  echo "NODE_TOOLKIT_TAG not set; defaulting to 'latest-main'"
+fi
 
 # Use the derived Docker Compose project name to create volume name
 DOCKER_VOLUME_NAME="${DOCKER_PROJECT_NAME}_node_data"
@@ -100,11 +105,18 @@ echo " NODE_TOOLKIT_TAG: $NODE_TOOLKIT_TAG"
 
 docker compose --profile cloud up -d
 
-echo "Waiting for services to start..."
-sleep 5
+echo "Waiting for indexer API to become ready..."
+for i in {1..30}; do
+  if curl -sf http://localhost:8088/ready >/dev/null; then
+    echo "Indexer API is ready"
+    break
+  fi
+  echo "Not ready yet... ($i)"
+  sleep 2
+done
 
-docker compose --profile cloud logs |grep "Highest known block"
-
+echo "Chain startup info:"
+docker compose --profile cloud logs | grep "Highest known block"
 
 docker ps --format "table {{.Image}}\t{{.Names}}\t{{.Status}}"
 

--- a/qa/tests/README.md
+++ b/qa/tests/README.md
@@ -77,6 +77,7 @@ Running the tests on your local/undeployed environment has some prerequisites, d
 ```bash
 # Startup a local environment with test data (transactions + contract actions)
 bash qa/scripts/startup-localenv-with-data.sh
+cd qa/tests
 TARGET_ENV=undeployed yarn test:integration
 ```
 
@@ -87,11 +88,21 @@ the script
 ```bash
 # Startup a local environment with test data (transactions + contract actions)
 # with desired node + node toolkit + indexer versions
-export NODE_TAG=0.18.0-rc.1
+export NODE_TAG=0.18.0-rc.7
 export NODE_TOOLKIT_TAG=latest-main
-export INDEXER_TAG=3.0.0-alpha.6
-bash qa/scripts/startup-localenv-with-data.sh
-TARGET_ENV=undeployed yarn test:integration
+export INDEXER_TAG=3.0.0-alpha.15
+```
+
+Note: if you need to reproduce a specific behaviour or match a particular toolkit version:
+
+```
+export NODE_TOOLKIT_TAG=$NODE_TAG
+```
+
+For example:
+```
+export NODE_TAG=0.18.0-rc.7
+export NODE_TOOLKIT_TAG=0.18.0-rc.7
 ```
 
 ## E2E tests on undeployed/local environment (from genesis without pre-existing data)
@@ -102,6 +113,7 @@ actions themselves so that they can assert on the outcome of those actions.
 ```bash
 # Startup a local environment from genesis block, without test data
 bash qa/scripts/startup-localenv-from-genesis.sh
+cd qa/tests
 TARGET_ENV=undeployed yarn test:e2e
 ```
 
@@ -111,14 +123,12 @@ explicitly set them with env vars like in the example below.
 ```bash
 # Startup a local environment from genesis block, without test data
 # with desired node + node toolkit + indexer versions
-export NODE_TAG=0.18.0-rc.1
+export NODE_TAG=0.18.0-rc.7
 export NODE_TOOLKIT_TAG=latest-main
-export INDEXER_TAG=3.0.0-alpha.6
-bash qa/scripts/startup-localenv-from-genesis.sh
-TARGET_ENV=undeployed yarn test:e2e
+export INDEXER_TAG=3.0.0-alpha.15
 ```
 
-Note: if If you need to reproduce a specific behaviour or match a particular toolkit version:
+Note: if you need to reproduce a specific behaviour or match a particular toolkit version:
 
 ```
 export NODE_TOOLKIT_TAG=$NODE_TAG

--- a/qa/tests/utils/toolkit/toolkit-wrapper.ts
+++ b/qa/tests/utils/toolkit/toolkit-wrapper.ts
@@ -238,7 +238,8 @@ class ToolkitWrapper {
     this.config.containerName = config.containerName || `mn-toolkit-${envName}-${randomId}`;
     this.config.targetDir = config.targetDir || resolve('./.tmp/toolkit');
     this.config.nodeTag = config.nodeTag || env.getNodeVersion();
-    this.config.nodeToolkitTag = config.nodeToolkitTag || env.getNodeToolkitVersion();
+    this.config.nodeToolkitTag =
+      config.nodeToolkitTag || process.env.NODE_TOOLKIT_TAG || 'latest-main';
     this.config.warmupCache = config.warmupCache || false;
 
     // Ensure the target directory exists


### PR DESCRIPTION
This PR updates the test startup scripts and Readme to use the latest-main Node Toolkit tag by default while still allowing to explicitly set a specific toolkit version when needed. Also updates the toolkit-wrapper to use latest-main by default.