### PR TITLE
test: fix tag extraction to handle Docker images validation

### DIFF
--- a/.github/workflows/build-indexer-images.yaml
+++ b/.github/workflows/build-indexer-images.yaml
@@ -157,15 +157,17 @@ jobs:
       - name: Set up Indexer Tag to target
         run: |
           echo "Raw tags output: ${{ steps.meta.outputs.tags }}"
-          tag_count=$(echo "${{ steps.meta.outputs.tags }}" | grep -c .)
-
-          if [ "$tag_count" -ne 1 ]; then
-            echo "Expected exactly one Docker tag, but got $tag_count:"
+          
+          # Filter "latest" for release tags
+          INDEXER_TAG=$(echo "${{ steps.meta.outputs.tags }}" | grep -v '^$' | grep -v '^latest$' | head -n1)
+          
+          if [ -z "$INDEXER_TAG" ]; then
+            echo "Failed to extract INDEXER_TAG from tags output"
+            echo "Available tags:"
+            echo "${{ steps.meta.outputs.tags }}"
             exit 1
           fi
-
-          # Extract the single tag
-          INDEXER_TAG=$(echo "${{ steps.meta.outputs.tags }}" | cut -d ':' -f2)
+          
           echo "Using INDEXER_TAG=$INDEXER_TAG"
           echo "INDEXER_TAG=$INDEXER_TAG" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
For full releases (e.g., 3.0.0), the Docker metadata action generates both the
version tag and 'latest'. This caused a failure.
The workflow now filters out 'latest' and uses the version tag instead of 
failing when multiple tags are present.

This fixes the Docker Compose Validation workflow failure for releases
(that typically don't have a pre-release suffix)