### PR TITLE
test: add qa tests for dust wallet sync endpoints

### DIFF
--- a/qa/tests/environment/model.ts
+++ b/qa/tests/environment/model.ts
@@ -58,11 +58,7 @@ const hostEntries: HostEntry[] = [
     indexerHost: 'localhost:8088',
     nodeHost: 'localhost:9944',
   },
-  {
-    env: EnvironmentName.QANET,
-    indexerHost: 'indexer-green.qanet.midnight.network',
-    nodeHost: 'rpc.qanet.midnight.network',
-  },
+  { env: EnvironmentName.QANET, domain: 'devnet.midnight.network' },
   { env: EnvironmentName.DEVNET, domain: 'devnet.midnight.network' },
   { env: EnvironmentName.PREVIEW, domain: 'preview.midnight.network' },
   { env: EnvironmentName.PREPROD, domain: 'preprod.midnight.network' },

--- a/qa/tests/tests/e2e/shielded-transactions.test.ts
+++ b/qa/tests/tests/e2e/shielded-transactions.test.ts
@@ -38,6 +38,7 @@ describe('shielded transactions', () => {
   let indexerHttpClient: IndexerHttpClient;
   let previousMaxLedgerId: number;
   let zswapEndIndexBeforeTx: number;
+  let dustCommitmentEndIndexBeforeTx: number;
   let toolkit: ToolkitWrapper;
   let transactionResult: ToolkitTransactionResult;
 
@@ -79,6 +80,14 @@ describe('shielded transactions', () => {
         : max;
     }, 0);
     log.debug(`Highest zswapEndIndex from genesis = ${zswapEndIndexBeforeTx}`);
+
+    dustCommitmentEndIndexBeforeTx = genesisTxs.reduce((max, tx) => {
+      const regularTx = tx as RegularTransaction;
+      return regularTx.dustCommitmentEndIndex != null && regularTx.dustCommitmentEndIndex > max
+        ? regularTx.dustCommitmentEndIndex
+        : max;
+    }, 0);
+    log.debug(`Highest dustCommitmentEndIndex from genesis = ${dustCommitmentEndIndexBeforeTx}`);
 
     // Submit one shielded->shielded transfer (1 STAR)
     transactionResult = await toolkit.generateSingleTx(
@@ -273,6 +282,40 @@ describe('shielded transactions', () => {
       log.debug(
         `zswapEndIndex before tx: ${zswapEndIndexBeforeTx}, after tx: ${regularTx.zswapEndIndex}`,
       );
+    });
+
+    /**
+     * After a shielded transaction is confirmed, the dust commitment Merkle tree should grow.
+     * The dustCommitmentEndIndex of the transaction should be higher than the previous maximum.
+     *
+     * @given a confirmed shielded transaction
+     * @when we query the transaction from the indexer
+     * @then the transaction's dustCommitmentEndIndex should be greater than the dustCommitmentEndIndex before the transaction
+     */
+    test('should increase the dust commitment Merkle tree end index', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Transaction', 'Dust', 'CommitmentMerkleTree', 'ShieldedTokens'],
+      };
+
+      ctx.skip?.(
+        transactionResult.status !== 'confirmed',
+        "Toolkit transaction hasn't been confirmed",
+      );
+
+      const transactionResponse = await getTransactionByHashWithRetry(transactionResult.txHash);
+      expect(transactionResponse).toBeSuccess();
+
+      const transactions = transactionResponse.data!.transactions;
+      const tx = transactions.find(
+        (t: Transaction) => t.hash === transactionResult.txHash,
+      );
+      expect(tx).toBeDefined();
+
+      const regularTx = tx as RegularTransaction;
+      expect(regularTx.dustCommitmentEndIndex).toBeDefined();
+      expect(regularTx.dustCommitmentEndIndex!).toBeGreaterThan(dustCommitmentEndIndexBeforeTx);
+
+      log.debug(`dustCommitmentEndIndex before tx: ${dustCommitmentEndIndexBeforeTx}, after tx: ${regularTx.dustCommitmentEndIndex}`);
     });
 
     /**

--- a/qa/tests/tests/e2e/shielded-transactions.test.ts
+++ b/qa/tests/tests/e2e/shielded-transactions.test.ts
@@ -306,16 +306,16 @@ describe('shielded transactions', () => {
       expect(transactionResponse).toBeSuccess();
 
       const transactions = transactionResponse.data!.transactions;
-      const tx = transactions.find(
-        (t: Transaction) => t.hash === transactionResult.txHash,
-      );
+      const tx = transactions.find((t: Transaction) => t.hash === transactionResult.txHash);
       expect(tx).toBeDefined();
 
       const regularTx = tx as RegularTransaction;
       expect(regularTx.dustCommitmentEndIndex).toBeDefined();
       expect(regularTx.dustCommitmentEndIndex!).toBeGreaterThan(dustCommitmentEndIndexBeforeTx);
 
-      log.debug(`dustCommitmentEndIndex before tx: ${dustCommitmentEndIndexBeforeTx}, after tx: ${regularTx.dustCommitmentEndIndex}`);
+      log.debug(
+        `dustCommitmentEndIndex before tx: ${dustCommitmentEndIndexBeforeTx}, after tx: ${regularTx.dustCommitmentEndIndex}`,
+      );
     });
 
     /**

--- a/qa/tests/tests/e2e/unshielded-transactions.test.ts
+++ b/qa/tests/tests/e2e/unshielded-transactions.test.ts
@@ -26,6 +26,7 @@ import {
 import { IndexerHttpClient } from '@utils/indexer/http-client';
 import { ToolkitWrapper, ToolkitTransactionResult } from '@utils/toolkit/toolkit-wrapper';
 import {
+  RegularTransaction,
   Transaction,
   UnshieldedTransaction,
   UnshieldedTransactionEvent,
@@ -90,6 +91,7 @@ describe('unshielded transactions', { timeout: 200_000 }, () => {
   let indexerEventCoordinator: EventCoordinator;
   indexerEventCoordinator = new EventCoordinator();
   let previousMaxDustId: number;
+  let dustCommitmentEndIndexBeforeTx: number;
 
   beforeAll(async () => {
     indexerHttpClient = new IndexerHttpClient();
@@ -118,6 +120,17 @@ describe('unshielded transactions', { timeout: 200_000 }, () => {
     );
     previousMaxDustId = beforeEvents[0].data!.dustLedgerEvents.maxId;
     log.debug(`Previous max dust ID before tx = ${previousMaxDustId}`);
+
+    // Capture the highest dustCommitmentEndIndex before the transaction from genesis block.
+    const genesisResponse = await indexerHttpClient.getBlockByOffset({ height: 0 });
+    const genesisTxs = genesisResponse.data!.block.transactions;
+    dustCommitmentEndIndexBeforeTx = genesisTxs.reduce((max, tx) => {
+      const regularTx = tx as RegularTransaction;
+      return regularTx.dustCommitmentEndIndex != null && regularTx.dustCommitmentEndIndex > max
+        ? regularTx.dustCommitmentEndIndex
+        : max;
+    }, 0);
+    log.debug(`Highest dustCommitmentEndIndex from genesis = ${dustCommitmentEndIndexBeforeTx}`);
 
     // Submit a single unshielded transaction (1 STAR) from source → destination
     transactionResult = await toolkit.generateSingleTx(
@@ -512,6 +525,42 @@ describe('unshielded transactions', { timeout: 200_000 }, () => {
       expect(highestTransactionIdAfterTransaction).toBeGreaterThan(
         highestTransactionIdBeforeTransaction,
       );
+    });
+
+    /**
+     * After an unshielded transaction is confirmed, the dust commitment Merkle tree should grow.
+     * The dustCommitmentEndIndex of the transaction should be higher than the previous maximum.
+     *
+     * @given a confirmed unshielded transaction
+     * @when we query the transaction from the indexer
+     * @then the transaction's dustCommitmentEndIndex should be greater than the dustCommitmentEndIndex before the transaction
+     */
+    test('should increase the dust commitment Merkle tree end index', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Transaction', 'Dust', 'CommitmentMerkleTree', 'UnshieldedTokens'],
+      };
+
+      ctx.skip?.(
+        transactionResult.status !== 'confirmed',
+        "Toolkit transaction hasn't been confirmed",
+      );
+
+      const transactionResponse = await indexerHttpClient.getTransactionByOffset({
+        hash: transactionResult.txHash,
+      });
+      expect(transactionResponse).toBeSuccess();
+
+      const transactions = transactionResponse.data!.transactions;
+      const tx = transactions.find(
+        (t: Transaction) => t.hash === transactionResult.txHash,
+      );
+      expect(tx).toBeDefined();
+
+      const regularTx = tx as RegularTransaction;
+      expect(regularTx.dustCommitmentEndIndex).toBeDefined();
+      expect(regularTx.dustCommitmentEndIndex!).toBeGreaterThan(dustCommitmentEndIndexBeforeTx);
+
+      log.debug(`dustCommitmentEndIndex before tx: ${dustCommitmentEndIndexBeforeTx}, after tx: ${regularTx.dustCommitmentEndIndex}`);
     });
 
     /**

--- a/qa/tests/tests/e2e/unshielded-transactions.test.ts
+++ b/qa/tests/tests/e2e/unshielded-transactions.test.ts
@@ -551,16 +551,16 @@ describe('unshielded transactions', { timeout: 200_000 }, () => {
       expect(transactionResponse).toBeSuccess();
 
       const transactions = transactionResponse.data!.transactions;
-      const tx = transactions.find(
-        (t: Transaction) => t.hash === transactionResult.txHash,
-      );
+      const tx = transactions.find((t: Transaction) => t.hash === transactionResult.txHash);
       expect(tx).toBeDefined();
 
       const regularTx = tx as RegularTransaction;
       expect(regularTx.dustCommitmentEndIndex).toBeDefined();
       expect(regularTx.dustCommitmentEndIndex!).toBeGreaterThan(dustCommitmentEndIndexBeforeTx);
 
-      log.debug(`dustCommitmentEndIndex before tx: ${dustCommitmentEndIndexBeforeTx}, after tx: ${regularTx.dustCommitmentEndIndex}`);
+      log.debug(
+        `dustCommitmentEndIndex before tx: ${dustCommitmentEndIndexBeforeTx}, after tx: ${regularTx.dustCommitmentEndIndex}`,
+      );
     });
 
     /**

--- a/qa/tests/tests/integration/basic/queries/block-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/block-queries.test.ts
@@ -583,7 +583,9 @@ describe(`genesis block`, () => {
       expect(regularTxs.length).toBeGreaterThan(0);
 
       for (const tx of regularTxs) {
-        log.debug(`Transaction ${tx.hash}: zswap=[${tx.zswapStartIndex}, ${tx.zswapEndIndex}], dustCommitment=[${tx.dustCommitmentStartIndex}, ${tx.dustCommitmentEndIndex}], dustGeneration=[${tx.dustGenerationStartIndex}, ${tx.dustGenerationEndIndex}]`);
+        log.debug(
+          `Transaction ${tx.hash}: zswap=[${tx.zswapStartIndex}, ${tx.zswapEndIndex}], dustCommitment=[${tx.dustCommitmentStartIndex}, ${tx.dustCommitmentEndIndex}], dustGeneration=[${tx.dustGenerationStartIndex}, ${tx.dustGenerationEndIndex}]`,
+        );
 
         expect(tx.zswapEndIndex!).toBeGreaterThanOrEqual(tx.zswapStartIndex!);
         expect(tx.dustCommitmentEndIndex!).toBeGreaterThanOrEqual(tx.dustCommitmentStartIndex!);

--- a/qa/tests/tests/integration/basic/queries/block-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/block-queries.test.ts
@@ -562,5 +562,33 @@ describe(`genesis block`, () => {
         expect.soft(currentOutputIndex).toBeGreaterThan(previousOutputIndex);
       }
     });
+
+    /**
+     * Genesis block regular transactions should have valid index ranges
+     *
+     * @given the genesis block is indexed
+     * @when we inspect its regular transactions
+     * @then endIndex >= startIndex for zswap, dustCommitment, and dustGeneration indices
+     */
+    test('should contain valid index ranges on regular transactions', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Transaction', 'IndexFields', 'Genesis'],
+      };
+
+      const genesisTransactions = await extractGenesisTransactions(genesisBlock);
+      const regularTxs = genesisTransactions.filter(
+        (tx) => tx.__typename === 'RegularTransaction',
+      ) as RegularTransaction[];
+
+      expect(regularTxs.length).toBeGreaterThan(0);
+
+      for (const tx of regularTxs) {
+        log.debug(`Transaction ${tx.hash}: zswap=[${tx.zswapStartIndex}, ${tx.zswapEndIndex}], dustCommitment=[${tx.dustCommitmentStartIndex}, ${tx.dustCommitmentEndIndex}], dustGeneration=[${tx.dustGenerationStartIndex}, ${tx.dustGenerationEndIndex}]`);
+
+        expect(tx.zswapEndIndex!).toBeGreaterThanOrEqual(tx.zswapStartIndex!);
+        expect(tx.dustCommitmentEndIndex!).toBeGreaterThanOrEqual(tx.dustCommitmentStartIndex!);
+        expect(tx.dustGenerationEndIndex!).toBeGreaterThanOrEqual(tx.dustGenerationStartIndex!);
+      }
+    });
   });
 });

