### PR TITLE
fix(indexer-api): prevent duplicate transactions

### DIFF
--- a/indexer-api/src/infra/api/v3/subscription/unshielded.rs
+++ b/indexer-api/src/infra/api/v3/subscription/unshielded.rs
@@ -157,7 +157,7 @@ where
             .await
             .map_err_into_server_error(|| format!("get next transaction for address {address}"))?
         {
-            if let Some(utxo_update) = make_unshielded_transaction(
+            if let Some(unshielded_transaction) = make_unshielded_transaction(
                 &mut transaction_id,
                 storage,
                 address,
@@ -166,7 +166,7 @@ where
             )
             .await?
             {
-                yield utxo_update;
+                yield unshielded_transaction;
             }
         }
 
@@ -219,22 +219,18 @@ async fn make_unshielded_transaction<S>(
 where
     S: Storage,
 {
-    *transaction_id = transaction.id();
-    let transaction_id = *transaction_id;
+    let id = transaction.id();
+    *transaction_id = id + 1;
 
     let created = storage
-        .get_unshielded_utxos_by_address_created_by_transaction(address, transaction_id)
+        .get_unshielded_utxos_by_address_created_by_transaction(address, id)
         .await
-        .map_err_into_server_error(|| {
-            format!("get created UTXOs for transaction with ID {transaction_id}")
-        })?;
+        .map_err_into_server_error(|| format!("get created UTXOs for transaction with ID {id}"))?;
 
     let spent = storage
-        .get_unshielded_utxos_by_address_spent_by_transaction(address, transaction_id)
+        .get_unshielded_utxos_by_address_spent_by_transaction(address, id)
         .await
-        .map_err_into_server_error(|| {
-            format!("get spent UTXOs for transaction with ID {transaction_id}")
-        })?;
+        .map_err_into_server_error(|| format!("get spent UTXOs for transaction with ID {id}"))?;
 
     // Only emit an event for transactions that have UTXOs for this address.
     let unshielded_utxo_update = (!created.is_empty() || !spent.is_empty()).then(|| {


### PR DESCRIPTION
Fix [PM-20829](https://shielded.atlassian.net/browse/PM-20829).

So far `make_transaction` did not increase the mutable `transaction_id` which is used as a starting point for subsequent database queries by one like in any other subscription (except for the shielded transactions one which uses an exclusive end range). This PR fixes this alongside some naming.

[PM-20829]: https://shielded.atlassian.net/browse/PM-20829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