### PR TITLE
chore(ci): queue Docker builds for better cache utilisation

### DIFF
--- a/.github/workflows/build-indexer-images.yaml
+++ b/.github/workflows/build-indexer-images.yaml
@@ -17,8 +17,8 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+  group: build-indexer-images
+  cancel-in-progress: false
 
 jobs:
   build-and-push:


### PR DESCRIPTION
- Changed concurrency group from dynamic (`run_id`) to fixed (`build-indexer-images`)
- Changed `cancel-in-progress` from `true` to `false`

## Context

Previously each push to main created a unique concurrency group, so multiple Docker builds ran in parallel. Concurrent builds can't benefit from each other's cache layers, leading to slower builds (>1h in some cases). With a fixed group, builds queue automatically, each build completes and pushes its cache before the next one starts.