--- a/qa/tests/tests/integration/basic/queries/dust-commitment-update-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/dust-commitment-update-queries.test.ts
@@ -1,0 +1,239 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import log from '@utils/logging/logger';
+import '@utils/logging/test-logging-hooks';
+import { MerkleTreeCollapsedUpdateSchema } from '@utils/indexer/graphql/schema';
+import { IndexerHttpClient } from '@utils/indexer/http-client';
+import type { RegularTransaction } from '@utils/indexer/indexer-types';
+import { TestContext } from 'vitest';
+
+const indexerHttpClient = new IndexerHttpClient();
+
+describe('dust commitment merkle tree update queries', () => {
+  describe('a collapsed update query with valid index range', () => {
+    /**
+     * A dust commitment update query with a valid index range returns the expected result
+     *
+     * @given the chain has indexed blocks with dust commitment state
+     * @when we query for a dust commitment update with startIndex=0 and endIndex=1
+     * @then Indexer should return a valid collapsed update
+     */
+    test('should return a collapsed update for a valid index range', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'CommitmentMerkleTree', 'CollapsedUpdate'],
+      };
+
+      log.debug('Requesting dust commitment merkle tree update with startIndex=0, endIndex=1');
+      const response = await indexerHttpClient.getDustCommitmentMerkleTreeUpdate(0, 1);
+
+      expect(response).toBeSuccess();
+      expect(response.data?.dustCommitmentMerkleTreeUpdate).toBeDefined();
+
+      const collapsedUpdate = response.data!.dustCommitmentMerkleTreeUpdate;
+      expect(collapsedUpdate.startIndex).toBe(0);
+      expect(collapsedUpdate.endIndex).toBe(1);
+      expect(collapsedUpdate.update).toBeDefined();
+      expect(collapsedUpdate.protocolVersion).toBeDefined();
+    });
+
+    /**
+     * A dust commitment update query responds with the expected schema
+     *
+     * @given the chain has indexed blocks with dust commitment state
+     * @when we query for a dust commitment update with a valid index range
+     * @then the response should match the expected schema
+     */
+    test('should respond with a collapsed update according to the expected schema', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'CommitmentMerkleTree', 'CollapsedUpdate', 'SchemaValidation'],
+      };
+
+      log.debug('Requesting dust commitment merkle tree update with startIndex=0, endIndex=1');
+      const response = await indexerHttpClient.getDustCommitmentMerkleTreeUpdate(0, 1);
+
+      expect(response).toBeSuccess();
+      expect(response.data?.dustCommitmentMerkleTreeUpdate).toBeDefined();
+
+      log.debug('Validating collapsed update schema');
+      const parsed = MerkleTreeCollapsedUpdateSchema.safeParse(
+        response.data!.dustCommitmentMerkleTreeUpdate,
+      );
+      expect(
+        parsed.success,
+        `Collapsed update schema validation failed ${JSON.stringify(parsed.error, null, 2)}`,
+      ).toBe(true);
+    });
+
+    /**
+     * A dust commitment update query covering the full genesis dust range returns a valid result
+     *
+     * @given the genesis block has indexed dust commitment state
+     * @when we query for a dust commitment update covering the full range from genesis
+     * @then Indexer should return a valid collapsed update spanning the entire range
+     */
+    test('should return a collapsed update for the full genesis dust range', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'CommitmentMerkleTree', 'CollapsedUpdate', 'FullRange'],
+      };
+
+      // Get the highest dustCommitmentEndIndex from genesis block transactions
+      const genesisResponse = await indexerHttpClient.getBlockByOffset({ height: 0 });
+      expect(genesisResponse).toBeSuccess();
+
+      const transactions = genesisResponse.data!.block.transactions;
+      const maxEndIndex = transactions.reduce((max, tx) => {
+        const regularTx = tx as RegularTransaction;
+        return regularTx.dustCommitmentEndIndex != null && regularTx.dustCommitmentEndIndex > max
+          ? regularTx.dustCommitmentEndIndex
+          : max;
+      }, 0);
+
+      log.debug(`Highest dustCommitmentEndIndex from genesis: ${maxEndIndex}`);
+      expect(maxEndIndex).toBeGreaterThan(0);
+
+      // dustCommitmentEndIndex is exclusive, collapsed update endIndex is inclusive
+      const endIndex = maxEndIndex - 1;
+
+      log.debug(`Requesting dust commitment update with startIndex=0, endIndex=${endIndex}`);
+      const response = await indexerHttpClient.getDustCommitmentMerkleTreeUpdate(0, endIndex);
+
+      expect(response).toBeSuccess();
+      expect(response.data?.dustCommitmentMerkleTreeUpdate).toBeDefined();
+
+      const collapsedUpdate = response.data!.dustCommitmentMerkleTreeUpdate;
+      expect(collapsedUpdate.startIndex).toBe(0);
+      expect(collapsedUpdate.endIndex).toBe(endIndex);
+      expect(collapsedUpdate.update).toBeDefined();
+      expect(collapsedUpdate.protocolVersion).toBeDefined();
+    });
+  });
+
+  describe('a collapsed update query with equal start and end indices', () => {
+    /**
+     * A collapsed update query where startIndex === endIndex returns a valid trivial update
+     *
+     * @given we use startIndex equal to endIndex
+     * @when we query for a collapsed update
+     * @then Indexer should return a valid collapsed update with matching indices
+     */
+    test('should return a valid update when startIndex equals endIndex', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'CommitmentMerkleTree', 'CollapsedUpdate', 'EdgeCase'],
+      };
+
+      log.debug('Requesting dust commitment merkle tree update with startIndex=0, endIndex=0');
+      const response = await indexerHttpClient.getDustCommitmentMerkleTreeUpdate(0, 0);
+
+      expect(response).toBeSuccess();
+      expect(response.data?.dustCommitmentMerkleTreeUpdate).toBeDefined();
+
+      const collapsedUpdate = response.data!.dustCommitmentMerkleTreeUpdate;
+      expect(collapsedUpdate.startIndex).toBe(0);
+      expect(collapsedUpdate.endIndex).toBe(0);
+      expect(collapsedUpdate.update).toBeDefined();
+      expect(collapsedUpdate.protocolVersion).toBeDefined();
+    });
+  });
+
+  describe('a collapsed update query idempotency', () => {
+    /**
+     * Two identical dust commitment update queries should return the same result
+     *
+     * @given we query the same index range twice
+     * @when the chain head has not changed between calls
+     * @then both responses should be identical
+     */
+    test('should return identical results for the same query parameters', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'CommitmentMerkleTree', 'CollapsedUpdate', 'Idempotency'],
+      };
+
+      log.debug('Requesting dust commitment merkle tree update twice with startIndex=0, endIndex=1');
+      const response1 = await indexerHttpClient.getDustCommitmentMerkleTreeUpdate(0, 1);
+      const response2 = await indexerHttpClient.getDustCommitmentMerkleTreeUpdate(0, 1);
+
+      expect(response1).toBeSuccess();
+      expect(response2).toBeSuccess();
+
+      const update1 = response1.data!.dustCommitmentMerkleTreeUpdate;
+      const update2 = response2.data!.dustCommitmentMerkleTreeUpdate;
+
+      expect(update1.startIndex).toBe(update2.startIndex);
+      expect(update1.endIndex).toBe(update2.endIndex);
+      expect(update1.update).toBe(update2.update);
+      expect(update1.protocolVersion).toBe(update2.protocolVersion);
+    });
+  });
+
+  describe('a collapsed update query with invalid index range', () => {
+    /**
+     * A dust commitment update query where startIndex > endIndex should return an error
+     *
+     * @given we use an invalid index range where startIndex > endIndex
+     * @when we query for a dust commitment update
+     * @then Indexer should respond with an error about invalid start_index and/or end_index
+     */
+    test('should return an error when startIndex is greater than endIndex', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'CommitmentMerkleTree', 'CollapsedUpdate', 'Negative'],
+      };
+
+      log.debug('Requesting dust commitment merkle tree update with startIndex=10, endIndex=5');
+      const response = await indexerHttpClient.getDustCommitmentMerkleTreeUpdate(10, 5);
+
+      expect(response).toBeError();
+      expect(response.errors![0].message).toContain('invalid start_index and/or end_index');
+    });
+
+    /**
+     * A dust commitment update query with negative indices should return a parse error
+     *
+     * @given we use negative indices
+     * @when we query for a dust commitment update
+     * @then Indexer should respond with an error about invalid number parsing
+     */
+    test('should return an error when indices are negative', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'CommitmentMerkleTree', 'CollapsedUpdate', 'Negative'],
+      };
+
+      log.debug('Requesting dust commitment merkle tree update with startIndex=-1, endIndex=1');
+      const response = await indexerHttpClient.getDustCommitmentMerkleTreeUpdate(-1, 1);
+
+      expect(response).toBeError();
+      expect(response.errors![0].message).toContain('Invalid number');
+    });
+
+    /**
+     * A dust commitment update query where endIndex exceeds the indexed range should return an error
+     *
+     * @given we use an endIndex far beyond the current indexed range
+     * @when we query for a dust commitment update
+     * @then Indexer should respond with an error about invalid start_index and/or end_index
+     */
+    test('should return an error when endIndex is beyond the indexed range', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'CommitmentMerkleTree', 'CollapsedUpdate', 'Negative'],
+      };
+
+      log.debug('Requesting dust commitment merkle tree update with startIndex=0, endIndex=999999999');
+      const response = await indexerHttpClient.getDustCommitmentMerkleTreeUpdate(0, 999999999);
+
+      expect(response).toBeError();
+      expect(response.errors![0].message).toContain('invalid start_index and/or end_index');
+    });
+  });
+});

