### PR TITLE
chore: update build-indexer-images workflow to use NODE_VERSIONS

### DIFF
--- a/.github/workflows/build-indexer-images.yaml
+++ b/.github/workflows/build-indexer-images.yaml
@@ -181,13 +181,13 @@ jobs:
 
       - name: Set up Node Tag to target
         run: |
-          # Use workflow dispatch input if provided, otherwise read from NODE_VERSION file
+          # Use workflow dispatch input if provided, otherwise read from NODE_VERSIONS file
           if [ -n "${{ github.event.inputs.node_tag }}" ]; then
             echo "Using node tag from workflow dispatch: ${{ github.event.inputs.node_tag }}"
             echo "NODE_TAG=${{ github.event.inputs.node_tag }}" >> "$GITHUB_ENV"
           else
-            echo "Reading node tag from NODE_VERSION file..."
-            node_tag=$(cat NODE_VERSION)
+            echo "Reading node tag from NODE_VERSIONS file..."
+            node_tag=$(tail -n 1 NODE_VERSIONS)
             echo "Using node tag: $node_tag"
             echo "NODE_TAG=$node_tag" >> "$GITHUB_ENV"
           fi


### PR DESCRIPTION
## Summary
  - `NODE_VERSION` was renamed to `NODE_VERSIONS` in #761, but the `build-indexer-images` workflow was not updated
  - Both Docker Compose Validation jobs (cloud, standalone) fail on release tags with `cat: NODE_VERSION: No such file or directory`
  - Changed `cat NODE_VERSION` to `tail -n 1 NODE_VERSIONS`, matching the pattern used in `ci-cloud.yaml` and `ci-standalone.yaml`

failing ci: https://github.com/midnightntwrk/midnight-indexer/actions/runs/21754784553/job/62772017754

<img width="360" height="590" alt="Screenshot 2026-02-06 at 16 26 01" src="https://github.com/user-attachments/assets/6432dd32-2ea6-4ec6-bd0c-984028ccf727" />
