### PR TITLE
chore(ci): remove redundant SARIF workaround for cargo-deny

### DIFF
--- a/.github/workflows/rust-security-scan.yaml
+++ b/.github/workflows/rust-security-scan.yaml
@@ -43,30 +43,9 @@ jobs:
           password: ${{ secrets.MIDNIGHTCI_REPO }}
 
       - name: Run cargo-deny
+        # cargo-deny 0.19.0+ includes fix for empty locations in SARIF output
         run: cargo deny -f sarif check -Aduplicate -Aunmaintained -Alicense-not-encountered -Aparse-error -Asource-not-allowed -Aunlicensed | tee scan.sarif || true
         # TODO: once everything's open sourced remove -Aunlicensed
-
-      - name: Fix SARIF for GitHub upload
-        run: |
-          # GitHub requires at least one location per result, but cargo-deny may generate
-          # results with empty locations (e.g., for git dependencies). Add Cargo.lock as
-          # the location for any results missing locations.
-          if [ -f scan.sarif ]; then
-            jq '.runs[].results |= map(
-              if .locations == [] or .locations == null then
-                .locations = [{
-                  "physicalLocation": {
-                    "artifactLocation": {
-                      "uri": "Cargo.lock"
-                    },
-                    "region": {
-                      "startLine": 1
-                    }
-                  }
-                }]
-              else . end
-            )' scan.sarif > scan-fixed.sarif && mv scan-fixed.sarif scan.sarif
-          fi
 
       - name: Upload SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@7273f08caa1dcf2c2837f362f1982de0ab4dc344


### PR DESCRIPTION
## Summary
Remove the jq workaround that added `Cargo.lock` as a fallback location for cargo-deny SARIF results with empty locations. This workaround is no longer needed as cargo-deny 0.19.0 now handles this natively.

## Changes
- Removed the "Fix SARIF for GitHub upload" step that used jq to inject fallback locations
- Added comment noting the cargo-deny version requirement

## Context
GitHub Code Scanning requires at least one location per SARIF result. Previously, cargo-deny produced results with empty `locations: []` arrays for dependency advisories (because Cargo.lock locations are filtered out). This caused GitHub to reject the SARIF upload.

The upstream fix ([EmbarkStudios/cargo-deny#819](https://github.com/EmbarkStudios/cargo-deny/pull/819)) adds `{workspace_root}/Cargo.toml` as a fallback location when no other locations exist. This was released in cargo-deny 0.19.0.

Since we use `cargo install cargo-deny` (which gets the latest version), we now automatically get this fix.

## Testing
CI `rust-security-scan` job passed:
  - cargo-deny SARIF output now includes fallback locations (e.g., `/home/runner/work/midnight-indexer/midnight-indexer/Cargo.toml`)
  - GitHub Code Scanning upload succeeded: "Successfully uploaded results"