### PR TITLE
chore(ci): remove Checkmarx references from rust-security-scan

### DIFF
--- a/.github/workflows/rust-security-scan.yaml
+++ b/.github/workflows/rust-security-scan.yaml
@@ -8,7 +8,7 @@ name: rust-security-scan
 # Fork PR behavior:
 # - cargo-deny runs successfully (no secrets needed)
 # - SARIF uploads to GitHub Security (no secrets needed)
-# - netrc and Checkmarx BYOR upload are skipped (require secrets)
+# - netrc is skipped (requires secrets)
 #
 # This is acceptable because fork PRs still get security scanning via cargo-deny.
 
@@ -51,15 +51,3 @@ jobs:
         uses: github/codeql-action/upload-sarif@7273f08caa1dcf2c2837f362f1982de0ab4dc344
         with:
           sarif_file: scan.sarif
-
-      # skip for now until checkmarx user has permissions to upload BYOR
-      # # Skip Checkmarx BYOR upload for fork PRs (no secrets available)
-      # - name: Upload SARIF to Checkmarx
-      #   if: github.event.pull_request.head.repo.full_name == github.repository
-      #   uses: midnightntwrk/upload-sarif-github-action@32b96caabd2472b3d142ed0a278d619d6bd82bf8
-      #   with:
-      #     sarif-file: scan.sarif
-      #     project-name: midnightntwrk/midnight-indexer
-      #     cx-client-id: ${{ secrets.CX_CLIENT_ID }}
-      #     cx-client-secret: ${{ secrets.CX_CLIENT_SECRET_EU }}
-      #     cx-tenant: ${{ secrets.CX_TENANT }}


### PR DESCRIPTION
Remove Checkmarx references from `rust-security-scan.yaml` now that Checkmarx has been replaced by open source scanners in `scan.yaml`.

  ## Changes

  - Removed commented-out Checkmarx BYOR upload section
  - Updated comment to remove Checkmarx mention