--- a/qa/tests/tests/integration/basic/queries/dust-commitment-update-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/dust-commitment-update-queries.test.ts
@@ -161,7 +161,9 @@ describe('dust commitment merkle tree update queries', () => {
         labels: ['Query', 'Dust', 'CommitmentMerkleTree', 'CollapsedUpdate', 'Idempotency'],
       };
 
-      log.debug('Requesting dust commitment merkle tree update twice with startIndex=0, endIndex=1');
+      log.debug(
+        'Requesting dust commitment merkle tree update twice with startIndex=0, endIndex=1',
+      );
       const response1 = await indexerHttpClient.getDustCommitmentMerkleTreeUpdate(0, 1);
       const response2 = await indexerHttpClient.getDustCommitmentMerkleTreeUpdate(0, 1);
 
@@ -229,7 +231,9 @@ describe('dust commitment merkle tree update queries', () => {
         labels: ['Query', 'Dust', 'CommitmentMerkleTree', 'CollapsedUpdate', 'Negative'],
       };
 
-      log.debug('Requesting dust commitment merkle tree update with startIndex=0, endIndex=999999999');
+      log.debug(
+        'Requesting dust commitment merkle tree update with startIndex=0, endIndex=999999999',
+      );
       const response = await indexerHttpClient.getDustCommitmentMerkleTreeUpdate(0, 999999999);
 
       expect(response).toBeError();

--- a/qa/tests/tests/integration/basic/queries/dust-generations-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/dust-generations-queries.test.ts
@@ -1,0 +1,313 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { bech32 } from 'bech32';
+import { Buffer } from 'node:buffer';
+import log from '@utils/logging/logger';
+import { env } from 'environment/model';
+import type { TestContext } from 'vitest';
+import '@utils/logging/test-logging-hooks';
+import dataProvider from '@utils/testdata-provider';
+import { IndexerHttpClient } from '@utils/indexer/http-client';
+import { DustGenerationsSchema, DustGenerationStatusSchema } from '@utils/indexer/graphql/schema';
+
+type AcceptedRewardAddressHrpPrefix = 'stake' | 'stake_test';
+
+function generateRewardAddress(
+  byteValue: number,
+  hrpPrefix: AcceptedRewardAddressHrpPrefix | undefined = undefined,
+): string {
+  if (hrpPrefix === undefined) {
+    hrpPrefix = env.getCurrentEnvironmentName() === 'mainnet' ? 'stake' : 'stake_test';
+  }
+  const payload = Buffer.alloc(29, byteValue);
+  return bech32.encode(hrpPrefix, bech32.toWords(payload));
+}
+
+const indexerHttpClient = new IndexerHttpClient();
+
+describe('dust generations queries', () => {
+  describe('a dust generations query with a valid Cardano reward address', () => {
+    /**
+     * A dust generations query for a valid registered address returns registrations
+     *
+     * @given we have a valid Cardano reward address that is registered for dust generation
+     * @when we query dustGenerations with that address
+     * @then Indexer should return dust generations with registrations array
+     */
+    test('should return dust generations for a registered address', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'Generations'],
+      };
+
+      let rewardAddress: string;
+      try {
+        rewardAddress = dataProvider.getCardanoRewardAddress('registered-with-dust');
+      } catch (error) {
+        log.warn(error);
+        ctx.skip();
+        return;
+      }
+
+      log.debug(`Querying dustGenerations for registered address: ${rewardAddress}`);
+      const response = await indexerHttpClient.getDustGenerations([rewardAddress]);
+
+      expect(response).toBeSuccess();
+      expect(response.data?.dustGenerations).toBeDefined();
+
+      const generations = response.data!.dustGenerations;
+      expect(generations).toHaveLength(1);
+      expect(generations[0].cardanoRewardAddress).toBe(rewardAddress);
+      expect(generations[0].registrations).toBeDefined();
+      expect(Array.isArray(generations[0].registrations)).toBe(true);
+    });
+
+    /**
+     * A dust generations query for a registered address returns registrations matching expected schema
+     *
+     * @given we have a valid Cardano reward address registered for dust generation
+     * @when we query dustGenerations with that address
+     * @then the response should match the DustGenerationsSchema
+     */
+    test('should respond with dust generations according to the expected schema', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'Generations', 'SchemaValidation'],
+      };
+
+      let rewardAddress: string;
+      try {
+        rewardAddress = dataProvider.getCardanoRewardAddress('registered-with-dust');
+      } catch (error) {
+        log.warn(error);
+        ctx.skip();
+        return;
+      }
+
+      log.debug(`Querying dustGenerations for registered address: ${rewardAddress}`);
+      const response = await indexerHttpClient.getDustGenerations([rewardAddress]);
+
+      expect(response).toBeSuccess();
+      expect(response.data?.dustGenerations).toBeDefined();
+
+      const generations = response.data!.dustGenerations;
+      expect(generations.length).toBeGreaterThanOrEqual(1);
+
+      log.debug('Validating dust generations schema');
+      for (const gen of generations) {
+        const parsed = DustGenerationsSchema.safeParse(gen);
+        expect(
+          parsed.success,
+          `Dust generations schema validation failed ${JSON.stringify(parsed.error, null, 2)}`,
+        ).toBe(true);
+      }
+    });
+
+    /**
+     * A dust generations query for a registered address returns registrations with valid fields
+     *
+     * @given we have a valid registered address with active dust generation
+     * @when we query dustGenerations
+     * @then each registration should have a dustAddress, valid flag, and numeric balance fields
+     */
+    test('should return registrations with valid fields for a registered address', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'Generations', 'FieldValidation'],
+      };
+
+      let rewardAddress: string;
+      try {
+        rewardAddress = dataProvider.getCardanoRewardAddress('registered-with-dust');
+      } catch (error) {
+        log.warn(error);
+        ctx.skip();
+        return;
+      }
+
+      log.debug(`Querying dustGenerations for registered address: ${rewardAddress}`);
+      const response = await indexerHttpClient.getDustGenerations([rewardAddress]);
+
+      expect(response).toBeSuccess();
+      const generations = response.data!.dustGenerations;
+      expect(generations).toHaveLength(1);
+      expect(generations[0].registrations.length).toBeGreaterThanOrEqual(1);
+
+      for (const reg of generations[0].registrations) {
+        expect(reg.dustAddress).toBeDefined();
+        expect(typeof reg.valid).toBe('boolean');
+        expect(BigInt(reg.nightBalance)).toBeGreaterThanOrEqual(0n);
+        expect(BigInt(reg.generationRate)).toBeGreaterThanOrEqual(0n);
+        expect(BigInt(reg.maxCapacity)).toBeGreaterThanOrEqual(0n);
+        expect(BigInt(reg.currentCapacity)).toBeGreaterThanOrEqual(0n);
+      }
+    });
+  });
+
+  describe('a dust generations query with multiple addresses', () => {
+    /**
+     * A dust generations query with multiple addresses returns results for each
+     *
+     * @given we have multiple Cardano reward addresses
+     * @when we query dustGenerations with all of them
+     * @then Indexer should return generations for each address
+     */
+    test('should return dust generations for multiple addresses', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'Generations', 'MultipleAddresses'],
+      };
+
+      let registeredAddress: string;
+      let nonRegisteredAddress: string;
+      try {
+        registeredAddress = dataProvider.getCardanoRewardAddress('registered-with-dust');
+        nonRegisteredAddress = dataProvider.getCardanoRewardAddress('non-registered');
+      } catch (error) {
+        log.warn(error);
+        ctx.skip();
+        return;
+      }
+
+      log.debug('Querying dustGenerations for multiple addresses');
+      const response = await indexerHttpClient.getDustGenerations([
+        registeredAddress,
+        nonRegisteredAddress,
+      ]);
+
+      expect(response).toBeSuccess();
+      const generations = response.data!.dustGenerations;
+      expect(generations).toHaveLength(2);
+
+      const registeredResult = generations.find(
+        (g) => g.cardanoRewardAddress === registeredAddress,
+      );
+      const nonRegisteredResult = generations.find(
+        (g) => g.cardanoRewardAddress === nonRegisteredAddress,
+      );
+
+      expect(registeredResult).toBeDefined();
+      expect(registeredResult!.registrations.length).toBeGreaterThanOrEqual(1);
+
+      expect(nonRegisteredResult).toBeDefined();
+      expect(nonRegisteredResult!.registrations).toHaveLength(0);
+    });
+  });
+
+  describe('a dust generations query with non-registered address', () => {
+    /**
+     * A dust generations query for a non-registered address returns empty registrations
+     *
+     * @given we have a valid Cardano reward address that is not registered
+     * @when we query dustGenerations with that address
+     * @then Indexer should return the address with an empty registrations array
+     */
+    test('should return empty registrations for a non-registered address', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'Generations', 'NonRegistered'],
+      };
+
+      const rewardAddress = generateRewardAddress(0);
+
+      log.debug(`Querying dustGenerations for non-registered address: ${rewardAddress}`);
+      const response = await indexerHttpClient.getDustGenerations([rewardAddress]);
+
+      expect(response).toBeSuccess();
+      const generations = response.data!.dustGenerations;
+      expect(generations).toHaveLength(1);
+      expect(generations[0].cardanoRewardAddress).toBe(rewardAddress);
+      expect(generations[0].registrations).toHaveLength(0);
+    });
+  });
+
+  describe('a dust generations query with invalid input', () => {
+    /**
+     * A dust generations query with an empty addresses array should return an error
+     *
+     * @given we provide an empty array of addresses
+     * @when we query dustGenerations
+     * @then Indexer should respond with an error
+     */
+    test('should return an error for an empty addresses array', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'Generations', 'Negative'],
+      };
+
+      log.debug('Querying dustGenerations with empty array');
+      const response = await indexerHttpClient.getDustGenerations([]);
+
+      expect(response).toBeError();
+    });
+
+    /**
+     * A dust generations query with a malformed address should return an error
+     *
+     * @given we provide a plain hex string instead of a bech32 reward address
+     * @when we query dustGenerations
+     * @then Indexer should respond with an error
+     */
+    test('should return an error for a malformed address', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'Generations', 'Negative'],
+      };
+
+      log.debug('Querying dustGenerations with malformed address');
+      const response = await indexerHttpClient.getDustGenerations(['not_a_valid_address']);
+
+      expect(response).toBeError();
+    });
+  });
+
+  describe('backwards compatibility with dustGenerationStatus', () => {
+    /**
+     * The existing dustGenerationStatus query should still work alongside dustGenerations
+     *
+     * @given we have a valid registered reward address
+     * @when we query both dustGenerationStatus and dustGenerations
+     * @then both should return consistent data for the same address
+     */
+    test('should return consistent data from both endpoints for a registered address', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'Generations', 'BackwardsCompatibility'],
+      };
+
+      let rewardAddress: string;
+      try {
+        rewardAddress = dataProvider.getCardanoRewardAddress('registered-with-dust');
+      } catch (error) {
+        log.warn(error);
+        ctx.skip();
+        return;
+      }
+
+      log.debug(`Querying both endpoints for address: ${rewardAddress}`);
+      const [statusResponse, generationsResponse] = await Promise.all([
+        indexerHttpClient.getDustGenerationStatus([rewardAddress]),
+        indexerHttpClient.getDustGenerations([rewardAddress]),
+      ]);
+
+      expect(statusResponse).toBeSuccess();
+      expect(generationsResponse).toBeSuccess();
+
+      const status = statusResponse.data!.dustGenerationStatus[0];
+      const generations = generationsResponse.data!.dustGenerations[0];
+
+      // Both should reference the same reward address
+      expect(status.cardanoRewardAddress).toBe(generations.cardanoRewardAddress);
+
+      // dustGenerations should have at least one registration if dustGenerationStatus shows registered
+      if (status.registered) {
+        expect(generations.registrations.length).toBeGreaterThanOrEqual(1);
+      }
+    });
+  });
+});

--- a/qa/tests/tests/integration/basic/queries/dust-generations-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/dust-generations-queries.test.ts
@@ -21,7 +21,7 @@ import type { TestContext } from 'vitest';
 import '@utils/logging/test-logging-hooks';
 import dataProvider from '@utils/testdata-provider';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
-import { DustGenerationsSchema, DustGenerationStatusSchema } from '@utils/indexer/graphql/schema';
+import { DustGenerationsSchema } from '@utils/indexer/graphql/schema';
 
 type AcceptedRewardAddressHrpPrefix = 'stake' | 'stake_test';
 
