### PR TITLE
test: update qa tests to support both qanet and qanet.dev

### DIFF
--- a/qa/tests/data/static/qanet.dev/cardano-stake-addresses.jsonc
+++ b/qa/tests/data/static/qanet.dev/cardano-stake-addresses.jsonc
@@ -1,0 +1,16 @@
+{
+  // A cardano address that is registered for dust production and has cNIGHT balance
+  // Expected status: registered=true, dustAddress not null, nightBalance > 0, generationRate = nightBalance * 8267, currentCapacity = 5000000000 (at max)
+  "registered-with-dust": "stake_test1uz6x47zhnk6f3nnpeg65st75t6gw7fzxv2hezafxtcgycdgyyhzh8",
+  // A cardano address that is registered for dust production but has no cNIGHT balance
+  // Expected status: registered=true, dustAddress not null, nightBalance="0", generationRate="0", currentCapacity="0"
+  // Note: No dust is generated because there is no cNIGHT to generate from
+  "registered-without-dust": "stake_test1uqq4wx2p5zr58zrte2e89tp0gqtjg5zhws97zyr0he5y7uqatzymz",
+  // A cardano address that has never been registered for dust production
+  // Expected status: registered=false, dustAddress=null, nightBalance="0", generationRate="0", currentCapacity="0"
+  "non-registered": "stake_test1uqg287q4tjltwaz55f3em78su32zn4as3n8sudhmelzyaws82w6gd",
+  // A cardano address that was previously registered for dust production but has been deregistered
+  // Expected status: registered=false, dustAddress=null, nightBalance="0", generationRate="0", currentCapacity="0"
+  // Note: This differs from non-registered in the execution path (deregistration vs never registered), but the status is the same
+  "deregistered": "stake_test1uqu5f7ctsrrfqys5rqf9843nwmrf2w0ea8hae0xe3f9fdcqucy6a8",
+}

