### PR TITLE
chore(ci): remove unused LEDGER_STATE_STORAGE env var from workflows

### DIFF
--- a/.github/workflows/build-indexer-images.yaml
+++ b/.github/workflows/build-indexer-images.yaml
@@ -115,7 +115,6 @@ jobs:
     env:
       APP__INFRA__STORAGE__PASSWORD: ${{ secrets.APP__INFRA__STORAGE__PASSWORD }}
       APP__INFRA__PUB_SUB__PASSWORD: ${{ secrets.APP__INFRA__PUB_SUB__PASSWORD }}
-      APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD: ${{ secrets.APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD }}
       APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci-cloud.yaml
+++ b/.github/workflows/ci-cloud.yaml
@@ -61,7 +61,6 @@ jobs:
         env:
           APP__INFRA__STORAGE__PASSWORD: ${{ secrets.APP__INFRA__STORAGE__PASSWORD }}
           APP__INFRA__PUB_SUB__PASSWORD: ${{ secrets.APP__INFRA__PUB_SUB__PASSWORD }}
-          APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD: ${{ secrets.APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD }}
           APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
 
   fmt-check:
@@ -118,7 +117,6 @@ jobs:
         env:
           APP__INFRA__STORAGE__PASSWORD: ${{ secrets.APP__INFRA__STORAGE__PASSWORD }}
           APP__INFRA__PUB_SUB__PASSWORD: ${{ secrets.APP__INFRA__PUB_SUB__PASSWORD }}
-          APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD: ${{ secrets.APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD }}
           APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
 
   test:
@@ -164,7 +162,6 @@ jobs:
         env:
           APP__INFRA__STORAGE__PASSWORD: ${{ secrets.APP__INFRA__STORAGE__PASSWORD }}
           APP__INFRA__PUB_SUB__PASSWORD: ${{ secrets.APP__INFRA__PUB_SUB__PASSWORD }}
-          APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD: ${{ secrets.APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD }}
           APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
 
   doc:

--- a/.github/workflows/qa-integration-tests-base-workflow.yml
+++ b/.github/workflows/qa-integration-tests-base-workflow.yml
@@ -122,7 +122,6 @@ jobs:
           APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
           APP__INFRA__STORAGE__PASSWORD: ${{ secrets.APP__INFRA__STORAGE__PASSWORD }}
           APP__INFRA__PUB_SUB__PASSWORD: ${{ secrets.APP__INFRA__PUB_SUB__PASSWORD }}
-          APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD: ${{ secrets.APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD }}
         run: |
           . ./.envrc
           echo "NODE_TAG: $NODE_TAG"


### PR DESCRIPTION
Since indexer 3.1.0, ledger state is stored in PostgreSQL instead of NATS JetStream. The `APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD` env var is no longer consumed by the application.

- Remove from ci-cloud.yaml (check, lint, test jobs)
- Remove from build-indexer-images.yaml
- Remove from qa-integration-tests-base-workflow.yml