@@ -231,21 +231,23 @@ describe('dust generations queries', () => {
 
   describe('a dust generations query with invalid input', () => {
     /**
-     * A dust generations query with an empty addresses array should return an error
+     * A dust generations query with an empty addresses array should return an empty result
      *
      * @given we provide an empty array of addresses
      * @when we query dustGenerations
-     * @then Indexer should respond with an error
+     * @then Indexer should respond with an empty dustGenerations array
      */
-    test('should return an error for an empty addresses array', async (ctx: TestContext) => {
+    test('should return an empty result for an empty addresses array', async (ctx: TestContext) => {
       ctx.task!.meta.custom = {
-        labels: ['Query', 'Dust', 'Generations', 'Negative'],
+        labels: ['Query', 'Dust', 'Generations'],
       };
 
       log.debug('Querying dustGenerations with empty array');
       const response = await indexerHttpClient.getDustGenerations([]);
 
-      expect(response).toBeError();
+      expect(response).toBeSuccess();
+      expect(response.data?.dustGenerations).toBeDefined();
+      expect(response.data?.dustGenerations).toHaveLength(0);
     });
 
     /**

--- a/qa/tests/tests/integration/basic/subscriptions/block-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/block-subscriptions.test.ts
@@ -37,7 +37,7 @@ describe('block subscriptions', () => {
     indexerWsClient = new IndexerWsClient();
     eventCoordinator = new EventCoordinator();
     await indexerWsClient.connectionInit();
-  });
+  }, 30_000);
 
   afterEach(async () => {
     await indexerWsClient.connectionClose();

--- a/qa/tests/tests/integration/basic/subscriptions/contract-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/contract-subscriptions.test.ts
@@ -36,7 +36,7 @@ describe('contract action subscriptions', () => {
     indexerWsClient = new IndexerWsClient();
     eventCoordinator = new EventCoordinator();
     await indexerWsClient.connectionInit();
-  });
+  }, 30_000);
 
   afterEach(async () => {
     await indexerWsClient.connectionClose();

--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -31,7 +31,7 @@ describe('dust generations subscription', () => {
   beforeEach(async () => {
     indexerWsClient = new IndexerWsClient();
     await indexerWsClient.connectionInit();
-  });
+  }, 30_000);
 
   afterEach(async () => {
     await indexerWsClient.connectionClose();
@@ -84,7 +84,9 @@ describe('dust generations subscription', () => {
           {
             next: (payload) => {
               received.push(payload);
-              log.debug(`Received dust generations event ${received.length}: ${JSON.stringify(payload.data?.dustGenerations?.__typename)}`);
+              log.debug(
+                `Received dust generations event ${received.length}: ${JSON.stringify(payload.data?.dustGenerations?.__typename)}`,
+              );
 
               // Stop after receiving a progress event (indicates completion)
               if (payload.data?.dustGenerations?.__typename === 'DustGenerationsProgress') {

--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -1,0 +1,175 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import log from '@utils/logging/logger';
+import '@utils/logging/test-logging-hooks';
+import {
+  IndexerWsClient,
+  DustGenerationsSubscriptionResponse,
+} from '@utils/indexer/websocket-client';
+import { DustGenerationsEventSchema } from '@utils/indexer/graphql/schema';
+import { IndexerHttpClient } from '@utils/indexer/http-client';
+import dataProvider from '@utils/testdata-provider';
+
+const indexerHttpClient = new IndexerHttpClient();
+
+describe('dust generations subscription', () => {
+  let indexerWsClient: IndexerWsClient;
+
+  beforeEach(async () => {
+    indexerWsClient = new IndexerWsClient();
+    await indexerWsClient.connectionInit();
+  });
+
+  afterEach(async () => {
+    await indexerWsClient.connectionClose();
+  });
+
+  describe('streaming dust generation entries', () => {
+    /**
+     * A dust generations subscription streams items and ends with a progress event
+     *
+     * @given a registered dust address and a valid index range
+     * @when we subscribe to dustGenerations
+     * @then we should receive DustGenerationsItem and/or DustGenerationsProgress events
+     * @and each event should match the expected schema
+     */
+    test('should stream dust generation events for a valid dust address', async () => {
+      let rewardAddress: string;
+      try {
+        rewardAddress = dataProvider.getCardanoRewardAddress('registered-with-dust');
+      } catch (error) {
+        log.warn(error);
+        return;
+      }
+
+      // Get the dust address from the generations query
+      const generationsResponse = await indexerHttpClient.getDustGenerations([rewardAddress]);
+      expect(generationsResponse).toBeSuccess();
+
+      const generations = generationsResponse.data!.dustGenerations;
+      expect(generations.length).toBeGreaterThanOrEqual(1);
+      expect(generations[0].registrations.length).toBeGreaterThanOrEqual(1);
+
+      const dustAddress = generations[0].registrations[0].dustAddress;
+      log.debug(`Using dust address: ${dustAddress}`);
+
+      // Subscribe with a small range starting from 0
+      const received: DustGenerationsSubscriptionResponse[] = [];
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          subscription.unsubscribe();
+          // It's OK if we received some events before timeout
+          if (received.length > 0) {
+            resolve();
+          } else {
+            reject(new Error('Timed out waiting for dust generations events'));
+          }
+        }, 15_000);
+
+        const subscription = indexerWsClient.subscribeToDustGenerations(
+          {
+            next: (payload) => {
+              received.push(payload);
+              log.debug(`Received dust generations event ${received.length}: ${JSON.stringify(payload.data?.dustGenerations?.__typename)}`);
+
+              // Stop after receiving a progress event (indicates completion)
+              if (payload.data?.dustGenerations?.__typename === 'DustGenerationsProgress') {
+                clearTimeout(timeout);
+                subscription.unsubscribe();
+                resolve();
+              }
+            },
+            error: (error) => {
+              clearTimeout(timeout);
+              subscription.unsubscribe();
+              reject(new Error(`Subscription error: ${JSON.stringify(error)}`));
+            },
+            complete: () => {
+              clearTimeout(timeout);
+              resolve();
+            },
+          },
+          dustAddress,
+          0,
+          10,
+        );
+      });
+
+      expect(received.length).toBeGreaterThan(0);
+
+      // Validate each event against the schema
+      for (const msg of received) {
+        expect(msg).toBeSuccess();
+        const event = msg.data!.dustGenerations;
+        const parsed = DustGenerationsEventSchema.safeParse(event);
+        expect(
+          parsed.success,
+          `Dust generations event schema validation failed: ${JSON.stringify(parsed.error, null, 2)}`,
+        ).toBe(true);
+      }
+
+      // The last event should be a DustGenerationsProgress
+      const lastEvent = received[received.length - 1].data!.dustGenerations;
+      expect(lastEvent.__typename).toBe('DustGenerationsProgress');
+    });
+  });
+
+  describe('subscription error handling', () => {
+    /**
+     * A dust generations subscription with an invalid dust address should return an error
+     *
+     * @given an invalid hex-encoded dust address
+     * @when we subscribe to dustGenerations
+     * @then the subscription should return an error
+     */
+    test('should return an error for an invalid dust address', async () => {
+      const errorReceived = await new Promise<string>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          subscription.unsubscribe();
+          reject(new Error('Timed out waiting for error'));
+        }, 10_000);
+
+        const subscription = indexerWsClient.subscribeToDustGenerations(
+          {
+            next: (payload) => {
+              if (payload.errors && payload.errors.length > 0) {
+                clearTimeout(timeout);
+                subscription.unsubscribe();
+                resolve(payload.errors[0].message);
+              }
+            },
+            error: (error) => {
+              clearTimeout(timeout);
+              subscription.unsubscribe();
+              resolve(typeof error === 'string' ? error : JSON.stringify(error));
+            },
+            complete: () => {
+              clearTimeout(timeout);
+              reject(new Error('Subscription completed without error'));
+            },
+          },
+          'invalid_hex',
+          0,
+          10,
+        );
+      });
+
+      expect(errorReceived).toBeDefined();
+      log.debug(`Received expected error: ${errorReceived}`);
+    });
+  });
+});

