### PR TITLE
fix: use lazy loading for ledger state deserialization to avoid recursion depth limit

### DIFF
--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -210,10 +210,9 @@ impl LedgerState {
                 >::deserialize(&mut key.as_slice(), 0)
                 .map_err(|error| Error::Deserialize("TypedArenaKeyV7", error))?;
                 let ledger_state = default_storage::<v1_1::LedgerDb>()
-                    .get(&arena_key)
+                    .get_lazy(&arena_key)
                     .map_err(|error| Error::LoadLedgerState(key.to_owned(), error))?;
-                let ledger_state =
-                    Sp::into_inner(ledger_state).expect("loaded ledger state exists");
+                let ledger_state = (*ledger_state).clone();
 
                 Self::V7 {
                     ledger_state,
@@ -228,10 +227,9 @@ impl LedgerState {
                 >::deserialize(&mut key.as_slice(), 0)
                 .map_err(|error| Error::Deserialize("TypedArenaKeyV8", error))?;
                 let ledger_state = default_storage::<v1_1::LedgerDb>()
-                    .get(&arena_key)
+                    .get_lazy(&arena_key)
                     .map_err(|error| Error::LoadLedgerState(key.to_owned(), error))?;
-                let ledger_state =
-                    Sp::into_inner(ledger_state).expect("loaded ledger state exists");
+                let ledger_state = (*ledger_state).clone();
 
                 Self::V8 {
                     ledger_state,
@@ -265,11 +263,11 @@ impl LedgerState {
 
                 let ledger_state =
                     default_storage::<v1_1::LedgerDb>()
-                        .get(&key)
+                        .get_lazy(&key)
                         .map_err(|error| {
                             Error::LedgerStateTranslation(LedgerVersion::V7, ledger_version, error)
                         })?;
-                let ledger_state = Sp::into_inner(ledger_state).expect("ledger state exists");
+                let ledger_state = (*ledger_state).clone();
 
                 Ok(LedgerState::V8 {
                     ledger_state,


### PR DESCRIPTION
- Replace `storage.get()` with `storage.get_lazy()` for ledger state loading to avoid hitting the `RECURSION_LIMIT=250` in midnight-serialize during deserialization
- Accumulated `StateValue` nesting (62 levels × 4 recursion depth per level) exceeds the limit when eagerly loading the full state tree
- `get_lazy` loads only the top level (`max_depth=1` on deref), keeping children as lazy `Sp` values that load on demand

## Context

Resolves [PM-22238](https://shielded.atlassian.net/browse/PM-22238).

Chain-indexer crashes on restart (and indexer-api on collapsed Merkle tree updates) when loading accumulated ledger state from PostgreSQL. The eager `get()` recursively deserializes the entire state tree, hitting the serialization recursion limit. `get_lazy()` avoids this by deferring child deserialization.

Three call sites changed in `indexer-common/src/domain/ledger/ledger_state.rs`:
- V7 load (line 213)
- V8 load (line 231)
- V7→V8 translation (line 268)

`Sp::into_inner()` is also replaced with `(*sp).clone()` because `get_lazy` returns a lazy `Sp` whose `OnceLock` is uninitialised. `into_inner` does not force lazy initialisation, so it returns `None` and the `.expect("loaded ledger state exists")` panics. Dereferencing (`*sp`) triggers `force_as_arc`, which loads only the top level (`max_depth=1`), and `.clone()` gives us the owned value needed by the `LedgerState` enum.

## Test plan

- [x] Reproduced the recursion depth crash locally (release build, devnet state at block 3930+)
- [x] Verified fix: chain-indexer resumes from block 4232 without error
- [x] Verified continued indexing past the previously-crashing block range
- [x] `just check` passes for all packages

[PM-22238]: https://shielded.atlassian.net/browse/PM-22238