### PR TITLE
fix(chain-indexer): fold system parameters update into save_block transaction

### DIFF
--- a/chain-indexer/src/domain/storage.rs
+++ b/chain-indexer/src/domain/storage.rs
@@ -31,13 +31,8 @@ where
         transactions: &[Transaction],
         dust_registration_events: &[DustRegistrationEvent],
         ledger_state_key: &SerializedLedgerStateKey,
+        system_parameters_change: Option<&SystemParametersChange>,
     ) -> Result<Option<u64>, sqlx::Error>;
-
-    /// Save system parameters change.
-    async fn save_system_parameters_change(
-        &self,
-        change: &SystemParametersChange,
-    ) -> Result<(), sqlx::Error>;
 
     /// Get the block ref, ledger state key and protocol version of the highest stored block.
     async fn get_highest_block(


### PR DESCRIPTION
Fixes [PM-21811](https://shielded.atlassian.net/browse/PM-21811).

- System parameters (D-parameter, T&C) are now saved in the same DB transaction as the block, preventing partial-commit on crash

[PM-21811]: https://shielded.atlassian.net/browse/PM-21811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