--- a/qa/tests/data/static/qanet.dev/contract-actions.jsonc
+++ b/qa/tests/data/static/qanet.dev/contract-actions.jsonc
@@ -1,0 +1,143 @@
+// Array of contract actions
+[
+  {
+    "contract-address": "ccc34d785e2967ccf5486a7dffd0cac996b7b546e8fce7653c4439645a2bca48",
+    "contract-actions": [
+      {
+        "action-type": "ContractDeploy",
+        "block-height": 1808,
+        "block-hash": "1a03173a5e3f6f4028514cf622136f9b389a49311ac2a0b1d4a458c73b2de919"
+      },
+      {
+        "action-type": "ContractCall",
+        "block-height": 2225,
+        "block-hash": "e576be5d3edc04eba6835bbc1c5153e7a36b6ada9655ce4ed22e493f72da28d9"
+      },
+      {
+        "action-type": "ContractCall",
+        "block-height": 3074,
+        "block-hash": "943a01e49c81783e7f8adf589b2e8e5219cd7d9092d2949a62b109694488398f"
+      }
+    ]
+  },
+  {
+    "contract-address": "6359d3fdfb4c73b04e0e7d210e98e339bce225a8783d0893702771458d6df20c",
+    "contract-actions": [
+      {
+        "action-type": "ContractDeploy",
+        "block-height": 3942,
+        "block-hash": "b7c671c42bec72a630611cbe853341a4f7e1edfca2e678136bba45dd42613d1a"
+      },
+      {
+        "action-type": "ContractCall",
+        "block-height": 3962,
+        "block-hash": "b9b8da833ec132e36c434a278468da0870675a61f8606712a78fb010a9746017"
+      },
+      {
+        "action-type": "ContractCall",
+        "block-height": 3973,
+        "block-hash": "933e77182d0f3676ca1a8a9331fa83717fdeb361274fe1c24df0e81d037eb35c"
+      }
+    ]
+  },
+  {
+    "contract-address": "7de0baef7036c5252aad881de894f2b2bbe40c2bcd4ae7817fcc59780711dc16",
+    "contract-actions": [
+      {
+        "action-type": "ContractDeploy",
+        "block-height": 12847,
+        "block-hash": "543a9a70e59664aa4b388b77cb6402222c0ed6ac7a8035ce47745f620425d7fb"
+      },
+      {
+        "action-type": "ContractDeploy",
+        "block-height": 12877,
+        "block-hash": "ebc809bdb99dbed920051b07adaf7ea8ad0e89fb0ec62d02fb91e0f6c57ee07f"
+      },
+      {
+        "action-type": "ContractDeploy",
+        "block-height": 12909,
+        "block-hash": "2fda63ddf91869a874156eb6a10dcca7b39f8332be0be5b73bb88951f7b24a17"
+      },
+      {
+        "action-type": "ContractCall",
+        "block-height": 12915,
+        "block-hash": "1a07e3d82b83244a421026dbdb82abb06599c452b6fc3d197ef7f31d845f1ad2"
+      },
+      {
+        "action-type": "ContractDeploy",
+        "block-height": 12999,
+        "block-hash": "81ead077264a2f39534c249038fafb6de618f87969ba0afcdd903c1f6c45eff6"
+      },
+      {
+        "action-type": "ContractCall",
+        "block-height": 13005,
+        "block-hash": "d76ebd3c071c555e1eebbc0a6efc94ebd2c706d05b0634aa1f803e6a0ba9e2bf"
+      },
+      {
+        "action-type": "ContractUpdate",
+        "block-height": 13011,
+        "block-hash": "dd3b43d801301284c2639b87e1950eb6c3d82d9fc5d00eac64c7da7db2b6f50c"
+      },
+      {
+        "action-type": "ContractDeploy",
+        "block-height": 13214,
+        "block-hash": "211fd6d08671920af2855c479dce584845ac4364f9a95f531facf3b932f62b50"
+      },
+      {
+        "action-type": "ContractCall",
+        "block-height": 13221,
+        "block-hash": "f4c9a73d6fd31f8c3a8955fcfc2519d1786017dee5db9a1a25f9d529aa877206"
+      },
+      {
+        "action-type": "ContractDeploy",
+        "block-height": 13322,
+        "block-hash": "14c2e467d0f25c87c85935a08e7957faf5d507855579681adb9fb9fca0ed4c4a"
+      },
+      {
+        "action-type": "ContractCall",
+        "block-height": 13329,
+        "block-hash": "fe7327ee72dd0d9402ee0fe08dfbebaac248589185c1cbfaef5ab614fb519ea1"
+      },
+      {
+        "action-type": "ContractDeploy",
+        "block-height": 13398,
+        "block-hash": "949d99272cc6d4bd6b0fcb36dac0989c3af813cb4790ec8f3cd4597d1fda307c"
+      },
+      {
+        "action-type": "ContractCall",
+        "block-height": 13405,
+        "block-hash": "8f18aa618b36b6259eed6991b08c45d0b61b3b1811042a1def8077a19c7d3d6c"
+      },
+      {
+        "action-type": "ContractDeploy",
+        "block-height": 13473,
+        "block-hash": "292796f44c94501444a4a51dc15091acbfaaaf0f4b6e19ad380b7de7d94fa78b"
+      },
+      {
+        "action-type": "ContractCall",
+        "block-height": 13480,
+        "block-hash": "46282d5e514c1d6d18bdf38048733245e80a3bb45cfb641e366dc06f8924ce63"
+      }
+    ]
+  },
+  {
+    "contract-address": "6aa1b13eebb79ad422df4a17e5139621c88528ceac8704f0202e5f7eeb56723c",
+    "contract-actions": [
+      {
+        "action-type": "ContractDeploy",
+        "block-height": 14079,
+        "block-hash": "c0456a3d34b07e45d0f0a90788bc61fc2cb485f2c53f9e8f01ac3459f62b8a4c"
+      },
+      {
+        "action-type": "ContractCall",
+        "block-height": 14086,
+        "block-hash": "e80116c0ab0fbdd3077221bc6d1e175901cd8c9cff933188fa336eb577ee1849"
+      },
+      {
+        "action-type": "ContractUpdate",
+        "block-height": 14099,
+        "block-hash": "4061a29a11492d8c4028c4f83c2811aecaadbeeba5c33b454340464e55041984"
+      }
+    ]
+  }
+]

