### PR TITLE
chore(indexer-api): include ledger parameters in block query

### DIFF
--- a/indexer-api/graphql/schema-v3.graphql
+++ b/indexer-api/graphql/schema-v3.graphql
@@ -23,6 +23,10 @@ type Block {
 	"""
 	author: HexEncoded
 	"""
+	The hex-encoded ledger parameters for this block.
+	"""
+	ledgerParameters: HexEncoded!
+	"""
 	The parent of this block.
 	"""
 	parent: Block
@@ -30,10 +34,6 @@ type Block {
 	The transactions within this block.
 	"""
 	transactions: [Transaction!]!
-	"""
-	The hex-encoded ledger parameters for this block.
-	"""
-	ledgerParameters: HexEncoded!
 	"""
 	The system parameters (governance) at this block height.
 	"""

--- a/indexer-api/src/domain/block.rs
+++ b/indexer-api/src/domain/block.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use indexer_common::domain::{BlockAuthor, BlockHash, ProtocolVersion};
+use indexer_common::domain::{BlockAuthor, BlockHash, ProtocolVersion, SerializedLedgerParameters};
 use sqlx::prelude::FromRow;
 
 /// Relevant block data from the perspective of the Indexer API.
@@ -38,4 +38,6 @@ pub struct Block {
 
     #[sqlx(try_from = "i64")]
     pub timestamp: u64,
+
+    pub ledger_parameters: SerializedLedgerParameters,
 }

--- a/indexer-api/src/domain/storage/block.rs
+++ b/indexer-api/src/domain/storage/block.rs
@@ -13,7 +13,7 @@
 
 use crate::domain::{Block, storage::NoopStorage};
 use futures::{Stream, stream};
-use indexer_common::domain::{BlockHash, SerializedLedgerParameters};
+use indexer_common::domain::BlockHash;
 use std::num::NonZeroU32;
 
 #[trait_variant::make(Send)]
@@ -36,12 +36,6 @@ where
         height: u32,
         batch_size: NonZeroU32,
     ) -> impl Stream<Item = Result<Block, sqlx::Error>> + Send;
-
-    /// Get ledger parameters for the given block ID.
-    async fn get_ledger_parameters(
-        &self,
-        block_id: u64,
-    ) -> Result<Option<SerializedLedgerParameters>, sqlx::Error>;
 }
 
 #[allow(unused_variables)]
@@ -64,12 +58,5 @@ impl BlockStorage for NoopStorage {
         batch_size: NonZeroU32,
     ) -> impl Stream<Item = Result<Block, sqlx::Error>> {
         stream::empty()
-    }
-
-    async fn get_ledger_parameters(
-        &self,
-        block_id: u64,
-    ) -> Result<Option<SerializedLedgerParameters>, sqlx::Error> {
-        unimplemented!()
     }
 }


### PR DESCRIPTION
Closes : https://shielded.atlassian.net/browse/PM-21698

Summary
  - Include ledger_parameters in the initial block SELECT queries instead of fetching it via a separate SQL roundtrip per block
  - Remove get_ledger_parameters from BlockStorage trait and its implementations
  - Move ledgerParameters from a ComplexObject resolver to a SimpleObject field on the GraphQL Block type
  - No GraphQL schema change — field name and type (ledgerParameters: HexEncoded!) are identical

Testing
  - just all passes (format, lint, 18/18 tests, schema check, docs)
  - All three block query paths (latest, by height, by hash) return ledgerParameters correctly on local instance