### PR TITLE
chore: bump ledger_v8 and zswap_v8 to 8.0.0-rc.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,86 +11,86 @@ members = [
 ]
 
 [workspace.package]
-version       = "4.0.0"
-edition       = "2024"
-license       = "Apache-2.0"
-readme        = "README.md"
-homepage      = "https://github.com/midnightntwrk/midnight-indexer"
-repository    = "https://github.com/midnightntwrk/midnight-indexer"
+version = "4.0.0"
+edition = "2024"
+license = "Apache-2.0"
+readme = "README.md"
+homepage = "https://github.com/midnightntwrk/midnight-indexer"
+repository = "https://github.com/midnightntwrk/midnight-indexer"
 documentation = "https://github.com/midnightntwrk/midnight-indexer"
-publish       = false
+publish = false
 
 [workspace.dependencies]
-midnight-base-crypto        = { version = "1.0" }
-midnight-coin-structure     = { version = "2.0" }
-midnight-ledger_v7          = { package = "midnight-ledger", version = "7.0" }
-midnight-ledger_v8          = { package = "midnight-ledger", version = "8.0.0-rc.4" }
+midnight-base-crypto = { version = "1.0" }
+midnight-coin-structure = { version = "2.0" }
+midnight-ledger_v7 = { package = "midnight-ledger", version = "7.0" }
+midnight-ledger_v8 = { package = "midnight-ledger", version = "8.0.0-rc.5" }
 midnight-onchain-runtime_v2 = { package = "midnight-onchain-runtime", version = "2.0" }
 midnight-onchain-runtime_v3 = { package = "midnight-onchain-runtime", version = "3.0.0-rc.1" }
-midnight-serialize          = { version = "1.0" }
-midnight-storage-core       = { version = "1.0" }
-midnight-transient-crypto   = { version = "2.0" }
-midnight-zswap_v7           = { package = "midnight-zswap", version = "7.0" }
-midnight-zswap_v8           = { package = "midnight-zswap", version = "8.0.0-rc.4" }
+midnight-serialize = { version = "1.0" }
+midnight-storage-core = { version = "1.0" }
+midnight-transient-crypto = { version = "2.0" }
+midnight-zswap_v7 = { package = "midnight-zswap", version = "7.0" }
+midnight-zswap_v8 = { package = "midnight-zswap", version = "8.0.0-rc.5" }
 # Other dependencies.
-anyhow                      = { version = "1.0" }
-assert_matches              = { version = "1.5" }
-async-graphql               = { version = "7.2" }
-async-graphql-axum          = { version = "7.2" }
-async-nats                  = { version = "0.46" }
-async-stream                = { version = "0.3" }
-axum                        = { version = "0.8" }
-bech32                      = { version = "0.11" }
-bip32                       = { version = "0.5" }
-blake2                      = { version = "0.10" }
-blockfrost                  = { version = "1.2" }
-byte-unit-serde             = { version = "0.1" }
-chacha20poly1305            = { version = "0.10" }
-clap                        = { version = "4.5" }
-const-hex                   = { version = "1.18" }
-dashmap                     = { version = "6.1" }
-derive_more                 = { version = "2.1" }
-drop-stream                 = { version = "0.3" }
-fake                        = { version = "2.10" }
-fastrace                    = { version = "0.7" }
-fastrace-axum               = { version = "0.2" }
-fastrace-opentelemetry      = { version = "0.16" }
-figment                     = { version = "0.10" }
-fs_extra                    = { version = "1.3" }
-futures                     = { version = "0.3" }
-graphql_client              = { version = "0.16" }
-http                        = { version = "1.4" }
-humantime-serde             = { version = "1.1" }
-indoc                       = { version = "2.0" }
-itertools                   = { version = "0.14" }
-log                         = { version = "0.4" }
-logforth                    = { version = "0.29" }
-metrics                     = { version = "0.24" }
+anyhow = { version = "1.0" }
+assert_matches = { version = "1.5" }
+async-graphql = { version = "7.2" }
+async-graphql-axum = { version = "7.2" }
+async-nats = { version = "0.46" }
+async-stream = { version = "0.3" }
+axum = { version = "0.8" }
+bech32 = { version = "0.11" }
+bip32 = { version = "0.5" }
+blake2 = { version = "0.10" }
+blockfrost = { version = "1.2" }
+byte-unit-serde = { version = "0.1" }
+chacha20poly1305 = { version = "0.10" }
+clap = { version = "4.5" }
+const-hex = { version = "1.18" }
+dashmap = { version = "6.1" }
+derive_more = { version = "2.1" }
+drop-stream = { version = "0.3" }
+fake = { version = "2.10" }
+fastrace = { version = "0.7" }
+fastrace-axum = { version = "0.2" }
+fastrace-opentelemetry = { version = "0.16" }
+figment = { version = "0.10" }
+fs_extra = { version = "1.3" }
+futures = { version = "0.3" }
+graphql_client = { version = "0.16" }
+http = { version = "1.4" }
+humantime-serde = { version = "1.1" }
+indoc = { version = "2.0" }
+itertools = { version = "0.14" }
+log = { version = "0.4" }
+logforth = { version = "0.29" }
+metrics = { version = "0.24" }
 metrics-exporter-prometheus = { version = "0.18", default-features = false }
