### PR TITLE
test: updated graphql request to include additional fields in tests

### DIFF
--- a/qa/tests/utils/indexer/graphql/subscriptions.ts
+++ b/qa/tests/utils/indexer/graphql/subscriptions.ts
@@ -73,6 +73,9 @@ const UNSHIELDED_TX_SUBSCRIPTION_FRAGMENT = `    ... on UnshieldedTransaction {
           value
           tokenType
           outputIndex
+          ctime
+          initialNonce
+          registeredForDustGeneration
           createdAtTransaction{
               hash
               ... on RegularTransaction {


### PR DESCRIPTION
The schema validation test for unshielded transactions was checking for the presence of ctime, initialNonce and registeredForDustGeneration, however the test wasn't requesting those fields in the graphq query. This caused the test to fail occasionally