### PR TITLE
[DO NOT MERGE] fix: turn off validation till we can match node's genesis

### DIFF
--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -67,6 +67,8 @@ const OUTPUT_INDEX_ZERO: u32 = 0;
 static STRICTNESS_V6: LazyLock<WellFormedStrictnessV6> = LazyLock::new(|| {
     let mut strictness = WellFormedStrictnessV6::default();
     strictness.enforce_balancing = false;
+    strictness.verify_native_proofs = false;
+    strictness.verify_contract_proofs = false;
     strictness
 });
 


### PR DESCRIPTION
Currently the way that node constructs the genesis block and the way indexer constructs it are slightly different. For now we will turn off the re-verification in the indexer until compatibility is restored.