### PR TITLE
perf(indexer-api): introduce DataLoader for contract-actions-by-transaction-id lookups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,3 +98,10 @@ The committed schema file `indexer-api/graphql/schema-v4.graphql` is checked by 
 - **E2E tests**: `indexer-tests/` crate — starts all components as child processes against a running node, exercises GraphQL queries and subscriptions end-to-end
 
 The `indexer-standalone` crate is excluded from `nextest` (it is only built as an artifact for e2e tests).
+
+## Coding Conventions
+
+- **`just all-all`** — run after completing a meaningful chunk of work, not after every small edit.
+- **Type annotations** — omit when the compiler can infer. Use turbofish (e.g. `.collect::<Vec<_>>()`) rather than annotating the binding if a hint is needed.
+- **Functional style** — prefer iterator combinators (`.map()`, `.fold()`, `.collect()`, etc.) over imperative loops with mutation.
+- **Multiline SQL** — always use `indoc!{ "..." }`. Never use `\` line continuations inside string literals.

--- a/indexer-api/src/domain/storage/contract_action.rs
+++ b/indexer-api/src/domain/storage/contract_action.rs
@@ -69,6 +69,12 @@ where
         id: u64,
     ) -> Result<Vec<ContractAction>, sqlx::Error>;
 
+    /// Get the contract actions for the transactions with the given ids, ordered by transaction ID.
+    async fn get_contract_actions_by_transaction_ids(
+        &self,
+        ids: &[u64],
+    ) -> Result<Vec<ContractAction>, sqlx::Error>;
+
     /// Get a stream of contract actions for the given address starting at the given contract_action
     /// ID, ordered by transaction ID.
     fn get_contract_actions_by_address(
@@ -143,6 +149,13 @@ impl ContractActionStorage for NoopStorage {
     async fn get_contract_actions_by_transaction_id(
         &self,
         id: u64,
+    ) -> Result<Vec<ContractAction>, sqlx::Error> {
+        unimplemented!()
+    }
+
+    async fn get_contract_actions_by_transaction_ids(
+        &self,
+        _ids: &[u64],
     ) -> Result<Vec<ContractAction>, sqlx::Error> {
         unimplemented!()
     }

--- a/indexer-api/src/infra/api.rs
+++ b/indexer-api/src/infra/api.rs
@@ -15,7 +15,9 @@ pub mod v4;
 
 use crate::{
     domain::{Api, LedgerStateCache, storage::Storage},
-    infra::api::v4::dataloader::{BlockByHashLoader, TransactionsByBlockIdLoader},
+    infra::api::v4::dataloader::{
+        BlockByHashLoader, ContractActionsByTransactionIdLoader, TransactionsByBlockIdLoader,
+    },
 };
 use async_graphql::{Context, dataloader::DataLoader};
 use axum::{
@@ -342,6 +344,12 @@ trait ContextExt {
     where
         S: Storage;
 
+    fn get_contract_actions_by_transaction_id_loader<S>(
+        &self,
+    ) -> &DataLoader<ContractActionsByTransactionIdLoader<S>>
+    where
+        S: Storage;
+
     fn get_subscriber<B>(&self) -> &B
     where
         B: Subscriber;
@@ -380,6 +388,16 @@ impl ContextExt for Context<'_> {
     {
         self.data::<DataLoader<TransactionsByBlockIdLoader<S>>>()
             .expect("TransactionsByBlockIdLoader is stored in Context")
+    }
+
+    fn get_contract_actions_by_transaction_id_loader<S>(
+        &self,
+    ) -> &DataLoader<ContractActionsByTransactionIdLoader<S>>
+    where
+        S: Storage,
+    {
+        self.data::<DataLoader<ContractActionsByTransactionIdLoader<S>>>()
+            .expect("ContractActionsByTransactionIdLoader is stored in Context")
     }
 
     fn get_subscriber<B>(&self) -> &B

--- a/indexer-api/src/infra/api/v4.rs
+++ b/indexer-api/src/infra/api/v4.rs
@@ -36,7 +36,10 @@ use crate::{
         ApiResult, ContextExt, Metrics, OptionExt, ResultExt, SubscriptionConfig,
         v4::{
             block::BlockOffset,
-            dataloader::{BlockByHashLoader, TransactionsByBlockIdLoader},
+            dataloader::{
+                BlockByHashLoader, ContractActionsByTransactionIdLoader,
+                TransactionsByBlockIdLoader,
+            },
             mutation::Mutation,
             query::Query,
             subscription::Subscription,
@@ -374,6 +377,10 @@ where
         ))
         .data(DataLoader::new(
             TransactionsByBlockIdLoader::new(storage.clone()),
+            tokio::spawn,
+        ))
+        .data(DataLoader::new(
+            ContractActionsByTransactionIdLoader::new(storage.clone()),
             tokio::spawn,
         ))
         .data(storage)

--- a/indexer-api/src/infra/api/v4/dataloader.rs
+++ b/indexer-api/src/infra/api/v4/dataloader.rs
@@ -36,17 +36,17 @@ impl<S: Storage> Loader<u64> for ContractActionsByTransactionIdLoader<S> {
         &self,
         keys: &[u64],
     ) -> Result<HashMap<u64, Vec<domain::ContractAction>>, Arc<sqlx::Error>> {
-        let actions = self
-            .get_contract_actions_by_transaction_ids(keys)
+        self.get_contract_actions_by_transaction_ids(keys)
             .await
-            .map_err(Arc::new)?;
-
-        let mut map: HashMap<u64, Vec<domain::ContractAction>> = HashMap::new();
-        for action in actions {
-            map.entry(action.transaction_id).or_default().push(action);
-        }
-
-        Ok(map)
+            .map_err(Arc::new)
+            .map(|actions| {
+                actions
+                    .into_iter()
+                    .fold(HashMap::<_, Vec<_>>::new(), |mut map, action| {
+                        map.entry(action.transaction_id).or_default().push(action);
+                        map
+                    })
+            })
     }
 }
 
@@ -69,17 +69,17 @@ impl<S: Storage> Loader<u64> for TransactionsByBlockIdLoader<S> {
         &self,
         keys: &[u64],
     ) -> Result<HashMap<u64, Vec<domain::Transaction>>, Arc<sqlx::Error>> {
-        let pairs = self
-            .get_transactions_by_block_ids(keys)
+        self.get_transactions_by_block_ids(keys)
             .await
-            .map_err(Arc::new)?;
-
-        let mut map: HashMap<u64, Vec<domain::Transaction>> = HashMap::new();
-        for (block_id, transaction) in pairs {
-            map.entry(block_id).or_default().push(transaction);
-        }
-
-        Ok(map)
+            .map_err(Arc::new)
+            .map(|pairs| {
+                pairs
+                    .into_iter()
+                    .fold(HashMap::<_, Vec<_>>::new(), |mut map, (block_id, tx)| {
+                        map.entry(block_id).or_default().push(tx);
+                        map
+                    })
+            })
     }
 }
 

--- a/indexer-api/src/infra/api/v4/dataloader.rs
+++ b/indexer-api/src/infra/api/v4/dataloader.rs
@@ -17,6 +17,39 @@ use derive_more::Deref;
 use indexer_common::domain::BlockHash;
 use std::{collections::HashMap, sync::Arc};
 
+// ---- ContractActionsByTransactionIdLoader ----
+
+#[derive(Deref)]
+pub struct ContractActionsByTransactionIdLoader<S>(S);
+
+impl<S: Storage> ContractActionsByTransactionIdLoader<S> {
+    pub fn new(storage: S) -> Self {
+        Self(storage)
+    }
+}
+
+impl<S: Storage> Loader<u64> for ContractActionsByTransactionIdLoader<S> {
+    type Value = Vec<domain::ContractAction>;
+    type Error = Arc<sqlx::Error>;
+
+    async fn load(
+        &self,
+        keys: &[u64],
+    ) -> Result<HashMap<u64, Vec<domain::ContractAction>>, Arc<sqlx::Error>> {
+        let actions = self
+            .get_contract_actions_by_transaction_ids(keys)
+            .await
+            .map_err(Arc::new)?;
+
+        let mut map: HashMap<u64, Vec<domain::ContractAction>> = HashMap::new();
+        for action in actions {
+            map.entry(action.transaction_id).or_default().push(action);
+        }
+
+        Ok(map)
+    }
+}
+
 // ---- TransactionsByBlockIdLoader ----
 
 #[derive(Deref)]

--- a/indexer-api/src/infra/api/v4/transaction.rs
+++ b/indexer-api/src/infra/api/v4/transaction.rs
@@ -448,12 +448,13 @@ where
     S: Storage,
 {
     let contract_actions = cx
-        .get_storage::<S>()
-        .get_contract_actions_by_transaction_id(id)
+        .get_contract_actions_by_transaction_id_loader::<S>()
+        .load_one(id)
         .await
         .map_err_into_server_error(|| {
             format!("cannot get contract actions by transaction ID {id}")
-        })?;
+        })?
+        .unwrap_or_default();
 
     Ok(contract_actions.into_iter().map(Into::into).collect())
 }

--- a/indexer-api/src/infra/storage/contract_action.rs
+++ b/indexer-api/src/infra/storage/contract_action.rs
@@ -373,7 +373,7 @@ impl Storage {
         &self,
         ids: &[u64],
     ) -> Result<Vec<ContractAction>, sqlx::Error> {
-        let ids: Vec<i64> = ids.iter().map(|id| *id as i64).collect();
+        let ids = ids.iter().map(|id| *id as i64).collect::<Vec<_>>();
 
         let query = indoc! {"
             SELECT
@@ -398,24 +398,26 @@ impl Storage {
     ) -> Result<Vec<ContractAction>, sqlx::Error> {
         use sqlx::{QueryBuilder, Sqlite};
 
-        let mut qb = QueryBuilder::<Sqlite>::new("WITH transaction_ids(id) AS (VALUES (");
+        let mut qb = QueryBuilder::<Sqlite>::new(indoc! {"
+            WITH transaction_ids(id) AS (VALUES (
+        "});
         let mut sep = qb.separated("), (");
         for id in ids {
             sep.push_bind(*id as i64);
         }
-        qb.push(
-            ")) \
-            SELECT \
-                id, \
-                address, \
-                state, \
-                attributes, \
-                zswap_state, \
-                transaction_id \
-            FROM contract_actions \
-            WHERE transaction_id IN (SELECT id FROM transaction_ids) \
-            ORDER BY id",
-        );
+        qb.push(indoc! {"
+            ))
+            SELECT
+                id,
+                address,
+                state,
+                attributes,
+                zswap_state,
+                transaction_id
+            FROM contract_actions
+            WHERE transaction_id IN (SELECT id FROM transaction_ids)
+            ORDER BY id
+        "});
 
         qb.build_query_as().fetch_all(&*self.pool).await
     }

--- a/indexer-api/src/infra/storage/contract_action.rs
+++ b/indexer-api/src/infra/storage/contract_action.rs
@@ -254,6 +254,16 @@ impl ContractActionStorage for Storage {
             .await
     }
 
+    async fn get_contract_actions_by_transaction_ids(
+        &self,
+        ids: &[u64],
+    ) -> Result<Vec<ContractAction>, sqlx::Error> {
+        if ids.is_empty() {
+            return Ok(vec![]);
+        }
+        self.fetch_contract_actions_by_transaction_ids(ids).await
+    }
+
     fn get_contract_actions_by_address(
         &self,
         address: &SerializedContractAddress,
@@ -356,5 +366,57 @@ impl Storage {
             .map_ok(ContractAction::from)
             .try_collect::<Vec<_>>()
             .await
+    }
+
+    #[cfg(feature = "cloud")]
+    async fn fetch_contract_actions_by_transaction_ids(
+        &self,
+        ids: &[u64],
+    ) -> Result<Vec<ContractAction>, sqlx::Error> {
+        let ids: Vec<i64> = ids.iter().map(|id| *id as i64).collect();
+
+        let query = indoc! {"
+            SELECT
+                id,
+                address,
+                state,
+                attributes,
+                zswap_state,
+                transaction_id
+            FROM contract_actions
+            WHERE transaction_id = ANY($1)
+            ORDER BY id
+        "};
+
+        sqlx::query_as(query).bind(ids).fetch_all(&*self.pool).await
+    }
+
+    #[cfg(feature = "standalone")]
+    async fn fetch_contract_actions_by_transaction_ids(
+        &self,
+        ids: &[u64],
+    ) -> Result<Vec<ContractAction>, sqlx::Error> {
+        use sqlx::{QueryBuilder, Sqlite};
+
+        let mut qb = QueryBuilder::<Sqlite>::new("WITH transaction_ids(id) AS (VALUES (");
+        let mut sep = qb.separated("), (");
+        for id in ids {
+            sep.push_bind(*id as i64);
+        }
+        qb.push(
+            ")) \
+            SELECT \
+                id, \
+                address, \
+                state, \
+                attributes, \
+                zswap_state, \
+                transaction_id \
+            FROM contract_actions \
+            WHERE transaction_id IN (SELECT id FROM transaction_ids) \
+            ORDER BY id",
+        );
+
+        qb.build_query_as().fetch_all(&*self.pool).await
     }
 }

--- a/indexer-api/src/infra/storage/transaction.rs
+++ b/indexer-api/src/infra/storage/transaction.rs
@@ -744,7 +744,7 @@ impl Storage {
         &self,
         ids: &[u64],
     ) -> Result<Vec<(u64, Transaction)>, sqlx::Error> {
-        let ids: Vec<i64> = ids.iter().map(|id| *id as i64).collect();
+        let ids = ids.iter().map(|id| *id as i64).collect::<Vec<_>>();
 
         let query = indoc! {"
             SELECT
@@ -816,67 +816,69 @@ impl Storage {
     ) -> Result<Vec<(u64, Transaction)>, sqlx::Error> {
         use sqlx::{QueryBuilder, Sqlite};
 
-        let mut qb = QueryBuilder::<Sqlite>::new("WITH block_ids(id) AS (VALUES (");
+        let mut qb = QueryBuilder::<Sqlite>::new(indoc! {"
+            WITH block_ids(id) AS (VALUES (
+        "});
         let mut sep = qb.separated("), (");
         for id in ids {
             sep.push_bind(*id as i64);
         }
-        qb.push(
-            ")) \
-            SELECT \
-                transactions.block_id AS block_id, \
-                transactions.id AS id, \
-                transactions.variant, \
-                transactions.hash, \
-                transactions.protocol_version, \
-                transactions.raw, \
-                blocks.hash AS block_hash, \
-                regular_transactions.transaction_result, \
-                regular_transactions.zswap_merkle_tree_root, \
-                regular_transactions.zswap_start_index, \
-                regular_transactions.zswap_end_index, \
-                regular_transactions.dust_commitment_start_index, \
-                regular_transactions.dust_commitment_end_index, \
-                regular_transactions.dust_generation_start_index, \
-                regular_transactions.dust_generation_end_index, \
-                regular_transactions.paid_fees, \
-                regular_transactions.estimated_fees \
-            FROM transactions \
-            INNER JOIN blocks ON blocks.id = transactions.block_id \
-            INNER JOIN regular_transactions ON regular_transactions.id = transactions.id \
-            WHERE transactions.block_id IN (SELECT id FROM block_ids) \
-            UNION ALL \
-            SELECT \
-                transactions.block_id, \
-                transactions.id, \
-                transactions.variant, \
-                transactions.hash, \
-                transactions.protocol_version, \
-                transactions.raw, \
-                blocks.hash AS block_hash, \
-                NULL AS transaction_result, \
-                NULL AS zswap_merkle_tree_root, \
-                NULL AS zswap_start_index, \
-                NULL AS zswap_end_index, \
-                NULL AS dust_commitment_start_index, \
-                NULL AS dust_commitment_end_index, \
-                NULL AS dust_generation_start_index, \
-                NULL AS dust_generation_end_index, \
-                NULL AS paid_fees, \
-                NULL AS estimated_fees \
-            FROM transactions \
-            INNER JOIN blocks ON blocks.id = transactions.block_id \
-            WHERE transactions.block_id IN (SELECT id FROM block_ids) \
-            AND transactions.variant = 'System' \
-            ORDER BY block_id, id",
-        );
+        qb.push(indoc! {"
+            ))
+            SELECT
+                transactions.block_id AS block_id,
+                transactions.id AS id,
+                transactions.variant,
+                transactions.hash,
+                transactions.protocol_version,
+                transactions.raw,
+                blocks.hash AS block_hash,
+                regular_transactions.transaction_result,
+                regular_transactions.zswap_merkle_tree_root,
+                regular_transactions.zswap_start_index,
+                regular_transactions.zswap_end_index,
+                regular_transactions.dust_commitment_start_index,
+                regular_transactions.dust_commitment_end_index,
+                regular_transactions.dust_generation_start_index,
+                regular_transactions.dust_generation_end_index,
+                regular_transactions.paid_fees,
+                regular_transactions.estimated_fees
+            FROM transactions
+            INNER JOIN blocks ON blocks.id = transactions.block_id
+            INNER JOIN regular_transactions ON regular_transactions.id = transactions.id
+            WHERE transactions.block_id IN (SELECT id FROM block_ids)
+            UNION ALL
+            SELECT
+                transactions.block_id,
+                transactions.id,
+                transactions.variant,
+                transactions.hash,
+                transactions.protocol_version,
+                transactions.raw,
+                blocks.hash AS block_hash,
+                NULL AS transaction_result,
+                NULL AS zswap_merkle_tree_root,
+                NULL AS zswap_start_index,
+                NULL AS zswap_end_index,
+                NULL AS dust_commitment_start_index,
+                NULL AS dust_commitment_end_index,
+                NULL AS dust_generation_start_index,
+                NULL AS dust_generation_end_index,
+                NULL AS paid_fees,
+                NULL AS estimated_fees
+            FROM transactions
+            INNER JOIN blocks ON blocks.id = transactions.block_id
+            WHERE transactions.block_id IN (SELECT id FROM block_ids)
+            AND transactions.variant = 'System'
+            ORDER BY block_id, id
+        "});
 
-        let mut transactions: Vec<(u64, Transaction)> = qb
+        let mut transactions = qb
             .build()
             .fetch(&*self.pool)
             .map_ok(make_transaction_with_block_id)
             .map(|result| result.flatten())
-            .try_collect()
+            .try_collect::<Vec<_>>()
             .await?;
 
         for (_, transaction) in transactions.iter_mut() {


### PR DESCRIPTION
Signed-off-by: Oxide Dyn0 <oxidyn0@proton.me>

See #1020.

`contract_actions` is called once per transaction in `RegularTransaction.contract_actions()` and `SystemTransaction.contract_actions()`, producing an N+1 query pattern whenever a client selects `contractActions { ... }` on a list of transactions.

Follow-up to #1018 and #1022, applying the same DataLoader pattern.

1. Added `get_contract_actions_by_transaction_ids(&[u64]) -> Vec<ContractAction>` to `ContractActionStorage`, implemented as `WHERE transaction_id = ANY($1)` (PostgreSQL) and a `VALUES`-CTE + `WHERE transaction_id IN (...)` (SQLite).
2. Added `ContractActionsByTransactionIdLoader` to `infra/api/v4/dataloader.rs`, implementing `Loader<u64>` with `Value = Vec<domain::ContractAction>`. The loader groups the flat result vec by `transaction_id` into the required `HashMap<u64, Vec<ContractAction>>`.
3. Registered `DataLoader<ContractActionsByTransactionIdLoader<S>>` in `make_app`.
4. Added `get_contract_actions_by_transaction_id_loader()` to `ContextExt`.
5. Migrated the shared `contract_actions` helper in `transaction.rs` to use the loader — both `RegularTransaction` and `SystemTransaction` benefit since they share the same helper function.
