### PR TITLE
feat(nats): add num_replicas config for JetStream stream replication

### DIFF
--- a/chain-indexer/config.yaml
+++ b/chain-indexer/config.yaml
@@ -27,6 +27,7 @@ infra:
     url: "localhost:4222"
     username: "indexer"
     max_reconnects: 4
+    num_replicas: 1
 
   node:
     url: "ws://localhost:9944"

--- a/indexer-api/config.yaml
+++ b/indexer-api/config.yaml
@@ -23,6 +23,7 @@ infra:
     url: "localhost:4222"
     username: "indexer"
     max_reconnects: 4
+    num_replicas: 1
 
   api:
     address: "0.0.0.0"


### PR DESCRIPTION
closes : https://shielded.atlassian.net/browse/PM-21055

## Summary
Add configurable `num_replicas` for NATS JetStream object store to enable data replication across cluster nodes.

## Problem
The indexer creates `OBJ_ledger_state_store` with default `num_replicas: 1`, meaning ledger state is stored on only one NATS node. With 3-node NATS clustering enabled (shielded-gitops PR #435), the NATS service has HA but the ledger state data is NOT replicated.

If the leader node's PVC is lost, the ledger state is gone.

## Changes
  - Add `num_replicas: usize` field to `ledger_state_storage::Config`
  - Pass `num_replicas` to `create_ledger_state_store()`
  - Set `num_replicas` in `object_store::Config`
  - Update config.yaml files with `num_replicas: 1` for local development

## Usage
  For production with 3-node NATS cluster, set in Helm values:
  ```yaml
  num_replicas: 3  # Replicate across all NATS nodes

Notes
  - Changing num_replicas on an existing stream may require stream recreation
  - Single-node NATS (standalone mode) should use num_replicas: 1