### PR TITLE
chore(build): fix .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,5 +11,5 @@ target
 # Additional files.
 .git
 .github
-.node
+.node/**/chain
 qa


### PR DESCRIPTION
Ignoring the full .node directory was too restrictive, because we need the metadata.scale files.