### PR TITLE
refactor: rename cardano_address DB column to cardano_stake_key for clarity

### DIFF
--- a/chain-indexer/src/domain/dust.rs
+++ b/chain-indexer/src/domain/dust.rs
@@ -16,21 +16,21 @@ use indexer_common::domain::{CardanoRewardAddress, DustPublicKey, DustUtxoId};
 /// Domain representation of DUST registration events from the NativeTokenObservation pallet.
 #[derive(Debug, Clone, PartialEq)]
 pub enum DustRegistrationEvent {
-    /// Cardano address registered with DUST address.
+    /// Cardano stake key registered with DUST address.
     Registration {
-        cardano_address: CardanoRewardAddress,
+        cardano_stake_key: CardanoRewardAddress,
         dust_address: DustPublicKey,
     },
 
-    /// Cardano address deregistered from DUST address.
+    /// Cardano stake key deregistered from DUST address.
     Deregistration {
-        cardano_address: CardanoRewardAddress,
+        cardano_stake_key: CardanoRewardAddress,
         dust_address: DustPublicKey,
     },
 
     /// UTXO mapping added for registration.
     MappingAdded {
-        cardano_address: CardanoRewardAddress,
+        cardano_stake_key: CardanoRewardAddress,
         dust_address: DustPublicKey,
         utxo_id: DustUtxoId,
         utxo_index: u32,
@@ -38,7 +38,7 @@ pub enum DustRegistrationEvent {
 
     /// UTXO mapping removed from registration.
     MappingRemoved {
-        cardano_address: CardanoRewardAddress,
+        cardano_stake_key: CardanoRewardAddress,
         dust_address: DustPublicKey,
         utxo_id: DustUtxoId,
         utxo_index: u32,

--- a/chain-indexer/src/infra/storage.rs
+++ b/chain-indexer/src/infra/storage.rs
@@ -808,19 +808,19 @@ async fn save_dust_registration_events(
     for event in events {
         match event {
             DustRegistrationEvent::Registration {
-                cardano_address,
+                cardano_stake_key,
                 dust_address,
             } => {
                 let query = indoc! {"
                     INSERT INTO cnight_registrations (
-                        cardano_address,
+                        cardano_stake_key,
                         dust_address,
                         valid,
                         registered_at,
                         block_id
                     )
                     VALUES ($1, $2, $3, $4, $5)
-                    ON CONFLICT (cardano_address, dust_address)
+                    ON CONFLICT (cardano_stake_key, dust_address)
                     DO UPDATE SET
                         valid = EXCLUDED.valid,
                         registered_at = EXCLUDED.registered_at,
@@ -829,7 +829,7 @@ async fn save_dust_registration_events(
                 "};
 
                 sqlx::query(query)
-                    .bind(cardano_address.as_ref())
+                    .bind(cardano_stake_key.as_ref())
                     .bind(dust_address.as_ref())
                     .bind(true)
                     .bind(block_timestamp as i64)
@@ -839,7 +839,7 @@ async fn save_dust_registration_events(
             }
 
             DustRegistrationEvent::Deregistration {
-                cardano_address,
+                cardano_stake_key,
                 dust_address,
             } => {
                 let query = indoc! {"
@@ -847,7 +847,7 @@ async fn save_dust_registration_events(
                     SET valid = $1,
                         removed_at = $2,
                         block_id = $3
-                    WHERE cardano_address = $4
+                    WHERE cardano_stake_key = $4
                     AND dust_address = $5
                 "};
 
@@ -855,14 +855,14 @@ async fn save_dust_registration_events(
                     .bind(false)
                     .bind(block_timestamp as i64)
                     .bind(block_id)
-                    .bind(cardano_address.as_ref())
+                    .bind(cardano_stake_key.as_ref())
                     .bind(dust_address.as_ref())
                     .execute(&mut **tx)
                     .await?;
             }
 
             DustRegistrationEvent::MappingAdded {
-                cardano_address,
+                cardano_stake_key,
                 dust_address,
                 utxo_id,
                 utxo_index,
@@ -871,21 +871,21 @@ async fn save_dust_registration_events(
                     UPDATE cnight_registrations
                     SET utxo_tx_hash = $1,
                         utxo_output_index = $2
-                    WHERE cardano_address = $3
+                    WHERE cardano_stake_key = $3
                     AND dust_address = $4
                 "};
 
                 sqlx::query(query)
                     .bind(utxo_id.as_ref())
                     .bind(*utxo_index as i64)
-                    .bind(cardano_address.as_ref())
+                    .bind(cardano_stake_key.as_ref())
                     .bind(dust_address.as_ref())
                     .execute(&mut **tx)
                     .await?;
             }
 
             DustRegistrationEvent::MappingRemoved {
-                cardano_address,
+                cardano_stake_key,
                 dust_address,
                 ..
             } => {
@@ -893,12 +893,12 @@ async fn save_dust_registration_events(
                     UPDATE cnight_registrations
                     SET utxo_tx_hash = NULL,
                         utxo_output_index = NULL
-                    WHERE cardano_address = $1
+                    WHERE cardano_stake_key = $1
                     AND dust_address = $2
                 "};
 
                 sqlx::query(query)
-                    .bind(cardano_address.as_ref())
+                    .bind(cardano_stake_key.as_ref())
                     .bind(dust_address.as_ref())
                     .execute(&mut **tx)
                     .await?;

--- a/chain-indexer/src/infra/subxt_node/runtimes/v0_20_0.rs
+++ b/chain-indexer/src/infra/subxt_node/runtimes/v0_20_0.rs
@@ -110,21 +110,21 @@ pub async fn make_block_details(
             Event::CNightObservation(native_token_event) => match native_token_event {
                 CnightObservationEvent::Registration(event) => {
                     dust_registration_events.push(DustRegistrationEvent::Registration {
-                        cardano_address: event.cardano_reward_address.0.into(),
+                        cardano_stake_key: event.cardano_reward_address.0.into(),
                         dust_address: event.dust_public_key.0.0.into(),
                     });
                 }
 
                 CnightObservationEvent::Deregistration(event) => {
                     dust_registration_events.push(DustRegistrationEvent::Deregistration {
-                        cardano_address: event.cardano_reward_address.0.into(),
+                        cardano_stake_key: event.cardano_reward_address.0.into(),
                         dust_address: event.dust_public_key.0.0.into(),
                     });
                 }
 
                 CnightObservationEvent::MappingAdded(event) => {
                     dust_registration_events.push(DustRegistrationEvent::MappingAdded {
-                        cardano_address: event.cardano_reward_address.0.into(),
+                        cardano_stake_key: event.cardano_reward_address.0.into(),
                         dust_address: event.dust_public_key.0.0.into(),
                         utxo_id: event.utxo_tx_hash.0.as_ref().into(),
                         utxo_index: event.utxo_index.into(),
@@ -133,7 +133,7 @@ pub async fn make_block_details(
 
                 CnightObservationEvent::MappingRemoved(event) => {
                     dust_registration_events.push(DustRegistrationEvent::MappingRemoved {
-                        cardano_address: event.cardano_reward_address.0.into(),
+                        cardano_stake_key: event.cardano_reward_address.0.into(),
                         dust_address: event.dust_public_key.0.0.into(),
                         utxo_id: event.utxo_tx_hash.0.as_ref().into(),
                         utxo_index: event.utxo_index.into(),
@@ -285,18 +285,18 @@ pub async fn fetch_genesis_cnight_registrations(
             // A registration is valid only if there is exactly one mapping entry.
             let events = if kv.value.len() == 1 {
                 let entry = &kv.value[0];
-                let cardano_address = entry.cardano_reward_address.0.into();
+                let cardano_stake_key = entry.cardano_reward_address.0.into();
                 let dust_address = DustPublicKey::from(entry.dust_public_key.0.0.clone());
                 let utxo_id = entry.utxo_tx_hash.0.as_ref().into();
                 let utxo_index = entry.utxo_index.into();
 
                 vec![
                     DustRegistrationEvent::Registration {
-                        cardano_address,
+                        cardano_stake_key,
                         dust_address: dust_address.clone(),
                     },
                     DustRegistrationEvent::MappingAdded {
-                        cardano_address,
+                        cardano_stake_key,
                         dust_address,
                         utxo_id,
                         utxo_index,

--- a/chain-indexer/src/infra/subxt_node/runtimes/v0_21_0.rs
+++ b/chain-indexer/src/infra/subxt_node/runtimes/v0_21_0.rs
@@ -110,21 +110,21 @@ pub async fn make_block_details(
             Event::CNightObservation(native_token_event) => match native_token_event {
                 CnightObservationEvent::Registration(event) => {
                     dust_registration_events.push(DustRegistrationEvent::Registration {
-                        cardano_address: event.cardano_reward_address.0.into(),
+                        cardano_stake_key: event.cardano_reward_address.0.into(),
                         dust_address: event.dust_public_key.0.0.into(),
                     });
                 }
 
                 CnightObservationEvent::Deregistration(event) => {
                     dust_registration_events.push(DustRegistrationEvent::Deregistration {
-                        cardano_address: event.cardano_reward_address.0.into(),
+                        cardano_stake_key: event.cardano_reward_address.0.into(),
                         dust_address: event.dust_public_key.0.0.into(),
                     });
                 }
 
                 CnightObservationEvent::MappingAdded(event) => {
                     dust_registration_events.push(DustRegistrationEvent::MappingAdded {
-                        cardano_address: event.cardano_reward_address.0.into(),
+                        cardano_stake_key: event.cardano_reward_address.0.into(),
                         dust_address: event.dust_public_key.0.0.into(),
                         utxo_id: event.utxo_tx_hash.0.as_ref().into(),
                         utxo_index: event.utxo_index.into(),
@@ -133,7 +133,7 @@ pub async fn make_block_details(
 
                 CnightObservationEvent::MappingRemoved(event) => {
                     dust_registration_events.push(DustRegistrationEvent::MappingRemoved {
-                        cardano_address: event.cardano_reward_address.0.into(),
+                        cardano_stake_key: event.cardano_reward_address.0.into(),
                         dust_address: event.dust_public_key.0.0.into(),
                         utxo_id: event.utxo_tx_hash.0.as_ref().into(),
                         utxo_index: event.utxo_index.into(),
@@ -285,18 +285,18 @@ pub async fn fetch_genesis_cnight_registrations(
             // A registration is valid only if there is exactly one mapping entry.
             let events = if kv.value.len() == 1 {
                 let entry = &kv.value[0];
-                let cardano_address = entry.cardano_reward_address.0.into();
+                let cardano_stake_key = entry.cardano_reward_address.0.into();
                 let dust_address = DustPublicKey::from(entry.dust_public_key.0.0.clone());
                 let utxo_id = entry.utxo_tx_hash.0.as_ref().into();
                 let utxo_index = entry.utxo_index.into();
 
                 vec![
                     DustRegistrationEvent::Registration {
-                        cardano_address,
+                        cardano_stake_key,
                         dust_address: dust_address.clone(),
                     },
                     DustRegistrationEvent::MappingAdded {
-                        cardano_address,
+                        cardano_stake_key,
                         dust_address,
                         utxo_id,
                         utxo_index,

--- a/chain-indexer/src/infra/subxt_node/runtimes/v0_22_0.rs
+++ b/chain-indexer/src/infra/subxt_node/runtimes/v0_22_0.rs
@@ -110,21 +110,21 @@ pub async fn make_block_details(
             Event::CNightObservation(native_token_event) => match native_token_event {
                 CnightObservationEvent::Registration(event) => {
                     dust_registration_events.push(DustRegistrationEvent::Registration {
-                        cardano_address: event.cardano_reward_address.0.into(),
+                        cardano_stake_key: event.cardano_reward_address.0.into(),
                         dust_address: event.dust_public_key.0.0.into(),
                     });
                 }
 
                 CnightObservationEvent::Deregistration(event) => {
                     dust_registration_events.push(DustRegistrationEvent::Deregistration {
-                        cardano_address: event.cardano_reward_address.0.into(),
+                        cardano_stake_key: event.cardano_reward_address.0.into(),
                         dust_address: event.dust_public_key.0.0.into(),
                     });
                 }
 
                 CnightObservationEvent::MappingAdded(event) => {
                     dust_registration_events.push(DustRegistrationEvent::MappingAdded {
-                        cardano_address: event.cardano_reward_address.0.into(),
+                        cardano_stake_key: event.cardano_reward_address.0.into(),
                         dust_address: event.dust_public_key.0.0.into(),
                         utxo_id: event.utxo_tx_hash.0.as_ref().into(),
                         utxo_index: event.utxo_index.into(),
@@ -133,7 +133,7 @@ pub async fn make_block_details(
 
                 CnightObservationEvent::MappingRemoved(event) => {
                     dust_registration_events.push(DustRegistrationEvent::MappingRemoved {
-                        cardano_address: event.cardano_reward_address.0.into(),
+                        cardano_stake_key: event.cardano_reward_address.0.into(),
                         dust_address: event.dust_public_key.0.0.into(),
                         utxo_id: event.utxo_tx_hash.0.as_ref().into(),
                         utxo_index: event.utxo_index.into(),
@@ -285,18 +285,18 @@ pub async fn fetch_genesis_cnight_registrations(
             // A registration is valid only if there is exactly one mapping entry.
             let events = if kv.value.len() == 1 {
                 let entry = &kv.value[0];
-                let cardano_address = entry.cardano_reward_address.0.into();
+                let cardano_stake_key = entry.cardano_reward_address.0.into();
                 let dust_address = DustPublicKey::from(entry.dust_public_key.0.0.clone());
                 let utxo_id = entry.utxo_tx_hash.0.as_ref().into();
                 let utxo_index = entry.utxo_index.into();
 
                 vec![
                     DustRegistrationEvent::Registration {
-                        cardano_address,
+                        cardano_stake_key,
                         dust_address: dust_address.clone(),
                     },
                     DustRegistrationEvent::MappingAdded {
-                        cardano_address,
+                        cardano_stake_key,
                         dust_address,
                         utxo_id,
                         utxo_index,

--- a/indexer-api/src/infra/storage/dust.rs
+++ b/indexer-api/src/infra/storage/dust.rs
@@ -42,7 +42,7 @@ impl DustStorage for Storage {
             let registration_query = indoc! {"
                 SELECT dust_address, valid, utxo_tx_hash, utxo_output_index
                 FROM cnight_registrations
-                WHERE cardano_address = $1
+                WHERE cardano_stake_key = $1
                 AND removed_at IS NULL
                 ORDER BY registered_at DESC
                 LIMIT 1

--- a/indexer-common/migrations/postgres/001_initial.sql
+++ b/indexer-common/migrations/postgres/001_initial.sql
@@ -166,7 +166,7 @@ CREATE INDEX ON dust_generation_info (night_utxo_hash);
 -- cNIGHT registration tracking
 CREATE TABLE cnight_registrations (
   id BIGSERIAL PRIMARY KEY,
-  cardano_address BYTEA NOT NULL,
+  cardano_stake_key BYTEA NOT NULL,
   dust_address BYTEA NOT NULL,
   valid BOOLEAN NOT NULL,
   registered_at BIGINT NOT NULL,
@@ -174,9 +174,9 @@ CREATE TABLE cnight_registrations (
   block_id BIGINT REFERENCES blocks (id),
   utxo_tx_hash BYTEA,
   utxo_output_index BIGINT,
-  UNIQUE (cardano_address, dust_address)
+  UNIQUE (cardano_stake_key, dust_address)
 );
-CREATE INDEX ON cnight_registrations (cardano_address);
+CREATE INDEX ON cnight_registrations (cardano_stake_key);
 CREATE INDEX ON cnight_registrations (dust_address);
 CREATE INDEX ON cnight_registrations (block_id);
 CREATE TABLE system_parameters_terms_and_conditions (

--- a/indexer-common/migrations/sqlite/001_initial.sql
+++ b/indexer-common/migrations/sqlite/001_initial.sql
@@ -167,7 +167,7 @@ CREATE INDEX dust_generation_info_night_utxo_hash_idx ON dust_generation_info (n
 -- cNIGHT registration tracking
 CREATE TABLE cnight_registrations (
   id INTEGER PRIMARY KEY,
-  cardano_address BLOB NOT NULL,
+  cardano_stake_key BLOB NOT NULL,
   dust_address BLOB NOT NULL,
   valid BOOLEAN NOT NULL,
   registered_at INTEGER NOT NULL,
@@ -175,9 +175,9 @@ CREATE TABLE cnight_registrations (
   block_id INTEGER REFERENCES blocks (id),
   utxo_tx_hash BLOB,
   utxo_output_index INTEGER,
-  UNIQUE (cardano_address, dust_address)
+  UNIQUE (cardano_stake_key, dust_address)
 );
-CREATE INDEX cnight_registrations_cardano_address_idx ON cnight_registrations (cardano_address);
+CREATE INDEX cnight_registrations_cardano_stake_key_idx ON cnight_registrations (cardano_stake_key);
 CREATE INDEX cnight_registrations_dust_address_idx ON cnight_registrations (dust_address);
 CREATE INDEX cnight_registrations_block_id_idx ON cnight_registrations (block_id);
 CREATE TABLE system_parameters_terms_and_conditions (


### PR DESCRIPTION
Closes #440

Rename `cardano_address` column to `cardano_stake_key` in `cnight_registrations` table to match the GraphQL field naming and documentation terminology.

The column stores Cardano stake keys, not addresses. The naming caused confusion during QA (see #440).

## Changes
- Rename column in postgres and sqlite 001_initial.sql migrations
- Rename field in `DustRegistrationEvent` domain enum
- Update SQL queries in chain-indexer storage and indexer-api storage
- Update field references in runtime event handlers (v0_20_0, v0_21_0, v0_22_0)

No API change — GraphQL field was already `cardanoStakeKey`.