### PR TITLE
chore(ci): simplify postgres healthcheck for CI compatibility

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -153,11 +153,9 @@ services:
       POSTGRES_PASSWORD: $APP__INFRA__STORAGE__PASSWORD
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U indexer"]
-      start_interval: "2s"
-      start_period: "30s"
-      interval: "5s"
+      interval: "3s"
       timeout: "2s"
-      retries: 5
+      retries: 20
     security_opt:
       - no-new-privileges:true
 


### PR DESCRIPTION
Remove `start_period` and `start_interval` from postgres healthcheck and use `interval: 3s` with `retries: 20` instead.

## Context

PR #936 added `start_period`/`start_interval` and PR #937 increased retries to 5, but the Docker Compose Validation (cloud) CI still fails — postgres is marked unhealthy almost immediately. `start_period` and `start_interval` likely require Docker Engine 25.0+ (API 1.44) which may not be available on the CI runner.

This PR removes the version-dependent features and uses only basic healthcheck options: `interval: 3s`, `retries: 20` = 60 seconds of checks. Works on all Docker Compose versions.