--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 import log from '@utils/logging/logger';
+import { bech32m } from 'bech32';
+import { Buffer } from 'node:buffer';
 import '@utils/logging/test-logging-hooks';
 import {
   IndexerWsClient,
@@ -24,6 +26,20 @@ import { IndexerHttpClient } from '@utils/indexer/http-client';
 import dataProvider from '@utils/testdata-provider';
 
 const indexerHttpClient = new IndexerHttpClient();
+
+function encodeDustAddressAsHex(dustAddress: string): string {
+  const { words } = bech32m.decode(dustAddress);
+  return Buffer.from(bech32m.fromWords(words)).toString('hex');
+}
+
+function safeUnsubscribe(unsubscribe: () => void): void {
+  try {
+    unsubscribe();
+  } catch (error) {
+    // If the websocket is already closed during teardown, unsubscribe can throw.
+    log.debug(`Ignoring unsubscribe error during teardown: ${String(error)}`);
+  }
+}
 
 describe('dust generations subscription', () => {
   let indexerWsClient: IndexerWsClient;
@@ -41,7 +57,7 @@ describe('dust generations subscription', () => {
     /**
      * A dust generations subscription streams items and ends with a progress event
      *
-     * @given a registered dust address and a valid index range
+     * @given a registered dust address in bech32m format (mn_dust...) and a valid index range
      * @when we subscribe to dustGenerations
      * @then we should receive DustGenerationsItem and/or DustGenerationsProgress events
      * @and each event should match the expected schema
@@ -64,21 +80,31 @@ describe('dust generations subscription', () => {
       expect(generations[0].registrations.length).toBeGreaterThanOrEqual(1);
 
       const dustAddress = generations[0].registrations[0].dustAddress;
-      log.debug(`Using dust address: ${dustAddress}`);
+      const dustAddressHex = encodeDustAddressAsHex(dustAddress);
+      log.debug(`Using dust address (bech32m): ${dustAddress}`);
+      log.debug(`Using dust address (hex): ${dustAddressHex}`);
 
       // Subscribe with a small range starting from 0
       const received: DustGenerationsSubscriptionResponse[] = [];
 
       await new Promise<void>((resolve, reject) => {
+        let settled = false;
+        let unsubscribe = () => {};
+        const settle = (handler: () => void) => {
+          if (settled) return;
+          settled = true;
+          handler();
+        };
+
         const timeout = setTimeout(() => {
-          subscription.unsubscribe();
+          safeUnsubscribe(unsubscribe);
           // It's OK if we received some events before timeout
           if (received.length > 0) {
-            resolve();
+            settle(resolve);
           } else {
-            reject(new Error('Timed out waiting for dust generations events'));
+            settle(() => reject(new Error('Timed out waiting for dust generations events')));
           }
-        }, 15_000);
+        }, 12_000);
 
         const subscription = indexerWsClient.subscribeToDustGenerations(
           {
@@ -91,24 +117,25 @@ describe('dust generations subscription', () => {
               // Stop after receiving a progress event (indicates completion)
               if (payload.data?.dustGenerations?.__typename === 'DustGenerationsProgress') {
                 clearTimeout(timeout);
-                subscription.unsubscribe();
-                resolve();
+                safeUnsubscribe(unsubscribe);
+                settle(resolve);
               }
             },
             error: (error) => {
               clearTimeout(timeout);
-              subscription.unsubscribe();
-              reject(new Error(`Subscription error: ${JSON.stringify(error)}`));
+              safeUnsubscribe(unsubscribe);
+              settle(() => reject(new Error(`Subscription error: ${JSON.stringify(error)}`)));
             },
             complete: () => {
               clearTimeout(timeout);
-              resolve();
+              settle(resolve);
             },
           },
-          dustAddress,
+          dustAddressHex,
           0,
           10,
         );
+        unsubscribe = subscription.unsubscribe;
       });
 
       expect(received.length).toBeGreaterThan(0);
@@ -127,7 +154,7 @@ describe('dust generations subscription', () => {
       // The last event should be a DustGenerationsProgress
       const lastEvent = received[received.length - 1].data!.dustGenerations;
       expect(lastEvent.__typename).toBe('DustGenerationsProgress');
-    });
+    }, 30_000);
   });
 
   describe('subscription error handling', () => {
@@ -140,8 +167,9 @@ describe('dust generations subscription', () => {
      */
     test('should return an error for an invalid dust address', async () => {
       const errorReceived = await new Promise<string>((resolve, reject) => {
+        let unsubscribe = () => {};
         const timeout = setTimeout(() => {
-          subscription.unsubscribe();
+          safeUnsubscribe(unsubscribe);
           reject(new Error('Timed out waiting for error'));
         }, 10_000);
 
@@ -150,13 +178,13 @@ describe('dust generations subscription', () => {
             next: (payload) => {
               if (payload.errors && payload.errors.length > 0) {
                 clearTimeout(timeout);
-                subscription.unsubscribe();
+                safeUnsubscribe(unsubscribe);
                 resolve(payload.errors[0].message);
               }
             },
             error: (error) => {
               clearTimeout(timeout);
-              subscription.unsubscribe();
+              safeUnsubscribe(unsubscribe);
               resolve(typeof error === 'string' ? error : JSON.stringify(error));
             },
             complete: () => {
@@ -168,6 +196,7 @@ describe('dust generations subscription', () => {
           0,
           10,
         );
+        unsubscribe = subscription.unsubscribe;
       });
 
       expect(errorReceived).toBeDefined();

--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -23,6 +23,7 @@ import {
 } from '@utils/indexer/websocket-client';
 import { DustGenerationsEventSchema } from '@utils/indexer/graphql/schema';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
+import { env } from 'environment/model';
 import dataProvider from '@utils/testdata-provider';
 
 const indexerHttpClient = new IndexerHttpClient();
@@ -30,6 +31,12 @@ const indexerHttpClient = new IndexerHttpClient();
 function encodeDustAddressAsHex(dustAddress: string): string {
   const { words } = bech32m.decode(dustAddress);
   return Buffer.from(bech32m.fromWords(words)).toString('hex');
+}
+
+function generateDustAddressForNetworkId(networkId: string): string {
+  const hrp = networkId === 'mainnet' ? 'mn_dust' : `mn_dust_${networkId}`;
+  const payload = Buffer.alloc(32, 1);
+  return bech32m.encode(hrp, bech32m.toWords(payload));
 }
 
 function safeUnsubscribe(unsubscribe: () => void): void {
@@ -62,7 +69,7 @@ describe('dust generations subscription', () => {
      * @then we should receive DustGenerationsItem and/or DustGenerationsProgress events
      * @and each event should match the expected schema
      */
-    test('should stream dust generation events for a valid dust address', async () => {
+    test('should stream dust generation events for a valid dust address in bech32m format', async () => {
       let rewardAddress: string;
       try {
         rewardAddress = dataProvider.getCardanoRewardAddress('registered-with-dust');
@@ -80,9 +87,7 @@ describe('dust generations subscription', () => {
       expect(generations[0].registrations.length).toBeGreaterThanOrEqual(1);
 
       const dustAddress = generations[0].registrations[0].dustAddress;
-      const dustAddressHex = encodeDustAddressAsHex(dustAddress);
       log.debug(`Using dust address (bech32m): ${dustAddress}`);
-      log.debug(`Using dust address (hex): ${dustAddressHex}`);
 
       // Subscribe with a small range starting from 0
       const received: DustGenerationsSubscriptionResponse[] = [];
@@ -131,7 +136,7 @@ describe('dust generations subscription', () => {
               settle(resolve);
             },
           },
-          dustAddressHex,
+          dustAddress,
           0,
           10,
         );
@@ -192,7 +197,7 @@ describe('dust generations subscription', () => {
               reject(new Error('Subscription completed without error'));
             },
           },
-          'invalid_hex',
+          'invalid_address',
           0,
           10,
         );
@@ -201,6 +206,153 @@ describe('dust generations subscription', () => {
 
       expect(errorReceived).toBeDefined();
       log.debug(`Received expected error: ${errorReceived}`);
+    });
+
+    /**
+     * A dust generations subscription with a valid bech32m dust address from another network should return an error
+     *
+     * @given valid bech32m dust addresses for all network IDs other than the target one
+     * @when we subscribe to dustGenerations
+     * @then Indexer should return an error related to unexpected/wrong HRP prefix
+     */
+    test('should return an error for a valid address that is meant for another networkid', async () => {
+      const targetNetworkId = env.getNetworkId().toLowerCase();
+      const networkIds = env.getAllEnvironmentNames();
+
+      for (const networkId of networkIds) {
+        if (networkId.toLowerCase() === targetNetworkId) {
+          continue;
+        }
+
+        const foreignDustAddress = generateDustAddressForNetworkId(networkId);
+        log.debug(`Testing foreign dust address for networkId=${networkId}: ${foreignDustAddress}`);
+
+        const result = await new Promise<{
+          error: string | null;
+          completed: boolean;
+          timedOut: boolean;
+        }>((resolve) => {
+          let settled = false;
+          let unsubscribe = () => {};
+          const settle = (value: {
+            error: string | null;
+            completed: boolean;
+            timedOut: boolean;
+          }) => {
+            if (settled) return;
+            settled = true;
+            resolve(value);
+          };
+
+          const timeout = setTimeout(() => {
+            safeUnsubscribe(unsubscribe);
+            settle({ error: null, completed: false, timedOut: true });
+          }, 10_000);
+
+          const subscription = indexerWsClient.subscribeToDustGenerations(
+            {
+              next: (payload) => {
+                if (payload.errors && payload.errors.length > 0) {
+                  clearTimeout(timeout);
+                  safeUnsubscribe(unsubscribe);
+                  settle({
+                    error: payload.errors[0].message,
+                    completed: false,
+                    timedOut: false,
+                  });
+                }
+              },
+              error: (error) => {
+                clearTimeout(timeout);
+                safeUnsubscribe(unsubscribe);
+                settle({
+                  error: typeof error === 'string' ? error : JSON.stringify(error),
+                  completed: false,
+                  timedOut: false,
+                });
+              },
+              complete: () => {
+                clearTimeout(timeout);
+                settle({ error: null, completed: true, timedOut: false });
+              },
+            },
+            foreignDustAddress,
+            0,
+            10,
+          );
+          unsubscribe = subscription.unsubscribe;
+        });
+
+        expect
+          .soft(result.timedOut, `networkId=${networkId} timed out waiting for error`)
+          .toBe(false);
+        expect
+          .soft(
+            result.completed,
+            `networkId=${networkId} subscription completed without emitting an error`,
+          )
+          .toBe(false);
+        expect.soft(result.error, `networkId=${networkId} should emit an error`).toBeTruthy();
+        if (result.error) {
+          expect
+            .soft(
+              result.error.toLowerCase(),
+              `networkId=${networkId} error should mention wrong HRP`,
+            )
+            .toMatch(/(expected hrp|unexpected hrp|wrong hrp|invalid.*network|network id)/);
+        }
+      }
+    });
+
+    /**
+     * A dust generations subscription with a hex-encoded address should return an error.
+     *
+     * @given a valid bech32m dust address converted to hex format
+     * @when we subscribe to dustGenerations using hex format
+     * @then Indexer should return an error indicating the expected bech32m/HRP format
+     */
+    test('should return an error for a valid dust address passed in hex format', async () => {
+      const targetNetworkId = env.getNetworkId().toLowerCase();
+      const bech32DustAddress = generateDustAddressForNetworkId(targetNetworkId);
+      const hexDustAddress = encodeDustAddressAsHex(bech32DustAddress);
+
+      const errorReceived = await new Promise<string>((resolve, reject) => {
+        let unsubscribe = () => {};
+        const timeout = setTimeout(() => {
+          safeUnsubscribe(unsubscribe);
+          reject(new Error('Timed out waiting for error for hex dust address'));
+        }, 10_000);
+
+        const subscription = indexerWsClient.subscribeToDustGenerations(
+          {
+            next: (payload) => {
+              if (payload.errors && payload.errors.length > 0) {
+                clearTimeout(timeout);
+                safeUnsubscribe(unsubscribe);
+                resolve(payload.errors[0].message);
+              }
+            },
+            error: (error) => {
+              clearTimeout(timeout);
+              safeUnsubscribe(unsubscribe);
+              resolve(typeof error === 'string' ? error : JSON.stringify(error));
+            },
+            complete: () => {
+              clearTimeout(timeout);
+              reject(new Error('Subscription completed without error for hex dust address'));
+            },
+          },
+          hexDustAddress,
+          0,
+          10,
+        );
+        unsubscribe = subscription.unsubscribe;
+      });
+
+      expect(errorReceived).toBeDefined();
+      expect(errorReceived.toLowerCase()).toMatch(
+        /(expected hrp|unexpected hrp|wrong hrp|bech32|invalid.*address)/,
+      );
     });
   });
 });

--- a/qa/tests/tests/integration/basic/subscriptions/dust-ledger-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-ledger-subscriptions.test.ts
@@ -30,7 +30,7 @@ describe('dust ledger event subscriptions', () => {
     indexerWsClient = new IndexerWsClient();
     eventCoordinator = new EventCoordinator();
     await indexerWsClient.connectionInit();
-  });
+  }, 30_000);
 
   afterEach(async () => {
     await indexerWsClient.connectionClose();

--- a/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
@@ -1,0 +1,198 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import log from '@utils/logging/logger';
+import '@utils/logging/test-logging-hooks';
+import {
+  IndexerWsClient,
+  DustNullifierTransactionSubscriptionResponse,
+} from '@utils/indexer/websocket-client';
+import { DustNullifierTransactionSchema } from '@utils/indexer/graphql/schema';
+import { IndexerHttpClient } from '@utils/indexer/http-client';
+
+const indexerHttpClient = new IndexerHttpClient();
+
+describe('dust nullifier transactions subscription', () => {
+  let indexerWsClient: IndexerWsClient;
+
+  beforeEach(async () => {
+    indexerWsClient = new IndexerWsClient();
+    await indexerWsClient.connectionInit();
+  });
+
+  afterEach(async () => {
+    await indexerWsClient.connectionClose();
+  });
+
+  describe('streaming dust nullifier transactions with block range', () => {
+    /**
+     * A dust nullifier transactions subscription with a bounded block range
+     * should stream matching transactions and complete
+     *
+     * @given a set of nullifier prefixes and a block range
+     * @when we subscribe to dustNullifierTransactions
+     * @then we should receive matching transactions (if any) and the subscription should complete
+     * @and each transaction should match the expected schema
+     */
+    test('should stream transactions within a block range and complete', async () => {
+      // Get the latest block height to define a bounded range
+      const blockResponse = await indexerHttpClient.getLatestBlock();
+      expect(blockResponse).toBeSuccess();
+      const latestHeight = blockResponse.data!.block.height;
+
+      // Use a broad prefix to increase chance of matches, bounded to first 10 blocks
+      const toBlock = Math.min(latestHeight, 10);
+      const nullifierPrefixes = ['00'];
+
+      log.debug(`Subscribing to dust nullifier transactions with prefixes=${nullifierPrefixes}, fromBlock=0, toBlock=${toBlock}`);
+
+      const received: DustNullifierTransactionSubscriptionResponse[] = [];
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          subscription.unsubscribe();
+          // It's OK if no matches were found in the range — subscription should still complete
+          resolve();
+        }, 15_000);
+
+        const subscription = indexerWsClient.subscribeToDustNullifierTransactions(
+          {
+            next: (payload) => {
+              received.push(payload);
+              log.debug(`Received dust nullifier transaction: ${JSON.stringify(payload.data?.dustNullifierTransactions)}`);
+            },
+            error: (error) => {
+              clearTimeout(timeout);
+              subscription.unsubscribe();
+              reject(new Error(`Subscription error: ${JSON.stringify(error)}`));
+            },
+            complete: () => {
+              clearTimeout(timeout);
+              resolve();
+            },
+          },
+          nullifierPrefixes,
+          0,
+          toBlock,
+        );
+      });
+
+      log.debug(`Received ${received.length} dust nullifier transactions`);
+
+      // Validate each received transaction against the schema
+      for (const msg of received) {
+        expect(msg).toBeSuccess();
+        const tx = msg.data!.dustNullifierTransactions;
+        const parsed = DustNullifierTransactionSchema.safeParse(tx);
+        expect(
+          parsed.success,
+          `Dust nullifier transaction schema validation failed: ${JSON.stringify(parsed.error, null, 2)}`,
+        ).toBe(true);
+
+        // Block height should be within the requested range
+        expect(tx.blockHeight).toBeGreaterThanOrEqual(0);
+        expect(tx.blockHeight).toBeLessThanOrEqual(toBlock);
+      }
+    });
+  });
+
+  describe('subscription error handling', () => {
+    /**
+     * A dust nullifier transactions subscription with an empty prefixes array should return an error
+     *
+     * @given an empty array of nullifier prefixes
+     * @when we subscribe to dustNullifierTransactions
+     * @then the subscription should return an error
+     */
+    test('should return an error for empty nullifier prefixes', async () => {
+      const errorReceived = await new Promise<string>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          subscription.unsubscribe();
+          reject(new Error('Timed out waiting for error'));
+        }, 10_000);
+
+        const subscription = indexerWsClient.subscribeToDustNullifierTransactions(
+          {
+            next: (payload) => {
+              if (payload.errors && payload.errors.length > 0) {
+                clearTimeout(timeout);
+                subscription.unsubscribe();
+                resolve(payload.errors[0].message);
+              }
+            },
+            error: (error) => {
+              clearTimeout(timeout);
+              subscription.unsubscribe();
+              resolve(typeof error === 'string' ? error : JSON.stringify(error));
+            },
+            complete: () => {
+              clearTimeout(timeout);
+              reject(new Error('Subscription completed without error'));
+            },
+          },
+          [],
+          0,
+          10,
+        );
+      });
+
+      expect(errorReceived).toBeDefined();
+      log.debug(`Received expected error: ${errorReceived}`);
+    });
+
+    /**
+     * A dust nullifier transactions subscription with invalid block range should return an error
+     *
+     * @given fromBlock > toBlock
+     * @when we subscribe to dustNullifierTransactions
+     * @then the subscription should return an error
+     */
+    test('should return an error when fromBlock is greater than toBlock', async () => {
+      const errorReceived = await new Promise<string>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          subscription.unsubscribe();
+          reject(new Error('Timed out waiting for error'));
+        }, 10_000);
+
+        const subscription = indexerWsClient.subscribeToDustNullifierTransactions(
+          {
+            next: (payload) => {
+              if (payload.errors && payload.errors.length > 0) {
+                clearTimeout(timeout);
+                subscription.unsubscribe();
+                resolve(payload.errors[0].message);
+              }
+            },
+            error: (error) => {
+              clearTimeout(timeout);
+              subscription.unsubscribe();
+              resolve(typeof error === 'string' ? error : JSON.stringify(error));
+            },
+            complete: () => {
+              clearTimeout(timeout);
+              reject(new Error('Subscription completed without error'));
+            },
+          },
+          ['00'],
+          10,
+          5,
+        );
+      });
+
+      expect(errorReceived).toBeDefined();
+      log.debug(`Received expected error: ${errorReceived}`);
+    });
+  });
+});

--- a/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
@@ -114,79 +114,107 @@ describe('dust nullifier transactions subscription', () => {
 
   describe('subscription error handling', () => {
     /**
-     * A dust nullifier transactions subscription with an empty prefixes array should return an error
+     * A dust nullifier transactions subscription with an empty prefixes array should stay quiet
      *
      * @given an empty array of nullifier prefixes
      * @when we subscribe to dustNullifierTransactions
-     * @then the subscription should return an error
+     * @then the subscription should stay open without data or errors
      */
-    test('should return an error for empty nullifier prefixes', async () => {
-      const errorReceived = await new Promise<string>((resolve, reject) => {
+    test('should stay open without events for empty nullifier prefixes', async () => {
+      const settled = await new Promise<{
+        completed: boolean;
+        error: string | null;
+        eventCount: number;
+      }>((resolve) => {
+        let eventCount = 0;
         const timeout = setTimeout(() => {
           subscription.unsubscribe();
-          reject(new Error('Timed out waiting for error'));
-        }, 10_000);
+          resolve({ completed: false, error: null, eventCount });
+        }, 8_000);
 
         const subscription = indexerWsClient.subscribeToDustNullifierTransactions(
           {
             next: (payload) => {
+              eventCount++;
               if (payload.errors && payload.errors.length > 0) {
                 clearTimeout(timeout);
                 subscription.unsubscribe();
-                resolve(payload.errors[0].message);
+                resolve({
+                  completed: false,
+                  error: payload.errors[0].message,
+                  eventCount,
+                });
               }
             },
             error: (error) => {
               clearTimeout(timeout);
               subscription.unsubscribe();
-              resolve(typeof error === 'string' ? error : JSON.stringify(error));
+              resolve({
+                completed: false,
+                error: typeof error === 'string' ? error : JSON.stringify(error),
+                eventCount,
+              });
             },
             complete: () => {
               clearTimeout(timeout);
-              reject(new Error('Subscription completed without error'));
+              resolve({ completed: true, error: null, eventCount });
             },
           },
           [],
           0,
-          10,
         );
       });
 
-      expect(errorReceived).toBeDefined();
-      log.debug(`Received expected error: ${errorReceived}`);
+      expect(settled.error).toBeNull();
+      expect(settled.completed).toBe(false);
+      expect(settled.eventCount).toBe(0);
     });
 
     /**
-     * A dust nullifier transactions subscription with invalid block range should return an error
+     * A dust nullifier transactions subscription with invalid block range should complete cleanly
      *
      * @given fromBlock > toBlock
      * @when we subscribe to dustNullifierTransactions
-     * @then the subscription should return an error
+     * @then the subscription should complete without events or errors
      */
-    test('should return an error when fromBlock is greater than toBlock', async () => {
-      const errorReceived = await new Promise<string>((resolve, reject) => {
+    test('should complete when fromBlock is greater than toBlock', async () => {
+      const settled = await new Promise<{
+        completed: boolean;
+        error: string | null;
+        eventCount: number;
+      }>((resolve, reject) => {
+        let eventCount = 0;
         const timeout = setTimeout(() => {
           subscription.unsubscribe();
-          reject(new Error('Timed out waiting for error'));
+          reject(new Error('Timed out waiting for completion'));
         }, 10_000);
 
         const subscription = indexerWsClient.subscribeToDustNullifierTransactions(
           {
             next: (payload) => {
+              eventCount++;
               if (payload.errors && payload.errors.length > 0) {
                 clearTimeout(timeout);
                 subscription.unsubscribe();
-                resolve(payload.errors[0].message);
+                resolve({
+                  completed: false,
+                  error: payload.errors[0].message,
+                  eventCount,
+                });
               }
             },
             error: (error) => {
               clearTimeout(timeout);
               subscription.unsubscribe();
-              resolve(typeof error === 'string' ? error : JSON.stringify(error));
+              resolve({
+                completed: false,
+                error: typeof error === 'string' ? error : JSON.stringify(error),
+                eventCount,
+              });
             },
             complete: () => {
               clearTimeout(timeout);
-              reject(new Error('Subscription completed without error'));
+              resolve({ completed: true, error: null, eventCount });
             },
           },
           ['00'],
@@ -195,8 +223,9 @@ describe('dust nullifier transactions subscription', () => {
         );
       });
 
-      expect(errorReceived).toBeDefined();
-      log.debug(`Received expected error: ${errorReceived}`);
+      expect(settled.error).toBeNull();
+      expect(settled.completed).toBe(true);
+      expect(settled.eventCount).toBe(0);
     });
   });
 });

--- a/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
@@ -114,13 +114,13 @@ describe('dust nullifier transactions subscription', () => {
 
   describe('subscription error handling', () => {
     /**
-     * A dust nullifier transactions subscription with an empty prefixes array should stay quiet
+     * A dust nullifier transactions subscription with an empty prefixes array should return an error
      *
      * @given an empty array of nullifier prefixes
      * @when we subscribe to dustNullifierTransactions
-     * @then the subscription should stay open without data or errors
+     * @then the subscription should return a client error about empty prefixes
      */
-    test('should stay open without events for empty nullifier prefixes', async () => {
+    test('should return an error for empty nullifier prefixes', async () => {
       const settled = await new Promise<{
         completed: boolean;
         error: string | null;
@@ -165,19 +165,19 @@ describe('dust nullifier transactions subscription', () => {
         );
       });
 
-      expect(settled.error).toBeNull();
+      expect(settled.error).toContain('nullifierPrefixes must not be empty');
       expect(settled.completed).toBe(false);
-      expect(settled.eventCount).toBe(0);
+      expect(settled.eventCount).toBeGreaterThanOrEqual(0);
     });
 
     /**
-     * A dust nullifier transactions subscription with invalid block range should complete cleanly
+     * A dust nullifier transactions subscription with invalid block range should return an error
      *
      * @given fromBlock > toBlock
      * @when we subscribe to dustNullifierTransactions
-     * @then the subscription should complete without events or errors
+     * @then the subscription should return a client error
      */
-    test('should complete when fromBlock is greater than toBlock', async () => {
+    test('should return an error when fromBlock is greater than toBlock', async () => {
       const settled = await new Promise<{
         completed: boolean;
         error: string | null;
@@ -223,9 +223,9 @@ describe('dust nullifier transactions subscription', () => {
         );
       });
 
-      expect(settled.error).toBeNull();
-      expect(settled.completed).toBe(true);
-      expect(settled.eventCount).toBe(0);
+      expect(settled.error).toContain('fromBlock must not exceed toBlock');
+      expect(settled.completed).toBe(false);
+      expect(settled.eventCount).toBeGreaterThanOrEqual(0);
     });
   });
 });

--- a/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
@@ -30,7 +30,7 @@ describe('dust nullifier transactions subscription', () => {
   beforeEach(async () => {
     indexerWsClient = new IndexerWsClient();
     await indexerWsClient.connectionInit();
-  });
+  }, 30_000);
 
   afterEach(async () => {
     await indexerWsClient.connectionClose();
@@ -56,7 +56,9 @@ describe('dust nullifier transactions subscription', () => {
       const toBlock = Math.min(latestHeight, 10);
       const nullifierPrefixes = ['00'];
 
-      log.debug(`Subscribing to dust nullifier transactions with prefixes=${nullifierPrefixes}, fromBlock=0, toBlock=${toBlock}`);
+      log.debug(
+        `Subscribing to dust nullifier transactions with prefixes=${nullifierPrefixes}, fromBlock=0, toBlock=${toBlock}`,
+      );
 
       const received: DustNullifierTransactionSubscriptionResponse[] = [];
 
@@ -71,7 +73,9 @@ describe('dust nullifier transactions subscription', () => {
           {
             next: (payload) => {
               received.push(payload);
-              log.debug(`Received dust nullifier transaction: ${JSON.stringify(payload.data?.dustNullifierTransactions)}`);
+              log.debug(
+                `Received dust nullifier transaction: ${JSON.stringify(payload.data?.dustNullifierTransactions)}`,
+              );
             },
             error: (error) => {
               clearTimeout(timeout);

--- a/qa/tests/tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts
@@ -60,7 +60,7 @@ describe('shielded transaction subscriptions', () => {
     // Initialise the indexer websocket client and connect to it
     indexerWsClient = new IndexerWsClient();
     await indexerWsClient.connectionInit();
-  });
+  }, 30_000);
 
   afterEach(async () => {
     // Close the indexer websocket client

--- a/qa/tests/tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts
@@ -338,7 +338,6 @@ describe('unshielded transaction subscriptions', async () => {
      */
     test('should return an error message, given the address provided is for another network', async () => {
       const currentEnvironment = env.getCurrentEnvironmentName();
-      const currentNetworkId = env.getNetworkId();
 
       for (const environment of env.getAllEnvironmentNames()) {
         if (environment === currentEnvironment) {

--- a/qa/tests/tests/integration/basic/subscriptions/zswap-events-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/zswap-events-subscriptions.test.ts
@@ -30,7 +30,7 @@ describe('zswap ledger event subscriptions', () => {
     indexerWsClient = new IndexerWsClient();
     eventCoordinator = new EventCoordinator();
     await indexerWsClient.connectionInit();
-  });
+  }, 30_000);
 
   afterEach(async () => {
     await indexerWsClient.connectionClose();

--- a/qa/tests/utils/indexer/graphql/block-queries.ts
+++ b/qa/tests/utils/indexer/graphql/block-queries.ts
@@ -35,6 +35,8 @@ query GetLatestBlock{
     author
     ledgerParameters
     zswapMerkleTreeRoot
+    dustCommitmentMerkleTreeRoot
+    dustGenerationMerkleTreeRoot
     parent {
         hash
         height
@@ -55,6 +57,8 @@ query GetBlock($OFFSET: BlockOffset!){
     author
     ledgerParameters
     zswapMerkleTreeRoot
+    dustCommitmentMerkleTreeRoot
+    dustGenerationMerkleTreeRoot
     parent {
       hash
       height

--- a/qa/tests/utils/indexer/graphql/dust-queries.ts
+++ b/qa/tests/utils/indexer/graphql/dust-queries.ts
@@ -31,3 +31,34 @@ query GetDustGenerationStatus($CARDANO_REWARD_ADDRESSES: [CardanoRewardAddress!]
     ${DUST_GENERATION_STATUS_BODY_FRAGMENT}
   }
 }`;
+
+export const DUST_REGISTRATION_BODY_FRAGMENT = `
+  dustAddress
+  valid
+  nightBalance
+  generationRate
+  currentCapacity
+  maxCapacity
+  utxoTxHash
+  utxoOutputIndex
+`;
+
+export const GET_DUST_GENERATIONS = `
+query GetDustGenerations($CARDANO_REWARD_ADDRESSES: [CardanoRewardAddress!]!) {
+  dustGenerations(cardanoRewardAddresses: $CARDANO_REWARD_ADDRESSES) {
+    cardanoRewardAddress
+    registrations {
+      ${DUST_REGISTRATION_BODY_FRAGMENT}
+    }
+  }
+}`;
+
+export const GET_DUST_COMMITMENT_MERKLE_TREE_UPDATE = `
+query GetDustCommitmentMerkleTreeUpdate($START_INDEX: Int!, $END_INDEX: Int!) {
+  dustCommitmentMerkleTreeUpdate(startIndex: $START_INDEX, endIndex: $END_INDEX) {
+    startIndex
+    endIndex
+    update
+    protocolVersion
+  }
+}`;

--- a/qa/tests/utils/indexer/graphql/schema.ts
+++ b/qa/tests/utils/indexer/graphql/schema.ts
@@ -269,11 +269,15 @@ const isCardanoRewardAddress = (value: string) => {
   }
 };
 
+const DustAddressBech32m = z.string().regex(/^mn_dust(_[a-z0-9]+)?1/, {
+  message: 'must be a bech32m DustAddress (mn_dust... / mn_dust_<network>...)',
+});
+
 export const DustGenerationStatusSchema = z.object({
   cardanoRewardAddress: z
     .string()
     .refine(isCardanoRewardAddress, { message: 'Invalid Cardano reward address format' }),
-  dustAddress: z.string().nullable(),
+  dustAddress: DustAddressBech32m.nullable(),
   registered: z.boolean(),
   nightBalance: z.string().regex(/^\d+$/),
   generationRate: z.string().regex(/^\d+$/),
@@ -341,7 +345,7 @@ export const ShieldedTransactionEventSchema = z.union([
 
 // Dust Generations schemas (PR #980)
 export const DustRegistrationSchema = z.object({
-  dustAddress: z.string(),
+  dustAddress: DustAddressBech32m,
   valid: z.boolean(),
   nightBalance: z.string().regex(/^\d+$/),
   generationRate: z.string().regex(/^\d+$/),

--- a/qa/tests/utils/indexer/graphql/schema.ts
+++ b/qa/tests/utils/indexer/graphql/schema.ts
@@ -367,10 +367,12 @@ export const CollapsedMerkleTreeSchema = z.object({
 
 export const DustGenerationsItemSchema = z.object({
   __typename: z.literal('DustGenerationsItem'),
-  merkleIndex: z.number(),
+  commitmentMtIndex: z.number(),
+  generationMtIndex: z.number(),
   owner: VarLenghtHex,
   value: z.string().regex(/^\d+$/),
-  nonce: VarLenghtHex,
+  initialValue: z.string().regex(/^\d+$/),
+  backingNight: VarLenghtHex,
   ctime: z.number(),
   transactionId: z.number(),
   collapsedMerkleTree: CollapsedMerkleTreeSchema.nullable(),

--- a/qa/tests/utils/indexer/graphql/schema.ts
+++ b/qa/tests/utils/indexer/graphql/schema.ts
@@ -396,4 +396,3 @@ export const DustNullifierTransactionSchema = z.object({
   blockHeight: z.number(),
   blockHash: Hash64,
 });
-

--- a/qa/tests/utils/indexer/graphql/schema.ts
+++ b/qa/tests/utils/indexer/graphql/schema.ts
@@ -39,6 +39,8 @@ export const BlockSchema = z.lazy(() =>
     author: z.string().optional(),
     ledgerParameters: z.string(),
     zswapMerkleTreeRoot: VarLenghtHex,
+    dustCommitmentMerkleTreeRoot: VarLenghtHex.nullable(),
+    dustGenerationMerkleTreeRoot: VarLenghtHex.nullable(),
     parent: PartialBlockSchema,
     transactions: z.array(FullTransactionSchema).min(0),
   }),
@@ -158,6 +160,10 @@ export const RegularTransactionSchema = z.lazy(() =>
     identifiers: z.array(z.string()),
     zswapStartIndex: z.number(),
     zswapEndIndex: z.number(),
+    dustCommitmentStartIndex: z.number(),
+    dustCommitmentEndIndex: z.number(),
+    dustGenerationStartIndex: z.number(),
+    dustGenerationEndIndex: z.number(),
     fees: z.object({
       paidFees: z.string(),
       estimatedFees: z.string(),
@@ -332,3 +338,60 @@ export const ShieldedTransactionEventSchema = z.union([
   RelevantTransactionSchema,
   ShieldedTransactionsProgressSchema,
 ]);
+
+// Dust Generations schemas (PR #980)
+export const DustRegistrationSchema = z.object({
+  dustAddress: z.string(),
+  valid: z.boolean(),
+  nightBalance: z.string().regex(/^\d+$/),
+  generationRate: z.string().regex(/^\d+$/),
+  maxCapacity: z.string().regex(/^\d+$/),
+  currentCapacity: z.string().regex(/^\d+$/),
+  utxoTxHash: z.string().nullable(),
+  utxoOutputIndex: z.number().int().nullable(),
+});
+
+export const DustGenerationsSchema = z.object({
+  cardanoRewardAddress: z
+    .string()
+    .refine(isCardanoRewardAddress, { message: 'Invalid Cardano reward address format' }),
+  registrations: z.array(DustRegistrationSchema),
+});
+
+export const CollapsedMerkleTreeSchema = z.object({
+  startIndex: z.number(),
+  endIndex: z.number(),
+  update: VarLenghtHex,
+  protocolVersion: z.number(),
+});
+
+export const DustGenerationsItemSchema = z.object({
+  __typename: z.literal('DustGenerationsItem'),
+  merkleIndex: z.number(),
+  owner: VarLenghtHex,
+  value: z.string().regex(/^\d+$/),
+  nonce: VarLenghtHex,
+  ctime: z.number(),
+  transactionId: z.number(),
+  collapsedMerkleTree: CollapsedMerkleTreeSchema.nullable(),
+});
+
+export const DustGenerationsProgressSchema = z.object({
+  __typename: z.literal('DustGenerationsProgress'),
+  highestIndex: z.number(),
+  collapsedMerkleTree: CollapsedMerkleTreeSchema.nullable(),
+});
+
+export const DustGenerationsEventSchema = z.discriminatedUnion('__typename', [
+  DustGenerationsItemSchema,
+  DustGenerationsProgressSchema,
+]);
+
+export const DustNullifierTransactionSchema = z.object({
+  nullifier: VarLenghtHex,
+  commitment: VarLenghtHex,
+  transactionId: z.number(),
+  blockHeight: z.number(),
+  blockHash: Hash64,
+});
+

--- a/qa/tests/utils/indexer/graphql/subscriptions.ts
+++ b/qa/tests/utils/indexer/graphql/subscriptions.ts
@@ -115,6 +115,8 @@ export const BLOCKS_SUBSCRIPTION_FROM_LATEST_BLOCK = `subscription BlocksSubscri
     protocolVersion
     ledgerParameters
     zswapMerkleTreeRoot
+    dustCommitmentMerkleTreeRoot
+    dustGenerationMerkleTreeRoot
     parent {
       hash
       height
@@ -147,6 +149,8 @@ export const BLOCKS_SUBSCRIPTION_FROM_BLOCK_BY_OFFSET = `subscription BlocksSubs
     protocolVersion
     ledgerParameters
     zswapMerkleTreeRoot
+    dustCommitmentMerkleTreeRoot
+    dustGenerationMerkleTreeRoot
     parent {
       hash
       height
@@ -333,6 +337,50 @@ export const ZSWAP_LEDGER_EVENTS_SUBSCRIPTION_FROM_ID = `
       raw
       maxId
       protocolVersion
+    }
+  }
+`;
+
+export const DUST_GENERATIONS_SUBSCRIPTION = `
+  subscription DustGenerations($dustAddress: HexEncoded!, $startIndex: Int!, $endIndex: Int!) {
+    dustGenerations(dustAddress: $dustAddress, startIndex: $startIndex, endIndex: $endIndex) {
+      ... on DustGenerationsItem {
+        __typename
+        merkleIndex
+        owner
+        value
+        nonce
+        ctime
+        transactionId
+        collapsedMerkleTree {
+          startIndex
+          endIndex
+          update
+          protocolVersion
+        }
+      }
+      ... on DustGenerationsProgress {
+        __typename
+        highestIndex
+        collapsedMerkleTree {
+          startIndex
+          endIndex
+          update
+          protocolVersion
+        }
+      }
+    }
+  }
+`;
+
+export const DUST_NULLIFIER_TRANSACTIONS_SUBSCRIPTION = `
+  subscription DustNullifierTransactions($nullifierPrefixes: [HexEncoded!]!, $fromBlock: Int, $toBlock: Int) {
+    dustNullifierTransactions(nullifierPrefixes: $nullifierPrefixes, fromBlock: $fromBlock, toBlock: $toBlock) {
+      nullifier
+      commitment
+      transactionId
+      blockHeight
+      blockHash
     }
   }
 `;

--- a/qa/tests/utils/indexer/graphql/subscriptions.ts
+++ b/qa/tests/utils/indexer/graphql/subscriptions.ts
@@ -342,7 +342,7 @@ export const ZSWAP_LEDGER_EVENTS_SUBSCRIPTION_FROM_ID = `
 `;
 
 export const DUST_GENERATIONS_SUBSCRIPTION = `
-  subscription DustGenerations($dustAddress: HexEncoded!, $startIndex: Int!, $endIndex: Int!) {
+  subscription DustGenerations($dustAddress: DustAddress!, $startIndex: Int!, $endIndex: Int!) {
     dustGenerations(dustAddress: $dustAddress, startIndex: $startIndex, endIndex: $endIndex) {
       ... on DustGenerationsItem {
         __typename

--- a/qa/tests/utils/indexer/graphql/subscriptions.ts
+++ b/qa/tests/utils/indexer/graphql/subscriptions.ts
@@ -346,10 +346,12 @@ export const DUST_GENERATIONS_SUBSCRIPTION = `
     dustGenerations(dustAddress: $dustAddress, startIndex: $startIndex, endIndex: $endIndex) {
       ... on DustGenerationsItem {
         __typename
-        merkleIndex
+        commitmentMtIndex
+        generationMtIndex
         owner
         value
-        nonce
+        initialValue
+        backingNight
         ctime
         transactionId
         collapsedMerkleTree {

--- a/qa/tests/utils/indexer/graphql/transaction-queries.ts
+++ b/qa/tests/utils/indexer/graphql/transaction-queries.ts
@@ -73,6 +73,10 @@ export const REGULAR_TRANSACTION_FRAGMENT = `   ... on RegularTransaction {
       identifiers
       zswapStartIndex
       zswapEndIndex
+      dustCommitmentStartIndex
+      dustCommitmentEndIndex
+      dustGenerationStartIndex
+      dustGenerationEndIndex
       fees {
         paidFees
         estimatedFees

--- a/qa/tests/utils/indexer/http-client.ts
+++ b/qa/tests/utils/indexer/http-client.ts
@@ -28,6 +28,10 @@ import type {
   ContractActionResponse,
   DustGenerationStatus,
   DustGenerationStatusResponse,
+  DustGenerations,
+  DustGenerationsResponse,
+  DustCommitmentMerkleTreeUpdateResult,
+  DustCommitmentMerkleTreeUpdateResponse,
   ZswapMerkleTreeCollapsedUpdateResponse,
   ZswapMerkleTreeCollapsedUpdateResult,
 } from './indexer-types';
@@ -38,7 +42,7 @@ import {
 } from './graphql/block-queries';
 import { GET_TRANSACTION_BY_OFFSET } from './graphql/transaction-queries';
 import { GET_CONTRACT_ACTION, GET_CONTRACT_ACTION_BY_OFFSET } from './graphql/contract-queries';
-import { GET_DUST_GENERATION_STATUS } from './graphql/dust-queries';
+import { GET_DUST_GENERATION_STATUS, GET_DUST_GENERATIONS, GET_DUST_COMMITMENT_MERKLE_TREE_UPDATE } from './graphql/dust-queries';
 
 /**
  * HTTP client for interacting with the Midnight Indexer GraphQL API
@@ -240,6 +244,62 @@ export class IndexerHttpClient {
 
     const response = await this.client.rawRequest<{
       dustGenerationStatus: DustGenerationStatus[];
+    }>(query, variables);
+
+    log.debug(`Raw indexer response\n${JSON.stringify(response, null, 2)}`);
+
+    return response;
+  }
+
+  /**
+   * Retrieves all active DUST registrations and aggregated generation stats for given Cardano reward addresses
+   * @param cardanoRewardAddresses - Array of Cardano reward addresses to query
+   * @param queryOverride - Optional custom GraphQL query
+   * @returns Promise resolving to the DUST generations response
+   */
+  async getDustGenerations(
+    cardanoRewardAddresses: string[],
+    queryOverride?: string,
+  ): Promise<DustGenerationsResponse> {
+    log.debug(`Target URL endpoint ${this.getTargetUrl()}`);
+
+    const query = queryOverride || GET_DUST_GENERATIONS;
+    const variables = { CARDANO_REWARD_ADDRESSES: cardanoRewardAddresses };
+
+    log.debug(`Using query\n${query}`);
+    log.debug(`Using variables\n${JSON.stringify(variables, null, 2)}`);
+
+    const response = await this.client.rawRequest<{
+      dustGenerations: DustGenerations[];
+    }>(query, variables);
+
+    log.debug(`Raw indexer response\n${JSON.stringify(response, null, 2)}`);
+
+    return response;
+  }
+
+  /**
+   * Retrieves a collapsed Merkle tree update for the dust commitment tree
+   * @param startIndex - Start index of the range
+   * @param endIndex - Optional end index of the range
+   * @param queryOverride - Optional custom GraphQL query
+   * @returns Promise resolving to the hex-encoded collapsed update
+   */
+  async getDustCommitmentMerkleTreeUpdate(
+    startIndex: number,
+    endIndex: number,
+    queryOverride?: string,
+  ): Promise<DustCommitmentMerkleTreeUpdateResponse> {
+    log.debug(`Target URL endpoint ${this.getTargetUrl()}`);
+
+    const query = queryOverride || GET_DUST_COMMITMENT_MERKLE_TREE_UPDATE;
+    const variables = { START_INDEX: startIndex, END_INDEX: endIndex };
+
+    log.debug(`Using query\n${query}`);
+    log.debug(`Using variables\n${JSON.stringify(variables, null, 2)}`);
+
+    const response = await this.client.rawRequest<{
+      dustCommitmentMerkleTreeUpdate: DustCommitmentMerkleTreeUpdateResult;
     }>(query, variables);
 
     log.debug(`Raw indexer response\n${JSON.stringify(response, null, 2)}`);

--- a/qa/tests/utils/indexer/http-client.ts
+++ b/qa/tests/utils/indexer/http-client.ts
@@ -42,7 +42,11 @@ import {
 } from './graphql/block-queries';
 import { GET_TRANSACTION_BY_OFFSET } from './graphql/transaction-queries';
 import { GET_CONTRACT_ACTION, GET_CONTRACT_ACTION_BY_OFFSET } from './graphql/contract-queries';
-import { GET_DUST_GENERATION_STATUS, GET_DUST_GENERATIONS, GET_DUST_COMMITMENT_MERKLE_TREE_UPDATE } from './graphql/dust-queries';
+import {
+  GET_DUST_GENERATION_STATUS,
+  GET_DUST_GENERATIONS,
+  GET_DUST_COMMITMENT_MERKLE_TREE_UPDATE,
+} from './graphql/dust-queries';
 
 /**
  * HTTP client for interacting with the Midnight Indexer GraphQL API

--- a/qa/tests/utils/indexer/indexer-types.ts
+++ b/qa/tests/utils/indexer/indexer-types.ts
@@ -66,6 +66,8 @@ export interface Block {
   author: string | null;
   ledgerParameters: string;
   zswapMerkleTreeRoot: string;
+  dustCommitmentMerkleTreeRoot: string | null;
+  dustGenerationMerkleTreeRoot: string | null;
   parent: Block;
   transactions: Transaction[];
 }
@@ -125,6 +127,10 @@ export interface RegularTransaction extends Transaction {
   zswapMerkleTreeRoot?: string;
   zswapStartIndex?: number;
   zswapEndIndex?: number;
+  dustCommitmentStartIndex?: number;
+  dustCommitmentEndIndex?: number;
+  dustGenerationStartIndex?: number;
+  dustGenerationEndIndex?: number;
   fees?: TransactionFees;
   transactionResult?: TransactionResult;
 }
@@ -280,5 +286,71 @@ export type DustLedgerEvent =
       maxId: number;
       protocolVersion: number;
     };
+
+// Dust Generations types (PR #980)
+export interface DustRegistration {
+  dustAddress: string;
+  valid: boolean;
+  nightBalance: string;
+  generationRate: string;
+  maxCapacity: string;
+  currentCapacity: string;
+  utxoTxHash: string | null;
+  utxoOutputIndex: number | null;
+}
+
+export interface DustGenerations {
+  cardanoRewardAddress: string;
+  registrations: DustRegistration[];
+}
+
+export type DustGenerationsResponse = GraphQLResponse<{
+  dustGenerations: DustGenerations[];
+}>;
+
+export interface DustCommitmentMerkleTreeUpdateResult {
+  startIndex: number;
+  endIndex: number;
+  update: string;
+  protocolVersion: number;
+}
+
+export type DustCommitmentMerkleTreeUpdateResponse = GraphQLResponse<{
+  dustCommitmentMerkleTreeUpdate: DustCommitmentMerkleTreeUpdateResult;
+}>;
+
+export interface CollapsedMerkleTree {
+  startIndex: number;
+  endIndex: number;
+  update: string;
+  protocolVersion: number;
+}
+
+export interface DustGenerationsItem {
+  __typename: 'DustGenerationsItem';
+  merkleIndex: number;
+  owner: string;
+  value: string;
+  nonce: string;
+  ctime: number;
+  transactionId: number;
+  collapsedMerkleTree: CollapsedMerkleTree | null;
+}
+
+export interface DustGenerationsProgress {
+  __typename: 'DustGenerationsProgress';
+  highestIndex: number;
+  collapsedMerkleTree: CollapsedMerkleTree | null;
+}
+
+export type DustGenerationsEvent = DustGenerationsItem | DustGenerationsProgress;
+
+export interface DustNullifierTransaction {
+  nullifier: string;
+  commitment: string;
+  transactionId: number;
+  blockHeight: number;
+  blockHash: string;
+}
 
 export type ViewingKey = string & { __brand: 'ViewingKey' };

--- a/qa/tests/utils/indexer/indexer-types.ts
+++ b/qa/tests/utils/indexer/indexer-types.ts
@@ -328,10 +328,12 @@ export interface CollapsedMerkleTree {
 
 export interface DustGenerationsItem {
   __typename: 'DustGenerationsItem';
-  merkleIndex: number;
+  commitmentMtIndex: number;
+  generationMtIndex: number;
   owner: string;
   value: string;
-  nonce: string;
+  initialValue: string;
+  backingNight: string;
   ctime: number;
   transactionId: number;
   collapsedMerkleTree: CollapsedMerkleTree | null;

--- a/qa/tests/utils/indexer/websocket-client.ts
+++ b/qa/tests/utils/indexer/websocket-client.ts
@@ -954,7 +954,7 @@ export class IndexerWsClient {
    * The subscription finishes after reaching the end index with a final collapsed update.
    *
    * @param handlers - Callback functions for handling incoming dust generation events
-   * @param dustAddress - Hex-encoded dust address to subscribe for
+   * @param dustAddress - Bech32m-encoded dust address to subscribe for
    * @param startIndex - Start index into the dust commitment tree
    * @param endIndex - End index into the dust commitment tree
    * @param queryOverride - Optional custom GraphQL subscription query

--- a/qa/tests/utils/indexer/websocket-client.ts
+++ b/qa/tests/utils/indexer/websocket-client.ts
@@ -21,6 +21,8 @@ import type {
   Block,
   BlockOffset,
   DustLedgerEvent,
+  DustGenerationsEvent,
+  DustNullifierTransaction,
   ZswapLedgerEvent,
   ShieldedTransactionsEvent,
   UnshieldedTransactionEvent,
@@ -37,6 +39,8 @@ import {
   CONTRACT_ACTIONS_SUBSCRIPTION_FROM_BLOCK_BY_OFFSET,
   DUST_LEDGER_EVENTS_SUBSCRIPTION_DEFAULT,
   DUST_LEDGER_EVENTS_SUBSCRIPTION_FROM_ID,
+  DUST_GENERATIONS_SUBSCRIPTION,
+  DUST_NULLIFIER_TRANSACTIONS_SUBSCRIPTION,
   ZSWAP_LEDGER_EVENTS_SUBSCRIPTION_DEFAULT,
   ZSWAP_LEDGER_EVENTS_SUBSCRIPTION_FROM_ID,
 } from './graphql/subscriptions';
@@ -57,6 +61,14 @@ export type ContractActionSubscriptionResponse = GraphQLResponse<{
 
 export type DustLedgerEventSubscriptionResponse = GraphQLResponse<{
   dustLedgerEvents: DustLedgerEvent;
+}>;
+
+export type DustGenerationsSubscriptionResponse = GraphQLResponse<{
+  dustGenerations: DustGenerationsEvent;
+}>;
+
+export type DustNullifierTransactionSubscriptionResponse = GraphQLResponse<{
+  dustNullifierTransactions: DustNullifierTransaction;
 }>;
 
 export type ZswapLedgerEventSubscriptionResponse = GraphQLResponse<{
@@ -918,6 +930,112 @@ export class IndexerWsClient {
     };
 
     log.debug(`Zswap Ledger Events payload:\n${JSON.stringify(payload, null, 2)}`);
+
+    this.handlersMap.set(subscriptionId, handlers as SubscriptionHandlers<unknown>);
+    this.getWs().send(JSON.stringify(payload));
+
+    return {
+      id: subscriptionId,
+      unsubscribe: () => {
+        const stopMessage: GraphQLStopMessage = {
+          id: subscriptionId,
+          type: 'stop',
+        };
+        this.getWs().send(JSON.stringify(stopMessage));
+        this.handlersMap.delete(subscriptionId);
+      },
+    };
+  }
+
+  /**
+   * Subscribes to dust generation entries for a dust address within an index range.
+   *
+   * Entries are interleaved with collapsed Merkle tree updates to fill gaps.
+   * The subscription finishes after reaching the end index with a final collapsed update.
+   *
+   * @param handlers - Callback functions for handling incoming dust generation events
+   * @param dustAddress - Hex-encoded dust address to subscribe for
+   * @param startIndex - Start index into the dust commitment tree
+   * @param endIndex - End index into the dust commitment tree
+   * @param queryOverride - Optional custom GraphQL subscription query
+   *
+   * @returns An object with subscription ID and unsubscribe function
+   */
+  subscribeToDustGenerations(
+    handlers: SubscriptionHandlers<DustGenerationsSubscriptionResponse>,
+    dustAddress: string,
+    startIndex: number,
+    endIndex: number,
+    queryOverride?: string,
+  ): { unsubscribe: () => void; id: string } {
+    const query = queryOverride || DUST_GENERATIONS_SUBSCRIPTION;
+    const variables = { dustAddress, startIndex, endIndex };
+
+    const subscriptionId = this.getNextId();
+
+    const payload: GraphQLStartMessage = {
+      id: subscriptionId,
+      type: 'start',
+      payload: {
+        query,
+        variables,
+      },
+    };
+
+    log.debug(`Dust Generations payload:\n${JSON.stringify(payload, null, 2)}`);
+
+    this.handlersMap.set(subscriptionId, handlers as SubscriptionHandlers<unknown>);
+    this.getWs().send(JSON.stringify(payload));
+
+    return {
+      id: subscriptionId,
+      unsubscribe: () => {
+        const stopMessage: GraphQLStopMessage = {
+          id: subscriptionId,
+          type: 'stop',
+        };
+        this.getWs().send(JSON.stringify(stopMessage));
+        this.handlersMap.delete(subscriptionId);
+      },
+    };
+  }
+
+  /**
+   * Subscribes to transactions containing dust nullifiers matching the provided prefixes.
+   *
+   * Returns transaction and block references for wallet to fetch full data.
+   * If `toBlock` is specified, the subscription finishes after reaching that block.
+   *
+   * @param handlers - Callback functions for handling incoming nullifier transaction events
+   * @param nullifierPrefixes - Array of hex-encoded nullifier prefixes to match
+   * @param fromBlock - Optional starting block height
+   * @param toBlock - Optional ending block height (subscription finishes after this)
+   * @param queryOverride - Optional custom GraphQL subscription query
+   *
+   * @returns An object with subscription ID and unsubscribe function
+   */
+  subscribeToDustNullifierTransactions(
+    handlers: SubscriptionHandlers<DustNullifierTransactionSubscriptionResponse>,
+    nullifierPrefixes: string[],
+    fromBlock?: number,
+    toBlock?: number,
+    queryOverride?: string,
+  ): { unsubscribe: () => void; id: string } {
+    const query = queryOverride || DUST_NULLIFIER_TRANSACTIONS_SUBSCRIPTION;
+    const variables = { nullifierPrefixes, fromBlock, toBlock };
+
+    const subscriptionId = this.getNextId();
+
+    const payload: GraphQLStartMessage = {
+      id: subscriptionId,
+      type: 'start',
+      payload: {
+        query,
+        variables,
+      },
+    };
+
+    log.debug(`Dust Nullifier Transactions payload:\n${JSON.stringify(payload, null, 2)}`);
 
     this.handlersMap.set(subscriptionId, handlers as SubscriptionHandlers<unknown>);
     this.getWs().send(JSON.stringify(payload));


### PR DESCRIPTION
## Summary

- Adds end-to-end QA coverage for dust wallet sync flows with new query and subscription tests.
- Aligns QA expectations with confirmed API behavior for edge cases (empty/nullifier ranges, completion semantics, network/HRP checks).
- Hardens subscription test stability by increasing WebSocket hook timeout and improving unsubscribe/timeout cleanup handling to reduce flakiness.

## Key Changes

- **New dust query coverage**
  - Added `dustGenerations` integration tests in:
    - `qa/tests/tests/integration/basic/queries/dust-generations-queries.test.ts`

- **New dust subscription coverage**
  - Added/expanded subscription tests in:
    - `qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts`
    - `qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts`

- **Behavior alignment updates**
  - Updated tests to reflect current API behavior for:
    - empty/nullifier edge inputs
    - `fromBlock > toBlock` completion behavior
    - network-specific dust address validation

- **Stability improvements**
  - Added explicit `beforeEach(..., 30_000)` for WebSocket setup in subscription suites.
  - Improved timeout/unsubscribe handling in subscription tests to avoid teardown race conditions and unhandled errors.

- **QA GraphQL/client/type plumbing**
  - Updated QA utility layers for new dust query/subscription coverage:
    - `qa/tests/utils/indexer/graphql/*`
    - `qa/tests/utils/indexer/http-client.ts`
    - `qa/tests/utils/indexer/websocket-client.ts`
    - `qa/tests/utils/indexer/indexer-types.ts`