### PR TITLE
chore: update debian trixie-slim base image to resolve CVE-2025-15467

### DIFF
--- a/chain-indexer/Dockerfile
+++ b/chain-indexer/Dockerfile
@@ -19,7 +19,7 @@ RUN cargo build -p chain-indexer --locked --features cloud --profile $PROFILE &&
     mkdir -p /runtime/opt/chain-indexer && \
     mv /build/chain-indexer/config.yaml /runtime/opt/chain-indexer
 
-FROM debian:trixie-slim@sha256:66b37a5078a77098bfc80175fb5eb881a3196809242fd295b25502854e12cbec AS runtime
+FROM debian:trixie-slim@sha256:f6e2cfac5cf956ea044b4bd75e6397b4372ad88fe00908045e9a0d21712ae3ba AS runtime
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates=20250419 && \
     rm -rf /var/lib/apt/lists/*

--- a/indexer-api/Dockerfile
+++ b/indexer-api/Dockerfile
@@ -19,7 +19,7 @@ RUN cargo build -p indexer-api --locked --features cloud --profile $PROFILE && \
     mkdir -p /runtime/opt/indexer-api && \
     mv /build/indexer-api/config.yaml /runtime/opt/indexer-api
 
-FROM debian:trixie-slim@sha256:66b37a5078a77098bfc80175fb5eb881a3196809242fd295b25502854e12cbec AS runtime
+FROM debian:trixie-slim@sha256:f6e2cfac5cf956ea044b4bd75e6397b4372ad88fe00908045e9a0d21712ae3ba AS runtime
 RUN useradd -u 10001 -d /nonexistent -s /usr/sbin/nologin -M -c "" appuser && \
     passwd -l appuser && \
     mkdir /var/run/indexer-api && \

--- a/indexer-standalone/Dockerfile
+++ b/indexer-standalone/Dockerfile
@@ -19,7 +19,7 @@ RUN cargo build -p indexer-standalone --locked --features standalone --profile $
     mkdir -p /runtime/opt/indexer-standalone && \
     mv /build/indexer-standalone/config.yaml /runtime/opt/indexer-standalone
 
-FROM debian:trixie-slim@sha256:66b37a5078a77098bfc80175fb5eb881a3196809242fd295b25502854e12cbec AS runtime
+FROM debian:trixie-slim@sha256:f6e2cfac5cf956ea044b4bd75e6397b4372ad88fe00908045e9a0d21712ae3ba AS runtime
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates=20250419 && \
     rm -rf /var/lib/apt/lists/*

--- a/spo-indexer/Dockerfile
+++ b/spo-indexer/Dockerfile
@@ -19,7 +19,7 @@ RUN cargo build -p spo-indexer --locked --features cloud --profile $PROFILE && \
     mkdir -p /runtime/opt/spo-indexer && \
     mv /build/spo-indexer/config.yaml /runtime/opt/spo-indexer
 
-FROM debian:trixie-slim@sha256:66b37a5078a77098bfc80175fb5eb881a3196809242fd295b25502854e12cbec AS runtime
+FROM debian:trixie-slim@sha256:f6e2cfac5cf956ea044b4bd75e6397b4372ad88fe00908045e9a0d21712ae3ba AS runtime
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates=20250419 && \
     rm -rf /var/lib/apt/lists/*

--- a/wallet-indexer/Dockerfile
+++ b/wallet-indexer/Dockerfile
@@ -19,7 +19,7 @@ RUN cargo build -p wallet-indexer --locked --features cloud --profile $PROFILE &
     mkdir -p /runtime/opt/wallet-indexer && \
     mv /build/wallet-indexer/config.yaml /runtime/opt/wallet-indexer
 
-FROM debian:trixie-slim@sha256:66b37a5078a77098bfc80175fb5eb881a3196809242fd295b25502854e12cbec AS runtime
+FROM debian:trixie-slim@sha256:f6e2cfac5cf956ea044b4bd75e6397b4372ad88fe00908045e9a0d21712ae3ba AS runtime
 RUN useradd -u 10001 -d /nonexistent -s /usr/sbin/nologin -M -c "" appuser && \
     passwd -l appuser && \
     mkdir /var/run/wallet-indexer && \


### PR DESCRIPTION
 - Update pinned debian:trixie-slim digest in all 5 Dockerfiles to resolve CVE-2025-15467 (Critical) in libssl3t64 and openssl-provider-legacy

Details
  - Old digest: sha256:[66b37a](https://hub.docker.com/layers/library/debian/trixie-slim/images/sha256-66b37a5078a77098bfc80175fb5eb881a3196809242fd295b25502854e12cbec)... — ships libssl3t64 3.5.1-1+deb13u1 (vulnerable)
  - New digest: sha256:[f6e2cf](https://hub.docker.com/layers/library/debian/trixie-slim/images/sha256-f6e2cfac5cf956ea044b4bd75e6397b4372ad88fe00908045e9a0d21712ae3ba)... — ships libssl3t64 3.5.4-1~deb13u2 (fixed)
 
Affected Dockerfiles: chain-indexer, wallet-indexer, indexer-api, spo-indexer, indexer-standalone