### PR TITLE
fix: use InitialNonce instead of HashOutput for night_utxo_hash in dtime update

### DIFF
--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -1031,7 +1031,7 @@ fn make_dust_generation_dtime_update_v7(
         .map_err(|error| Error::Serialize("DustPublicKeyV7", error))?;
 
     let generation_info = dust::DustGenerationInfo {
-        night_utxo_hash: update.leaf.0.0.into(),
+        night_utxo_hash: generation.nonce.0.0.into(),
         value: generation.value,
         owner,
         nonce: generation.nonce.0.0.into(),
@@ -1081,7 +1081,7 @@ fn make_dust_generation_dtime_update_v8(
         .map_err(|error| Error::Serialize("DustPublicKeyV8", error))?;
 
     let generation_info = dust::DustGenerationInfo {
-        night_utxo_hash: update.leaf.0.0.into(),
+        night_utxo_hash: generation.nonce.0.0.into(),
         value: generation.value,
         owner,
         nonce: generation.nonce.0.0.into(),


### PR DESCRIPTION
- Dtime update paths (make_dust_generation_dtime_update_v7 and _v8) used update.leaf.0 (Merkle tree HashOutput) for night_utxo_hash, while the initial UTXO creation paths correctly use output.backing_night (InitialNonce)
- Changed to generation.nonce (update.leaf.1.nonce) to match, as confirmed by Thomas (ledger team)