### PR TITLE
feat: add shieldedNullifierTransactions subscription

### DIFF
--- a/chain-indexer/src/infra/storage.rs
+++ b/chain-indexer/src/infra/storage.rs
@@ -234,7 +234,7 @@ pub enum LedgerEventVariant {
 impl From<&LedgerEventAttributes> for LedgerEventVariant {
     fn from(attributes: &LedgerEventAttributes) -> Self {
         match attributes {
-            LedgerEventAttributes::ZswapInput => Self::ZswapInput,
+            LedgerEventAttributes::ZswapInput { .. } => Self::ZswapInput,
             LedgerEventAttributes::ZswapOutput => Self::ZswapOutput,
             LedgerEventAttributes::ParamChange => Self::ParamChange,
             LedgerEventAttributes::DustInitialUtxo { .. } => Self::DustInitialUtxo,
@@ -432,6 +432,8 @@ async fn save_regular_transaction(
     save_dust_generation_info(&transaction.ledger_events, transaction_id, tx).await?;
 
     save_dust_nullifiers(&transaction.ledger_events, transaction_id, block_id, tx).await?;
+
+    save_zswap_nullifiers(&transaction.ledger_events, transaction_id, block_id, tx).await?;
 
     Ok(transaction_id as u64)
 }
@@ -795,6 +797,47 @@ async fn save_dust_nullifiers(
         .push_values(nullifier_events, |mut q, (nullifier, commitment)| {
             q.push_bind(nullifier.as_ref())
                 .push_bind(commitment.as_ref())
+                .push_bind(transaction_id)
+                .push_bind(block_id);
+        })
+        .build()
+        .execute(&mut **tx)
+        .await?;
+
+    Ok(())
+}
+
+#[trace(properties = { "transaction_id": "{transaction_id}", "block_id": "{block_id}" })]
+async fn save_zswap_nullifiers(
+    ledger_events: &[LedgerEvent],
+    transaction_id: i64,
+    block_id: i64,
+    tx: &mut SqlxTransaction,
+) -> Result<(), sqlx::Error> {
+    let nullifier_events = ledger_events
+        .iter()
+        .filter_map(|event| match &event.attributes {
+            LedgerEventAttributes::ZswapInput { nullifier } => Some(nullifier),
+
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    if nullifier_events.is_empty() {
+        return Ok(());
+    }
+
+    let query = indoc! {"
+        INSERT INTO zswap_nullifiers (
+            nullifier,
+            transaction_id,
+            block_id
+        )
+    "};
+
+    QueryBuilder::new(query)
+        .push_values(nullifier_events, |mut q, nullifier| {
+            q.push_bind(nullifier.as_ref())
                 .push_bind(transaction_id)
                 .push_bind(block_id);
         })

--- a/chain-indexer/src/infra/storage.rs
+++ b/chain-indexer/src/infra/storage.rs
@@ -829,17 +829,17 @@ async fn save_zswap_nullifiers(
 
     let query = indoc! {"
         INSERT INTO zswap_nullifiers (
-            nullifier,
             transaction_id,
-            block_id
+            block_id,
+            nullifier
         )
     "};
 
     QueryBuilder::new(query)
         .push_values(nullifier_events, |mut q, nullifier| {
-            q.push_bind(nullifier.as_ref())
-                .push_bind(transaction_id)
-                .push_bind(block_id);
+            q.push_bind(transaction_id)
+                .push_bind(block_id)
+                .push_bind(nullifier.as_ref());
         })
         .build()
         .execute(&mut **tx)

--- a/indexer-api/config.yaml
+++ b/indexer-api/config.yaml
@@ -41,6 +41,8 @@ infra:
         batch_size: 20
       dust_nullifier_transactions:
         batch_size: 20
+      shielded_nullifier_transactions:
+        batch_size: 20
       shielded_transactions:
         batch_size: 20
         progress_update_interval: "30s"

--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -909,6 +909,28 @@ type Segment {
 }
 
 """
+A transaction containing a shielded (zswap) nullifier match with block context.
+"""
+type ShieldedNullifierTransaction {
+	"""
+	The hex-encoded matched nullifier.
+	"""
+	nullifier: HexEncoded!
+	"""
+	The transaction ID (use to query full transaction via `transaction` query).
+	"""
+	transactionId: Int!
+	"""
+	The block height containing this transaction.
+	"""
+	blockHeight: Int!
+	"""
+	The hex-encoded block hash (use to query block with ledger parameters).
+	"""
+	blockHash: HexEncoded!
+}
+
+"""
 An event of the shielded transactions subscription.
 """
 union ShieldedTransactionsEvent = RelevantTransaction | ShieldedTransactionsProgress
@@ -1076,6 +1098,12 @@ type Subscription {
 	If `toBlock` is specified, the subscription finishes after reaching that block.
 	"""
 	dustNullifierTransactions(nullifierPrefixes: [HexEncoded!]!, fromBlock: Int, toBlock: Int): DustNullifierTransaction!
+	"""
+	Subscribe to transactions containing shielded (zswap) nullifiers matching the provided
+	prefixes. Returns transaction and block references for wallet to fetch full data.
+	If `toBlock` is specified, the subscription finishes after reaching that block.
+	"""
+	shieldedNullifierTransactions(nullifierPrefixes: [HexEncoded!]!, fromBlock: Int, toBlock: Int): ShieldedNullifierTransaction!
 	"""
 	Subscribe to shielded transaction events for the given session ID starting at the given
 	index or at zero if omitted.

--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -913,21 +913,21 @@ A transaction containing a shielded (zswap) nullifier match with block context.
 """
 type ShieldedNullifierTransaction {
 	"""
-	The hex-encoded matched nullifier.
-	"""
-	nullifier: HexEncoded!
-	"""
 	The transaction ID (use to query full transaction via `transaction` query).
 	"""
 	transactionId: Int!
+	"""
+	The hex-encoded block hash (use to query block with ledger parameters).
+	"""
+	blockHash: HexEncoded!
 	"""
 	The block height containing this transaction.
 	"""
 	blockHeight: Int!
 	"""
-	The hex-encoded block hash (use to query block with ledger parameters).
+	The hex-encoded matched nullifier.
 	"""
-	blockHash: HexEncoded!
+	nullifier: HexEncoded!
 }
 
 """

--- a/indexer-api/src/domain/shielded_nullifier.rs
+++ b/indexer-api/src/domain/shielded_nullifier.rs
@@ -2,7 +2,7 @@
 // Copyright (C) Midnight Foundation
 // SPDX-License-Identifier: Apache-2.0
 // Licensed under the Apache License, Version 2.0 (the "License");
-// You may not use this file except in compliance with the License.
+// you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
 // Unless required by applicable law or agreed to in writing, software
@@ -11,27 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod storage;
+use indexer_common::domain::ByteVec;
 
-mod api;
-mod block;
-mod contract_action;
-pub mod dust;
-mod ledger_event;
-mod ledger_state;
-pub mod shielded_nullifier;
-pub mod spo;
-pub mod system_parameters;
-mod transaction;
-mod unshielded;
-
-pub use api::*;
-pub use block::*;
-pub use contract_action::*;
-pub use dust::*;
-pub use ledger_event::*;
-pub use ledger_state::*;
-pub use shielded_nullifier::*;
-pub use system_parameters::*;
-pub use transaction::*;
-pub use unshielded::*;
+/// A shielded nullifier transaction for the subscription stream.
+#[derive(Debug, Clone)]
+pub struct ShieldedNullifierTransaction {
+    pub nullifier: ByteVec,
+    pub transaction_id: u64,
+    pub block_height: u32,
+    pub block_hash: ByteVec,
+}

--- a/indexer-api/src/domain/shielded_nullifier.rs
+++ b/indexer-api/src/domain/shielded_nullifier.rs
@@ -16,8 +16,8 @@ use indexer_common::domain::ByteVec;
 /// A shielded nullifier transaction for the subscription stream.
 #[derive(Debug, Clone)]
 pub struct ShieldedNullifierTransaction {
-    pub nullifier: ByteVec,
     pub transaction_id: u64,
-    pub block_height: u32,
     pub block_hash: ByteVec,
+    pub block_height: u32,
+    pub nullifier: ByteVec,
 }

--- a/indexer-api/src/domain/storage.rs
+++ b/indexer-api/src/domain/storage.rs
@@ -19,6 +19,7 @@ pub mod dust;
 pub mod dust_generations;
 pub mod ledger_events;
 pub mod ledger_state;
+pub mod shielded_nullifiers;
 pub mod spo;
 pub mod system_parameters;
 pub mod transaction;
@@ -28,8 +29,9 @@ pub mod wallet;
 use crate::domain::storage::{
     block::BlockStorage, contract_action::ContractActionStorage, dust::DustStorage,
     dust_generations::DustGenerationsStorage, ledger_events::LedgerEventStorage,
-    ledger_state::LedgerStateStorage, spo::SpoStorage, system_parameters::SystemParametersStorage,
-    transaction::TransactionStorage, unshielded::UnshieldedUtxoStorage, wallet::WalletStorage,
+    ledger_state::LedgerStateStorage, shielded_nullifiers::ShieldedNullifiersStorage,
+    spo::SpoStorage, system_parameters::SystemParametersStorage, transaction::TransactionStorage,
+    unshielded::UnshieldedUtxoStorage, wallet::WalletStorage,
 };
 
 /// Storage abstraction.
@@ -47,6 +49,7 @@ where
         + TransactionStorage
         + UnshieldedUtxoStorage
         + WalletStorage
+        + ShieldedNullifiersStorage
         + Clone
         + Send
         + Sync

--- a/indexer-api/src/domain/storage/shielded_nullifiers.rs
+++ b/indexer-api/src/domain/storage/shielded_nullifiers.rs
@@ -1,0 +1,45 @@
+// This file is part of midnight-indexer.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::domain::{shielded_nullifier::ShieldedNullifierTransaction, storage::NoopStorage};
+use futures::{Stream, stream};
+use std::num::NonZeroU32;
+
+/// Storage for zswap (shielded) nullifier transaction queries.
+#[trait_variant::make(Send)]
+pub trait ShieldedNullifiersStorage
+where
+    Self: Clone + Send + Sync + 'static,
+{
+    /// Get transactions containing zswap nullifiers matching a prefix.
+    async fn get_shielded_nullifier_transactions(
+        &self,
+        nullifier_prefixes: &[Vec<u8>],
+        from_block: u64,
+        to_block: u64,
+        batch_size: NonZeroU32,
+    ) -> impl Stream<Item = Result<ShieldedNullifierTransaction, sqlx::Error>> + Send;
+}
+
+#[allow(unused_variables)]
+impl ShieldedNullifiersStorage for NoopStorage {
+    async fn get_shielded_nullifier_transactions(
+        &self,
+        nullifier_prefixes: &[Vec<u8>],
+        from_block: u64,
+        to_block: u64,
+        batch_size: NonZeroU32,
+    ) -> impl Stream<Item = Result<ShieldedNullifierTransaction, sqlx::Error>> + Send {
+        stream::empty()
+    }
+}

--- a/indexer-api/src/infra/api.rs
+++ b/indexer-api/src/infra/api.rs
@@ -145,6 +145,7 @@ pub struct SubscriptionConfig {
     pub dust_generations: DustGenerationsSubscriptionConfig,
     dust_ledger_events: DustLedgerEventsSubscriptionConfig,
     pub dust_nullifier_transactions: DustNullifierTransactionsSubscriptionConfig,
+    pub shielded_nullifier_transactions: ShieldedNullifierTransactionsSubscriptionConfig,
     shielded_transactions: ShieldedTransactionsSubscriptionConfig,
     unshielded_transactions: UnshieldedTransactionsSubscriptionConfig,
     zswap_ledger_events: ZswapLedgerEventsSubscriptionConfig,
@@ -172,6 +173,11 @@ pub struct DustLedgerEventsSubscriptionConfig {
 
 #[derive(Debug, Clone, Copy, Deserialize)]
 pub struct DustNullifierTransactionsSubscriptionConfig {
+    pub batch_size: NonZeroU32,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub struct ShieldedNullifierTransactionsSubscriptionConfig {
     pub batch_size: NonZeroU32,
 }
 

--- a/indexer-api/src/infra/api/v4/ledger_events.rs
+++ b/indexer-api/src/infra/api/v4/ledger_events.rs
@@ -40,12 +40,14 @@ impl TryFrom<LedgerEvent> for ZswapLedgerEvent {
 
     fn try_from(ledger_event: LedgerEvent) -> Result<Self, Self::Error> {
         match ledger_event.attributes {
-            LedgerEventAttributes::ZswapInput | LedgerEventAttributes::ZswapOutput => Ok(Self {
-                id: ledger_event.id,
-                raw: ledger_event.raw.hex_encode(),
-                max_id: ledger_event.max_id,
-                protocol_version: ledger_event.protocol_version.into(),
-            }),
+            LedgerEventAttributes::ZswapInput { .. } | LedgerEventAttributes::ZswapOutput => {
+                Ok(Self {
+                    id: ledger_event.id,
+                    raw: ledger_event.raw.hex_encode(),
+                    max_id: ledger_event.max_id,
+                    protocol_version: ledger_event.protocol_version.into(),
+                })
+            }
 
             other => Err(UnexpectedLedgerEvent(other)),
         }

--- a/indexer-api/src/infra/api/v4/subscription.rs
+++ b/indexer-api/src/infra/api/v4/subscription.rs
@@ -17,6 +17,7 @@ mod dust_generations;
 mod dust_ledger_events;
 mod dust_nullifier_transactions;
 mod shielded;
+mod shielded_nullifier_transactions;
 mod unshielded;
 mod zswap_ledger_events;
 
@@ -27,7 +28,9 @@ use crate::{
         dust_generations::DustGenerationsSubscription,
         dust_ledger_events::DustLedgerEventsSubscription,
         dust_nullifier_transactions::DustNullifierTransactionsSubscription,
-        shielded::ShieldedTransactionsSubscription, unshielded::UnshieldedTransactionsSubscription,
+        shielded::ShieldedTransactionsSubscription,
+        shielded_nullifier_transactions::ShieldedNullifierTransactionsSubscription,
+        unshielded::UnshieldedTransactionsSubscription,
         zswap_ledger_events::ZswapLedgerEventsSubscription,
     },
 };
@@ -41,6 +44,7 @@ pub struct Subscription<S, B>(
     DustGenerationsSubscription<S, B>,
     DustLedgerEventsSubscription<S, B>,
     DustNullifierTransactionsSubscription<S, B>,
+    ShieldedNullifierTransactionsSubscription<S, B>,
     ShieldedTransactionsSubscription<S, B>,
     UnshieldedTransactionsSubscription<S, B>,
     ZswapLedgerEventsSubscription<S, B>,
@@ -61,6 +65,7 @@ where
             DustGenerationsSubscription::default(),
             DustLedgerEventsSubscription::default(),
             DustNullifierTransactionsSubscription::default(),
+            ShieldedNullifierTransactionsSubscription::default(),
             ShieldedTransactionsSubscription::default(),
             UnshieldedTransactionsSubscription::default(),
             ZswapLedgerEventsSubscription::default(),

--- a/indexer-api/src/infra/api/v4/subscription/dust_nullifier_transactions.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_nullifier_transactions.rs
@@ -87,7 +87,7 @@ where
                 .map_err_into_client_error(|| "invalid hex-encoded nullifier prefix")?;
 
             let from = from_block.unwrap_or(0);
-            let to = to_block.unwrap_or(i64::MAX as u64);
+            let to = to_block.unwrap_or(u64::MAX);
 
             debug!("streaming existing dust nullifier transactions");
 

--- a/indexer-api/src/infra/api/v4/subscription/shielded_nullifier_transactions.rs
+++ b/indexer-api/src/infra/api/v4/subscription/shielded_nullifier_transactions.rs
@@ -113,7 +113,7 @@ where
                 .await
                 .map_err_into_server_error(|| "get next shielded nullifier transaction")?
             {
-                yield ShieldedNullifierTransaction::from(transaction);
+                yield transaction.into();
             }
 
             if let Some(to) = to_block {
@@ -146,7 +146,7 @@ where
                     .await
                     .map_err_into_server_error(|| "get next shielded nullifier transaction")?
                 {
-                    yield ShieldedNullifierTransaction::from(transaction);
+                    yield transaction.into();
                 }
 
                 if let Some(to) = to_block {

--- a/indexer-api/src/infra/api/v4/subscription/shielded_nullifier_transactions.rs
+++ b/indexer-api/src/infra/api/v4/subscription/shielded_nullifier_transactions.rs
@@ -1,0 +1,164 @@
+// This file is part of midnight-indexer.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    domain::storage::Storage,
+    infra::api::{
+        ApiResult, ContextExt, ResultExt,
+        v4::{HexEncodable, HexEncoded},
+    },
+};
+use async_graphql::{Context, SimpleObject, Subscription};
+use async_stream::try_stream;
+use futures::{Stream, TryStreamExt};
+use indexer_common::domain::{BlockIndexed, Subscriber};
+use log::{debug, warn};
+use std::{marker::PhantomData, pin::pin};
+
+pub struct ShieldedNullifierTransactionsSubscription<S, B> {
+    _s: PhantomData<S>,
+    _b: PhantomData<B>,
+}
+
+impl<S, B> Default for ShieldedNullifierTransactionsSubscription<S, B> {
+    fn default() -> Self {
+        Self {
+            _s: PhantomData,
+            _b: PhantomData,
+        }
+    }
+}
+
+/// A transaction containing a shielded (zswap) nullifier match with block context.
+#[derive(Debug, Clone, SimpleObject)]
+pub struct ShieldedNullifierTransaction {
+    /// The hex-encoded matched nullifier.
+    pub nullifier: HexEncoded,
+    /// The transaction ID (use to query full transaction via `transaction` query).
+    pub transaction_id: u64,
+    /// The block height containing this transaction.
+    pub block_height: u32,
+    /// The hex-encoded block hash (use to query block with ledger parameters).
+    pub block_hash: HexEncoded,
+}
+
+#[Subscription]
+impl<S, B> ShieldedNullifierTransactionsSubscription<S, B>
+where
+    S: Storage,
+    B: Subscriber,
+{
+    /// Subscribe to transactions containing shielded (zswap) nullifiers matching the provided
+    /// prefixes. Returns transaction and block references for wallet to fetch full data.
+    /// If `toBlock` is specified, the subscription finishes after reaching that block.
+    async fn shielded_nullifier_transactions<'a>(
+        &self,
+        cx: &'a Context<'a>,
+        nullifier_prefixes: Vec<HexEncoded>,
+        from_block: Option<u64>,
+        to_block: Option<u64>,
+    ) -> impl Stream<Item = ApiResult<ShieldedNullifierTransaction>> {
+        let storage = cx.get_storage::<S>();
+        let subscriber = cx.get_subscriber::<B>();
+        let batch_size = cx
+            .get_subscription_config()
+            .shielded_nullifier_transactions
+            .batch_size;
+
+        let block_indexed_stream = subscriber.subscribe::<BlockIndexed>();
+
+        try_stream! {
+            let prefix_bytes = nullifier_prefixes
+                .iter()
+                .map(|p| const_hex::decode(p.as_ref()))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err_into_client_error(|| "invalid hex-encoded nullifier prefix")?;
+
+            let from = from_block.unwrap_or(0);
+            let to = to_block.unwrap_or(i64::MAX as u64);
+
+            debug!("streaming existing shielded nullifier transactions");
+
+            let entries = storage
+                .get_shielded_nullifier_transactions(&prefix_bytes, from, to, batch_size)
+                .await;
+            let mut entries = pin!(entries);
+            while let Some(entry) = entries
+                .try_next()
+                .await
+                .map_err_into_server_error(|| "get next shielded nullifier transaction")?
+            {
+                yield ShieldedNullifierTransaction {
+                    nullifier: entry.nullifier.hex_encode(),
+                    transaction_id: entry.transaction_id,
+                    block_height: entry.block_height,
+                    block_hash: entry.block_hash.hex_encode(),
+                };
+            }
+
+            if let Some(to) = to_block {
+                let latest_block = storage
+                    .get_latest_block()
+                    .await
+                    .map_err_into_server_error(|| "get latest block")?;
+
+                if let Some(block) = latest_block
+                    && block.height as u64 >= to
+                {
+                    return;
+                }
+            }
+
+            debug!("streaming live shielded nullifier transactions");
+            let mut block_indexed_stream = pin!(block_indexed_stream);
+            while block_indexed_stream
+                .try_next()
+                .await
+                .map_err_into_server_error(|| "get next BlockIndexed event")?
+                .is_some()
+            {
+                let entries = storage
+                    .get_shielded_nullifier_transactions(&prefix_bytes, from, to, batch_size)
+                    .await;
+                let mut entries = pin!(entries);
+                while let Some(entry) = entries
+                    .try_next()
+                    .await
+                    .map_err_into_server_error(|| "get next shielded nullifier transaction")?
+                {
+                    yield ShieldedNullifierTransaction {
+                        nullifier: entry.nullifier.hex_encode(),
+                        transaction_id: entry.transaction_id,
+                        block_height: entry.block_height,
+                        block_hash: entry.block_hash.hex_encode(),
+                    };
+                }
+
+                if let Some(to) = to_block {
+                    let latest_block = storage
+                        .get_latest_block()
+                        .await
+                        .map_err_into_server_error(|| "get latest block")?;
+
+                    if let Some(block) = latest_block
+                        && block.height as u64 >= to
+                    {
+                        return;
+                    }
+                }
+            }
+
+            warn!("stream of BlockIndexed events completed unexpectedly");
+        }
+    }
+}

--- a/indexer-api/src/infra/api/v4/subscription/shielded_nullifier_transactions.rs
+++ b/indexer-api/src/infra/api/v4/subscription/shielded_nullifier_transactions.rs
@@ -14,7 +14,7 @@
 use crate::{
     domain::storage::Storage,
     infra::api::{
-        ApiResult, ContextExt, ResultExt,
+        ApiResult, ContextExt, OptionExt, ResultExt,
         v4::{HexEncodable, HexEncoded},
     },
 };
@@ -42,14 +42,25 @@ impl<S, B> Default for ShieldedNullifierTransactionsSubscription<S, B> {
 /// A transaction containing a shielded (zswap) nullifier match with block context.
 #[derive(Debug, Clone, SimpleObject)]
 pub struct ShieldedNullifierTransaction {
-    /// The hex-encoded matched nullifier.
-    pub nullifier: HexEncoded,
     /// The transaction ID (use to query full transaction via `transaction` query).
     pub transaction_id: u64,
-    /// The block height containing this transaction.
-    pub block_height: u32,
     /// The hex-encoded block hash (use to query block with ledger parameters).
     pub block_hash: HexEncoded,
+    /// The block height containing this transaction.
+    pub block_height: u32,
+    /// The hex-encoded matched nullifier.
+    pub nullifier: HexEncoded,
+}
+
+impl From<crate::domain::ShieldedNullifierTransaction> for ShieldedNullifierTransaction {
+    fn from(t: crate::domain::ShieldedNullifierTransaction) -> Self {
+        Self {
+            transaction_id: t.transaction_id,
+            block_hash: t.block_hash.hex_encode(),
+            block_height: t.block_height,
+            nullifier: t.nullifier.hex_encode(),
+        }
+    }
 }
 
 #[Subscription]
@@ -78,6 +89,10 @@ where
         let block_indexed_stream = subscriber.subscribe::<BlockIndexed>();
 
         try_stream! {
+            (nullifier_prefixes.len() <= 10)
+                .then_some(())
+                .some_or_client_error(|| "maximum of ten nullifier prefixes allowed")?;
+
             let prefix_bytes = nullifier_prefixes
                 .iter()
                 .map(|p| const_hex::decode(p.as_ref()))
@@ -85,25 +100,20 @@ where
                 .map_err_into_client_error(|| "invalid hex-encoded nullifier prefix")?;
 
             let from = from_block.unwrap_or(0);
-            let to = to_block.unwrap_or(i64::MAX as u64);
+            let to = to_block.unwrap_or(u64::MAX);
 
             debug!("streaming existing shielded nullifier transactions");
 
-            let entries = storage
+            let transactions = storage
                 .get_shielded_nullifier_transactions(&prefix_bytes, from, to, batch_size)
                 .await;
-            let mut entries = pin!(entries);
-            while let Some(entry) = entries
+            let mut transactions = pin!(transactions);
+            while let Some(transaction) = transactions
                 .try_next()
                 .await
                 .map_err_into_server_error(|| "get next shielded nullifier transaction")?
             {
-                yield ShieldedNullifierTransaction {
-                    nullifier: entry.nullifier.hex_encode(),
-                    transaction_id: entry.transaction_id,
-                    block_height: entry.block_height,
-                    block_hash: entry.block_hash.hex_encode(),
-                };
+                yield ShieldedNullifierTransaction::from(transaction);
             }
 
             if let Some(to) = to_block {
@@ -127,21 +137,16 @@ where
                 .map_err_into_server_error(|| "get next BlockIndexed event")?
                 .is_some()
             {
-                let entries = storage
+                let transactions = storage
                     .get_shielded_nullifier_transactions(&prefix_bytes, from, to, batch_size)
                     .await;
-                let mut entries = pin!(entries);
-                while let Some(entry) = entries
+                let mut transactions = pin!(transactions);
+                while let Some(transaction) = transactions
                     .try_next()
                     .await
                     .map_err_into_server_error(|| "get next shielded nullifier transaction")?
                 {
-                    yield ShieldedNullifierTransaction {
-                        nullifier: entry.nullifier.hex_encode(),
-                        transaction_id: entry.transaction_id,
-                        block_height: entry.block_height,
-                        block_hash: entry.block_hash.hex_encode(),
-                    };
+                    yield ShieldedNullifierTransaction::from(transaction);
                 }
 
                 if let Some(to) = to_block {

--- a/indexer-api/src/infra/storage.rs
+++ b/indexer-api/src/infra/storage.rs
@@ -17,6 +17,7 @@ mod dust;
 mod dust_generations;
 mod ledger_events;
 mod ledger_state;
+mod shielded_nullifiers;
 mod spo;
 mod system_parameters;
 mod transaction;

--- a/indexer-api/src/infra/storage/dust_generations.rs
+++ b/indexer-api/src/infra/storage/dust_generations.rs
@@ -198,28 +198,19 @@ impl DustGenerationsStorage for Storage {
         let nullifier_prefixes = nullifier_prefixes.to_vec();
 
         try_stream! {
-            let conditions = nullifier_prefixes
-                .iter()
-                .map(|prefix| {
-                    let mut next_prefix = prefix.clone();
-                    if let Some(last) = next_prefix.last_mut() {
-                        if *last < 255 {
-                            *last += 1;
-                        } else {
-                            next_prefix.push(0);
-                        }
+            for prefix in &nullifier_prefixes {
+                let mut next_prefix = prefix.clone();
+                if let Some(last) = next_prefix.last_mut() {
+                    if *last < 255 {
+                        *last += 1;
+                    } else {
+                        next_prefix.push(0);
                     }
-                    (prefix.clone(), next_prefix)
-                })
-                .collect::<Vec<_>>();
+                }
 
-            // Per-prefix cursor tracking: each prefix advances independently through the result set.
-            let mut cursors = vec![0i64; conditions.len()];
+                let mut cursor = 0i64;
 
-            loop {
-                let mut found_any = false;
-
-                for (i, (prefix, next_prefix)) in conditions.iter().enumerate() {
+                loop {
                     let query = indoc! {"
                         SELECT dn.id, dn.nullifier, dn.commitment, t.id, b.height, b.hash
                         FROM dust_nullifiers dn
@@ -238,14 +229,14 @@ impl DustGenerationsStorage for Storage {
                         .bind(&next_prefix[..])
                         .bind(from_block as i64)
                         .bind(to_block.min(i64::MAX as u64) as i64)
-                        .bind(cursors[i])
+                        .bind(cursor)
                         .bind(batch_size.get() as i64)
                         .fetch_all(&*pool)
                         .await?;
 
-                    if let Some(last) = rows.last() {
-                        cursors[i] = last.0;
-                        found_any = true;
+                    match rows.last() {
+                        Some(last) => cursor = last.0,
+                        None => break,
                     }
 
                     for (_, nullifier, commitment, transaction_id, block_height, block_hash) in rows {
@@ -257,10 +248,6 @@ impl DustGenerationsStorage for Storage {
                             block_hash,
                         };
                     }
-                }
-
-                if !found_any {
-                    break;
                 }
             }
         }

--- a/indexer-api/src/infra/storage/dust_generations.rs
+++ b/indexer-api/src/infra/storage/dust_generations.rs
@@ -213,6 +213,7 @@ impl DustGenerationsStorage for Storage {
                 })
                 .collect::<Vec<_>>();
 
+            // Per-prefix cursor tracking: each prefix advances independently through the result set.
             let mut cursors = vec![0i64; conditions.len()];
 
             loop {
@@ -236,7 +237,7 @@ impl DustGenerationsStorage for Storage {
                         .bind(&prefix[..])
                         .bind(&next_prefix[..])
                         .bind(from_block as i64)
-                        .bind(to_block as i64)
+                        .bind(to_block.min(i64::MAX as u64) as i64)
                         .bind(cursors[i])
                         .bind(batch_size.get() as i64)
                         .fetch_all(&*pool)

--- a/indexer-api/src/infra/storage/shielded_nullifiers.rs
+++ b/indexer-api/src/infra/storage/shielded_nullifiers.rs
@@ -36,6 +36,7 @@ impl ShieldedNullifiersStorage for Storage {
         let nullifier_prefixes = nullifier_prefixes.to_vec();
 
         try_stream! {
+            // Collected because per-prefix cursors require indexed access.
             let conditions = nullifier_prefixes
                 .iter()
                 .map(|prefix| {
@@ -51,6 +52,7 @@ impl ShieldedNullifiersStorage for Storage {
                 })
                 .collect::<Vec<_>>();
 
+            // Per-prefix cursor tracking: each prefix advances independently through the result set.
             let mut cursors = vec![0i64; conditions.len()];
 
             loop {
@@ -74,7 +76,7 @@ impl ShieldedNullifiersStorage for Storage {
                         .bind(&prefix[..])
                         .bind(&next_prefix[..])
                         .bind(from_block as i64)
-                        .bind(to_block as i64)
+                        .bind(to_block.min(i64::MAX as u64) as i64)
                         .bind(cursors[i])
                         .bind(batch_size.get() as i64)
                         .fetch_all(&*pool)

--- a/indexer-api/src/infra/storage/shielded_nullifiers.rs
+++ b/indexer-api/src/infra/storage/shielded_nullifiers.rs
@@ -1,0 +1,104 @@
+// This file is part of midnight-indexer.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    domain::{
+        shielded_nullifier::ShieldedNullifierTransaction,
+        storage::shielded_nullifiers::ShieldedNullifiersStorage,
+    },
+    infra::storage::Storage,
+};
+use async_stream::try_stream;
+use futures::Stream;
+use indexer_common::domain::ByteVec;
+use indoc::indoc;
+use std::num::NonZeroU32;
+
+impl ShieldedNullifiersStorage for Storage {
+    async fn get_shielded_nullifier_transactions(
+        &self,
+        nullifier_prefixes: &[Vec<u8>],
+        from_block: u64,
+        to_block: u64,
+        batch_size: NonZeroU32,
+    ) -> impl Stream<Item = Result<ShieldedNullifierTransaction, sqlx::Error>> + Send {
+        let pool = self.pool.clone();
+        let nullifier_prefixes = nullifier_prefixes.to_vec();
+
+        try_stream! {
+            let conditions = nullifier_prefixes
+                .iter()
+                .map(|prefix| {
+                    let mut next_prefix = prefix.clone();
+                    if let Some(last) = next_prefix.last_mut() {
+                        if *last < 255 {
+                            *last += 1;
+                        } else {
+                            next_prefix.push(0);
+                        }
+                    }
+                    (prefix.clone(), next_prefix)
+                })
+                .collect::<Vec<_>>();
+
+            let mut cursors = vec![0i64; conditions.len()];
+
+            loop {
+                let mut found_any = false;
+
+                for (i, (prefix, next_prefix)) in conditions.iter().enumerate() {
+                    let query = indoc! {"
+                        SELECT zn.id, zn.nullifier, t.id, b.height, b.hash
+                        FROM zswap_nullifiers zn
+                        JOIN transactions t ON t.id = zn.transaction_id
+                        JOIN blocks b ON b.id = zn.block_id
+                        WHERE zn.nullifier >= $1 AND zn.nullifier < $2
+                        AND b.height >= $3
+                        AND b.height <= $4
+                        AND zn.id > $5
+                        ORDER BY zn.id
+                        LIMIT $6
+                    "};
+
+                    let rows = sqlx::query_as::<_, (i64, ByteVec, i64, i64, ByteVec)>(query)
+                        .bind(&prefix[..])
+                        .bind(&next_prefix[..])
+                        .bind(from_block as i64)
+                        .bind(to_block as i64)
+                        .bind(cursors[i])
+                        .bind(batch_size.get() as i64)
+                        .fetch_all(&*pool)
+                        .await?;
+
+                    if let Some(last) = rows.last() {
+                        cursors[i] = last.0;
+                        found_any = true;
+                    }
+
+                    for (_, nullifier, transaction_id, block_height, block_hash) in rows {
+                        yield ShieldedNullifierTransaction {
+                            nullifier,
+                            transaction_id: transaction_id as u64,
+                            block_height: block_height as u32,
+                            block_hash,
+                        };
+                    }
+                }
+
+                if !found_any {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/indexer-api/src/infra/storage/shielded_nullifiers.rs
+++ b/indexer-api/src/infra/storage/shielded_nullifiers.rs
@@ -36,29 +36,19 @@ impl ShieldedNullifiersStorage for Storage {
         let nullifier_prefixes = nullifier_prefixes.to_vec();
 
         try_stream! {
-            // Collected because per-prefix cursors require indexed access.
-            let conditions = nullifier_prefixes
-                .iter()
-                .map(|prefix| {
-                    let mut next_prefix = prefix.clone();
-                    if let Some(last) = next_prefix.last_mut() {
-                        if *last < 255 {
-                            *last += 1;
-                        } else {
-                            next_prefix.push(0);
-                        }
+            for prefix in &nullifier_prefixes {
+                let mut next_prefix = prefix.clone();
+                if let Some(last) = next_prefix.last_mut() {
+                    if *last < 255 {
+                        *last += 1;
+                    } else {
+                        next_prefix.push(0);
                     }
-                    (prefix.clone(), next_prefix)
-                })
-                .collect::<Vec<_>>();
+                }
 
-            // Per-prefix cursor tracking: each prefix advances independently through the result set.
-            let mut cursors = vec![0i64; conditions.len()];
+                let mut cursor = 0i64;
 
-            loop {
-                let mut found_any = false;
-
-                for (i, (prefix, next_prefix)) in conditions.iter().enumerate() {
+                loop {
                     let query = indoc! {"
                         SELECT zn.id, zn.nullifier, t.id, b.height, b.hash
                         FROM zswap_nullifiers zn
@@ -77,28 +67,24 @@ impl ShieldedNullifiersStorage for Storage {
                         .bind(&next_prefix[..])
                         .bind(from_block as i64)
                         .bind(to_block.min(i64::MAX as u64) as i64)
-                        .bind(cursors[i])
+                        .bind(cursor)
                         .bind(batch_size.get() as i64)
                         .fetch_all(&*pool)
                         .await?;
 
-                    if let Some(last) = rows.last() {
-                        cursors[i] = last.0;
-                        found_any = true;
+                    match rows.last() {
+                        Some(last) => cursor = last.0,
+                        None => break,
                     }
 
                     for (_, nullifier, transaction_id, block_height, block_hash) in rows {
                         yield ShieldedNullifierTransaction {
-                            nullifier,
                             transaction_id: transaction_id as u64,
-                            block_height: block_height as u32,
                             block_hash,
+                            block_height: block_height as u32,
+                            nullifier,
                         };
                     }
-                }
-
-                if !found_any {
-                    break;
                 }
             }
         }

--- a/indexer-common/migrations/postgres/001_initial.sql
+++ b/indexer-common/migrations/postgres/001_initial.sql
@@ -180,6 +180,16 @@ CREATE TABLE dust_nullifiers (
 CREATE INDEX ON dust_nullifiers (nullifier);
 CREATE INDEX ON dust_nullifiers (transaction_id);
 CREATE INDEX ON dust_nullifiers (block_id);
+-- Zswap (shielded) nullifier tracking for shieldedNullifierTransactions subscription
+CREATE TABLE zswap_nullifiers (
+  id BIGSERIAL PRIMARY KEY,
+  nullifier BYTEA NOT NULL,
+  transaction_id BIGINT NOT NULL REFERENCES transactions (id),
+  block_id BIGINT NOT NULL REFERENCES blocks (id)
+);
+CREATE INDEX ON zswap_nullifiers (nullifier);
+CREATE INDEX ON zswap_nullifiers (transaction_id);
+CREATE INDEX ON zswap_nullifiers (block_id);
 -- cNIGHT registration tracking
 CREATE TABLE cnight_registrations (
   id BIGSERIAL PRIMARY KEY,

--- a/indexer-common/migrations/postgres/001_initial.sql
+++ b/indexer-common/migrations/postgres/001_initial.sql
@@ -183,9 +183,9 @@ CREATE INDEX ON dust_nullifiers (block_id);
 -- Zswap (shielded) nullifier tracking for shieldedNullifierTransactions subscription
 CREATE TABLE zswap_nullifiers (
   id BIGSERIAL PRIMARY KEY,
-  nullifier BYTEA NOT NULL,
   transaction_id BIGINT NOT NULL REFERENCES transactions (id),
-  block_id BIGINT NOT NULL REFERENCES blocks (id)
+  block_id BIGINT NOT NULL REFERENCES blocks (id),
+  nullifier BYTEA NOT NULL
 );
 CREATE INDEX ON zswap_nullifiers (nullifier);
 CREATE INDEX ON zswap_nullifiers (transaction_id);

--- a/indexer-common/migrations/sqlite/001_initial.sql
+++ b/indexer-common/migrations/sqlite/001_initial.sql
@@ -184,9 +184,9 @@ CREATE INDEX dust_nullifiers_block_id_idx ON dust_nullifiers (block_id);
 -- Zswap (shielded) nullifier tracking for shieldedNullifierTransactions subscription
 CREATE TABLE zswap_nullifiers (
   id INTEGER PRIMARY KEY,
-  nullifier BLOB NOT NULL,
   transaction_id INTEGER NOT NULL REFERENCES transactions (id),
-  block_id INTEGER NOT NULL REFERENCES blocks (id)
+  block_id INTEGER NOT NULL REFERENCES blocks (id),
+  nullifier BLOB NOT NULL
 );
 CREATE INDEX zswap_nullifiers_nullifier_idx ON zswap_nullifiers (nullifier);
 CREATE INDEX zswap_nullifiers_transaction_id_idx ON zswap_nullifiers (transaction_id);

--- a/indexer-common/migrations/sqlite/001_initial.sql
+++ b/indexer-common/migrations/sqlite/001_initial.sql
@@ -181,6 +181,16 @@ CREATE TABLE dust_nullifiers (
 CREATE INDEX dust_nullifiers_nullifier_idx ON dust_nullifiers (nullifier);
 CREATE INDEX dust_nullifiers_transaction_id_idx ON dust_nullifiers (transaction_id);
 CREATE INDEX dust_nullifiers_block_id_idx ON dust_nullifiers (block_id);
+-- Zswap (shielded) nullifier tracking for shieldedNullifierTransactions subscription
+CREATE TABLE zswap_nullifiers (
+  id INTEGER PRIMARY KEY,
+  nullifier BLOB NOT NULL,
+  transaction_id INTEGER NOT NULL REFERENCES transactions (id),
+  block_id INTEGER NOT NULL REFERENCES blocks (id)
+);
+CREATE INDEX zswap_nullifiers_nullifier_idx ON zswap_nullifiers (nullifier);
+CREATE INDEX zswap_nullifiers_transaction_id_idx ON zswap_nullifiers (transaction_id);
+CREATE INDEX zswap_nullifiers_block_id_idx ON zswap_nullifiers (block_id);
 -- cNIGHT registration tracking
 CREATE TABLE cnight_registrations (
   id INTEGER PRIMARY KEY,

--- a/indexer-common/src/domain.rs
+++ b/indexer-common/src/domain.rs
@@ -243,11 +243,11 @@ pub struct LedgerEvent {
 }
 
 impl LedgerEvent {
-    fn zswap_input(raw: SerializedLedgerEvent) -> Self {
+    fn zswap_input(raw: SerializedLedgerEvent, nullifier: ByteVec) -> Self {
         Self {
             grouping: LedgerEventGrouping::Zswap,
             raw,
-            attributes: LedgerEventAttributes::ZswapInput,
+            attributes: LedgerEventAttributes::ZswapInput { nullifier },
         }
     }
 
@@ -319,7 +319,9 @@ impl LedgerEvent {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LedgerEventAttributes {
-    ZswapInput,
+    ZswapInput {
+        nullifier: ByteVec,
+    },
 
     ZswapOutput,
 

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -591,7 +591,10 @@ where
             Ok::<_, Error>((event, raw))
         })
         .filter_map_ok(|(event, raw)| match event.content {
-            EventDetailsV8::ZswapInput { .. } => Some(Ok(LedgerEvent::zswap_input(raw))),
+            EventDetailsV8::ZswapInput { nullifier, .. } => Some(Ok(LedgerEvent::zswap_input(
+                raw,
+                nullifier.0.0.to_vec().into(),
+            ))),
 
             EventDetailsV8::ZswapOutput { .. } => Some(Ok(LedgerEvent::zswap_output(raw))),
 

--- a/indexer-standalone/config.yaml
+++ b/indexer-standalone/config.yaml
@@ -44,6 +44,8 @@ infra:
         batch_size: 20
       dust_nullifier_transactions:
         batch_size: 20
+      shielded_nullifier_transactions:
+        batch_size: 20
       shielded_transactions:
         batch_size: 20
         progress_update_interval: "30s"

--- a/indexer-tests/e2e.graphql
+++ b/indexer-tests/e2e.graphql
@@ -823,6 +823,23 @@ subscription DustLedgerEventsSubscription($id: Int) {
     }
 }
 
+subscription ShieldedNullifierTransactionsSubscription(
+    $nullifierPrefixes: [HexEncoded!]!
+    $fromBlock: Int
+    $toBlock: Int
+) {
+    shieldedNullifierTransactions(
+        nullifierPrefixes: $nullifierPrefixes
+        fromBlock: $fromBlock
+        toBlock: $toBlock
+    ) {
+        nullifier
+        transactionId
+        blockHeight
+        blockHash
+    }
+}
+
 query DustGenerationStatusQuery(
     $cardanoRewardAddresses: [CardanoRewardAddress!]!
 ) {

--- a/indexer-tests/src/e2e.rs
+++ b/indexer-tests/src/e2e.rs
@@ -18,9 +18,10 @@ use crate::{
         BlockQuery, BlockSubscription, ConnectMutation, ContractActionQuery,
         ContractActionSubscription, DParameterHistoryQuery, DisconnectMutation,
         DustCommitmentMerkleTreeUpdateQuery, DustGenerationStatusQuery, DustGenerationsQuery,
-        DustLedgerEventsSubscription, ShieldedTransactionsSubscription,
-        TermsAndConditionsHistoryQuery, TransactionsQuery, UnshieldedTransactionsSubscription,
-        ZswapLedgerEventsSubscription, ZswapMerkleTreeCollapsedUpdateQuery, block_query,
+        DustLedgerEventsSubscription, ShieldedNullifierTransactionsSubscription,
+        ShieldedTransactionsSubscription, TermsAndConditionsHistoryQuery, TransactionsQuery,
+        UnshieldedTransactionsSubscription, ZswapLedgerEventsSubscription,
+        ZswapMerkleTreeCollapsedUpdateQuery, block_query,
         block_subscription::{
             self, BlockSubscriptionBlocks, BlockSubscriptionBlocksTransactions,
             BlockSubscriptionBlocksTransactionsContractActions,
@@ -35,8 +36,8 @@ use crate::{
         contract_action_subscription, disconnect_mutation,
         dust_commitment_merkle_tree_update_query, dust_generation_status_query,
         dust_generations_query, dust_ledger_events_subscription,
-        shielded_transactions_subscription, transactions_query,
-        unshielded_transactions_subscription, zswap_ledger_events_subscription,
+        shielded_nullifier_transactions_subscription, shielded_transactions_subscription,
+        transactions_query, unshielded_transactions_subscription, zswap_ledger_events_subscription,
         zswap_merkle_tree_collapsed_update_query,
     },
     graphql_ws_client,
@@ -138,6 +139,9 @@ pub async fn run(network_id: NetworkId, host: &str, port: u16, secure: bool) -> 
     test_dust_ledger_events_subscription(&indexer_data, &ws_api_url)
         .await
         .context("test dust ledger events subscription")?;
+    test_shielded_nullifier_transactions_subscription(&ws_api_url)
+        .await
+        .context("test shielded nullifier transactions subscription")?;
 
     println!("Successfully finished e2e testing");
 
@@ -1037,6 +1041,31 @@ async fn test_dust_ledger_events_subscription(
     Ok(())
 }
 
+/// Test the shieldedNullifierTransactions subscription with a non-matching prefix.
+async fn test_shielded_nullifier_transactions_subscription(ws_api_url: &str) -> anyhow::Result<()> {
+    let variables = shielded_nullifier_transactions_subscription::Variables {
+        nullifier_prefixes: vec!["00".to_string().try_into().unwrap()],
+        from_block: Some(0),
+        to_block: Some(0),
+    };
+    let events = graphql_ws_client::subscribe::<ShieldedNullifierTransactionsSubscription>(
+        ws_api_url, variables,
+    )
+    .await
+    .context("subscribe to shielded nullifier transactions")?;
+    let events = tokio_stream::StreamExt::timeout(events, Duration::from_secs(3))
+        .take_while(|timeout_result| ready(timeout_result.is_ok()))
+        .filter_map(|timeout_result| ready(timeout_result.map(Some).unwrap_or(None)))
+        .try_collect::<Vec<_>>()
+        .await
+        .context("collect shielded nullifier transactions from subscription")?;
+
+    // No matching nullifiers expected in test data.
+    assert!(events.is_empty());
+
+    Ok(())
+}
+
 trait SerializeExt
 where
     Self: Serialize,
@@ -1192,6 +1221,14 @@ mod graphql {
         response_derives = "Debug, Clone, Serialize"
     )]
     pub struct DustLedgerEventsSubscription;
+
+    #[derive(GraphQLQuery)]
+    #[graphql(
+        schema_path = "../indexer-api/graphql/schema-v4.graphql",
+        query_path = "./e2e.graphql",
+        response_derives = "Debug, Clone, Serialize"
+    )]
+    pub struct ShieldedNullifierTransactionsSubscription;
 
     #[derive(GraphQLQuery)]
     #[graphql(


### PR DESCRIPTION
#994.

## Summary

Adds a `shieldedNullifierTransactions` subscription so wallets can detect spent shielded coins not found by `shieldedTransactions` trial-decryption. Wallets compute nullifiers for their own coins locally, then use this subscription to find transactions containing matching nullifier prefixes.

## Changes

- DB schema: `zswap_nullifiers` table (nullifier, transaction_id, block_id) in both postgres and sqlite
- Chain-indexer: extracts nullifier from `ZswapInput` events, stores in `zswap_nullifiers`
- New subscription: `shieldedNullifierTransactions(nullifierPrefixes, fromBlock?, toBlock?)` with prefix-based byte range matching and `BlockIndexed` live streaming
- Domain type `ShieldedNullifierTransaction` and storage trait `ShieldedNullifiersStorage`
- Also fixes `u64::MAX as i64` overflow in `dustNullifierTransactions` (sentinel for no `toBlock` now uses `i64::MAX as u64`)
- Also switches `dustNullifierTransactions` storage from OFFSET to cursor-based pagination

Follows the same pattern as `dustNullifierTransactions` from #980.

- Requires DB reset + re-index (new zswap_nullifiers table, values populated during block processing)

## Test plan

- [ ] `just all` passes
- [ ] Requires DB reset + re-index (new `zswap_nullifiers` table, values populated during block processing)
- [ ] Wallet team validates the subscription returns matching transactions for known nullifier prefixes
