### PR TITLE
fix: correct timestamp unit mismatch in currentCapacity calculation

### DIFF
--- a/indexer-api/src/infra/storage/dust.rs
+++ b/indexer-api/src/infra/storage/dust.rs
@@ -86,7 +86,7 @@ impl DustStorage for Storage {
                     generation_rate = value.saturating_mul(generation_decay_rate);
 
                     // dust_generation_info.ctime is in seconds (ledger convention).
-                    let ctime = TimestampSecs(ctime_raw);
+                    let ctime = TimestampSecs(ctime_raw as u64);
 
                     // Get current timestamp from latest block.
                     // blocks.timestamp is in milliseconds (Substrate Timestamp pallet).
@@ -100,7 +100,7 @@ impl DustStorage for Storage {
                     let now = sqlx::query_as::<_, (i64,)>(current_time_query)
                         .fetch_optional(&*self.pool)
                         .await?
-                        .map(|(t,)| TimestampMs(t))
+                        .map(|(t,)| TimestampMs(t as u64))
                         .unwrap_or(ctime.to_ms());
 
                     let elapsed_seconds = now.elapsed_seconds_since(ctime.to_ms());
@@ -112,7 +112,7 @@ impl DustStorage for Storage {
                     // elapsed_seconds. Capped at max_capacity.
                     let generated_capacity = value
                         .saturating_mul(generation_decay_rate)
-                        .saturating_mul(elapsed_seconds);
+                        .saturating_mul(elapsed_seconds as u128);
                     current_capacity = generated_capacity.min(max_capacity);
                 }
             }

--- a/indexer-common/src/domain.rs
+++ b/indexer-common/src/domain.rs
@@ -127,12 +127,12 @@ mod network_id_tests {
 /// A timestamp in milliseconds since the Unix epoch (Substrate Timestamp pallet convention).
 /// Use when working with values from the `blocks.timestamp` column.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct TimestampMs(pub i64);
+pub struct TimestampMs(pub u64);
 
 /// A timestamp in seconds since the Unix epoch (ledger convention).
 /// Use when working with values from `dust_generation_info.ctime`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct TimestampSecs(pub i64);
+pub struct TimestampSecs(pub u64);
 
 impl TimestampSecs {
     /// Convert to milliseconds.
@@ -143,8 +143,8 @@ impl TimestampSecs {
 
 impl TimestampMs {
     /// Calculate elapsed seconds since an earlier timestamp.
-    pub fn elapsed_seconds_since(self, earlier: TimestampMs) -> u128 {
-        ((self.0 - earlier.0).max(0) as u128) / 1000
+    pub fn elapsed_seconds_since(self, earlier: TimestampMs) -> u64 {
+        self.0.saturating_sub(earlier.0) / 1000
     }
 }
 


### PR DESCRIPTION
Closes: https://github.com/midnightntwrk/midnight-indexer/issues/930

Fix `currentCapacity` always equalling `maxCapacity` regardless of when the registration was made.

## Root Cause
`dust_generation_info.ctime` is stored in seconds (ledger convention), but `blocks.timestamp` is stored in milliseconds (Substrate Timestamp pallet). The subtraction in `indexer-api/src/infra/storage/dust.rs:105` mixed the two units, inflating elapsed time to ~56 years and immediately maxing out `currentCapacity`.

Confirmed by Thomas Kerber: "All ledger-side timestamps are in seconds."
Confirmed from midnight-node/runtime/src/lib.rs:471: "A timestamp: milliseconds since the unix epoch."

## Fix
- Introduce `TimestampMs` and `TimestampSecs` newtypes in `indexer-common/src/domain.rs` to make the unit distinction explicit at the type level
- Convert `ctime` to milliseconds via `TimestampSecs::to_ms()` before subtraction
- Use `TimestampMs::elapsed_seconds_since()` for safe elapsed time calculation

## Impact
For a fresh registration (1 hour old):
- Before: shows 100% of max capacity (fully loaded)
- After: shows 0.6% of max capacity

Not caught earlier because test environments only had registrations older than 7 days, where the correct result would also be maxCapacity.
