### PR TITLE
chore(ci): use GHCR for Docker Compose validation on non-tag pushes

### DIFF
--- a/.github/workflows/build-indexer-images.yaml
+++ b/.github/workflows/build-indexer-images.yaml
@@ -193,11 +193,18 @@ jobs:
             echo "NODE_TAG=$node_tag" >> "$GITHUB_ENV"
           fi
 
+      - name: Set image registry
+        run: |
+          if [ "${{ github.ref_type }}" != "tag" ]; then
+            echo "IMAGE_REGISTRY=ghcr.io/midnight-ntwrk" >> "$GITHUB_ENV"
+          fi
+
       - name: Docker Compose Up
         run: |
           echo "Compose up with:"
           echo "- Indexer tag: $INDEXER_TAG"
           echo "- Node tag   : $NODE_TAG"
+          echo "- Registry   : ${IMAGE_REGISTRY:-midnightntwrk}"
           docker compose --profile "${{ matrix.profile }}" up -d
 
       - name: Show running containers

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
         condition: "service_healthy"
       nats:
         condition: "service_started"
-    image: "midnightntwrk/chain-indexer:${INDEXER_TAG:-latest}"
+    image: "${IMAGE_REGISTRY:-midnightntwrk}/chain-indexer:${INDEXER_TAG:-latest}"
     restart: "no"
     environment:
       RUST_LOG: "chain_indexer=debug,indexer_common=debug,fastrace_opentelemetry=off,info"
@@ -50,7 +50,7 @@ services:
         condition: "service_healthy"
       nats:
         condition: "service_started"
-    image: "midnightntwrk/wallet-indexer:${INDEXER_TAG:-latest}"
+    image: "${IMAGE_REGISTRY:-midnightntwrk}/wallet-indexer:${INDEXER_TAG:-latest}"
     restart: "no"
     environment:
       RUST_LOG: "wallet_indexer=debug,indexer_common=debug,fastrace_opentelemetry=off,info"
@@ -73,7 +73,7 @@ services:
     depends_on:
       postgres:
         condition: "service_healthy"
-    image: "midnightntwrk/spo-indexer:${INDEXER_TAG:-latest}"
+    image: "${IMAGE_REGISTRY:-midnightntwrk}/spo-indexer:${INDEXER_TAG:-latest}"
     restart: "no"
     environment:
       RUST_LOG: "spo_indexer=debug,indexer_common=debug,fastrace_opentelemetry=off,info"
@@ -98,7 +98,7 @@ services:
         condition: "service_healthy"
       nats:
         condition: "service_started"
-    image: "midnightntwrk/indexer-api:${INDEXER_TAG:-latest}"
+    image: "${IMAGE_REGISTRY:-midnightntwrk}/indexer-api:${INDEXER_TAG:-latest}"
     restart: "no"
     ports:
       - "8088:8088"
@@ -122,7 +122,7 @@ services:
       - standalone
     depends_on:
       - node
-    image: "midnightntwrk/indexer-standalone:${INDEXER_TAG:-latest}"
+    image: "${IMAGE_REGISTRY:-midnightntwrk}/indexer-standalone:${INDEXER_TAG:-latest}"
     restart: "no"
     ports:
       - "8088:8088"


### PR DESCRIPTION
The `Docker Compose Validation` CI job has been failing on every non-tag push to main because `docker-compose.yaml` pulls images from DockerHub (`midnightntwrk/...`), but the `build-and-push` job only pushes to DockerHub for tag (release) pushes. Non-tag pushes only go to GHCR (`ghcr.io/midnight-ntwrk/...`).

<img width="929" height="1263" alt="Screenshot 2026-03-13 at 14 32 19" src="https://github.com/user-attachments/assets/f5287b35-1cd3-40da-86fd-443657e12c42" />

### Changes

- Add `IMAGE_REGISTRY` env var to all indexer image references in `docker-compose.yaml`, defaulting to `midnightntwrk` (DockerHub) for backwards compatibility
- Add a "Set image registry" step in `build-indexer-images.yaml` that sets `IMAGE_REGISTRY=ghcr.io/midnight-ntwrk` for non-tag pushes
- Tag (release) pushes continue to use DockerHub as before

### Test plan

- [ ] Verify CI passes on this PR's branch (non-tag push should pull from GHCR)
- [ ] Verify next release tag still works (should pull from DockerHub)
- [ ] `docker compose config --quiet` with no `IMAGE_REGISTRY` set defaults to `midnightntwrk`
