### PR TITLE
perf(indexer-api): introduce DataLoader for transactions-by-block-id lookups

### DIFF
--- a/indexer-api/src/domain/storage/transaction.rs
+++ b/indexer-api/src/domain/storage/transaction.rs
@@ -25,8 +25,12 @@ where
     /// Get a transaction for the given ID.
     async fn get_transaction_by_id(&self, id: u64) -> Result<Option<Transaction>, sqlx::Error>;
 
-    /// Get the transactions for the block with the given ID, ordered by transaction ID.
-    async fn get_transactions_by_block_id(&self, id: u64) -> Result<Vec<Transaction>, sqlx::Error>;
+    /// Get the transactions for the blocks with the given IDs, ordered by block ID and transaction
+    /// ID. Each tuple carries the block ID alongside its transaction for grouping by the caller.
+    async fn get_transactions_by_block_ids(
+        &self,
+        ids: &[u64],
+    ) -> Result<Vec<(u64, Transaction)>, sqlx::Error>;
 
     /// Get transactions for the given hash, ordered descendingly by transaction ID. Transaction
     /// hashes are unique for successful transactions, yet not for failed ones.
@@ -83,7 +87,10 @@ impl TransactionStorage for NoopStorage {
         unimplemented!()
     }
 
-    async fn get_transactions_by_block_id(&self, id: u64) -> Result<Vec<Transaction>, sqlx::Error> {
+    async fn get_transactions_by_block_ids(
+        &self,
+        _ids: &[u64],
+    ) -> Result<Vec<(u64, Transaction)>, sqlx::Error> {
         unimplemented!()
     }
 

--- a/indexer-api/src/infra/api.rs
+++ b/indexer-api/src/infra/api.rs
@@ -15,7 +15,7 @@ pub mod v4;
 
 use crate::{
     domain::{Api, LedgerStateCache, storage::Storage},
-    infra::api::v4::dataloader::BlockByHashLoader,
+    infra::api::v4::dataloader::{BlockByHashLoader, TransactionsByBlockIdLoader},
 };
 use async_graphql::{Context, dataloader::DataLoader};
 use axum::{
@@ -338,6 +338,10 @@ trait ContextExt {
     where
         S: Storage;
 
+    fn get_transactions_by_block_id_loader<S>(&self) -> &DataLoader<TransactionsByBlockIdLoader<S>>
+    where
+        S: Storage;
+
     fn get_subscriber<B>(&self) -> &B
     where
         B: Subscriber;
@@ -368,6 +372,14 @@ impl ContextExt for Context<'_> {
     {
         self.data::<DataLoader<BlockByHashLoader<S>>>()
             .expect("BlockByHashLoader is stored in Context")
+    }
+
+    fn get_transactions_by_block_id_loader<S>(&self) -> &DataLoader<TransactionsByBlockIdLoader<S>>
+    where
+        S: Storage,
+    {
+        self.data::<DataLoader<TransactionsByBlockIdLoader<S>>>()
+            .expect("TransactionsByBlockIdLoader is stored in Context")
     }
 
     fn get_subscriber<B>(&self) -> &B

--- a/indexer-api/src/infra/api/v4.rs
+++ b/indexer-api/src/infra/api/v4.rs
@@ -35,7 +35,10 @@ use crate::{
     infra::api::{
         ApiResult, ContextExt, Metrics, OptionExt, ResultExt, SubscriptionConfig,
         v4::{
-            block::BlockOffset, dataloader::BlockByHashLoader, mutation::Mutation, query::Query,
+            block::BlockOffset,
+            dataloader::{BlockByHashLoader, TransactionsByBlockIdLoader},
+            mutation::Mutation,
+            query::Query,
             subscription::Subscription,
         },
     },
@@ -367,6 +370,10 @@ where
         .data(ledger_state_cache)
         .data(DataLoader::new(
             BlockByHashLoader::new(storage.clone()),
+            tokio::spawn,
+        ))
+        .data(DataLoader::new(
+            TransactionsByBlockIdLoader::new(storage.clone()),
             tokio::spawn,
         ))
         .data(storage)

--- a/indexer-api/src/infra/api/v4/block.rs
+++ b/indexer-api/src/infra/api/v4/block.rs
@@ -85,10 +85,11 @@ where
     /// The transactions within this block.
     async fn transactions(&self, cx: &Context<'_>) -> ApiResult<Vec<Transaction<S>>> {
         let transactions = cx
-            .get_storage::<S>()
-            .get_transactions_by_block_id(self.id)
+            .get_transactions_by_block_id_loader::<S>()
+            .load_one(self.id)
             .await
-            .map_err_into_server_error(|| format!("get transactions by block id {}", self.id))?;
+            .map_err_into_server_error(|| format!("get transactions by block id {}", self.id))?
+            .unwrap_or_default();
 
         Ok(transactions.into_iter().map(Into::into).collect())
     }

--- a/indexer-api/src/infra/api/v4/dataloader.rs
+++ b/indexer-api/src/infra/api/v4/dataloader.rs
@@ -17,6 +17,41 @@ use derive_more::Deref;
 use indexer_common::domain::BlockHash;
 use std::{collections::HashMap, sync::Arc};
 
+// ---- TransactionsByBlockIdLoader ----
+
+#[derive(Deref)]
+pub struct TransactionsByBlockIdLoader<S>(S);
+
+impl<S: Storage> TransactionsByBlockIdLoader<S> {
+    pub fn new(storage: S) -> Self {
+        Self(storage)
+    }
+}
+
+impl<S: Storage> Loader<u64> for TransactionsByBlockIdLoader<S> {
+    type Value = Vec<domain::Transaction>;
+    type Error = Arc<sqlx::Error>;
+
+    async fn load(
+        &self,
+        keys: &[u64],
+    ) -> Result<HashMap<u64, Vec<domain::Transaction>>, Arc<sqlx::Error>> {
+        let pairs = self
+            .get_transactions_by_block_ids(keys)
+            .await
+            .map_err(Arc::new)?;
+
+        let mut map: HashMap<u64, Vec<domain::Transaction>> = HashMap::new();
+        for (block_id, transaction) in pairs {
+            map.entry(block_id).or_default().push(transaction);
+        }
+
+        Ok(map)
+    }
+}
+
+// ---- BlockByHashLoader ----
+
 #[derive(Deref)]
 pub struct BlockByHashLoader<S>(S);
 

--- a/indexer-api/src/infra/storage/transaction.rs
+++ b/indexer-api/src/infra/storage/transaction.rs
@@ -151,130 +151,14 @@ impl TransactionStorage for Storage {
         Ok(transaction)
     }
 
-    #[trace(properties = { "id": "{id}" })]
-    async fn get_transactions_by_block_id(&self, id: u64) -> Result<Vec<Transaction>, sqlx::Error> {
-        #[cfg(feature = "cloud")]
-        let query = indoc! {"
-            SELECT
-                transactions.id,
-                transactions.variant,
-                transactions.hash,
-                transactions.protocol_version,
-                transactions.raw,
-                blocks.hash AS block_hash,
-                regular_transactions.transaction_result,
-                regular_transactions.zswap_merkle_tree_root,
-                regular_transactions.zswap_start_index,
-                regular_transactions.zswap_end_index,
-                regular_transactions.dust_commitment_start_index,
-                regular_transactions.dust_commitment_end_index,
-                regular_transactions.dust_generation_start_index,
-                regular_transactions.dust_generation_end_index,
-                regular_transactions.paid_fees,
-                regular_transactions.estimated_fees,
-                regular_transactions.identifiers
-            FROM transactions
-            INNER JOIN blocks ON blocks.id = transactions.block_id
-            INNER JOIN regular_transactions ON regular_transactions.id = transactions.id
-            WHERE transactions.block_id = $1
-
-            UNION ALL
-
-            SELECT
-                transactions.id as id,
-                transactions.variant,
-                transactions.hash,
-                transactions.protocol_version,
-                transactions.raw,
-                blocks.hash AS block_hash,
-                NULL AS transaction_result,
-                NULL AS zswap_merkle_tree_root,
-                NULL AS zswap_start_index,
-                NULL AS zswap_end_index,
-                NULL AS dust_commitment_start_index,
-                NULL AS dust_commitment_end_index,
-                NULL AS dust_generation_start_index,
-                NULL AS dust_generation_end_index,
-                NULL AS paid_fees,
-                NULL AS estimated_fees,
-                NULL AS identifiers
-            FROM transactions
-            INNER JOIN blocks ON blocks.id = transactions.block_id
-            WHERE transactions.block_id = $1
-            AND transactions.variant = 'System'
-
-            ORDER BY id
-        "};
-
-        #[cfg(feature = "standalone")]
-        let query = indoc! {"
-            SELECT
-                transactions.id as id,
-                transactions.variant,
-                transactions.hash,
-                transactions.protocol_version,
-                transactions.raw,
-                blocks.hash AS block_hash,
-                regular_transactions.transaction_result,
-                regular_transactions.zswap_merkle_tree_root,
-                regular_transactions.zswap_start_index,
-                regular_transactions.zswap_end_index,
-                regular_transactions.dust_commitment_start_index,
-                regular_transactions.dust_commitment_end_index,
-                regular_transactions.dust_generation_start_index,
-                regular_transactions.dust_generation_end_index,
-                regular_transactions.paid_fees,
-                regular_transactions.estimated_fees
-            FROM transactions
-            INNER JOIN blocks ON blocks.id = transactions.block_id
-            INNER JOIN regular_transactions ON regular_transactions.id = transactions.id
-            WHERE transactions.block_id = $1
-
-            UNION ALL
-
-            SELECT
-                transactions.id as id,
-                transactions.variant,
-                transactions.hash,
-                transactions.protocol_version,
-                transactions.raw,
-                blocks.hash AS block_hash,
-                NULL AS transaction_result,
-                NULL AS zswap_merkle_tree_root,
-                NULL AS zswap_start_index,
-                NULL AS zswap_end_index,
-                NULL AS dust_commitment_start_index,
-                NULL AS dust_commitment_end_index,
-                NULL AS dust_generation_start_index,
-                NULL AS dust_generation_end_index,
-                NULL AS paid_fees,
-                NULL AS estimated_fees
-            FROM transactions
-            INNER JOIN blocks ON blocks.id = transactions.block_id
-            WHERE transactions.block_id = $1
-            AND transactions.variant = 'System'
-
-            ORDER BY id
-        "};
-
-        #[cfg_attr(feature = "cloud", allow(unused_mut))]
-        let mut transactions = sqlx::query(query)
-            .bind(id as i64)
-            .fetch(&*self.pool)
-            .map_ok(make_transaction)
-            .map(|result| result.flatten())
-            .try_collect::<Vec<_>>()
-            .await?;
-
-        #[cfg(feature = "standalone")]
-        for transaction in transactions.iter_mut() {
-            if let Transaction::Regular(transaction) = transaction {
-                transaction.identifiers =
-                    get_identifiers_for_transaction(transaction.id, &self.pool).await?;
-            }
+    async fn get_transactions_by_block_ids(
+        &self,
+        ids: &[u64],
+    ) -> Result<Vec<(u64, Transaction)>, sqlx::Error> {
+        if ids.is_empty() {
+            return Ok(vec![]);
         }
-
-        Ok(transactions)
+        self.fetch_transactions_by_block_ids(ids).await
     }
 
     #[trace(properties = { "hash": "{hash}" })]
@@ -854,6 +738,156 @@ impl Storage {
 
         Ok(transactions)
     }
+
+    #[cfg(feature = "cloud")]
+    async fn fetch_transactions_by_block_ids(
+        &self,
+        ids: &[u64],
+    ) -> Result<Vec<(u64, Transaction)>, sqlx::Error> {
+        let ids: Vec<i64> = ids.iter().map(|id| *id as i64).collect();
+
+        let query = indoc! {"
+            SELECT
+                transactions.block_id,
+                transactions.id,
+                transactions.variant,
+                transactions.hash,
+                transactions.protocol_version,
+                transactions.raw,
+                blocks.hash AS block_hash,
+                regular_transactions.transaction_result,
+                regular_transactions.zswap_merkle_tree_root,
+                regular_transactions.zswap_start_index,
+                regular_transactions.zswap_end_index,
+                regular_transactions.dust_commitment_start_index,
+                regular_transactions.dust_commitment_end_index,
+                regular_transactions.dust_generation_start_index,
+                regular_transactions.dust_generation_end_index,
+                regular_transactions.paid_fees,
+                regular_transactions.estimated_fees,
+                regular_transactions.identifiers
+            FROM transactions
+            INNER JOIN blocks ON blocks.id = transactions.block_id
+            INNER JOIN regular_transactions ON regular_transactions.id = transactions.id
+            WHERE transactions.block_id = ANY($1)
+
+            UNION ALL
+
+            SELECT
+                transactions.block_id,
+                transactions.id,
+                transactions.variant,
+                transactions.hash,
+                transactions.protocol_version,
+                transactions.raw,
+                blocks.hash AS block_hash,
+                NULL AS transaction_result,
+                NULL AS zswap_merkle_tree_root,
+                NULL AS zswap_start_index,
+                NULL AS zswap_end_index,
+                NULL AS dust_commitment_start_index,
+                NULL AS dust_commitment_end_index,
+                NULL AS dust_generation_start_index,
+                NULL AS dust_generation_end_index,
+                NULL AS paid_fees,
+                NULL AS estimated_fees,
+                NULL AS identifiers
+            FROM transactions
+            INNER JOIN blocks ON blocks.id = transactions.block_id
+            WHERE transactions.block_id = ANY($1)
+            AND transactions.variant = 'System'
+
+            ORDER BY block_id, id
+        "};
+
+        sqlx::query(query)
+            .bind(ids)
+            .fetch(&*self.pool)
+            .map_ok(make_transaction_with_block_id)
+            .map(|result| result.flatten())
+            .try_collect()
+            .await
+    }
+
+    #[cfg(feature = "standalone")]
+    async fn fetch_transactions_by_block_ids(
+        &self,
+        ids: &[u64],
+    ) -> Result<Vec<(u64, Transaction)>, sqlx::Error> {
+        use sqlx::{QueryBuilder, Sqlite};
+
+        let mut qb = QueryBuilder::<Sqlite>::new("WITH block_ids(id) AS (VALUES (");
+        let mut sep = qb.separated("), (");
+        for id in ids {
+            sep.push_bind(*id as i64);
+        }
+        qb.push(
+            ")) \
+            SELECT \
+                transactions.block_id AS block_id, \
+                transactions.id AS id, \
+                transactions.variant, \
+                transactions.hash, \
+                transactions.protocol_version, \
+                transactions.raw, \
+                blocks.hash AS block_hash, \
+                regular_transactions.transaction_result, \
+                regular_transactions.zswap_merkle_tree_root, \
+                regular_transactions.zswap_start_index, \
+                regular_transactions.zswap_end_index, \
+                regular_transactions.dust_commitment_start_index, \
+                regular_transactions.dust_commitment_end_index, \
+                regular_transactions.dust_generation_start_index, \
+                regular_transactions.dust_generation_end_index, \
+                regular_transactions.paid_fees, \
+                regular_transactions.estimated_fees \
+            FROM transactions \
+            INNER JOIN blocks ON blocks.id = transactions.block_id \
+            INNER JOIN regular_transactions ON regular_transactions.id = transactions.id \
+            WHERE transactions.block_id IN (SELECT id FROM block_ids) \
+            UNION ALL \
+            SELECT \
+                transactions.block_id, \
+                transactions.id, \
+                transactions.variant, \
+                transactions.hash, \
+                transactions.protocol_version, \
+                transactions.raw, \
+                blocks.hash AS block_hash, \
+                NULL AS transaction_result, \
+                NULL AS zswap_merkle_tree_root, \
+                NULL AS zswap_start_index, \
+                NULL AS zswap_end_index, \
+                NULL AS dust_commitment_start_index, \
+                NULL AS dust_commitment_end_index, \
+                NULL AS dust_generation_start_index, \
+                NULL AS dust_generation_end_index, \
+                NULL AS paid_fees, \
+                NULL AS estimated_fees \
+            FROM transactions \
+            INNER JOIN blocks ON blocks.id = transactions.block_id \
+            WHERE transactions.block_id IN (SELECT id FROM block_ids) \
+            AND transactions.variant = 'System' \
+            ORDER BY block_id, id",
+        );
+
+        let mut transactions: Vec<(u64, Transaction)> = qb
+            .build()
+            .fetch(&*self.pool)
+            .map_ok(make_transaction_with_block_id)
+            .map(|result| result.flatten())
+            .try_collect()
+            .await?;
+
+        for (_, transaction) in transactions.iter_mut() {
+            if let Transaction::Regular(transaction) = transaction {
+                transaction.identifiers =
+                    get_identifiers_for_transaction(transaction.id, &self.pool).await?;
+            }
+        }
+
+        Ok(transactions)
+    }
 }
 
 #[cfg(feature = "cloud")]
@@ -874,6 +908,24 @@ fn make_transaction(row: sqlx::sqlite::SqliteRow) -> Result<Transaction, sqlx::E
         TransactionVariant::System => Transaction::System(SystemTransaction::from_row(&row)?),
     };
     Ok(transaction)
+}
+
+#[cfg(feature = "cloud")]
+fn make_transaction_with_block_id(
+    row: sqlx::postgres::PgRow,
+) -> Result<(u64, Transaction), sqlx::Error> {
+    let block_id = row.try_get::<i64, _>("block_id")? as u64;
+    let transaction = make_transaction(row)?;
+    Ok((block_id, transaction))
+}
+
+#[cfg(feature = "standalone")]
+fn make_transaction_with_block_id(
+    row: sqlx::sqlite::SqliteRow,
+) -> Result<(u64, Transaction), sqlx::Error> {
+    let block_id = row.try_get::<i64, _>("block_id")? as u64;
+    let transaction = make_transaction(row)?;
+    Ok((block_id, transaction))
 }
 
 #[cfg(feature = "standalone")]


### PR DESCRIPTION
See #1021.

## Overview

Follow-up to the block-by-hash DataLoader (#[previous PR]), continuing the work toward resolving midnightntwrk/midnight-indexer#875.

`get_transactions_by_block_id` is called once per block in `Block.transactions()`, producing an N+1 query pattern whenever a client selects `transactions { ... }` on a list of blocks. This is particularly impactful in the block subscription, where the stream emits many consecutive blocks each triggering an individual query.

With `DataLoader`, all `load_one(block_id)` calls within a single request tick are coalesced into a single batched query (`WHERE block_id = ANY($1)` on PostgreSQL, a CTE-based `IN` query on SQLite). The results are grouped by `block_id` before being returned as `Vec<Transaction>` per block, and cached for the remainder of the request.

**Changes:**
- Replaces `TransactionStorage::get_transactions_by_block_id` with `get_transactions_by_block_ids(&[u64]) -> Vec<(u64, Transaction)>`. The block ID is carried alongside each transaction so the loader can group them into the required `HashMap<u64, Vec<Transaction>>`.
- Adds `TransactionsByBlockIdLoader<S>` to `infra/api/v4/dataloader.rs`, implementing `Loader<u64, Value = Vec<domain::Transaction>>`.
- Registers `DataLoader<TransactionsByBlockIdLoader<S>>` in `make_app`.
- Exposes `get_transactions_by_block_id_loader<S>()` on `ContextExt`.
- Migrates `Block.transactions()` to use the loader, with `.unwrap_or_default()` for blocks that carry no transactions.

## Links

- Partly solves midnightntwrk/midnight-indexer#875