### PR TITLE
fix: add start_period to postgres healthcheck in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -153,6 +153,8 @@ services:
       POSTGRES_PASSWORD: $APP__INFRA__STORAGE__PASSWORD
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U indexer"]
+      start_interval: "2s"
+      start_period: "30s"
       interval: "5s"
       timeout: "2s"
       retries: 2


### PR DESCRIPTION
Add `start_period` and `start_interval` to the postgres healthcheck in docker-compose, matching the pattern used by all other services.

## Context

The Docker Compose Validation CI job is failing intermittently — postgres is marked unhealthy before it finishes initializing. The healthcheck has `retries: 2` and `interval: 5s` but no `start_period`, so dependent services fail with "dependency failed to start: container is unhealthy" if postgres takes longer than ~10s to start (common on CI runners).

All other services (chain-indexer, wallet-indexer, indexer-api, spo-indexer) already have `start_period: 30s` and `start_interval: 2s`. Postgres was the only one missing it.

<img width="669" height="820" alt="Screenshot 2026-03-24 at 19 12 03" src="https://github.com/user-attachments/assets/76814dd0-7e05-44b0-b920-973b1d1ae138" />
