### PR TITLE
fix(spo): replace deprecated sidechain_getAriadneParameters RPC

### DIFF
--- a/spo-indexer/src/infra/subxt_node.rs
+++ b/spo-indexer/src/infra/subxt_node.rs
@@ -181,13 +181,13 @@ impl SPOClient {
         let raw_response = self
             .rpc_client
             .request(
-                "sidechain_getAriadneParameters".to_owned(),
+                "systemParameters_getAriadneParameters".to_owned(),
                 Some(rpc_params),
             )
             .await
             .map_err(|error| {
                 SPOClientError::RpcCall(
-                    "sidechain_getAriadneParameters".to_owned(),
+                    "systemParameters_getAriadneParameters".to_owned(),
                     error.to_string(),
                 )
             })?;


### PR DESCRIPTION
Closes : https://shielded.atlassian.net/browse/PM-21555

## Summary
  - Replace deprecated `sidechain_getAriadneParameters` with `systemParameters_getAriadneParameters` in spo-indexer RPC calls

  ## Context
  The node team deprecated `sidechain_getAriadneParameters` in favour of `systemParameters_getAriadneParameters`. See PM-21555.

## Test plan
  - [ ] Verify spo-indexer connects and fetches Ariadne parameters using the new RPC endpoint