### PR TITLE
fix(chain-indexer): rebuild ledger state from correct block height

### DIFF
--- a/chain-indexer/src/application.rs
+++ b/chain-indexer/src/application.rs
@@ -112,15 +112,14 @@ pub async fn run(
     // highest saved block height (inclusively); save ledger state thereafter.
     if let Some(highest_block_height) = highest_block_height {
         if ledger_state_block_height < Some(highest_block_height) {
-            debug!(ledger_state_block_height, highest_block_height; "updating ledger state");
+            debug!(ledger_state_block_height:?, highest_block_height; "updating ledger state");
 
             // Start from zero (genesis) for None, else add one to start from the next block after
             // the one for which the ledger state was saved.
-            let ledger_state_block_height =
-                ledger_state_block_height.map(|n| n + 1).unwrap_or_default();
+            let start_block_height = ledger_state_block_height.map(|n| n + 1).unwrap_or_default();
             let mut protocol_version = None;
 
-            for block_height in ledger_state_block_height..=highest_block_height {
+            for block_height in start_block_height..=highest_block_height {
                 let block_transactions = storage
                     .get_block_transactions(block_height)
                     .await


### PR DESCRIPTION
When the Chain Indexer starts up it will update the ledger state from the latest stored one up to the highest indexed block by applying all missing transactions. The logic to determine from where to start was broken in the case of no ledger state stored at all. This PR fixes it.