--- a/qa/tests/environment/model.ts
+++ b/qa/tests/environment/model.ts
@@ -47,14 +47,14 @@ type HostConfig = {
 
 type HostEntry =
   | {
-    env: EnvironmentName;
-    indexerHost: string;
-    nodeHost: string;
-  }
+      env: EnvironmentName;
+      indexerHost: string;
+      nodeHost: string;
+    }
   | {
-    env: EnvironmentName;
-    domain: string;
-  };
+      env: EnvironmentName;
+      domain: string;
+    };
 
 const hostEntries: HostEntry[] = [
   {
@@ -144,7 +144,7 @@ export class Environment {
     if (!rawEnv || !validEnvNames.includes(rawEnv as EnvironmentName)) {
       throw new Error(
         `Invalid or missing TARGET_ENV: "${rawEnv}". ` +
-        `Expected one of: \n  ${validEnvNames.map((name) => `"${name}"`).join(',\n  ')}`,
+          `Expected one of: \n  ${validEnvNames.map((name) => `"${name}"`).join(',\n  ')}`,
       );
     }
     this.envName = rawEnv as EnvironmentName;
@@ -228,6 +228,10 @@ export class Environment {
   }
 
   getNetworkId(): string {
+    // This check will have to be removed once we sunset the old qanet environment.
+    if (this.envName === EnvironmentName.QANET_DEV) {
+      return 'qanet';
+    }
     return this.networkId;
   }
 

--- a/qa/tests/tests/e2e/toolkit/key-material.test.ts
+++ b/qa/tests/tests/e2e/toolkit/key-material.test.ts
@@ -46,7 +46,7 @@ describe('key material derivation validation', () => {
       log.info(`Shielded address: ${address}`);
 
       // Mainnet addresses do not have a network ID prefix
-      const networkId = env.getCurrentEnvironmentName();
+      const networkId = env.getNetworkId();
       const addressPrefix =
         networkId === 'mainnet' ? `mn_shield-addr` : `mn_shield-addr_${networkId}`;
       expect(address).toMatch(new RegExp(`^${addressPrefix}`));
@@ -60,13 +60,14 @@ describe('key material derivation validation', () => {
      * @then the address should start with the expected prefix
      */
     test('should show with the expected prefix for all network IDs', async () => {
-      // For all known networks check if the right prefix is present
-      const networkIds = env.getAllEnvironmentNames();
-      for (const networkId of networkIds) {
-        const address = (await toolkit.showAddress(seed, networkId)).shielded;
+      // For all known environments check if the right prefix is present (prefix uses network ID)
+      const environmentNames = env.getAllEnvironmentNames();
+      for (const envName of environmentNames) {
+        const address = (await toolkit.showAddress(seed, envName)).shielded;
         log.info(`Shielded address: ${address}`);
 
-        // Mainnet addresses do not have a network ID prefix
+        // Address prefix uses network ID (e.g. qanet.dev env uses network ID "qanet")
+        const networkId = envName === 'qanet.dev' ? 'qanet' : envName;
         const addressPrefix =
           networkId === 'mainnet' ? `mn_shield-addr` : `mn_shield-addr_${networkId}`;
         expect(address).toMatch(new RegExp(`^${addressPrefix}`));
@@ -88,7 +89,7 @@ describe('key material derivation validation', () => {
       log.info(`Unshielded address: ${address}`);
 
       // Mainnet addresses do not have a network ID prefix
-      const networkId = env.getCurrentEnvironmentName();
+      const networkId = env.getNetworkId();
       const addressPrefix = networkId === 'mainnet' ? `mn_addr` : `mn_addr_${networkId}`;
       expect(address).toMatch(new RegExp(`^${addressPrefix}`));
     });
@@ -101,13 +102,14 @@ describe('key material derivation validation', () => {
      * @then the address should start with the expected prefix
      */
     test('should show with the expected prefix for all network IDs', async () => {
-      // For all known networks check if the right prefix is present
-      const networkIds = env.getAllEnvironmentNames();
-      for (const networkId of networkIds) {
-        const address = (await toolkit.showAddress(seed, networkId)).unshielded;
+      // For all known environments check if the right prefix is present (prefix uses network ID)
+      const environmentNames = env.getAllEnvironmentNames();
+      for (const envName of environmentNames) {
+        const address = (await toolkit.showAddress(seed, envName)).unshielded;
         log.info(`Unshielded address: ${address}`);
 
-        // Mainnet addresses do not have a network ID prefix
+        // Address prefix uses network ID (e.g. qanet.dev env uses network ID "qanet")
+        const networkId = envName === 'qanet.dev' ? 'qanet' : envName;
         const addressPrefix = networkId === 'mainnet' ? `mn_addr` : `mn_addr_${networkId}`;
         expect(address).toMatch(new RegExp(`^${addressPrefix}`));
       }
@@ -139,13 +141,14 @@ describe('key material derivation validation', () => {
      * @then the viewing key should start with the expected prefix
      */
     test('should show with the expected prefix for all network IDs', async () => {
-      // For all known networks check if the right prefix is present
-      const networkIds = env.getAllEnvironmentNames();
-      for (const networkId of networkIds) {
-        const address = await toolkit.showViewingKey(seed, networkId);
-        log.info(`Viewing key for ${networkId}: ${address}`);
+      // For all known environments check if the right prefix is present (prefix uses network ID)
+      const environmentNames = env.getAllEnvironmentNames();
+      for (const envName of environmentNames) {
+        const address = await toolkit.showViewingKey(seed, envName);
+        log.info(`Viewing key for ${envName}: ${address}`);
 
-        // Mainnet addresses do not have a network ID prefix
+        // Viewing key prefix uses network ID (e.g. qanet.dev env uses network ID "qanet")
+        const networkId = envName === 'qanet.dev' ? 'qanet' : envName;
         const addressPrefix =
           networkId === 'mainnet' ? `mn_shield-esk` : `mn_shield-esk_${networkId}`;
         expect(address).toMatch(new RegExp(`^${addressPrefix}`));

--- a/qa/tests/tests/integration/basic/queries/dust-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/dust-queries.test.ts
@@ -171,7 +171,7 @@ describe('dust generation status queries', () => {
       expect(dustGenerationStatus?.dustAddress).not.toBeNull();
 
       // The DUST destination address should have hrp prefix for the target network
-      const dustAddressHrpPrefix = 'mn_dust_' + env.getCurrentEnvironmentName();
+      const dustAddressHrpPrefix = 'mn_dust_' + env.getNetworkId();
       expect(dustGenerationStatus?.dustAddress).toMatch(new RegExp(`^${dustAddressHrpPrefix}`));
     });
 

--- a/qa/tests/tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts
@@ -15,7 +15,7 @@
 
 import log from '@utils/logging/logger';
 import '@utils/logging/test-logging-hooks';
-import { env } from 'environment/model';
+import { env, EnvironmentName } from 'environment/model';
 import dataProvider from 'utils/testdata-provider';
 import { GraphQLError } from 'graphql/error/GraphQLError';
 import {
@@ -343,12 +343,27 @@ describe('unshielded transaction subscriptions', async () => {
      */
     test('should return an error message, given the address provided is for another network', async () => {
       const currentEnvironment = env.getCurrentEnvironmentName();
+      const currentNetworkId = env.getNetworkId();
+
       for (const environment of env.getAllEnvironmentNames()) {
-        if (environment == currentEnvironment) {
+        if (environment === currentEnvironment) {
           // We don't want to test the current environment because the address HRP
           // should be accepted in this case
           log.info(
             `Skipping test for environment ${environment} because it is the current environment`,
+          );
+          continue;
+        }
+
+        // Environments can share the same underlying network id (e.g. qanet and qanet.dev both map
+        // to the "qanet" network id). In those cases, an address for that environment should be
+        // accepted, so we skip the check here as well.
+        const environmentNetworkId =
+          environment === EnvironmentName.QANET_DEV ? 'qanet' : environment;
+
+        if (environmentNetworkId === currentNetworkId) {
+          log.info(
+            `Skipping test for environment ${environment} because it shares the same network id as ${currentEnvironment}`,
           );
           continue;
         }

--- a/qa/tools/block-scanner/src/env.ts
+++ b/qa/tools/block-scanner/src/env.ts
@@ -20,7 +20,7 @@ const INDEXER_BASE_URL: Record<string, string> = {
   preview: "indexer.preview.midnight.network",
   preprod: "indexer.preprod.midnight.network",
   qanet: "indexer.qanet.midnight.network",
-  qanet_dev: "indexer.qanet.dev.midnight.network",
+  "qanet.dev": "indexer.qanet.dev.midnight.network",
   testnet02: "indexer.testnet-02.midnight.network",
 };
 


### PR DESCRIPTION
this change tries to make sure that we can support both new and old qanet environment
until we sunset the the old one