### PR TITLE
fix(chain-indexer): treat unknown highest block on node as not caught up

### DIFF
--- a/chain-indexer/src/application.rs
+++ b/chain-indexer/src/application.rs
@@ -33,7 +33,7 @@ use parking_lot::RwLock;
 use serde::Deserialize;
 use std::{
     collections::HashSet, error::Error as StdError, future::ready, pin::pin, sync::Arc,
-    time::Duration, u32,
+    time::Duration,
 };
 use tokio::{
     select,


### PR DESCRIPTION
Fix [PM-21810](https://shielded.atlassian.net/browse/PM-21810).

[PM-21810]: https://shielded.atlassian.net/browse/PM-21810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