### PR TITLE
chore: propagate system parameters update errors

### DIFF
--- a/chain-indexer/src/application.rs
+++ b/chain-indexer/src/application.rs
@@ -415,9 +415,9 @@ where
         .context("save block")?;
 
     // Fetch and store system parameters if changed.
-    if let Err(error) = update_system_parameters(&block, storage, node).await {
-        warn!(error:%; "failed to update system parameters, continuing");
-    }
+    update_system_parameters(&block, storage, node)
+        .await
+        .context("update system parameters")?;
 
     let ledger_state_size = serialize_ledger_state.map(|s| s.len());
 


### PR DESCRIPTION
## Summary
Fail instead of silently continuing when system parameters update fails, ensuring complete governance data (D-Parameter, Terms & Conditions).

## Changes
- Changed `update_system_parameters` error handling from warn-and-continue to fail-hard
- Errors are now propagated with context instead of being logged and ignored

## Context
Raised by Heiko during code review. Silent failures could lead to incomplete governance history, which violates the requirement for full traceability (PM-20215 User Story #3).