### PR TITLE
chore(release): prepare for 4.0.0-rc.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0-rc.10] - 2026-03-16
+
+### 🐛 Bug Fixes
+
+- Flush pending inserts before delete/root-count to preserve batch_update ordering (#904)
+
 ## [4.0.0-rc.9] - 2026-03-16
 
 ### 🚜 Refactor


### PR DESCRIPTION
- Update CHANGELOG.md for 4.0.0-rc.10

## Changes since 4.0.0-rc.9
- fix: flush pending inserts before delete/root-count to preserve batch_update ordering (#904)
