### PR TITLE
perf(chain-indexer): fetch contract states and transaction cost concurrently

### DIFF
--- a/chain-indexer/src/infra/subxt_node.rs
+++ b/chain-indexer/src/infra/subxt_node.rs
@@ -644,16 +644,16 @@ async fn make_regular_transaction(
 
     let identifiers = ledger_transaction.identifiers()?;
 
-    let contract_actions = ledger_transaction
-        .contract_actions(|address| async move {
+    let (contract_actions, fees) = tokio::join!(
+        ledger_transaction.contract_actions(|address| async move {
             runtimes::get_contract_state(address, node_version, block).await
-        })
-        .await?
-        .into_iter()
-        .map(Into::into)
-        .collect();
+        }),
+        runtimes::get_transaction_cost(&transaction, node_version, block),
+    );
 
-    let fees = match runtimes::get_transaction_cost(&transaction, node_version, block).await {
+    let contract_actions = contract_actions?.into_iter().map(Into::into).collect();
+
+    let fees = match fees {
         Ok(fees) => TransactionFees {
             paid_fees: fees,
             estimated_fees: fees,

--- a/indexer-common/src/domain/ledger/transaction.rs
+++ b/indexer-common/src/domain/ledger/transaction.rs
@@ -21,7 +21,7 @@ use crate::{
     infra::ledger_db::v1_1,
 };
 use fastrace::trace;
-use futures::{StreamExt, TryStreamExt};
+use futures::future::try_join_all;
 use midnight_coin_structure::{coin::Info, contract::ContractAddress};
 use midnight_ledger_v8::structure::{
     ContractAction as ContractActionV8, StandardTransaction as StandardTransactionV8,
@@ -88,70 +88,79 @@ impl Transaction {
         F: Future<Output = Result<SerializedContractState, E>>,
     {
         match self {
-            Self::V8(transaction) => match transaction {
-                TransactionV8::Standard(standard_transaction) => {
-                    let contract_actions = futures::stream::iter(standard_transaction.actions())
-                        .then(|(_, contract_action)| async {
-                            match contract_action {
-                                ContractActionV8::Deploy(deploy) => {
-                                    let address = serialize_contract_address(deploy.address())?;
-                                    let state = get_contract_state(address.clone()).await.map_err(
-                                        |error| {
-                                            Error::GetContractState(address.clone(), error.into())
-                                        },
-                                    )?;
-
-                                    Ok::<_, Error>(ContractAction {
-                                        address,
-                                        state,
-                                        attributes: ContractAttributes::Deploy,
-                                    })
-                                }
-
-                                ContractActionV8::Call(call) => {
-                                    let address = serialize_contract_address(call.address)?;
-                                    let state = get_contract_state(address.clone()).await.map_err(
-                                        |error| {
-                                            Error::GetContractState(address.clone(), error.into())
-                                        },
-                                    )?;
-                                    let entry_point =
-                                        String::from_utf8(call.entry_point.as_ref().to_owned())
+            Self::V8(transaction) => {
+                match transaction {
+                    TransactionV8::Standard(standard_transaction) => {
+                        try_join_all(standard_transaction.actions().map(
+                            |(_, contract_action)| async {
+                                match contract_action {
+                                    ContractActionV8::Deploy(deploy) => {
+                                        let address = serialize_contract_address(deploy.address())?;
+                                        let state = get_contract_state(address.clone())
+                                            .await
                                             .map_err(|error| {
-                                                Error::FromUtf8("EntryPointBufV8", error)
+                                                Error::GetContractState(
+                                                    address.clone(),
+                                                    error.into(),
+                                                )
                                             })?;
 
-                                    Ok(ContractAction {
-                                        address,
-                                        state,
-                                        attributes: ContractAttributes::Call { entry_point },
-                                    })
+                                        Ok::<_, Error>(ContractAction {
+                                            address,
+                                            state,
+                                            attributes: ContractAttributes::Deploy,
+                                        })
+                                    }
+
+                                    ContractActionV8::Call(call) => {
+                                        let address = serialize_contract_address(call.address)?;
+                                        let state = get_contract_state(address.clone())
+                                            .await
+                                            .map_err(|error| {
+                                                Error::GetContractState(
+                                                    address.clone(),
+                                                    error.into(),
+                                                )
+                                            })?;
+                                        let entry_point =
+                                            String::from_utf8(call.entry_point.as_ref().to_owned())
+                                                .map_err(|error| {
+                                                    Error::FromUtf8("EntryPointBufV8", error)
+                                                })?;
+
+                                        Ok(ContractAction {
+                                            address,
+                                            state,
+                                            attributes: ContractAttributes::Call { entry_point },
+                                        })
+                                    }
+
+                                    ContractActionV8::Maintain(update) => {
+                                        let address = serialize_contract_address(update.address)?;
+                                        let state = get_contract_state(address.clone())
+                                            .await
+                                            .map_err(|error| {
+                                                Error::GetContractState(
+                                                    address.clone(),
+                                                    error.into(),
+                                                )
+                                            })?;
+
+                                        Ok(ContractAction {
+                                            address,
+                                            state,
+                                            attributes: ContractAttributes::Update,
+                                        })
+                                    }
                                 }
+                            },
+                        ))
+                        .await
+                    }
 
-                                ContractActionV8::Maintain(update) => {
-                                    let address = serialize_contract_address(update.address)?;
-                                    let state = get_contract_state(address.clone()).await.map_err(
-                                        |error| {
-                                            Error::GetContractState(address.clone(), error.into())
-                                        },
-                                    )?;
-
-                                    Ok(ContractAction {
-                                        address,
-                                        state,
-                                        attributes: ContractAttributes::Update,
-                                    })
-                                }
-                            }
-                        })
-                        .try_collect::<Vec<_>>()
-                        .await?;
-
-                    Ok(contract_actions)
+                    TransactionV8::ClaimRewards(_) => Ok(vec![]),
                 }
-
-                TransactionV8::ClaimRewards(_) => Ok(vec![]),
-            },
+            }
         }
     }
 


### PR DESCRIPTION
Addresses #874 partially.

Per-transaction RPC calls were the main sequential bottleneck inside block processing. For a transaction with N contract actions, `get_contract_state` was called one after another, accumulating N × round-trip latency before `get_transaction_cost` was even started.

Two changes:

- **`indexer-common`** — `Transaction::contract_actions()`: replace the sequential `stream::iter(...).then(...).try_collect()` with `try_join_all(actions.map(...))`, so all `get_contract_state` RPC calls for a given transaction are dispatched concurrently. Output order is preserved (`try_join_all` guarantees this).

- **`chain-indexer`** — `make_regular_transaction()`: dispatch `contract_actions()` and `get_transaction_cost()` concurrently via `tokio::join!`. These two calls are independent; previously `get_transaction_cost` waited for all contract state fetches to complete before starting. The fallback behaviour of `get_transaction_cost` on error is preserved unchanged.