### PR TITLE
ci: add spo-indexer to Docker image build matrix

### DIFF
--- a/.github/workflows/build-indexer-images.yaml
+++ b/.github/workflows/build-indexer-images.yaml
@@ -37,6 +37,8 @@ jobs:
             description: Midnight Wallet Indexer
           - name: indexer-standalone
             description: Midnight Indexer
+          - name: spo-indexer
+            description: Midnight SPO Indexer
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Add spo-indexer to the build-indexer-images workflow so its Docker image is built and pushed alongside the other indexer components (chain-indexer, indexer-api, wallet-indexer, indexer-standalone).

Changes:
- Add spo-indexer entry to the strategy matrix in build-indexer-images.yaml