### PR TITLE
chore(build): get rid of secrets for CI testing

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,13 +3,6 @@
 git config --local commit.gpgSign true
 git config --local tag.gpgSign true
 
-export NETRC="${NETRC:=$HOME/.netrc}"
-
-if [[ -f ~/.midnight-indexer.envrc ]]; then
-    echo direnv: using ~/.midnight-indexer.envrc
-    source ~/.midnight-indexer.envrc
-fi
-
 if [[ -f "$PWD/.envrc.local" ]]; then
     echo direnv: using .envrc.local
     source "$PWD/.envrc.local"

--- a/.github/workflows/ci-cloud.yaml
+++ b/.github/workflows/ci-cloud.yaml
@@ -54,14 +54,15 @@ jobs:
 
       - name: just check
         run: |
-          . ./.envrc
+          APP__INFRA__PUB_SUB__PASSWORD=$(openssl rand -hex 32)
+          APP__INFRA__SECRET=$(openssl rand -hex 32)
+          APP__INFRA__STORAGE__PASSWORD=$(openssl rand -hex 32)
+          export APP__INFRA__PUB_SUB__PASSWORD
+          export APP__INFRA__SECRET
+          export APP__INFRA__STORAGE__PASSWORD
           git config --global url."https://@github.com".insteadOf "ssh://git@github.com"
           rustup override set ${{needs.toolchain.outputs.toolchain}}
           just feature=cloud check
-        env:
-          APP__INFRA__STORAGE__PASSWORD: ${{ secrets.APP__INFRA__STORAGE__PASSWORD }}
-          APP__INFRA__PUB_SUB__PASSWORD: ${{ secrets.APP__INFRA__PUB_SUB__PASSWORD }}
-          APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
 
   fmt-check:
     runs-on: ubuntu-latest
@@ -110,14 +111,15 @@ jobs:
 
       - name: just lint
         run: |
-          . ./.envrc
+          APP__INFRA__PUB_SUB__PASSWORD=$(openssl rand -hex 32)
+          APP__INFRA__SECRET=$(openssl rand -hex 32)
+          APP__INFRA__STORAGE__PASSWORD=$(openssl rand -hex 32)
+          export APP__INFRA__PUB_SUB__PASSWORD
+          export APP__INFRA__SECRET
+          export APP__INFRA__STORAGE__PASSWORD
           git config --global url."https://@github.com".insteadOf "ssh://git@github.com"
           rustup override set ${{needs.toolchain.outputs.toolchain}}
           just feature=cloud lint
-        env:
-          APP__INFRA__STORAGE__PASSWORD: ${{ secrets.APP__INFRA__STORAGE__PASSWORD }}
-          APP__INFRA__PUB_SUB__PASSWORD: ${{ secrets.APP__INFRA__PUB_SUB__PASSWORD }}
-          APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
 
   test:
     runs-on: ubuntu-latest-8-core-x64
@@ -155,14 +157,15 @@ jobs:
 
       - name: just test
         run: |
-          . ./.envrc
+          APP__INFRA__PUB_SUB__PASSWORD=$(openssl rand -hex 32)
+          APP__INFRA__SECRET=$(openssl rand -hex 32)
+          APP__INFRA__STORAGE__PASSWORD=$(openssl rand -hex 32)
+          export APP__INFRA__PUB_SUB__PASSWORD
+          export APP__INFRA__SECRET
+          export APP__INFRA__STORAGE__PASSWORD
           git config --global url."https://@github.com".insteadOf "ssh://git@github.com"
           rustup override set ${{needs.toolchain.outputs.toolchain}}
           just feature=cloud test
-        env:
-          APP__INFRA__STORAGE__PASSWORD: ${{ secrets.APP__INFRA__STORAGE__PASSWORD }}
-          APP__INFRA__PUB_SUB__PASSWORD: ${{ secrets.APP__INFRA__PUB_SUB__PASSWORD }}
-          APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
 
   doc:
     runs-on: ubuntu-latest-8-core-x64
@@ -186,6 +189,5 @@ jobs:
 
       - name: just doc
         run: |
-          . ./.envrc
           git config --global url."https://@github.com".insteadOf "ssh://git@github.com"
           just feature=cloud doc

--- a/.github/workflows/ci-standalone.yaml
+++ b/.github/workflows/ci-standalone.yaml
@@ -54,12 +54,11 @@ jobs:
 
       - name: just check
         run: |
-          . ./.envrc
+          APP__INFRA__SECRET=$(openssl rand -hex 32)
+          export APP__INFRA__SECRET
           git config --global url."https://@github.com".insteadOf "ssh://git@github.com"
           rustup override set ${{needs.toolchain.outputs.toolchain}}
           just feature=standalone check
-        env:
-          APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
 
   fmt-check:
     runs-on: ubuntu-latest
@@ -108,12 +107,11 @@ jobs:
 
       - name: just lint
         run: |
-          . ./.envrc
+          APP__INFRA__SECRET=$(openssl rand -hex 32)
+          export APP__INFRA__SECRET
           git config --global url."https://@github.com".insteadOf "ssh://git@github.com"
           rustup override set ${{needs.toolchain.outputs.toolchain}}
           just feature=standalone lint
-        env:
-          APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
 
   test:
     runs-on: ubuntu-latest-8-core-x64
@@ -151,12 +149,11 @@ jobs:
 
       - name: just test
         run: |
-          . ./.envrc
+          APP__INFRA__SECRET=$(openssl rand -hex 32)
+          export APP__INFRA__SECRET
           git config --global url."https://@github.com".insteadOf "ssh://git@github.com"
           rustup override set ${{needs.toolchain.outputs.toolchain}}
           just feature=standalone test
-        env:
-          APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
 
   doc:
     runs-on: ubuntu-latest-8-core-x64
@@ -180,6 +177,5 @@ jobs:
 
       - name: just doc
         run: |
-          . ./.envrc
           git config --global url."https://@github.com".insteadOf "ssh://git@github.com"
           just feature=standalone doc


### PR DESCRIPTION
This makes it possible to get rid of the GH secrets for CI and hence allows for external PRs.