### PR TITLE
feat: support ledger 8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "derive-where"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -3111,8 +3111,7 @@ dependencies = [
  "midnight-base-crypto",
  "midnight-coin-structure",
  "midnight-ledger",
- "midnight-onchain-runtime 2.0.1",
- "midnight-onchain-runtime 3.0.0",
+ "midnight-onchain-runtime",
  "midnight-serialize",
  "midnight-storage-core",
  "midnight-transient-crypto",
@@ -3984,9 +3983,8 @@ dependencies = [
 
 [[package]]
 name = "midnight-ledger"
-version = "8.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ab921a746fc8cceb4d9f4f68800e29cdd038dbd3486f6675428b79ebe04ded"
+version = "8.1.0-rc.1"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=crate-ledger-8.1.0-rc.1#fc4ebb35bb2e061f7ce2315929bffc59823d15fd"
 dependencies = [
  "anyhow",
  "derive-where",
@@ -4000,9 +3998,9 @@ dependencies = [
  "midnight-base-crypto",
  "midnight-coin-structure",
  "midnight-ledger-static",
- "midnight-onchain-runtime 3.0.0",
+ "midnight-onchain-runtime",
  "midnight-serialize",
- "midnight-storage 2.0.1",
+ "midnight-storage",
  "midnight-transient-crypto",
  "midnight-zswap",
  "rand 0.8.5",
@@ -4027,9 +4025,8 @@ dependencies = [
 
 [[package]]
 name = "midnight-onchain-runtime"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "251e828965432c89a3d13fec3c82fda23649eda3f8f76fa1326d97e00f195334"
+version = "3.1.0"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=onchain-runtime-3.1.0-rc.1#279fa7d8d5ad171472e787533b76efa3b1ed3a3e"
 dependencies = [
  "derive-where",
  "enum_index",
@@ -4040,36 +4037,10 @@ dependencies = [
  "lazy_static",
  "midnight-base-crypto",
  "midnight-coin-structure",
- "midnight-onchain-state 2.0.1",
- "midnight-onchain-vm 1.0.2",
+ "midnight-onchain-state",
+ "midnight-onchain-vm",
  "midnight-serialize",
- "midnight-storage 1.1.1",
- "midnight-transient-crypto",
- "rand 0.8.5",
- "serde",
- "serde_bytes",
- "tracing",
-]
-
-[[package]]
-name = "midnight-onchain-runtime"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f57168b906d68eddcf14fe6b34b1b8202ad3415e9796fdb59a38c01205610"
-dependencies = [
- "derive-where",
- "enum_index",
- "enum_index_derive",
- "fake",
- "hex",
- "konst",
- "lazy_static",
- "midnight-base-crypto",
- "midnight-coin-structure",
- "midnight-onchain-state 3.0.0",
- "midnight-onchain-vm 3.0.0",
- "midnight-serialize",
- "midnight-storage 2.0.1",
+ "midnight-storage",
  "midnight-transient-crypto",
  "rand 0.8.5",
  "serde",
@@ -4079,28 +4050,8 @@ dependencies = [
 
 [[package]]
 name = "midnight-onchain-state"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e153e26062e19ad07a065f8b4466243a6964e5fce5820d371fc9f4b036666ee7"
-dependencies = [
- "derive-where",
- "fake",
- "hex",
- "midnight-base-crypto",
- "midnight-coin-structure",
- "midnight-serialize",
- "midnight-storage 1.1.1",
- "midnight-transient-crypto",
- "rand 0.8.5",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "midnight-onchain-state"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cf32b5175d303251d7051fb30532d4fdef3c19c7e36c5831c002a27e8440163"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=onchain-state-3.1.0-rc.1#3ab59364bad95304af01d84e6d6fd7544d5b2c78"
 dependencies = [
  "derive-where",
  "fake",
@@ -4108,7 +4059,7 @@ dependencies = [
  "midnight-base-crypto",
  "midnight-coin-structure",
  "midnight-serialize",
- "midnight-storage 2.0.1",
+ "midnight-storage",
  "midnight-transient-crypto",
  "rand 0.8.5",
  "serde",
@@ -4117,9 +4068,8 @@ dependencies = [
 
 [[package]]
 name = "midnight-onchain-vm"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f737f8a5d227d07683d0c5829e1de02bdf297e39ab8ef954a3d4f49072f973f"
+version = "3.1.0"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=onchain-vm-3.1.0-rc.1#cbcdac28eb3fa30f759e733e74555b7c9f202bac"
 dependencies = [
  "derive-where",
  "fake",
@@ -4127,31 +4077,9 @@ dependencies = [
  "konst",
  "midnight-base-crypto",
  "midnight-coin-structure",
- "midnight-onchain-state 2.0.1",
+ "midnight-onchain-state",
  "midnight-serialize",
- "midnight-storage 1.1.1",
- "midnight-transient-crypto",
- "rand 0.8.5",
- "rpds",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "midnight-onchain-vm"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe2080991c8f6063cb204480db6b5db4072fb6fe7cb807ef77371ea7f0bbc62"
-dependencies = [
- "derive-where",
- "fake",
- "hex",
- "konst",
- "midnight-base-crypto",
- "midnight-coin-structure",
- "midnight-onchain-state 3.0.0",
- "midnight-serialize",
- "midnight-storage 2.0.1",
+ "midnight-storage",
  "midnight-transient-crypto",
  "rand 0.8.5",
  "rpds",
@@ -4181,9 +4109,8 @@ dependencies = [
 
 [[package]]
 name = "midnight-serialize"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cf09a5e7e71e9cda92d6a401448cccaf6147ecb2b473bda2bb0afcccebdfd12"
+version = "1.1.0"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=serialize-1.1.0-rc.1#fdea5bbdd2759c293843cfc52543436b94673e95"
 dependencies = [
  "crypto",
  "konst",
@@ -4202,24 +4129,6 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.45",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "midnight-storage"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df40bcb4aa0a709f5c4441f6d05aa15e853f434d777c6ef8a4692c00f24d3f6e"
-dependencies = [
- "crypto",
- "derive-where",
- "midnight-base-crypto",
- "midnight-serialize",
- "midnight-storage-core",
- "parking_lot",
- "rand 0.8.5",
- "serde",
- "sha2 0.10.9",
- "tempfile",
 ]
 
 [[package]]
@@ -4243,9 +4152,8 @@ dependencies = [
 
 [[package]]
 name = "midnight-storage-core"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bc1be493c1a38918c0629d4b0ab8725ef0b759a6243410c5f7504700c851feb"
+version = "1.2.0"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.1#b23837b2dacc2284bb18853bc37148448b04d419"
 dependencies = [
  "archery",
  "crypto",
@@ -4280,9 +4188,8 @@ dependencies = [
 
 [[package]]
 name = "midnight-transient-crypto"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0e92f0e835fc85d3e22d54b2e0fbfd3d3777439475da8d10020ef7bf016bb1"
+version = "2.1.0"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=transient-crypto-2.1.0-rc.1#08a5076a88c089f9687e8017475224985dbb008b"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -4339,9 +4246,8 @@ dependencies = [
 
 [[package]]
 name = "midnight-zswap"
-version = "8.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1ef7334eb838a0fb19c3ca769b358a1e4796a76548a10f5f1c369fac41bc92"
+version = "8.1.0-rc.1"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=zswap-8.1.0-rc.1#83e660749c1abfb9f3b52762bd0a761714aa10a1"
 dependencies = [
  "derive-where",
  "fake",
@@ -4352,9 +4258,9 @@ dependencies = [
  "midnight-base-crypto",
  "midnight-coin-structure",
  "midnight-ledger-static",
- "midnight-onchain-runtime 3.0.0",
+ "midnight-onchain-runtime",
  "midnight-serialize",
- "midnight-storage 2.0.1",
+ "midnight-storage",
  "midnight-transient-crypto",
  "rand 0.8.5",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,15 +21,14 @@ documentation = "https://github.com/midnightntwrk/midnight-indexer"
 publish       = false
 
 [workspace.dependencies]
-midnight-base-crypto        = { version = "1.0" }
-midnight-coin-structure     = { version = "2.0" }
-midnight-ledger_v8          = { package = "midnight-ledger", version = "8.0.3" }
-midnight-onchain-runtime_v2 = { package = "midnight-onchain-runtime", version = "2.0" }
-midnight-onchain-runtime_v3 = { package = "midnight-onchain-runtime", version = "3.0.0" }
-midnight-serialize          = { version = "1.0" }
-midnight-storage-core       = { version = "1.1", features = [ "layout-v2" ] }
-midnight-transient-crypto   = { version = "2.0" }
-midnight-zswap_v8           = { package = "midnight-zswap", version = "8.0.3" }
+midnight-base-crypto_v1      = { package = "midnight-base-crypto", version = "1.0" }
+midnight-coin-structure_v2   = { package = "midnight-coin-structure", version = "2.0" }
+midnight-ledger_v8           = { package = "midnight-ledger", version = "8.1.0-rc.1" }
+midnight-onchain-runtime_v3  = { package = "midnight-onchain-runtime", version = "3.0" }
+midnight-serialize_v1        = { package = "midnight-serialize", version = "1.0" }
+midnight-storage-core_v1     = { package = "midnight-storage-core", version = "1.2" }
+midnight-transient-crypto_v2 = { package = "midnight-transient-crypto", version = "2.0" }
+midnight-zswap_v8            = { package = "midnight-zswap", version = "8.1.0-rc.1" }
 # Other dependencies.
 anyhow                      = { version = "1.0" }
 assert_matches              = { version = "1.5" }
@@ -95,3 +94,13 @@ tower-http                  = { version = "0.6" }
 trait-variant               = { version = "0.1" }
 uuid                        = { version = "1.23", features = [ "serde" ] }
 walkdir                     = { version = "2.5" }
+
+[patch.crates-io]
+midnight-ledger           = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "crate-ledger-8.1.0-rc.1" }
+midnight-zswap            = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "zswap-8.1.0-rc.1" }
+midnight-transient-crypto = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "transient-crypto-2.1.0-rc.1" }
+midnight-onchain-vm       = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "onchain-vm-3.1.0-rc.1" }
+midnight-onchain-state    = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "onchain-state-3.1.0-rc.1" }
+midnight-onchain-runtime  = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "onchain-runtime-3.1.0-rc.1" }
+midnight-serialize        = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "serialize-1.1.0-rc.1" }
+midnight-storage-core     = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ publish       = false
 midnight-base-crypto_v1      = { package = "midnight-base-crypto", version = "1.0" }
 midnight-coin-structure_v2   = { package = "midnight-coin-structure", version = "2.0" }
 midnight-ledger_v8           = { package = "midnight-ledger", version = "8.1.0-rc.1" }
-midnight-onchain-runtime_v3  = { package = "midnight-onchain-runtime", version = "3.0" }
-midnight-serialize_v1        = { package = "midnight-serialize", version = "1.0" }
+midnight-onchain-runtime_v3  = { package = "midnight-onchain-runtime", version = "3.1.0" }
+midnight-serialize_v1        = { package = "midnight-serialize", version = "1.1.0" }
 midnight-storage-core_v1     = { package = "midnight-storage-core", version = "1.2" }
 midnight-transient-crypto_v2 = { package = "midnight-transient-crypto", version = "2.0" }
 midnight-zswap_v8            = { package = "midnight-zswap", version = "8.1.0-rc.1" }

--- a/indexer-common/Cargo.toml
+++ b/indexer-common/Cargo.toml
@@ -15,48 +15,47 @@ all-features = true
 rustdoc-args = [ "--cfg", "docsrs" ]
 
 [dependencies]
-midnight-base-crypto        = { workspace = true }
-midnight-coin-structure     = { workspace = true }
-midnight-ledger_v8          = { workspace = true }
-midnight-onchain-runtime_v2 = { workspace = true }
-midnight-onchain-runtime_v3 = { workspace = true }
-midnight-serialize          = { workspace = true }
-midnight-storage-core       = { workspace = true }
-midnight-transient-crypto   = { workspace = true }
-midnight-zswap_v8           = { workspace = true }
-async-nats                  = { workspace = true, optional = true }
-byte-unit-serde             = { workspace = true }
-chacha20poly1305            = { workspace = true, features = [ "std" ] }
-const-hex                   = { workspace = true, features = [ "serde" ] }
-derive_more                 = { workspace = true, features = [ "as_ref", "debug", "deref", "display", "from", "into" ] }
-fastrace                    = { workspace = true }
-fastrace-opentelemetry      = { workspace = true }
-fastrace-tracing            = { workspace = true }
-figment                     = { workspace = true, features = [ "env", "yaml" ] }
-futures                     = { workspace = true }
-humantime-serde             = { workspace = true }
-indoc                       = { workspace = true }
-itertools                   = { workspace = true }
-log                         = { workspace = true, features = [ "kv_std" ] }
-logforth                    = { workspace = true, features = [ "append-fastrace", "diagnostic-fastrace", "starter-log" ] }
-metrics-exporter-prometheus = { workspace = true, features = [ "http-listener" ] }
-opentelemetry               = { workspace = true }
-opentelemetry_sdk           = { workspace = true }
-opentelemetry-otlp          = { workspace = true, features = [ "grpc-tonic" ] }
-parity-scale-codec          = { workspace = true }
-secrecy                     = { workspace = true, features = [ "serde" ] }
-serde                       = { workspace = true, features = [ "derive" ] }
-serde_json                  = { workspace = true }
-serde_with                  = { workspace = true, optional = true }
-sha2                        = { workspace = true }
-sqlx                        = { workspace = true, features = [ "runtime-tokio", "uuid" ] }
-thiserror                   = { workspace = true }
-tokio                       = { workspace = true, features = [ "time" ] }
-tracing                     = { workspace = true }
-tracing-subscriber          = { workspace = true, features = [ "registry" ] }
-tokio-stream                = { workspace = true, features = [ "sync" ] }
-trait-variant               = { workspace = true }
-uuid                        = { workspace = true }
+midnight-base-crypto_v1      = { workspace = true }
+midnight-coin-structure_v2   = { workspace = true }
+midnight-ledger_v8           = { workspace = true }
+midnight-onchain-runtime_v3  = { workspace = true }
+midnight-serialize_v1        = { workspace = true }
+midnight-storage-core_v1     = { workspace = true, features = [ "layout-v2" ] }
+midnight-transient-crypto_v2 = { workspace = true }
+midnight-zswap_v8            = { workspace = true }
+async-nats                   = { workspace = true, optional = true }
+byte-unit-serde              = { workspace = true }
+chacha20poly1305             = { workspace = true, features = [ "std" ] }
+const-hex                    = { workspace = true, features = [ "serde" ] }
+derive_more                  = { workspace = true, features = [ "as_ref", "debug", "deref", "display", "from", "into" ] }
+fastrace                     = { workspace = true }
+fastrace-opentelemetry       = { workspace = true }
+fastrace-tracing             = { workspace = true }
+figment                      = { workspace = true, features = [ "env", "yaml" ] }
+futures                      = { workspace = true }
+humantime-serde              = { workspace = true }
+indoc                        = { workspace = true }
+itertools                    = { workspace = true }
+log                          = { workspace = true, features = [ "kv_std" ] }
+logforth                     = { workspace = true, features = [ "append-fastrace", "diagnostic-fastrace", "starter-log" ] }
+metrics-exporter-prometheus  = { workspace = true, features = [ "http-listener" ] }
+opentelemetry                = { workspace = true }
+opentelemetry_sdk            = { workspace = true }
+opentelemetry-otlp           = { workspace = true, features = [ "grpc-tonic" ] }
+parity-scale-codec           = { workspace = true }
+secrecy                      = { workspace = true, features = [ "serde" ] }
+serde                        = { workspace = true, features = [ "derive" ] }
+serde_json                   = { workspace = true }
+serde_with                   = { workspace = true, optional = true }
+sha2                         = { workspace = true }
+sqlx                         = { workspace = true, features = [ "runtime-tokio", "uuid" ] }
+thiserror                    = { workspace = true }
+tokio                        = { workspace = true, features = [ "time" ] }
+tracing                      = { workspace = true }
+tracing-subscriber           = { workspace = true, features = [ "registry" ] }
+tokio-stream                 = { workspace = true, features = [ "sync" ] }
+trait-variant                = { workspace = true }
+uuid                         = { workspace = true }
 
 [dev-dependencies]
 anyhow                 = { workspace = true }

--- a/indexer-common/src/domain/ledger.rs
+++ b/indexer-common/src/domain/ledger.rs
@@ -29,13 +29,13 @@ use crate::{
     error::BoxError,
 };
 use fastrace::trace;
-use midnight_base_crypto::signatures::Signature;
+use midnight_base_crypto_v1::signatures::Signature;
 use midnight_ledger_v8::{
     dust::INITIAL_DUST_PARAMETERS as INITIAL_DUST_PARAMETERS_V8,
     structure::ProofMarker as ProofMarkerV8,
 };
-use midnight_serialize::{Serializable, Tagged, tagged_serialize};
-use midnight_transient_crypto::commitment::PureGeneratorPedersen;
+use midnight_serialize_v1::{Serializable, Tagged, tagged_serialize};
+use midnight_transient_crypto_v2::commitment::PureGeneratorPedersen;
 use std::{io, string::FromUtf8Error};
 use thiserror::Error;
 

--- a/indexer-common/src/domain/ledger/contract_state.rs
+++ b/indexer-common/src/domain/ledger/contract_state.rs
@@ -16,10 +16,10 @@ use crate::domain::{
     ledger::{Error, TaggedSerializableExt},
 };
 use fastrace::trace;
-use midnight_coin_structure::coin::TokenType as MidnightTokenType;
+use midnight_coin_structure_v2::coin::TokenType as MidnightTokenType;
 use midnight_onchain_runtime_v3::state::ContractState as ContractStateV3;
-use midnight_serialize::tagged_deserialize;
-use midnight_storage_core::{DefaultDB, arena::Sp};
+use midnight_serialize_v1::tagged_deserialize;
+use midnight_storage_core_v1::{DefaultDB, arena::Sp};
 
 /// Facade for `ContractState` from `midnight_ledger` across supported (protocol) versions.
 #[derive(Debug, Clone)]

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -26,12 +26,12 @@ use crate::{
 use fastrace::trace;
 use itertools::Itertools;
 use log::info;
-use midnight_base_crypto::{
+use midnight_base_crypto_v1::{
     cost_model::{FixedPoint, NormalizedCost, SyntheticCost},
     hash::{HashOutput, persistent_commit},
     time::Timestamp,
 };
-use midnight_coin_structure::{
+use midnight_coin_structure_v2::{
     coin::{NIGHT, TokenType as LedgerTokenType, UnshieldedTokenType, UserAddress},
     contract::ContractAddress as ContractAddressV8,
 };
@@ -52,13 +52,13 @@ use midnight_ledger_v8::{
     verify::WellFormedStrictness as WellFormedStrictnessV8,
 };
 use midnight_onchain_runtime_v3::context::BlockContext as BlockContextV3;
-use midnight_serialize::{Deserializable, tagged_deserialize};
-use midnight_storage_core::{
+use midnight_serialize_v1::{Deserializable, tagged_deserialize};
+use midnight_storage_core_v1::{
     arena::{Sp, TypedArenaKey},
     db::DB,
     storage::default_storage,
 };
-use midnight_transient_crypto::merkle_tree::{
+use midnight_transient_crypto_v2::merkle_tree::{
     MerkleTreeCollapsedUpdate, MerkleTreeDigest, TreeInsertionPath,
 };
 use midnight_zswap_v8::ledger::State as ZswapStateV8;

--- a/indexer-common/src/domain/ledger/secret_key.rs
+++ b/indexer-common/src/domain/ledger/secret_key.rs
@@ -13,15 +13,15 @@
 
 use crate::domain::{ByteArray, VIEWING_KEY_LEN, ledger::Error};
 use fastrace::trace;
-use midnight_serialize::Deserializable;
+use midnight_serialize_v1::Deserializable;
 
 #[derive(Debug, Clone)]
-pub struct SecretKey(midnight_transient_crypto::encryption::SecretKey);
+pub struct SecretKey(midnight_transient_crypto_v2::encryption::SecretKey);
 
 impl SecretKey {
     #[trace]
     pub fn deserialize(secret_key: impl AsRef<[u8]>) -> Result<Self, Error> {
-        let inner = midnight_transient_crypto::encryption::SecretKey::deserialize(
+        let inner = midnight_transient_crypto_v2::encryption::SecretKey::deserialize(
             &mut secret_key.as_ref(),
             0,
         )

--- a/indexer-common/src/domain/ledger/transaction.rs
+++ b/indexer-common/src/domain/ledger/transaction.rs
@@ -21,14 +21,14 @@ use crate::{
 };
 use fastrace::trace;
 use futures::{StreamExt, TryStreamExt};
-use midnight_coin_structure::{coin::Info, contract::ContractAddress};
+use midnight_coin_structure_v2::{coin::Info, contract::ContractAddress};
 use midnight_ledger_v8::structure::{
     ContractAction as ContractActionV8, StandardTransaction as StandardTransactionV8,
     SystemTransaction as LedgerSystemTransactionV8,
 };
-use midnight_serialize::tagged_deserialize;
-use midnight_storage_core::db::DB;
-use midnight_transient_crypto::{encryption::SecretKey, proofs::Proof};
+use midnight_serialize_v1::tagged_deserialize;
+use midnight_storage_core_v1::db::DB;
+use midnight_transient_crypto_v2::{encryption::SecretKey, proofs::Proof};
 use midnight_zswap_v8::Offer as OfferV8;
 use std::error::Error as StdError;
 

--- a/indexer-common/src/infra/ledger_db.rs
+++ b/indexer-common/src/infra/ledger_db.rs
@@ -22,8 +22,8 @@ pub fn init(config: Config, pool: crate::infra::pool::postgres::PostgresPool) {
     let Config { cache_size } = config;
 
     let db = v1_1::LedgerDb::new(pool);
-    let _ = midnight_storage_core::storage::set_default_storage(|| {
-        midnight_storage_core::Storage::new(cache_size as usize, db)
+    let _ = midnight_storage_core_v1::storage::set_default_storage(|| {
+        midnight_storage_core_v1::Storage::new(cache_size as usize, db)
     });
 }
 
@@ -40,8 +40,8 @@ pub async fn init(config: Config) -> Result<(), Error> {
     migrations::sqlite::run_for_ledger_db(&pool).await?;
 
     let db = v1_1::LedgerDb::new(pool);
-    let _ = midnight_storage_core::storage::set_default_storage(|| {
-        midnight_storage_core::Storage::new(cache_size as usize, db)
+    let _ = midnight_storage_core_v1::storage::set_default_storage(|| {
+        midnight_storage_core_v1::Storage::new(cache_size as usize, db)
     });
 
     Ok(())

--- a/indexer-common/src/infra/ledger_db/v1_1.rs
+++ b/indexer-common/src/infra/ledger_db/v1_1.rs
@@ -15,8 +15,8 @@ use crate::error::StdErrorExt;
 use derive_more::Debug;
 use futures::TryStreamExt;
 use indoc::indoc;
-use midnight_serialize::{Deserializable, Serializable};
-use midnight_storage_core::{
+use midnight_serialize_v1::{Deserializable, Serializable};
+use midnight_storage_core_v1::{
     DefaultHasher, WellBehavedHasher,
     arena::ArenaHash,
     backend::OnDiskObject,


### PR DESCRIPTION
Closes #1024

## Summary
Bump ledger dependencies to 8.1.0-rc.1, aligning with node 1.0.0-rc.2 (midnightntwrk/midnight-node#1301).

- Bump midnight-ledger to 8.1.0-rc.1, midnight-zswap to 8.1.0-rc.1
- Bump midnight-onchain-runtime to 3.1.0, midnight-serialize to 1.1.0, midnight-storage-core to 1.2.0
- Add cargo patches for pre-release sub-crates (required until full releases land on crates.io)
- Rename workspace deps to versioned names (e.g. midnight-base-crypto → midnight-base-crypto_v1)
- Drop midnight-onchain-runtime_v2 (ledger v7 dependency no longer needed)

storage-core 1.2.0-rc.1 includes the fix for #987 (chain-indexer panic on v1.0 contract-action transactions).

Based on Heiko's draft, rebased on current main and aligned versions with node 1.0.0-rc.2.