### PR TITLE
test: add qa tests for zswap updates

### DIFF
--- a/qa/scripts/test-runtime-upgrade.sh
+++ b/qa/scripts/test-runtime-upgrade.sh
@@ -129,12 +129,13 @@ docker run --rm \
   "midnightntwrk/midnight-node-toolkit:${NODE_TOOLKIT_TAG}" \
   runtime-upgrade \
   --wasm-file /wasm/runtime.wasm \
-  # nosemgrep: javascript.lang.security.detect-insecure-websocket.detect-insecure-websocket
   --rpc-url ws://node:9944 \
   -c "//Eve" \
   -c "//Ferdie" \
+  -c "//Dave" \
   -t "//Alice" \
   -t "//Bob" \
+  -t "//Charlie" \
   --signer-key "//Alice"
 
 # --- Step 6: Verify runtime upgraded ---

--- a/qa/tests/tests/e2e/shielded-transactions.test.ts
+++ b/qa/tests/tests/e2e/shielded-transactions.test.ts
@@ -18,7 +18,8 @@ import log from '@utils/logging/logger';
 import dataProvider from '@utils/testdata-provider';
 import { ToolkitWrapper, type ToolkitTransactionResult } from '@utils/toolkit/toolkit-wrapper';
 
-import type { Transaction } from '@utils/indexer/indexer-types';
+import type { Transaction, RegularTransaction } from '@utils/indexer/indexer-types';
+import { IndexerHttpClient } from '@utils/indexer/http-client';
 import { getBlockByHashWithRetry, getTransactionByHashWithRetry, resolveBlockHash } from './test-utils';
 import { TestContext } from 'vitest';
 import { collectValidZswapEvents } from 'tests/shared/zswap-events-utils';
