### PR TITLE
fix: per-generation capacity calculation and cursor pagination for dust queries

### DIFF
--- a/indexer-api/src/infra/api/v4/subscription/dust_nullifier_transactions.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_nullifier_transactions.rs
@@ -87,7 +87,7 @@ where
                 .map_err_into_client_error(|| "invalid hex-encoded nullifier prefix")?;
 
             let from = from_block.unwrap_or(0);
-            let to = to_block.unwrap_or(u64::MAX);
+            let to = to_block.unwrap_or(i64::MAX as u64);
 
             debug!("streaming existing dust nullifier transactions");
 

--- a/indexer-api/src/infra/storage/dust_generations.rs
+++ b/indexer-api/src/infra/storage/dust_generations.rs
@@ -74,40 +74,41 @@ impl DustGenerationsStorage for Storage {
 
             for (dust_address, valid, utxo_tx_hash, utxo_output_index) in registrations {
                 let generation_query = indoc! {"
-                    SELECT SUM(value), MIN(ctime)
-                    FROM (
-                        SELECT value, ctime
-                        FROM dust_generation_info
-                        WHERE owner = $1
-                        AND dtime IS NULL
-                    ) active_generations
+                    SELECT value, ctime
+                    FROM dust_generation_info
+                    WHERE owner = $1
+                    AND dtime IS NULL
                 "};
 
-                let (night_balance, generation_rate, max_capacity, current_capacity) =
-                    sqlx::query_as::<_, (Option<U128BeBytes>, Option<i64>)>(generation_query)
-                        .bind(dust_address.as_ref())
-                        .fetch_optional(&*self.pool)
-                        .await?
-                        .and_then(|(value, ctime)| {
-                            let value = u128::from(value?);
-                            let ctime = TimestampSecs(ctime? as u64);
+                let generations = sqlx::query_as::<_, (U128BeBytes, i64)>(generation_query)
+                    .bind(dust_address.as_ref())
+                    .fetch_all(&*self.pool)
+                    .await?;
 
-                            let generation_rate = value.saturating_mul(generation_decay_rate);
-                            let max_capacity = value.saturating_mul(night_dust_ratio);
+                let mut night_balance = 0u128;
+                let mut generation_rate = 0u128;
+                let mut max_capacity = 0u128;
+                let mut current_capacity = 0u128;
 
-                            let current_capacity = if let Some(now) = now {
-                                let elapsed_seconds = now.elapsed_seconds_since(ctime.to_ms());
-                                value
-                                    .saturating_mul(generation_decay_rate)
-                                    .saturating_mul(elapsed_seconds as u128)
-                                    .min(max_capacity)
-                            } else {
-                                0
-                            };
+                for (value, ctime_raw) in &generations {
+                    let value = u128::from(*value);
+                    let ctime = TimestampSecs(*ctime_raw as u64);
 
-                            Some((value, generation_rate, max_capacity, current_capacity))
-                        })
-                        .unwrap_or_default();
+                    night_balance = night_balance.saturating_add(value);
+                    generation_rate =
+                        generation_rate.saturating_add(value.saturating_mul(generation_decay_rate));
+                    let gen_max = value.saturating_mul(night_dust_ratio);
+                    max_capacity = max_capacity.saturating_add(gen_max);
+
+                    if let Some(now) = now {
+                        let elapsed_seconds = now.elapsed_seconds_since(ctime.to_ms());
+                        let gen_capacity = value
+                            .saturating_mul(generation_decay_rate)
+                            .saturating_mul(elapsed_seconds as u128)
+                            .min(gen_max);
+                        current_capacity = current_capacity.saturating_add(gen_capacity);
+                    }
+                }
 
                 registration_data.push(DustRegistration {
                     dust_address,
@@ -197,11 +198,9 @@ impl DustGenerationsStorage for Storage {
         let nullifier_prefixes = nullifier_prefixes.to_vec();
 
         try_stream! {
-            let mut offset = 0i64;
-
-            loop {
-                let mut conditions = vec![];
-                for prefix in &nullifier_prefixes {
+            let conditions = nullifier_prefixes
+                .iter()
+                .map(|prefix| {
                     let mut next_prefix = prefix.clone();
                     if let Some(last) = next_prefix.last_mut() {
                         if *last < 255 {
@@ -210,40 +209,45 @@ impl DustGenerationsStorage for Storage {
                             next_prefix.push(0);
                         }
                     }
-                    conditions.push((prefix.clone(), next_prefix));
-                }
+                    (prefix.clone(), next_prefix)
+                })
+                .collect::<Vec<_>>();
 
+            let mut cursors = vec![0i64; conditions.len()];
+
+            loop {
                 let mut found_any = false;
 
-                for (prefix, next_prefix) in &conditions {
+                for (i, (prefix, next_prefix)) in conditions.iter().enumerate() {
                     let query = indoc! {"
-                        SELECT dn.nullifier, dn.commitment, t.id, b.height, b.hash
+                        SELECT dn.id, dn.nullifier, dn.commitment, t.id, b.height, b.hash
                         FROM dust_nullifiers dn
                         JOIN transactions t ON t.id = dn.transaction_id
                         JOIN blocks b ON b.id = dn.block_id
                         WHERE dn.nullifier >= $1 AND dn.nullifier < $2
                         AND b.height >= $3
                         AND b.height <= $4
-                        ORDER BY b.height, t.id
-                        LIMIT $5
-                        OFFSET $6
+                        AND dn.id > $5
+                        ORDER BY dn.id
+                        LIMIT $6
                     "};
 
-                    let rows = sqlx::query_as::<_, (ByteVec, ByteVec, i64, i64, ByteVec)>(query)
+                    let rows = sqlx::query_as::<_, (i64, ByteVec, ByteVec, i64, i64, ByteVec)>(query)
                         .bind(&prefix[..])
                         .bind(&next_prefix[..])
                         .bind(from_block as i64)
                         .bind(to_block as i64)
+                        .bind(cursors[i])
                         .bind(batch_size.get() as i64)
-                        .bind(offset)
                         .fetch_all(&*pool)
                         .await?;
 
-                    if !rows.is_empty() {
+                    if let Some(last) = rows.last() {
+                        cursors[i] = last.0;
                         found_any = true;
                     }
 
-                    for (nullifier, commitment, transaction_id, block_height, block_hash) in rows {
+                    for (_, nullifier, commitment, transaction_id, block_height, block_hash) in rows {
                         yield DustNullifierTransaction {
                             nullifier,
                             commitment,
@@ -257,8 +261,6 @@ impl DustGenerationsStorage for Storage {
                 if !found_any {
                     break;
                 }
-
-                offset += batch_size.get() as i64;
             }
         }
     }

--- a/indexer-api/src/infra/storage/dust_generations.rs
+++ b/indexer-api/src/infra/storage/dust_generations.rs
@@ -73,14 +73,14 @@ impl DustGenerationsStorage for Storage {
             let mut registration_data = Vec::with_capacity(registrations.len());
 
             for (dust_address, valid, utxo_tx_hash, utxo_output_index) in registrations {
-                let generation_query = indoc! {"
+                let generations_query = indoc! {"
                     SELECT value, ctime
                     FROM dust_generation_info
                     WHERE owner = $1
                     AND dtime IS NULL
                 "};
 
-                let generations = sqlx::query_as::<_, (U128BeBytes, i64)>(generation_query)
+                let generations = sqlx::query_as::<_, (U128BeBytes, i64)>(generations_query)
                     .bind(dust_address.as_ref())
                     .fetch_all(&*self.pool)
                     .await?;


### PR DESCRIPTION
#983.

## Summary

Fixes the `dustGenerations` query to compute `currentCapacity` per-generation instead of using `SUM(value)` with `MIN(ctime)`, which overestimated capacity when a dust address had multiple active generations with different creation times. Also fixes cursor pagination and an i64 overflow in the dust nullifier subscription.

## Changes

**Per-generation capacity (#983):**
- Changed from `SELECT SUM(value), MIN(ctime)` to `SELECT value, ctime` with per-row computation
- Each generation's capacity is computed individually using its own `ctime`, then summed
- Prevents overestimation when later registrations get credited with the oldest ctime

**Cursor pagination:**
- Replaced OFFSET-based pagination with cursor-based (`dn.id > $cursor`) in `get_dust_nullifier_transactions`
- Per-prefix cursor tracking, conditions built once outside the loop
- Aligns with the main branch convention used in block, ledger_events, and transaction streaming

**i64 overflow:**
- Changed `to_block.unwrap_or(u64::MAX)` to `to_block.unwrap_or(i64::MAX as u64)` in `dustNullifierTransactions` subscription
- `u64::MAX as i64` wraps to -1, causing `b.height <= -1` (always false) when no `toBlock` specified

## Test plan
- [ ] Verify with multiple dust generations at different ctimes: capacity should reflect per-generation elapsed time, not the oldest
