### PR TITLE
test: reduce historical dust events request for preprod compatibility

### DIFF
--- a/qa/tests/tests/integration/basic/subscriptions/dust-ledger-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-ledger-subscriptions.test.ts
@@ -98,11 +98,12 @@ describe('dust ledger event subscriptions', () => {
      * @then each received event must match the DustLedgerEventsUnionSchema definition
      */
     test('validates historical dust events against schema', async () => {
-      const firstEvent = await await collectValidDustEvents(indexerWsClient, eventCoordinator, 1);
+      const firstEvent = await collectValidDustEvents(indexerWsClient, eventCoordinator, 1);
       const latestId = firstEvent[0].data!.dustLedgerEvents.maxId;
 
-      const fromId = Math.max(latestId - 5, 0);
-      const received = await collectValidDustEvents(indexerWsClient, eventCoordinator, 5, fromId);
+      const fromId = Math.max(latestId - 1, 0);
+      const received = await collectValidDustEvents(indexerWsClient, eventCoordinator, 1, fromId);
+      
       received
         .filter((msg) => msg.data?.dustLedgerEvents)
         .forEach((msg) => {


### PR DESCRIPTION
- Changed from requesting 5 events from latestId-5 to 1 event from latestId-1
- Fixed double await typo
- Test now passes on preprod, qanet, and preview environments