### PR TITLE
fix(indexer-api): remove encode() call on varchar column in stakePoolOperators query

### DIFF
--- a/indexer-api/src/infra/storage/spo.rs
+++ b/indexer-api/src/infra/storage/spo.rs
@@ -414,7 +414,7 @@ impl SpoStorage for Storage {
     #[trace]
     async fn get_stake_pool_operator_ids(&self, limit: i64) -> Result<Vec<String>, sqlx::Error> {
         let query = indoc! {"
-            SELECT encode(sep.spo_sk,'hex') AS spo_sk_hex
+            SELECT sep.spo_sk
             FROM spo_epoch_performance sep
             GROUP BY sep.spo_sk
             ORDER BY MAX(sep.produced_blocks) DESC


### PR DESCRIPTION
The `stakePoolOperators` GraphQL query returned an internal server error because the SQL used `encode(sep.spo_sk, 'hex')` on a `VARCHAR` column. PostgreSQL's `encode()` function only accepts `bytea` input.

Since `spo_sk` is already stored as a hex string (`VARCHAR`), the `encode()` call is unnecessary — select the column directly.

### Context
Discovered while testing spo-indexer on qanet after deployment. The query fails at runtime with:
```
function encode(character varying, unknown) does not exist
```

### Test plan
- [ ] `stakePoolOperators` query returns results instead of internal server error