-nix                         = { version = "0.31" }
-opentelemetry               = { version = "0.31" }
-opentelemetry-otlp          = { version = "0.31" }
-opentelemetry_sdk           = { version = "0.31" }
-parity-scale-codec          = { version = "3.7" }
-parking_lot                 = { version = "0.12" }
-reqwest                     = { version = "0.13", default-features = false }
-secrecy                     = { version = "0.10" }
-serde                       = { version = "1.0" }
-serde_json                  = { version = "1.0" }
-serde_with                  = { version = "3.17" }
-sha2                        = { version = "0.10" }
-sqlx                        = { version = "0.8" }
-stream-cancel               = { version = "0.8" }
-subxt                       = { version = "0.44" }
-tempfile                    = { version = "3.25" }
-testcontainers              = { version = "0.27" }
-testcontainers-modules      = { version = "0.15" }
-thiserror                   = { version = "2.0" }
-tokio                       = { version = "1" }
-tokio-stream                = { version = "0.1" }
-tokio-tungstenite           = { version = "0.28" }
-tower                       = { version = "0.5" }
-tower-http                  = { version = "0.6" }
-trait-variant               = { version = "0.1" }
-uuid                        = { version = "1.21", features = ["serde"] }
-walkdir                     = { version = "2.5" }
+nix = { version = "0.31" }
+opentelemetry = { version = "0.31" }
+opentelemetry-otlp = { version = "0.31" }
+opentelemetry_sdk = { version = "0.31" }
+parity-scale-codec = { version = "3.7" }
+parking_lot = { version = "0.12" }
+reqwest = { version = "0.13", default-features = false }
+secrecy = { version = "0.10" }
+serde = { version = "1.0" }
+serde_json = { version = "1.0" }
+serde_with = { version = "3.17" }
+sha2 = { version = "0.10" }
+sqlx = { version = "0.8" }
+stream-cancel = { version = "0.8" }
+subxt = { version = "0.44" }
+tempfile = { version = "3.25" }
+testcontainers = { version = "0.27" }
+testcontainers-modules = { version = "0.15" }
+thiserror = { version = "2.0" }
+tokio = { version = "1" }
+tokio-stream = { version = "0.1" }
+tokio-tungstenite = { version = "0.28" }
+tower = { version = "0.5" }
+tower-http = { version = "0.6" }
+trait-variant = { version = "0.1" }
+uuid = { version = "1.21", features = ["serde"] }
+walkdir = { version = "2.5" }


### PR DESCRIPTION
## Summary

Bump `midnight-ledger-v8` and `midnight-zswap-v8` dependencies from 8.0.0-rc.4 to 8.0.0-rc.5, with whitespace normalization.

## Changes

- `midnight-ledger-v8`: 8.0.0-rc.4 → 8.0.0-rc.5
- `midnight-zswap-v8`: 8.0.0-rc.4 → 8.0.0-rc.5
- Normalize whitespace formatting in `Cargo.toml`