### PR TITLE
refactor(spo): move updated_at logic from DB trigger to application layer

### DIFF
--- a/indexer-common/migrations/postgres/001_initial.sql
+++ b/indexer-common/migrations/postgres/001_initial.sql
@@ -217,18 +217,6 @@ CREATE TABLE pool_metadata_cache (
   updated_at TIMESTAMPTZ,
   url TEXT
 );
--- TODO: Move updated_at trigger logic to application layer (PM-21550).
-CREATE OR REPLACE FUNCTION set_updated_at_timestamp()
-RETURNS TRIGGER AS $$
-BEGIN
-  NEW.updated_at = NOW();
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-CREATE TRIGGER update_pool_metadata_cache_updated_at
-BEFORE UPDATE ON pool_metadata_cache
-FOR EACH ROW
-EXECUTE FUNCTION set_updated_at_timestamp();
 --------------------------------------------------------------------------------
 -- spo_identity
 --------------------------------------------------------------------------------

--- a/spo-indexer/src/infra/storage.rs
+++ b/spo-indexer/src/infra/storage.rs
@@ -212,7 +212,8 @@ impl domain::storage::Storage for Storage {
                 name = CASE WHEN EXCLUDED.name IS NOT NULL AND EXCLUDED.name <> '' THEN EXCLUDED.name ELSE pool_metadata_cache.name END,
                 ticker = CASE WHEN EXCLUDED.ticker IS NOT NULL AND EXCLUDED.ticker <> '' THEN EXCLUDED.ticker ELSE pool_metadata_cache.ticker END,
                 homepage_url = CASE WHEN EXCLUDED.homepage_url IS NOT NULL AND EXCLUDED.homepage_url <> '' THEN EXCLUDED.homepage_url ELSE pool_metadata_cache.homepage_url END,
-                url = CASE WHEN EXCLUDED.url IS NOT NULL AND EXCLUDED.url <> '' THEN EXCLUDED.url ELSE pool_metadata_cache.url END"
+                url = CASE WHEN EXCLUDED.url IS NOT NULL AND EXCLUDED.url <> '' THEN EXCLUDED.url ELSE pool_metadata_cache.url END,
+                updated_at = NOW()"
         })
         .bind(&metadata.pool_id)
         .bind(&metadata.hex_id)


### PR DESCRIPTION
Closes : https://shielded.atlassian.net/browse/PM-21550

## Summary
- Remove `set_updated_at_timestamp` trigger function and trigger from `pool_metadata_cache`                                                  
- Set `updated_at = NOW()` explicitly in the `save_pool_meta` upsert query                                                                   

## Context
The `updated_at` column on `pool_metadata_cache` was previously maintained by a PostgreSQL trigger. This moves the logic to the application layer for consistency with the rest of the codebase and to support SQLite standalone mode. See PM-21550.

  ## Test plan
  - [ ] Verify `pool_metadata_cache.updated_at` is set on insert and updated on conflict