### PR TITLE
ci: add permissions and replace secrets:inherit (PM-22119)

### DIFF
--- a/.github/workflows/qa-integration-tests-devnet.yml
+++ b/.github/workflows/qa-integration-tests-devnet.yml
@@ -20,4 +20,11 @@ jobs:
       target_env: devnet
       ref: main
       publish_to_xray: ${{ inputs.publish_to_xray }}
-    secrets: inherit
+    secrets:
+      MIDNIGHTCI_PACKAGES_READ: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
+      APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
+      APP__INFRA__STORAGE__PASSWORD: ${{ secrets.APP__INFRA__STORAGE__PASSWORD }}
+      APP__INFRA__PUB_SUB__PASSWORD: ${{ secrets.APP__INFRA__PUB_SUB__PASSWORD }}
+      APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD: ${{ secrets.APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD }}
+      XRAY_CLIENT_ID: ${{ secrets.XRAY_CLIENT_ID }}
+      XRAY_CLIENT_SECRET: ${{ secrets.XRAY_CLIENT_SECRET }}

--- a/.github/workflows/qa-integration-tests-undeployed.yml
+++ b/.github/workflows/qa-integration-tests-undeployed.yml
@@ -32,4 +32,11 @@ jobs:
       publish_to_xray: ${{ inputs.publish_to_xray }}
       node_tag: ${{ inputs.node_tag }}
       indexer_tag: ${{ inputs.indexer_tag }}
-    secrets: inherit
+    secrets:
+      MIDNIGHTCI_PACKAGES_READ: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
+      APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
+      APP__INFRA__STORAGE__PASSWORD: ${{ secrets.APP__INFRA__STORAGE__PASSWORD }}
+      APP__INFRA__PUB_SUB__PASSWORD: ${{ secrets.APP__INFRA__PUB_SUB__PASSWORD }}
+      APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD: ${{ secrets.APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD }}
+      XRAY_CLIENT_ID: ${{ secrets.XRAY_CLIENT_ID }}
+      XRAY_CLIENT_SECRET: ${{ secrets.XRAY_CLIENT_SECRET }}

--- a/.github/workflows/qa-test-block-subscription-base-workflow.yml
+++ b/.github/workflows/qa-test-block-subscription-base-workflow.yml
@@ -19,6 +19,10 @@ on:
         type: string
         default: 'v4'
 
+# no top level default permissions for security reasons
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test - block-subscriptions

--- a/.github/workflows/qa-test-block-subscriptions-devnet.yml
+++ b/.github/workflows/qa-test-block-subscriptions-devnet.yml
@@ -6,6 +6,10 @@ on:
     # Every 30 minutes on workdays (Mon-Fri), covering UK and US working hours (07:00-21:00 UTC)
     - cron: '*/30 7-21 * * 1-5'
 
+# no top level default permissions for security reasons
+permissions:
+  contents: read
+
 jobs:
   test-block-subscriptions:
     name: Test Block Subscriptions

--- a/.github/workflows/qa-test-block-subscriptions-preprod.yml
+++ b/.github/workflows/qa-test-block-subscriptions-preprod.yml
@@ -6,6 +6,10 @@ on:
     # Every 10 minutes on workdays (Mon-Fri), covering UK and US working hours (07:00-21:00 UTC)
     - cron: '*/10 7-21 * * 1-5'
 
+# no top level default permissions for security reasons
+permissions:
+  contents: read
+
 jobs:
   test-block-subscriptions:
     name: Test Block Subscriptions

--- a/.github/workflows/qa-test-block-subscriptions-preview.yml
+++ b/.github/workflows/qa-test-block-subscriptions-preview.yml
@@ -6,6 +6,10 @@ on:
     # Every 10 minutes on workdays (Mon-Fri), covering UK and US working hours (07:00-21:00 UTC)
     - cron: '*/10 7-21 * * 1-5'
 
+# no top level default permissions for security reasons
+permissions:
+  contents: read
+
 jobs:
   test-block-subscriptions:
     name: Test Block Subscriptions

--- a/.github/workflows/qa-test-block-subscriptions-qanet.yml
+++ b/.github/workflows/qa-test-block-subscriptions-qanet.yml
@@ -6,6 +6,10 @@ on:
     # Every 30 minutes on workdays (Mon-Fri), covering UK and US working hours (07:00-21:00 UTC)
     - cron: '*/30 7-21 * * 1-5'
 
+# no top level default permissions for security reasons
+permissions:
+  contents: read
+
 jobs:
   test-block-subscriptions:
     name: Test Block Subscriptions


### PR DESCRIPTION
## Summary

Add explicit `permissions:` blocks to 5 QA workflow files and replace `secrets: inherit` with explicit secret passing in 2 integration test files.

🎫 [Ticket](https://shielded.atlassian.net/browse/PM-22119)

---

## Motivation

Part of CI/CD permissions hardening (PM-22119). The 5 QA test workflows lacked `permissions:` blocks, inheriting repository defaults. The 2 integration test files passed all secrets via `secrets: inherit` when only 7 are consumed.

---

## Changes

- **5 QA workflow files (M-F006)** — Add `permissions: { contents: read }` at workflow level
- **2 integration test files (M-F015)** — Replace `secrets: inherit` with explicit passing of 7 consumed secrets

---

## 📌 Submission Checklist

- [x] Changes are backward-compatible
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: CI/CD config only