### PR TITLE
ci: normalise scan job name

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  scan:
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
Scan job being called  is confusing. Rename jobname to 