### PR TITLE
perf(indexer-api): introduce DataLoader for transaction-by-id lookups

### DIFF
--- a/indexer-api/src/domain/storage/transaction.rs
+++ b/indexer-api/src/domain/storage/transaction.rs
@@ -22,8 +22,8 @@ pub trait TransactionStorage
 where
     Self: Clone + Send + Sync + 'static,
 {
-    /// Get a transaction for the given ID.
-    async fn get_transaction_by_id(&self, id: u64) -> Result<Option<Transaction>, sqlx::Error>;
+    /// Get the transactions for the given IDs.
+    async fn get_transactions_by_ids(&self, ids: &[u64]) -> Result<Vec<Transaction>, sqlx::Error>;
 
     /// Get the transactions for the blocks with the given IDs, ordered by block ID and transaction
     /// ID. Each tuple carries the block ID alongside its transaction for grouping by the caller.
@@ -83,7 +83,7 @@ where
 
 #[allow(unused_variables)]
 impl TransactionStorage for NoopStorage {
-    async fn get_transaction_by_id(&self, id: u64) -> Result<Option<Transaction>, sqlx::Error> {
+    async fn get_transactions_by_ids(&self, ids: &[u64]) -> Result<Vec<Transaction>, sqlx::Error> {
         unimplemented!()
     }
 

--- a/indexer-api/src/infra/api.rs
+++ b/indexer-api/src/infra/api.rs
@@ -16,7 +16,8 @@ pub mod v4;
 use crate::{
     domain::{Api, LedgerStateCache, storage::Storage},
     infra::api::v4::dataloader::{
-        BlockByHashLoader, ContractActionsByTransactionIdLoader, TransactionsByBlockIdLoader,
+        BlockByHashLoader, ContractActionsByTransactionIdLoader, TransactionByIdLoader,
+        TransactionsByBlockIdLoader,
     },
 };
 use async_graphql::{Context, dataloader::DataLoader};
@@ -346,6 +347,10 @@ trait ContextExt {
     where
         S: Storage;
 
+    fn get_transaction_by_id_loader<S>(&self) -> &DataLoader<TransactionByIdLoader<S>>
+    where
+        S: Storage;
+
     fn get_transactions_by_block_id_loader<S>(&self) -> &DataLoader<TransactionsByBlockIdLoader<S>>
     where
         S: Storage;
@@ -386,6 +391,14 @@ impl ContextExt for Context<'_> {
     {
         self.data::<DataLoader<BlockByHashLoader<S>>>()
             .expect("BlockByHashLoader is stored in Context")
+    }
+
+    fn get_transaction_by_id_loader<S>(&self) -> &DataLoader<TransactionByIdLoader<S>>
+    where
+        S: Storage,
+    {
+        self.data::<DataLoader<TransactionByIdLoader<S>>>()
+            .expect("TransactionByIdLoader is stored in Context")
     }
 
     fn get_transactions_by_block_id_loader<S>(&self) -> &DataLoader<TransactionsByBlockIdLoader<S>>

--- a/indexer-api/src/infra/api/v4.rs
+++ b/indexer-api/src/infra/api/v4.rs
@@ -37,7 +37,7 @@ use crate::{
         v4::{
             block::BlockOffset,
             dataloader::{
-                BlockByHashLoader, ContractActionsByTransactionIdLoader,
+                BlockByHashLoader, ContractActionsByTransactionIdLoader, TransactionByIdLoader,
                 TransactionsByBlockIdLoader,
             },
             mutation::Mutation,
@@ -373,6 +373,10 @@ where
         .data(ledger_state_cache)
         .data(DataLoader::new(
             BlockByHashLoader::new(storage.clone()),
+            tokio::spawn,
+        ))
+        .data(DataLoader::new(
+            TransactionByIdLoader::new(storage.clone()),
             tokio::spawn,
         ))
         .data(DataLoader::new(

--- a/indexer-api/src/infra/api/v4/contract_action.rs
+++ b/indexer-api/src/infra/api/v4/contract_action.rs
@@ -296,10 +296,10 @@ where
     S: Storage,
 {
     let transaction = cx
-        .get_storage::<S>()
-        .get_transaction_by_id(id)
+        .get_transaction_by_id_loader::<S>()
+        .load_one(id)
         .await
-        .map_err_into_server_error(|| format!("get transaction by id {id})"))?
+        .map_err_into_server_error(|| format!("get transaction by id {id}"))?
         .some_or_server_error(|| format!("transaction with id {id} not found"))?;
 
     Ok(transaction.into())

--- a/indexer-api/src/infra/api/v4/dataloader.rs
+++ b/indexer-api/src/infra/api/v4/dataloader.rs
@@ -113,3 +113,32 @@ impl<S: Storage> Loader<BlockHash> for BlockByHashLoader<S> {
         Ok(blocks)
     }
 }
+
+#[derive(Deref)]
+pub struct TransactionByIdLoader<S>(S);
+
+impl<S: Storage> TransactionByIdLoader<S> {
+    pub fn new(storage: S) -> Self {
+        Self(storage)
+    }
+}
+
+impl<S: Storage> Loader<u64> for TransactionByIdLoader<S> {
+    type Value = domain::Transaction;
+    type Error = Arc<sqlx::Error>;
+
+    async fn load(
+        &self,
+        keys: &[u64],
+    ) -> Result<HashMap<u64, domain::Transaction>, Arc<sqlx::Error>> {
+        let transactions = self
+            .get_transactions_by_ids(keys)
+            .await
+            .map_err(Arc::new)?
+            .into_iter()
+            .map(|t: domain::Transaction| (t.id(), t))
+            .collect();
+
+        Ok(transactions)
+    }
+}

--- a/indexer-api/src/infra/api/v4/unshielded.rs
+++ b/indexer-api/src/infra/api/v4/unshielded.rs
@@ -82,10 +82,10 @@ where
         let id = self.creating_transaction_id;
 
         let transaction = cx
-            .get_storage::<S>()
-            .get_transaction_by_id(id)
+            .get_transaction_by_id_loader::<S>()
+            .load_one(id)
             .await
-            .map_err_into_server_error(|| format!("get transaction by id {id})"))?
+            .map_err_into_server_error(|| format!("get transaction by id {id}"))?
             .some_or_server_error(|| format!("transaction with id {id} not found"))?;
 
         Ok(transaction.into())
@@ -98,8 +98,8 @@ where
         };
 
         let transaction = cx
-            .get_storage::<S>()
-            .get_transaction_by_id(id)
+            .get_transaction_by_id_loader::<S>()
+            .load_one(id)
             .await
             .map_err_into_server_error(|| format!("get transaction by id {id}"))?
             .some_or_server_error(|| format!("transaction with id {id} not found"))?;

--- a/indexer-api/src/infra/storage/transaction.rs
+++ b/indexer-api/src/infra/storage/transaction.rs
@@ -29,11 +29,17 @@ use indexer_common::{
 };
 use indoc::indoc;
 use sqlx::{FromRow, Row, types::Uuid};
+#[cfg(feature = "standalone")]
+use sqlx::{QueryBuilder, Sqlite};
 use std::num::NonZeroU32;
 
 impl TransactionStorage for Storage {
-    #[trace(properties = { "id": "{id}" })]
-    async fn get_transaction_by_id(&self, id: u64) -> Result<Option<Transaction>, sqlx::Error> {
+    #[trace(properties = { "ids": "{ids:?}" })]
+    async fn get_transactions_by_ids(&self, ids: &[u64]) -> Result<Vec<Transaction>, sqlx::Error> {
+        if ids.is_empty() {
+            return Ok(vec![]);
+        }
+
         #[cfg(feature = "cloud")]
         let query = indoc! {"
             SELECT
@@ -57,7 +63,7 @@ impl TransactionStorage for Storage {
             FROM transactions
             INNER JOIN blocks ON blocks.id = transactions.block_id
             INNER JOIN regular_transactions ON regular_transactions.id = transactions.id
-            WHERE transactions.id = $1
+            WHERE transactions.id = ANY($1)
 
             UNION ALL
 
@@ -81,14 +87,14 @@ impl TransactionStorage for Storage {
                 NULL AS identifiers
             FROM transactions
             INNER JOIN blocks ON blocks.id = transactions.block_id
-            WHERE transactions.id = $1
+            WHERE transactions.id = ANY($1)
             AND transactions.variant = 'System'
         "};
 
         #[cfg(feature = "standalone")]
         let query = indoc! {"
             SELECT
-                transactions.id,
+                transactions.id as id,
                 transactions.variant,
                 transactions.hash,
                 transactions.protocol_version,
@@ -107,48 +113,73 @@ impl TransactionStorage for Storage {
             FROM transactions
             INNER JOIN blocks ON blocks.id = transactions.block_id
             INNER JOIN regular_transactions ON regular_transactions.id = transactions.id
-            WHERE transactions.id = $1
-
-            UNION ALL
-
-            SELECT
-                transactions.id,
-                transactions.variant,
-                transactions.hash,
-                transactions.protocol_version,
-                transactions.raw,
-                blocks.hash AS block_hash,
-                NULL AS transaction_result,
-                NULL AS zswap_merkle_tree_root,
-                NULL AS zswap_start_index,
-                NULL AS zswap_end_index,
-                NULL AS dust_commitment_start_index,
-                NULL AS dust_commitment_end_index,
-                NULL AS dust_generation_start_index,
-                NULL AS dust_generation_end_index,
-                NULL AS paid_fees,
-                NULL AS estimated_fees
-            FROM transactions
-            INNER JOIN blocks ON blocks.id = transactions.block_id
-            WHERE transactions.id = $1
-            AND transactions.variant = 'System'
+            WHERE transactions.id IN (SELECT id FROM ids)
         "};
 
-        #[cfg_attr(feature = "cloud", allow(unused_mut))]
-        let mut transaction = sqlx::query(query)
-            .bind(id as i64)
-            .fetch_optional(&*self.pool)
-            .await?
-            .map(make_transaction)
-            .transpose()?;
+        #[cfg(feature = "cloud")]
+        let ids = ids.iter().map(|id| *id as i64).collect::<Vec<_>>();
+
+        #[cfg(feature = "cloud")]
+        let transactions = sqlx::query(query)
+            .bind(ids)
+            .fetch(&*self.pool)
+            .map_ok(make_transaction)
+            .map(|result| result.flatten())
+            .try_collect::<Vec<_>>()
+            .await?;
 
         #[cfg(feature = "standalone")]
-        if let Some(Transaction::Regular(transaction)) = &mut transaction {
-            transaction.identifiers =
-                get_identifiers_for_transaction(transaction.id, &self.pool).await?;
+        let mut transactions = {
+            let mut query_builder = QueryBuilder::<Sqlite>::new("WITH ids(id) AS (VALUES (");
+            let mut sep = query_builder.separated("), (");
+            for id in ids {
+                sep.push_bind(*id as i64);
+            }
+            query_builder.push(")) ");
+            query_builder.push(query);
+            query_builder.push(indoc! {"
+                 UNION ALL
+                SELECT
+                    transactions.id AS id,
+                    transactions.variant,
+                    transactions.hash,
+                    transactions.protocol_version,
+                    transactions.raw,
+                    blocks.hash AS block_hash,
+                    NULL AS transaction_result,
+                    NULL AS zswap_merkle_tree_root,
+                    NULL AS zswap_start_index,
+                    NULL AS zswap_end_index,
+                    NULL AS dust_commitment_start_index,
+                    NULL AS dust_commitment_end_index,
+                    NULL AS dust_generation_start_index,
+                    NULL AS dust_generation_end_index,
+                    NULL AS paid_fees,
+                    NULL AS estimated_fees
+                FROM transactions
+                INNER JOIN blocks ON blocks.id = transactions.block_id
+                WHERE transactions.variant = 'System'
+                AND transactions.id IN (SELECT id FROM ids)
+            "});
+
+            query_builder
+                .build()
+                .fetch(&*self.pool)
+                .map_ok(make_transaction)
+                .map(|result| result.flatten())
+                .try_collect::<Vec<_>>()
+                .await?
+        };
+
+        #[cfg(feature = "standalone")]
+        for transaction in transactions.iter_mut() {
+            if let Transaction::Regular(transaction) = transaction {
+                transaction.identifiers =
+                    get_identifiers_for_transaction(transaction.id, &self.pool).await?;
+            }
         }
 
-        Ok(transaction)
+        Ok(transactions)
     }
 
     async fn get_transactions_by_block_ids(


### PR DESCRIPTION
## Related Issues
See #1019

This pull request optimizes the `indexer-api` by introducing a `DataLoader` for transaction-by-id lookups. This resolves an N+1 query pattern where parent transactions were being fetched individually for each item in contract action and unshielded UTXO lists.

### Key Changes
- **Storage Layer**: Replaced `TransactionStorage::get_transaction_by_id` with a batch-fetching `get_transactions_by_ids` implementation.
  - PostgreSQL: Implemented using `WHERE id = ANY($1)`.
  - SQLite: Implemented using `WHERE id IN (...)` via `QueryBuilder`.
- **DataLoader**: Added `TransactionByIdLoader<S>` in `infra/api/v4/dataloader.rs` to handle request batching.
- **API Integration**: Registered the loader in the application context and extended `ContextExt` for easy access in resolvers.
- **Resolver Migration**: Updated `ContractDeploy/Call/Update.transaction()` and `UnshieldedUtxo` transaction resolvers to use the new batching mechanism.

