### PR TITLE
fix(ci): set RUST_VERSION in docker-compose-test job

### DIFF
--- a/.github/workflows/build-indexer-images.yaml
+++ b/.github/workflows/build-indexer-images.yaml
@@ -123,7 +123,7 @@ jobs:
           docker version
           docker compose version
 
-      - name: Set RUST_VERSION for Dockerfile build arg
+      - name: Set toolchain
         run: |
           toolchain=$(grep channel rust-toolchain.toml | sed -r 's/channel = "(.*)"/\1/')
           echo "RUST_VERSION=$toolchain" | tee -a "$GITHUB_ENV"


### PR DESCRIPTION
[The Docker Compose Validation job](https://github.com/midnightntwrk/midnight-indexer/actions/runs/21640066523/job/62387714123) fails because `RUST_VERSION` is not set, causing the Dockerfile's `FROM cargo-chef:0.1.73-rust-$RUST_VERSION-trixie` to resolve as `cargo-chef:0.1.73-rust--trixie` (not found).

The build-and-push job already extracts the toolchain from `rust-toolchain.toml` but the docker-compose-test job doesn't. Add a step to extract it before `docker compose config` runs.