### PR TITLE
chore(ci): use install-action for cargo-deny instead of cargo install

### DIFF
--- a/.github/workflows/rust-security-scan.yaml
+++ b/.github/workflows/rust-security-scan.yaml
@@ -31,7 +31,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install cargo-deny
-        run: cargo install cargo-deny
+        uses: taiki-e/install-action@80a23c5ba9e1100fd8b777106e810018ed662a7b # v2.69.12
+        with:
+          tool: cargo-deny
 
       # Skip for fork PRs (no secrets available)
       - name: Add github.com credentials to netrc


### PR DESCRIPTION
Use `taiki-e/install-action` to install cargo-deny, consistent with how other tools (just, nextest) are installed in CI.

## Changes

- Replaced `cargo install cargo-deny` with `taiki-e/install-action` in `rust-security-scan.yaml`

## Context

`cargo install cargo-deny` compiles from source every run (~2 min). `taiki-e/install-action` downloads pre-built binaries and caches them, making the install near-instant on subsequent runs. This is the same action already used for `just` and `nextest` in `ci-cloud.yaml` and `ci-standalone.yaml`.