### PR TITLE
fix(chain-indexer): fix(chain-indexer): check all spent UTXOs are updated in save_spent_unshielded_utxos

### DIFF
--- a/chain-indexer/src/infra/storage.rs
+++ b/chain-indexer/src/infra/storage.rs
@@ -619,9 +619,10 @@ async fn save_spent_unshielded_utxos(
             .rows_affected();
     }
 
-    if rows_affected == 0 {
+    if rows_affected != utxos.len() as u64 {
         return Err(sqlx::Error::Protocol(format!(
-            "invalid spent UTXOs: {utxos:?}"
+            "expected {} spent UTXOs but updated {rows_affected}: {utxos:?}",
+            utxos.len()
         )));
     }
 


### PR DESCRIPTION
Fixes https://shielded.atlassian.net/browse/PM-21812

- save_spent_unshielded_utxos only errored when zero rows were updated (rows_affected == 0), silently accepting partial spend-sets
- Changed to rows_affected != utxos.len() to ensure all UTXOs in the spend-set are actually updated