### PR TITLE
chore(ci): increase postgres healthcheck retries to 5

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -157,7 +157,7 @@ services:
       start_period: "30s"
       interval: "5s"
       timeout: "2s"
-      retries: 2
+      retries: 5
     security_opt:
       - no-new-privileges:true
 


### PR DESCRIPTION
Increase postgres healthcheck retries from 2 to 5 to fix CI Docker Compose Validation flake.

Previous PR #936 added start_period and start_interval but CI still fails. docker compose up -d waits for service_healthy before starting dependent services, and with retries: 2 postgres gets marked unhealthy before start_period expires on slow CI runners.