### PR TITLE
chore: use pre-built GHCR image for spo-indexer in docker-compose and remove unused NATS dependency

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -75,12 +75,7 @@ services:
     depends_on:
       postgres:
         condition: "service_healthy"
-      nats:
-        condition: "service_started"
-    build:
-      context: .
-      dockerfile: spo-indexer/Dockerfile
-    image: "spo-indexer:local"
+    image: "ghcr.io/midnight-ntwrk/spo-indexer:${INDEXER_TAG:-latest}"
     restart: "no"
     environment:
       RUST_LOG: "spo_indexer=debug,indexer_common=debug,fastrace_opentelemetry=off,info"
@@ -89,8 +84,6 @@ services:
       APP__INFRA__NODE__BLOCKFROST_ID: $APP__INFRA__NODE__BLOCKFROST_ID
       APP__INFRA__STORAGE__HOST: "postgres"
       APP__INFRA__STORAGE__PASSWORD: $APP__INFRA__STORAGE__PASSWORD
-      APP__INFRA__PUB_SUB__URL: "nats:4222"
-      APP__INFRA__PUB_SUB__PASSWORD: $APP__INFRA__PUB_SUB__PASSWORD
     healthcheck:
       test: ["CMD-SHELL", "cat /var/run/spo-indexer/running || exit 0"]
       start_interval: "2s"


### PR DESCRIPTION
- Use pre-built GHCR image for spo-indexer instead of local `build:`, matching all other services
- Remove unused NATS `depends_on` and `APP__INFRA__PUB_SUB__*` env vars (spo-indexer doesn't use NATS)

### Context
CI Docker Compose Validation (cloud) was failing because spo-indexer had a `build:` section but didn't pass `RUST_VERSION` as a build arg. The Dockerfile's `ARG RUST_VERSION` was empty, producing an invalid image tag `cargo-chef:0.1.73-rust--trixie`.

The root cause is that spo-indexer shouldn't be built locally in docker-compose — CI already builds and publishes it to GHCR like every other service.

Note: the APP__INFRA__PUB_SUB__URL: "nats:4222" in docker-compose.yaml did not cause the spo-indexer pod stuck in Init:1/2 state on qanet. docker-compose.yaml is only used for local development, not Kubernetes deployments.