### PR TITLE
fix(api): align dustCommitmentMerkleTreeUpdate with zswapMerkleTreeCollapsedUpdate pattern

### DIFF
--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -662,7 +662,7 @@ type Query {
 	"""
 	Get a collapsed Merkle tree update for the dust commitment tree.
 	"""
-	dustCommitmentMerkleTreeUpdate(startIndex: Int!, endIndex: Int): HexEncoded!
+	dustCommitmentMerkleTreeUpdate(startIndex: Int!, endIndex: Int!): MerkleTreeCollapsedUpdate!
 	"""
 	Get the full history of D-parameter changes for governance auditability.
 	"""

--- a/indexer-api/src/infra/api/v4/query.rs
+++ b/indexer-api/src/infra/api/v4/query.rs
@@ -16,7 +16,7 @@ use crate::{
     infra::api::{
         ApiError, ApiResult, ContextExt, OptionExt, ResultExt,
         v4::{
-            CardanoNetworkId, CardanoRewardAddress, HexEncodable, HexEncoded,
+            CardanoNetworkId, CardanoRewardAddress, HexEncoded,
             block::{Block, BlockOffset},
             contract_action::{ContractAction, ContractActionOffset},
             dust::DustGenerationStatus,
@@ -310,31 +310,32 @@ where
     }
 
     /// Get a collapsed Merkle tree update for the dust commitment tree.
-    #[trace]
+    #[trace(properties = { "start_index": "{start_index}", "end_index": "{end_index}" })]
     async fn dust_commitment_merkle_tree_update(
         &self,
         cx: &Context<'_>,
         start_index: u64,
-        end_index: Option<u64>,
-    ) -> ApiResult<HexEncoded> {
-        let ledger_state_cache = cx.get_ledger_state_cache();
+        end_index: u64,
+    ) -> ApiResult<MerkleTreeCollapsedUpdate> {
         let storage = cx.get_storage::<S>();
 
-        let protocol_version = storage
-            .get_latest_block()
+        let (protocol_version, _) = storage
+            .get_highest_ledger_state()
             .await
-            .map_err_into_server_error(|| "get latest block")?
-            .some_or_server_error(|| "no blocks stored")?
-            .protocol_version;
+            .map_err_into_server_error(|| "get highest ledger state")?
+            .some_or_server_error(|| "no ledger state available")?;
 
-        let end_index = end_index.unwrap_or(u64::MAX);
-
-        Ok(ledger_state_cache
+        cx.get_ledger_state_cache()
             .dust_commitments_collapsed_update(start_index, end_index, storage, protocol_version)
             .await
-            .map_err_into_server_error(|| "create dust commitment collapsed update")?
-            .update
-            .hex_encode())
+            .map_err(|error| match error {
+                error @ LedgerStateCacheError::Ledger(ledger::Error::InvalidUpdate(_)) => {
+                    ApiError::client("invalid start_index and/or end_index", error)
+                }
+
+                error => ApiError::server("create dust commitment collapsed update", error),
+            })
+            .map(MerkleTreeCollapsedUpdate::from)
     }
 
     /// Get the full history of D-parameter changes for governance auditability.

--- a/indexer-tests/e2e.graphql
+++ b/indexer-tests/e2e.graphql
@@ -867,8 +867,13 @@ query DustGenerationsQuery($cardanoRewardAddresses: [CardanoRewardAddress!]!) {
     }
 }
 
-query DustCommitmentMerkleTreeUpdateQuery($startIndex: Int!, $endIndex: Int) {
-    dustCommitmentMerkleTreeUpdate(startIndex: $startIndex, endIndex: $endIndex)
+query DustCommitmentMerkleTreeUpdateQuery($startIndex: Int!, $endIndex: Int!) {
+    dustCommitmentMerkleTreeUpdate(startIndex: $startIndex, endIndex: $endIndex) {
+        startIndex
+        endIndex
+        update
+        protocolVersion
+    }
 }
 
 query DParameterHistoryQuery {

--- a/indexer-tests/src/e2e.rs
+++ b/indexer-tests/src/e2e.rs
@@ -736,20 +736,13 @@ async fn test_dust_commitment_merkle_tree_update_query(
     api_client: &Client,
     api_url: &str,
 ) -> anyhow::Result<()> {
-    // Test with start_index 0 and no end_index — should succeed if blocks have been indexed.
     let variables = dust_commitment_merkle_tree_update_query::Variables {
         start_index: 0,
-        end_index: Some(0),
+        end_index: 0,
     };
     let response =
         send_query::<DustCommitmentMerkleTreeUpdateQuery>(api_client, api_url, variables).await?;
-    // The result is a hex-encoded collapsed merkle tree update.
-    assert!(
-        !response
-            .dust_commitment_merkle_tree_update
-            .as_ref()
-            .is_empty()
-    );
+    assert!(response.dust_commitment_merkle_tree_update.start_index >= 0);
 
     Ok(())
 }


### PR DESCRIPTION
Addresses #974.

## Summary

Fixes `dustCommitmentMerkleTreeUpdate` query failing with Internal Server Error when `endIndex` is not provided. The query was using `u64::MAX` as default which exceeds the Merkle tree bounds. Aligns with the `zswapMerkleTreeCollapsedUpdate` pattern from #982.

## Changes

- Made `endIndex` required (was optional with `u64::MAX` default that caused "attempted update with end outside of the tree")
- Changed return type from `HexEncoded` to `MerkleTreeCollapsedUpdate` (matches zswap query)
- Invalid index ranges now return client error instead of server error
- Uses `get_highest_ledger_state` instead of `get_latest_block` for protocol version (matches zswap pattern)
- Updated e2e test to match new signature
