### PR TITLE
fix(indexer-api): correctly set next index for loading relevant transactions

### DIFF
--- a/indexer-api/src/infra/storage/transaction.rs
+++ b/indexer-api/src/infra/storage/transaction.rs
@@ -441,7 +441,7 @@ impl TransactionStorage for Storage {
                     .await?;
 
                 match transactions.last() {
-                    Some(transaction) => index = transaction.end_index + 1,
+                    Some(transaction) => index = transaction.end_index,
                     None => break,
                 }
 


### PR DESCRIPTION
Fix [PM-21819](https://shielded.atlassian.net/browse/PM-21819).

[PM-21819]: https://shielded.atlassian.net/browse/PM-21819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