### PR TITLE
test: env variable to override the default API version

### DIFF
--- a/.github/workflows/qa-test-block-subscription-base-workflow.yml
+++ b/.github/workflows/qa-test-block-subscription-base-workflow.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: '22'
+      indexer_api_version:
+        description: 'Indexer API version (e.g. v3, v4)'
+        required: false
+        type: string
+        default: 'v4'
 
 jobs:
   test:
@@ -28,6 +33,7 @@ jobs:
         working-directory: qa/tests
     env:
       TARGET_ENV: ${{ inputs.target_env }}
+      INDEXER_API_VERSION: ${{ inputs.indexer_api_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/qa-test-block-subscriptions-devnet.yml
+++ b/.github/workflows/qa-test-block-subscriptions-devnet.yml
@@ -12,3 +12,4 @@ jobs:
     uses: ./.github/workflows/qa-test-block-subscription-base-workflow.yml
     with:
       target_env: devnet
+      indexer_api_version: v3

--- a/.github/workflows/qa-test-block-subscriptions-preprod.yml
+++ b/.github/workflows/qa-test-block-subscriptions-preprod.yml
@@ -12,3 +12,4 @@ jobs:
     uses: ./.github/workflows/qa-test-block-subscription-base-workflow.yml
     with:
       target_env: preprod
+      indexer_api_version: v3

--- a/.github/workflows/qa-test-block-subscriptions-preview.yml
+++ b/.github/workflows/qa-test-block-subscriptions-preview.yml
@@ -12,3 +12,4 @@ jobs:
     uses: ./.github/workflows/qa-test-block-subscription-base-workflow.yml
     with:
       target_env: preview
+      indexer_api_version: v3

--- a/.github/workflows/qa-test-block-subscriptions-qanet.yml
+++ b/.github/workflows/qa-test-block-subscriptions-qanet.yml
@@ -12,3 +12,4 @@ jobs:
     uses: ./.github/workflows/qa-test-block-subscription-base-workflow.yml
     with:
       target_env: qanet
+      indexer_api_version: v3

--- a/qa/tests/README.md
+++ b/qa/tests/README.md
@@ -137,6 +137,16 @@ Note: if you need to match a particular toolkit version:
 export NODE_TOOLKIT_TAG=0.17.0-rc.4
 ```
 
+#### Indexer API Version
+
+The GraphQL API version used by the HTTP and WebSocket clients defaults to `v4`. If the target environment uses a different API version, you can override it with the `INDEXER_API_VERSION` environment variable:
+
+```bash
+export INDEXER_API_VERSION=v3
+```
+
+This controls the version segment in the API endpoint paths (e.g. `/api/v3/graphql` and `/api/v3/graphql/ws`). If not set, the clients will use `/api/v4/graphql` and `/api/v4/graphql/ws`.
+
 For full instructions on updating the Node version, see the [Updating Node Version Guide](../../docs/updating-node-version.md)
 
 ## Running Test Projects on undeployed/local environment 
@@ -218,6 +228,12 @@ To execute the tests against these environments just change the TARGET_ENV varia
 ```bash
 TARGET_ENV=devnet yarn test       # devnet
 TARGET_ENV=qanet yarn test    # qanet
+```
+
+If the target environment uses a different indexer API version than the default (`v4`), set `INDEXER_API_VERSION` accordingly:
+
+```bash
+TARGET_ENV=preprod INDEXER_API_VERSION=v3 yarn test:integration
 ```
 
 ## ✨ Features

--- a/qa/tests/utils/indexer/http-client.ts
+++ b/qa/tests/utils/indexer/http-client.ts
@@ -51,7 +51,7 @@ import { GET_DUST_GENERATION_STATUS } from './graphql/dust-queries';
  */
 export class IndexerHttpClient {
   private client: GraphQLClient;
-  private readonly graphqlAPIEndpoint: string = '/api/v4/graphql';
+  private readonly graphqlAPIEndpoint: string;
   private targetUrl: string;
 
   /**
@@ -59,6 +59,8 @@ export class IndexerHttpClient {
    * @param endpoint - The base URL for the indexer HTTP endpoint. Defaults to the environment configuration
    */
   constructor() {
+    const apiVersion = process.env.INDEXER_API_VERSION || 'v4';
+    this.graphqlAPIEndpoint = `/api/${apiVersion}/graphql`;
     this.targetUrl = env.getIndexerHttpBaseURL() + this.graphqlAPIEndpoint;
     this.client = new GraphQLClient(this.targetUrl, { errorPolicy: 'all' });
   }

--- a/qa/tests/utils/indexer/websocket-client.ts
+++ b/qa/tests/utils/indexer/websocket-client.ts
@@ -150,7 +150,7 @@ export class IndexerWsClient {
   private ws: WebSocket | null = null;
 
   /** The endpoint where to send graphql subscriptions */
-  private readonly graphqlAPIEndpoint: string = '/api/v4/graphql/ws';
+  private readonly graphqlAPIEndpoint: string;
 
   /** WebSocket URL; set in constructor */
   private readonly targetUrl: string;
@@ -166,6 +166,8 @@ export class IndexerWsClient {
    * is created in connectionInit().
    */
   constructor() {
+    const apiVersion = process.env.INDEXER_API_VERSION || 'v4';
+    this.graphqlAPIEndpoint = `/api/${apiVersion}/graphql/ws`;
     this.targetUrl = env.getIndexerWebsocketBaseURL() + this.graphqlAPIEndpoint;
   }
 


### PR DESCRIPTION
this is useful when there's a need to support multiple version in between API upgrades