@@ -30,7 +31,9 @@ import { collectValidDustLedgerEvents } from 'tests/shared/dust-ledger-utils';
 describe('shielded transactions', () => {
   let indexerWsClient: IndexerWsClient;
   let indexerEventCoordinator: EventCoordinator;
+  let indexerHttpClient: IndexerHttpClient;
   let previousMaxLedgerId: number;
+  let zswapEndIndexBeforeTx: number;
   let toolkit: ToolkitWrapper;
   let transactionResult: ToolkitTransactionResult;
 
@@ -43,6 +46,7 @@ describe('shielded transactions', () => {
   beforeAll(async () => {
     indexerWsClient = new IndexerWsClient();
     indexerEventCoordinator = new EventCoordinator();
+    indexerHttpClient = new IndexerHttpClient();
     await indexerWsClient.connectionInit();
     // Start a one-off toolkit container
     toolkit = new ToolkitWrapper({});
@@ -59,6 +63,18 @@ describe('shielded transactions', () => {
     );
     previousMaxLedgerId = beforeDustEvents[0].data!.dustLedgerEvents.maxId;
     log.debug(`Previous max ledger ID before tx = ${previousMaxLedgerId}`);
+
+    // Capture the highest zswapEndIndex before the transaction from genesis block.
+    // E2E tests run on a fresh environment, so genesis provides the baseline zswap state.
+    const genesisResponse = await indexerHttpClient.getBlockByOffset({ height: 0 });
+    const genesisTxs = genesisResponse.data!.block.transactions;
+    zswapEndIndexBeforeTx = genesisTxs.reduce((max, tx) => {
+      const regularTx = tx as RegularTransaction;
+      return regularTx.zswapEndIndex != null && regularTx.zswapEndIndex > max
+        ? regularTx.zswapEndIndex
+        : max;
+    }, 0);
+    log.debug(`Highest zswapEndIndex from genesis = ${zswapEndIndexBeforeTx}`);
 
     // Submit one shielded->shielded transfer (1 STAR)
     transactionResult = await toolkit.generateSingleTx(
@@ -215,6 +231,40 @@ describe('shielded transactions', () => {
       const dust = dustEvents[0].data!.dustLedgerEvents;
       expect(dust.__typename).toBe('DustSpendProcessed');
       expect(dust.id).toBe(lastZswapMaxId + 1);
+    });
+
+    /**
+     * After a shielded transaction is confirmed, the zswap Merkle tree should grow.
+     * The zswapEndIndex of the transaction should be higher than the previous maximum.
+     *
+     * @given a confirmed shielded transaction
+     * @when we query the transaction from the indexer
+     * @then the transaction's zswapEndIndex should be greater than the zswapEndIndex before the transaction
+     */
+    test('should increase the zswap Merkle tree end index', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Transaction', 'Zswap', 'ShieldedTokens'],
+      };
+
+      ctx.skip?.(
+        transactionResult.status !== 'confirmed',
+        "Toolkit transaction hasn't been confirmed",
+      );
+
+      const transactionResponse = await getTransactionByHashWithRetry(transactionResult.txHash);
+      expect(transactionResponse).toBeSuccess();
+
+      const transactions = transactionResponse.data!.transactions;
+      const tx = transactions.find(
+        (t: Transaction) => t.hash === transactionResult.txHash,
+      );
+      expect(tx).toBeDefined();
+
+      const regularTx = tx as RegularTransaction;
+      expect(regularTx.zswapEndIndex).toBeDefined();
+      expect(regularTx.zswapEndIndex!).toBeGreaterThan(zswapEndIndexBeforeTx);
+
+      log.debug(`zswapEndIndex before tx: ${zswapEndIndexBeforeTx}, after tx: ${regularTx.zswapEndIndex}`);
     });
 
     /**

--- a/qa/tests/tests/integration/basic/queries/transaction-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/transaction-queries.test.ts
@@ -382,7 +382,7 @@ describe(`genesis transactions`, () => {
 
     /**
      * SystemTransactions should not have RegularTransaction-specific fields like
-     * merkleTreeRoot, identifiers, fees, or transactionResult.
+     * zswapMerkleTreeRoot, identifiers, fees, or transactionResult.
      *
      * @given system transactions are fetched from the genesis block
      * @when we inspect their fields
@@ -394,7 +394,7 @@ describe(`genesis transactions`, () => {
 
       for (const tx of systemTxs) {
         const txAny = tx as unknown as Record<string, unknown>;
-        expect(txAny['merkleTreeRoot']).toBeUndefined();
+        expect(txAny['zswapMerkleTreeRoot']).toBeUndefined();
         expect(txAny['identifiers']).toBeUndefined();
         expect(txAny['fees']).toBeUndefined();
         expect(txAny['transactionResult']).toBeUndefined();

--- a/qa/tests/tests/integration/basic/queries/zswap-collapsed-update-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/zswap-collapsed-update-queries.test.ts
@@ -1,0 +1,117 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import log from '@utils/logging/logger';
+import '@utils/logging/test-logging-hooks';
+import { MerkleTreeCollapsedUpdateSchema } from '@utils/indexer/graphql/schema';
+import { IndexerHttpClient } from '@utils/indexer/http-client';
+import { TestContext } from 'vitest';
+
+const indexerHttpClient = new IndexerHttpClient();
+
+describe('zswap merkle tree collapsed update queries', () => {
+  describe('a collapsed update query with valid index range', () => {
+    /**
+     * A collapsed update query with a valid index range returns the expected result
+     *
+     * @given the chain has indexed blocks with zswap state
+     * @when we query for a collapsed update with startIndex=0 and endIndex=1
+     * @then Indexer should return a valid collapsed update
+     */
+    test('should return a collapsed update for a valid index range', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Zswap', 'CollapsedUpdate'],
+      };
+
+      log.debug('Requesting zswap merkle tree collapsed update with startIndex=0, endIndex=1');
+      const response = await indexerHttpClient.getZswapMerkleTreeCollapsedUpdate(0, 1);
+
+      expect(response).toBeSuccess();
+      expect(response.data?.zswapMerkleTreeCollapsedUpdate).toBeDefined();
+
+      const collapsedUpdate = response.data!.zswapMerkleTreeCollapsedUpdate;
+      expect(collapsedUpdate.startIndex).toBe(0);
+      expect(collapsedUpdate.endIndex).toBe(1);
+      expect(collapsedUpdate.update).toBeDefined();
+      expect(collapsedUpdate.protocolVersion).toBeDefined();
+    });
+
+    /**
+     * A collapsed update query responds with the expected schema
+     *
+     * @given the chain has indexed blocks with zswap state
+     * @when we query for a collapsed update with a valid index range
+     * @then the response should match the expected schema
+     */
+    test('should respond with a collapsed update according to the expected schema', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Zswap', 'CollapsedUpdate', 'SchemaValidation'],
+      };
+
+      log.debug('Requesting zswap merkle tree collapsed update with startIndex=0, endIndex=1');
+      const response = await indexerHttpClient.getZswapMerkleTreeCollapsedUpdate(0, 1);
+
+      expect(response).toBeSuccess();
+      expect(response.data?.zswapMerkleTreeCollapsedUpdate).toBeDefined();
+
+      log.debug('Validating collapsed update schema');
+      const parsed = MerkleTreeCollapsedUpdateSchema.safeParse(
+        response.data!.zswapMerkleTreeCollapsedUpdate,
+      );
+      expect(
+        parsed.success,
+        `Collapsed update schema validation failed ${JSON.stringify(parsed.error, null, 2)}`,
+      ).toBe(true);
+    });
+  });
+
+  describe('a collapsed update query with invalid index range', () => {
+    /**
+     * A collapsed update query where startIndex > endIndex should return an error
+     *
+     * @given we use an invalid index range where startIndex > endIndex
+     * @when we query for a collapsed update
+     * @then Indexer should respond with an error
+     */
+    test('should return an error when startIndex is greater than endIndex', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Zswap', 'CollapsedUpdate', 'Negative'],
+      };
+
+      log.debug('Requesting zswap merkle tree collapsed update with startIndex=10, endIndex=5');
+      const response = await indexerHttpClient.getZswapMerkleTreeCollapsedUpdate(10, 5);
+
+      expect(response).toBeError();
+    });
+
+    /**
+     * A collapsed update query with negative indices should return an error
+     *
+     * @given we use negative indices
+     * @when we query for a collapsed update
+     * @then Indexer should respond with an error
+     */
+    test('should return an error when indices are negative', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Zswap', 'CollapsedUpdate', 'Negative'],
+      };
+
+      log.debug('Requesting zswap merkle tree collapsed update with startIndex=-1, endIndex=1');
+      const response = await indexerHttpClient.getZswapMerkleTreeCollapsedUpdate(-1, 1);
+
+      expect(response).toBeError();
+    });
+  });
+});

