### PR TITLE
refactor: replace window function with scalar subquery in ledger events query

### DIFF
--- a/indexer-api/src/infra/storage/ledger_events.rs
+++ b/indexer-api/src/infra/storage/ledger_events.rs
@@ -55,7 +55,7 @@ impl LedgerEventStorage for Storage {
                 ledger_events.id,
                 ledger_events.raw,
                 ledger_events.attributes,
-                MAX(ledger_events.id) OVER (PARTITION BY ledger_events.grouping) AS max_id,
+                (SELECT MAX(id) FROM ledger_events WHERE grouping = $1) AS max_id,
                 transactions.protocol_version
             FROM ledger_events
             INNER JOIN transactions ON transactions.id = ledger_events.transaction_id
@@ -89,7 +89,7 @@ impl Storage {
                 ledger_events.id,
                 ledger_events.raw,
                 ledger_events.attributes,
-                MAX(ledger_events.id) OVER (PARTITION BY ledger_events.grouping) AS max_id,
+                (SELECT MAX(id) FROM ledger_events WHERE grouping = $1) AS max_id,
                 transactions.protocol_version
             FROM ledger_events
             INNER JOIN transactions ON transactions.id = ledger_events.transaction_id


### PR DESCRIPTION
- Replace `MAX(id) OVER (PARTITION BY grouping)` window function with `(SELECT MAX(id) FROM ledger_events WHERE grouping = $1)` scalar subquery in both ledger events queries

## Context
After 55K transactions on qanet, `dustLedgerEvents` subscription appeared to hang while `zswapLedgerEvents` worked fine. Both use identical code paths and the same SQL query.

The window function forces PostgreSQL to scan the entire partition (all rows matching the grouping filter) before applying `LIMIT`, because window functions are evaluated after `WHERE` but before `LIMIT`. With ~100K dust events, each batch of 20 triggers a full partition scan taking minutes.

The scalar subquery uses the existing `(id, grouping)` composite index via reverse index scan — O(1) instead of O(n).

## Test plan
- [x] Deploy to qanet, verify `dustLedgerEvents` subscription streams at comparable speed to `zswapLedgerEvents`