### PR TITLE
fix: resolve Docker Compose permission denied errors for mounted volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ For development, you can use Docker Compose or run components manually:
 
 A `docker-compose.yaml` file is provided that defines services for the Indexer components as well as for dependencies like `postgres`, `nats`, and `node`. The latter are particularly interesting when running Indexer components "manually".
 
+**Note on Permissions:** The Docker Compose configuration uses `user: "${UID:-1000}:${GID:-1000}"` for services with mounted volumes (postgres, nats) to avoid permission issues. If you encounter "permission denied" errors, ensure the `UID` and `GID` environment variables match your host user:
+
+```bash
+export UID=$(id -u)
+export GID=$(id -g)
+docker compose --profile cloud up
+```
+
 #### Manual Startup
 
 The justfile defines recipes for each Indexer component to start it alongside its dependencies. E.g. run the Chain Indexer like this:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -124,6 +124,9 @@ services:
       - cloud
     image: "postgres:17.1-alpine"
     restart: "always"
+    # Run as the host user to avoid permission issues with mounted volumes.
+    # This ensures the postgres data directory is accessible by the host user.
+    user: "${UID:-1000}:${GID:-1000}"
     ports:
       - "5432:5432"
     volumes:
@@ -145,6 +148,8 @@ services:
       - cloud
     image: "nats:2.11.1"
     restart: "always"
+    # Run as the host user to avoid permission issues with mounted volumes.
+    user: "${UID:-1000}:${GID:-1000}"
     command:
       ["--user", "indexer", "--pass", $APP__INFRA__PUB_SUB__PASSWORD, "-js"]
     ports:


### PR DESCRIPTION
# Fix: Resolve Docker Compose Permission Denied Errors

## Overview

This Pull Request addresses **issue #591** by fixing the "permission denied" errors that occur when running Docker Compose with mounted volumes.

## Problem

When users attempt to run the indexer using Docker Compose:

```bash
docker compose --profile cloud up
```

They encounter permission denied errors because:

1. The `postgres` and `nats` containers run as internal users (postgres user, nats user)
2. These internal users have different UID/GID than the host user
3. When mounting host directories (`./target/data/postgres`, `./target/data/nats`), the container cannot write to them due to ownership mismatch

This is a common Docker issue that affects many users, especially on Linux systems where file permissions are strictly enforced.

## Solution

Added explicit user mapping to the affected services in `docker-compose.yaml`:

```yaml
user: "${UID:-1000}:${GID:-1000}"
```

This configuration:
- Uses the `UID` and `GID` environment variables if set
- Falls back to `1000:1000` (common default for first user on Linux)
- Ensures containers run with the same permissions as the host user

## Changes

### docker-compose.yaml

Added `user` directive to:
- `postgres` service (line 129)
- `nats` service (line 152)

Added explanatory comments for clarity.

### README.md

Added documentation in the "Using Docker Compose" section explaining:
- The permission handling mechanism
- How to set UID/GID environment variables
- Example commands for running Docker Compose

## Usage

After this fix, users can run Docker Compose in two ways:

**Option 1: Use defaults (works for most users)**
```bash
docker compose --profile cloud up
```

**Option 2: Explicitly set UID/GID (recommended)**
```bash
export UID=$(id -u)
export GID=$(id -g)
docker compose --profile cloud up
```

## Testing

This fix has been validated by:
1. Reviewing the Docker Compose configuration syntax
2. Verifying the user directive format is correct
3. Ensuring the environment variable substitution follows Docker Compose conventions

## Impact

This is a non-breaking change that:
- Improves the developer experience for local development
- Reduces friction for new contributors
- Maintains backward compatibility (defaults to UID/GID 1000)

## Related Issues

- Addresses #591 - Attempting to run with Docker Compose yields permission Denied