--- a/qa/tests/tests/integration/basic/queries/zswap-collapsed-update-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/zswap-collapsed-update-queries.test.ts
@@ -104,15 +104,18 @@ describe('zswap merkle tree collapsed update queries', () => {
       log.debug(`Highest zswapEndIndex from genesis: ${maxEndIndex}`);
       expect(maxEndIndex).toBeGreaterThan(0);
 
-      log.debug(`Requesting collapsed update with startIndex=0, endIndex=${maxEndIndex}`);
-      const response = await indexerHttpClient.getZswapMerkleTreeCollapsedUpdate(0, maxEndIndex);
+      // zswapEndIndex is exclusive (next free index), collapsed update endIndex is inclusive
+      const endIndex = maxEndIndex - 1;
+
+      log.debug(`Requesting collapsed update with startIndex=0, endIndex=${endIndex}`);
+      const response = await indexerHttpClient.getZswapMerkleTreeCollapsedUpdate(0, endIndex);
 
       expect(response).toBeSuccess();
       expect(response.data?.zswapMerkleTreeCollapsedUpdate).toBeDefined();
 
       const collapsedUpdate = response.data!.zswapMerkleTreeCollapsedUpdate;
       expect(collapsedUpdate.startIndex).toBe(0);
-      expect(collapsedUpdate.endIndex).toBe(maxEndIndex);
+      expect(collapsedUpdate.endIndex).toBe(endIndex);
       expect(collapsedUpdate.update).toBeDefined();
       expect(collapsedUpdate.protocolVersion).toBeDefined();
     });

--- a/qa/tests/tests/integration/basic/queries/zswap-collapsed-update-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/zswap-collapsed-update-queries.test.ts
@@ -17,6 +17,7 @@ import log from '@utils/logging/logger';
 import '@utils/logging/test-logging-hooks';
 import { MerkleTreeCollapsedUpdateSchema } from '@utils/indexer/graphql/schema';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
+import type { RegularTransaction } from '@utils/indexer/indexer-types';
 import { TestContext } from 'vitest';
 
 const indexerHttpClient = new IndexerHttpClient();
@@ -75,6 +76,103 @@ describe('zswap merkle tree collapsed update queries', () => {
         `Collapsed update schema validation failed ${JSON.stringify(parsed.error, null, 2)}`,
       ).toBe(true);
     });
+
+    /**
+     * A collapsed update query covering the full genesis zswap range returns a valid result
+     *
+     * @given the genesis block has indexed zswap state
+     * @when we query for a collapsed update covering the full range from genesis
+     * @then Indexer should return a valid collapsed update spanning the entire range
+     */
+    test('should return a collapsed update for the full genesis zswap range', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Zswap', 'CollapsedUpdate', 'FullRange'],
+      };
+
+      // Get the highest zswapEndIndex from genesis block transactions
+      const genesisResponse = await indexerHttpClient.getBlockByOffset({ height: 0 });
+      expect(genesisResponse).toBeSuccess();
+
+      const transactions = genesisResponse.data!.block.transactions;
+      const maxEndIndex = transactions.reduce((max, tx) => {
+        const regularTx = tx as RegularTransaction;
+        return regularTx.zswapEndIndex != null && regularTx.zswapEndIndex > max
+          ? regularTx.zswapEndIndex
+          : max;
+      }, 0);
+
+      log.debug(`Highest zswapEndIndex from genesis: ${maxEndIndex}`);
+      expect(maxEndIndex).toBeGreaterThan(0);
+
+      log.debug(`Requesting collapsed update with startIndex=0, endIndex=${maxEndIndex}`);
+      const response = await indexerHttpClient.getZswapMerkleTreeCollapsedUpdate(0, maxEndIndex);
+
+      expect(response).toBeSuccess();
+      expect(response.data?.zswapMerkleTreeCollapsedUpdate).toBeDefined();
+
+      const collapsedUpdate = response.data!.zswapMerkleTreeCollapsedUpdate;
+      expect(collapsedUpdate.startIndex).toBe(0);
+      expect(collapsedUpdate.endIndex).toBe(maxEndIndex);
+      expect(collapsedUpdate.update).toBeDefined();
+      expect(collapsedUpdate.protocolVersion).toBeDefined();
+    });
+  });
+
+  describe('a collapsed update query with equal start and end indices', () => {
+    /**
+     * A collapsed update query where startIndex === endIndex returns a valid trivial update
+     *
+     * @given we use startIndex equal to endIndex
+     * @when we query for a collapsed update
+     * @then Indexer should return a valid collapsed update with matching indices
+     */
+    test('should return a valid update when startIndex equals endIndex', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Zswap', 'CollapsedUpdate', 'EdgeCase'],
+      };
+
+      log.debug('Requesting zswap merkle tree collapsed update with startIndex=0, endIndex=0');
+      const response = await indexerHttpClient.getZswapMerkleTreeCollapsedUpdate(0, 0);
+
+      expect(response).toBeSuccess();
+      expect(response.data?.zswapMerkleTreeCollapsedUpdate).toBeDefined();
+
+      const collapsedUpdate = response.data!.zswapMerkleTreeCollapsedUpdate;
+      expect(collapsedUpdate.startIndex).toBe(0);
+      expect(collapsedUpdate.endIndex).toBe(0);
+      expect(collapsedUpdate.update).toBeDefined();
+      expect(collapsedUpdate.protocolVersion).toBeDefined();
+    });
+  });
+
+  describe('a collapsed update query idempotency', () => {
+    /**
+     * Two identical collapsed update queries should return the same result
+     *
+     * @given we query the same index range twice
+     * @when the chain head has not changed between calls
+     * @then both responses should be identical
+     */
+    test('should return identical results for the same query parameters', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Zswap', 'CollapsedUpdate', 'Idempotency'],
+      };
+
+      log.debug('Requesting zswap merkle tree collapsed update twice with startIndex=0, endIndex=1');
+      const response1 = await indexerHttpClient.getZswapMerkleTreeCollapsedUpdate(0, 1);
+      const response2 = await indexerHttpClient.getZswapMerkleTreeCollapsedUpdate(0, 1);
+
+      expect(response1).toBeSuccess();
+      expect(response2).toBeSuccess();
+
+      const update1 = response1.data!.zswapMerkleTreeCollapsedUpdate;
+      const update2 = response2.data!.zswapMerkleTreeCollapsedUpdate;
+
+      expect(update1.startIndex).toBe(update2.startIndex);
+      expect(update1.endIndex).toBe(update2.endIndex);
+      expect(update1.update).toBe(update2.update);
+      expect(update1.protocolVersion).toBe(update2.protocolVersion);
+    });
   });
 
   describe('a collapsed update query with invalid index range', () => {
@@ -83,7 +181,7 @@ describe('zswap merkle tree collapsed update queries', () => {
      *
      * @given we use an invalid index range where startIndex > endIndex
      * @when we query for a collapsed update
-     * @then Indexer should respond with an error
+     * @then Indexer should respond with an error about invalid start_index and/or end_index
      */
     test('should return an error when startIndex is greater than endIndex', async (ctx: TestContext) => {
       ctx.task!.meta.custom = {
@@ -94,14 +192,15 @@ describe('zswap merkle tree collapsed update queries', () => {
       const response = await indexerHttpClient.getZswapMerkleTreeCollapsedUpdate(10, 5);
 
       expect(response).toBeError();
+      expect(response.errors![0].message).toContain('invalid start_index and/or end_index');
     });
 
     /**
-     * A collapsed update query with negative indices should return an error
+     * A collapsed update query with negative indices should return a parse error
      *
      * @given we use negative indices
      * @when we query for a collapsed update
-     * @then Indexer should respond with an error
+     * @then Indexer should respond with an error about invalid number parsing
      */
     test('should return an error when indices are negative', async (ctx: TestContext) => {
       ctx.task!.meta.custom = {
@@ -112,6 +211,26 @@ describe('zswap merkle tree collapsed update queries', () => {
       const response = await indexerHttpClient.getZswapMerkleTreeCollapsedUpdate(-1, 1);
 
       expect(response).toBeError();
+      expect(response.errors![0].message).toContain('Invalid number');
+    });
+
+    /**
+     * A collapsed update query where endIndex exceeds the indexed zswap range should return an error
+     *
+     * @given we use an endIndex far beyond the current indexed range
+     * @when we query for a collapsed update
+     * @then Indexer should respond with an error about invalid Merkle tree collapsed update
+     */
+    test('should return an error when endIndex is beyond the indexed range', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Zswap', 'CollapsedUpdate', 'Negative'],
+      };
+
+      log.debug('Requesting zswap merkle tree collapsed update with startIndex=0, endIndex=999999999');
+      const response = await indexerHttpClient.getZswapMerkleTreeCollapsedUpdate(0, 999999999);
+
+      expect(response).toBeError();
+      expect(response.errors![0].message).toContain('invalid start_index and/or end_index');
     });
   });
 });

--- a/qa/tests/tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts
@@ -26,7 +26,8 @@ import {
 } from '@utils/indexer/websocket-client';
 import { generateSyntheticViewingKey } from '@utils/bech32-codec';
 import { ToolkitWrapper } from '@utils/toolkit/toolkit-wrapper';
-import { ShieldedTransactionEventSchema } from '@utils/indexer/graphql/schema';
+import { IndexerHttpClient } from '@utils/indexer/http-client';
+import { MerkleTreeCollapsedUpdateSchema, ShieldedTransactionEventSchema } from '@utils/indexer/graphql/schema';
 import dataProvider from '@utils/testdata-provider';
 
 // This is longer because it might take some time when
@@ -289,6 +290,69 @@ describe('shielded transaction subscriptions', () => {
           ).toBe(true);
         });
     });
+
+    /**
+     * The shielded transaction subscription provides progress events with highestZswapEndIndex.
+     * A wallet can use this value to request a collapsed Merkle tree update via the
+     * zswapMerkleTreeCollapsedUpdate query, mirroring the real wallet sync flow.
+     *
+     * @given a valid viewing key and an open wallet session
+     * @when we receive a ShieldedTransactionsProgress event with highestZswapEndIndex
+     * @then using that endIndex in zswapMerkleTreeCollapsedUpdate should return a valid result
+     */
+    test('should be able to use highestZswapEndIndex from progress event in collapsed update query', async () => {
+      const seedWithTransactions = dataProvider.getFundingSeed();
+      const viewingKey = await toolkit.showViewingKey(seedWithTransactions);
+
+      const sessionId: string = await indexerWsClient.openWalletSession(viewingKey);
+
+      // Collect events until we get a ShieldedTransactionsProgress
+      const highestZswapEndIndex = await new Promise<number>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error('Timed out waiting for ShieldedTransactionsProgress event'));
+        }, 15_000);
+
+        const unsubscribe = indexerWsClient.subscribeToShieldedTransactionEvents(
+          {
+            next: (payload) => {
+              const event = payload.data?.shieldedTransactions;
+              if (event?.__typename === 'ShieldedTransactionsProgress') {
+                log.debug(`Received progress event: ${JSON.stringify(event)}`);
+                clearTimeout(timeout);
+                unsubscribe();
+                resolve(event.highestZswapEndIndex);
+              }
+            },
+          },
+          sessionId,
+        );
+      });
+
+      log.debug(`highestZswapEndIndex from progress event = ${highestZswapEndIndex}`);
+      expect(highestZswapEndIndex).toBeGreaterThan(0);
+
+      // highestZswapEndIndex is exclusive, so the collapsed update query needs (highestZswapEndIndex - 1)
+      const indexerHttpClient = new IndexerHttpClient();
+      const endIndex = highestZswapEndIndex - 1;
+      log.debug(`Querying collapsed update with startIndex=0, endIndex=${endIndex}`);
+      const response = await indexerHttpClient.getZswapMerkleTreeCollapsedUpdate(0, endIndex);
+
+      expect(response).toBeSuccess();
+      expect(response.data?.zswapMerkleTreeCollapsedUpdate).toBeDefined();
+
+      const collapsedUpdate = response.data!.zswapMerkleTreeCollapsedUpdate;
+      expect(collapsedUpdate.startIndex).toBe(0);
+      expect(collapsedUpdate.endIndex).toBe(endIndex);
+
+      log.debug('Validating collapsed update schema');
+      const parsed = MerkleTreeCollapsedUpdateSchema.safeParse(collapsedUpdate);
+      expect(
+        parsed.success,
+        `Collapsed update schema validation failed ${JSON.stringify(parsed.error, null, 2)}`,
+      ).toBe(true);
+
+      await indexerWsClient.closeWalletSession(sessionId);
+    }, 30_000);
 
     /**
     * Ensures that a shielded transaction subscription cannot use a session ID

--- a/qa/tests/utils/indexer/graphql/block-queries.ts
+++ b/qa/tests/utils/indexer/graphql/block-queries.ts
@@ -34,6 +34,7 @@ query GetLatestBlock{
     timestamp
     author
     ledgerParameters
+    zswapMerkleTreeRoot
     parent {
         hash
         height
@@ -53,6 +54,7 @@ query GetBlock($OFFSET: BlockOffset!){
     timestamp
     author
     ledgerParameters
+    zswapMerkleTreeRoot
     parent {
       hash
       height

--- a/qa/tests/utils/indexer/graphql/block-queries.ts
+++ b/qa/tests/utils/indexer/graphql/block-queries.ts
@@ -15,6 +15,16 @@
 
 import { TRANSACTION_BODY_FRAGMENT } from './transaction-queries';
 
+export const GET_ZSWAP_MERKLE_TREE_COLLAPSED_UPDATE = `
+query ZswapMerkleTreeCollapsedUpdate($START_INDEX: Int!, $END_INDEX: Int!) {
+  zswapMerkleTreeCollapsedUpdate(startIndex: $START_INDEX, endIndex: $END_INDEX) {
+    startIndex
+    endIndex
+    update
+    protocolVersion
+  }
+}`;
+
 export const GET_LATEST_BLOCK = `
 query GetLatestBlock{
   block{

--- a/qa/tests/utils/indexer/graphql/schema.ts
+++ b/qa/tests/utils/indexer/graphql/schema.ts
@@ -67,6 +67,14 @@ export const UnshieldedUtxoSchema = z.object({
     .nullable(),
 });
 
+// Zswap Merkle tree collapsed update schema
+export const MerkleTreeCollapsedUpdateSchema = z.object({
+  startIndex: z.number(),
+  endIndex: z.number(),
+  update: VarLenghtHex,
+  protocolVersion: z.number(),
+});
+
 // Ledger event schemas
 export const ZswapLedgerEventSchema = z.object({
   id: z.number(),
@@ -145,10 +153,10 @@ const BaseTransactionFields = {
 export const RegularTransactionSchema = z.lazy(() =>
   z.object({
     ...BaseTransactionFields,
-    merkleTreeRoot: z.string().regex(/^[a-f0-9]+$/),
+    zswapMerkleTreeRoot: z.string().regex(/^[a-f0-9]+$/),
     identifiers: z.array(z.string()),
-    startIndex: z.number(),
-    endIndex: z.number(),
+    zswapStartIndex: z.number(),
+    zswapEndIndex: z.number(),
     fees: z.object({
       paidFees: z.string(),
       estimatedFees: z.string(),
@@ -302,7 +310,7 @@ export const RelevantTransactionSchema = z.object({
   transaction: z.object({
     hash: Hash64,
   }),
-  collapsedMerkleTree: z
+  zswapCollapsedUpdate: z
     .object({
       startIndex: z.number(),
       endIndex: z.number(),
@@ -314,9 +322,9 @@ export const RelevantTransactionSchema = z.object({
 
 export const ShieldedTransactionsProgressSchema = z.object({
   __typename: z.literal('ShieldedTransactionsProgress'),
-  highestEndIndex: z.number(),
-  highestCheckedEndIndex: z.number(),
-  highestRelevantEndIndex: z.number(),
+  highestZswapEndIndex: z.number(),
+  highestCheckedZswapEndIndex: z.number(),
+  highestRelevantZswapEndIndex: z.number(),
 });
 
 export const ShieldedTransactionEventSchema = z.union([

--- a/qa/tests/utils/indexer/graphql/schema.ts
+++ b/qa/tests/utils/indexer/graphql/schema.ts
@@ -38,6 +38,7 @@ export const BlockSchema = z.lazy(() =>
     protocolVersion: z.number(),
     author: z.string().optional(),
     ledgerParameters: z.string(),
+    zswapMerkleTreeRoot: VarLenghtHex,
     parent: PartialBlockSchema,
     transactions: z.array(FullTransactionSchema).min(0),
   }),

--- a/qa/tests/utils/indexer/graphql/subscriptions.ts
+++ b/qa/tests/utils/indexer/graphql/subscriptions.ts
@@ -114,6 +114,7 @@ export const BLOCKS_SUBSCRIPTION_FROM_LATEST_BLOCK = `subscription BlocksSubscri
     timestamp
     protocolVersion
     ledgerParameters
+    zswapMerkleTreeRoot
     parent {
       hash
       height
@@ -145,6 +146,7 @@ export const BLOCKS_SUBSCRIPTION_FROM_BLOCK_BY_OFFSET = `subscription BlocksSubs
     timestamp
     protocolVersion
     ledgerParameters
+    zswapMerkleTreeRoot
     parent {
       hash
       height

--- a/qa/tests/utils/indexer/graphql/subscriptions.ts
+++ b/qa/tests/utils/indexer/graphql/subscriptions.ts
@@ -20,7 +20,7 @@ export const SHIELDED_TRANSACTION_SUBSCRIPTION_BY_SESSION_ID = `subscription Wal
             transaction {
                 hash
             }
-            collapsedMerkleTree {
+            zswapCollapsedUpdate {
                 startIndex
                 endIndex
                 update
@@ -29,9 +29,9 @@ export const SHIELDED_TRANSACTION_SUBSCRIPTION_BY_SESSION_ID = `subscription Wal
         }
         ... on ShieldedTransactionsProgress {
             __typename
-            highestEndIndex
-            highestCheckedEndIndex
-            highestRelevantEndIndex
+            highestZswapEndIndex
+            highestCheckedZswapEndIndex
+            highestRelevantZswapEndIndex
         }
     }
 }`;
@@ -201,10 +201,10 @@ export const BLOCKS_SUBSCRIPTION_FROM_BLOCK_BY_OFFSET = `subscription BlocksSubs
         protocolVersion
       }
       ... on RegularTransaction {
-        merkleTreeRoot
+        zswapMerkleTreeRoot
         identifiers
-        startIndex
-        endIndex
+        zswapStartIndex
+        zswapEndIndex
         fees {
           paidFees
           estimatedFees

--- a/qa/tests/utils/indexer/graphql/transaction-queries.ts
+++ b/qa/tests/utils/indexer/graphql/transaction-queries.ts
@@ -69,10 +69,10 @@ export const BASE_TRANSACTION_FRAGMENT = `   id
 
 export const REGULAR_TRANSACTION_FRAGMENT = `   ... on RegularTransaction {
       ${BASE_TRANSACTION_FRAGMENT}
-      merkleTreeRoot
+      zswapMerkleTreeRoot
       identifiers
-      startIndex
-      endIndex
+      zswapStartIndex
+      zswapEndIndex
       fees {
         paidFees
         estimatedFees

--- a/qa/tests/utils/indexer/http-client.ts
+++ b/qa/tests/utils/indexer/http-client.ts
@@ -28,8 +28,10 @@ import type {
   ContractActionResponse,
   DustGenerationStatus,
   DustGenerationStatusResponse,
+  ZswapMerkleTreeCollapsedUpdateResponse,
+  ZswapMerkleTreeCollapsedUpdateResult,
 } from './indexer-types';
-import { GET_LATEST_BLOCK, GET_BLOCK_BY_OFFSET } from './graphql/block-queries';
+import { GET_LATEST_BLOCK, GET_BLOCK_BY_OFFSET, GET_ZSWAP_MERKLE_TREE_COLLAPSED_UPDATE } from './graphql/block-queries';
 import { GET_TRANSACTION_BY_OFFSET } from './graphql/transaction-queries';
 import { GET_CONTRACT_ACTION, GET_CONTRACT_ACTION_BY_OFFSET } from './graphql/contract-queries';
 import { GET_DUST_GENERATION_STATUS } from './graphql/dust-queries';
@@ -177,6 +179,37 @@ export class IndexerHttpClient {
       query,
       variables,
     );
+
+    log.debug(`Raw indexer response\n${JSON.stringify(response, null, 2)}`);
+
+    return response;
+  }
+
+  /**
+   * Retrieves a zswap Merkle tree collapsed update for the given index range
+   *
+   * @param startIndex - The start index of the range
+   * @param endIndex - The end index of the range
+   * @param queryOverride - Optional custom GraphQL query to override the default query
+   *
+   * @returns Promise resolving to the collapsed update response
+   */
+  async getZswapMerkleTreeCollapsedUpdate(
+    startIndex: number,
+    endIndex: number,
+    queryOverride?: string,
+  ): Promise<ZswapMerkleTreeCollapsedUpdateResponse> {
+    log.debug(`Target URL endpoint ${this.getTargetUrl()}`);
+
+    const query = queryOverride || GET_ZSWAP_MERKLE_TREE_COLLAPSED_UPDATE;
+    const variables = { START_INDEX: startIndex, END_INDEX: endIndex };
+
+    log.debug(`Using query\n${query}`);
+    log.debug(`Using variables\n${JSON.stringify(variables, null, 2)}`);
+
+    const response = await this.client.rawRequest<{
+      zswapMerkleTreeCollapsedUpdate: ZswapMerkleTreeCollapsedUpdateResult;
+    }>(query, variables);
 
     log.debug(`Raw indexer response\n${JSON.stringify(response, null, 2)}`);
 

--- a/qa/tests/utils/indexer/indexer-types.ts
+++ b/qa/tests/utils/indexer/indexer-types.ts
@@ -26,6 +26,17 @@ export type TransactionResponse = GraphQLResponse<{ transactions: Transaction[] 
 
 export type ContractActionResponse = GraphQLResponse<{ contractAction: ContractAction }>;
 
+export interface ZswapMerkleTreeCollapsedUpdateResult {
+  startIndex: number;
+  endIndex: number;
+  update: string;
+  protocolVersion: number;
+}
+
+export type ZswapMerkleTreeCollapsedUpdateResponse = GraphQLResponse<{
+  zswapMerkleTreeCollapsedUpdate: ZswapMerkleTreeCollapsedUpdateResult;
+}>;
+
 export type DustGenerationStatusResponse = GraphQLResponse<{
   dustGenerationStatus: DustGenerationStatus[];
 }>;
@@ -110,9 +121,9 @@ export interface Transaction {
 // RegularTransaction interface (includes additional fields)
 export interface RegularTransaction extends Transaction {
   identifiers?: string[];
-  merkleTreeRoot?: string;
-  startIndex?: number;
-  endIndex?: number;
+  zswapMerkleTreeRoot?: string;
+  zswapStartIndex?: number;
+  zswapEndIndex?: number;
   fees?: TransactionFees;
   transactionResult?: TransactionResult;
 }
@@ -141,7 +152,7 @@ export interface MerkleTreeCollapsedUpdate {
   protocolVersion: number;
 }
 
-export interface CollapsedMerkleTree {
+export interface ZswapCollapsedUpdate {
   startIndex: number;
   endIndex: number;
   update: string;
@@ -151,14 +162,14 @@ export interface CollapsedMerkleTree {
 export interface RelevantTransaction {
   __typename: 'RelevantTransaction';
   transaction: RegularTransaction;
-  collapsedMerkleTree?: CollapsedMerkleTree;
+  zswapCollapsedUpdate?: ZswapCollapsedUpdate;
 }
 
 export interface ShieldedTransactionsProgress {
   __typename: 'ShieldedTransactionsProgress';
-  highestEndIndex: number;
-  highestCheckedEndIndex: number;
-  highestRelevantEndIndex: number;
+  highestZswapEndIndex: number;
+  highestCheckedZswapEndIndex: number;
+  highestRelevantZswapEndIndex: number;
 }
 
 export type UnshieldedTransactionEvent = UnshieldedTransaction | UnshieldedTransactionsProgress;

--- a/qa/tests/utils/indexer/indexer-types.ts
+++ b/qa/tests/utils/indexer/indexer-types.ts
@@ -65,6 +65,7 @@ export interface Block {
   protocolVersion: number;
   author: string | null;
   ledgerParameters: string;
+  zswapMerkleTreeRoot: string;
   parent: Block;
   transactions: Transaction[];
 }


### PR DESCRIPTION
Summary
- update GraphQL queries, subscriptions, types, and schemas to use renamed zswap fields from #982
- `merkleTreeRoot` → `zswapMerkleTreeRoot`, `startIndex` → `zswapStartIndex`, `endIndex` → `zswapEndIndex`,  `collapsedMerkleTree` → `zswapCollapsedUpdate`, `highestEndIndex` → `highestZswapEndIndex` (and related progress fields)
- add new integration test for `zswapMerkleTreeCollapsedUpdate` query (#982)
- add `zswapMerkleTreeRoot` to block queries, subscriptions, and schema validation (#988)
- add wallet sync flow integration test: subscribe to shieldedTransactions, capture highestZswapEndIndex from progress event, use it to query zswapMerkleTreeCollapsedUpdate (endIndex is exclusive, so query uses highestZswapEndIndex - 1)
- add e2e test verifying zswap Merkle tree grows after a shielded transaction (zswapEndIndex increases)
- add edge case tests for zswapMerkleTreeCollapsedUpdate: startIndex === endIndex, endIndex beyond indexed range, idempotency, exact error message assertions
