### PR TITLE
refactor: simplify and make recent code more consistent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3054,6 +3054,7 @@ dependencies = [
  "humantime-serde",
  "indexer-common",
  "indoc",
+ "itertools 0.14.0",
  "log",
  "metrics",
  "secrecy",

--- a/indexer-api/Cargo.toml
+++ b/indexer-api/Cargo.toml
@@ -33,6 +33,7 @@ futures            = { workspace = true }
 humantime-serde    = { workspace = true }
 indexer-common     = { path = "../indexer-common" }
 indoc              = { workspace = true }
+itertools          = { workspace = true }
 log                = { workspace = true, features = [ "kv" ] }
 metrics            = { workspace = true }
 secrecy            = { workspace = true }

--- a/indexer-api/src/infra/api/v4/dataloader.rs
+++ b/indexer-api/src/infra/api/v4/dataloader.rs
@@ -15,75 +15,8 @@ use crate::domain::{self, storage::Storage};
 use async_graphql::dataloader::Loader;
 use derive_more::Deref;
 use indexer_common::domain::BlockHash;
+use itertools::Itertools;
 use std::{collections::HashMap, sync::Arc};
-
-// ---- ContractActionsByTransactionIdLoader ----
-
-#[derive(Deref)]
-pub struct ContractActionsByTransactionIdLoader<S>(S);
-
-impl<S: Storage> ContractActionsByTransactionIdLoader<S> {
-    pub fn new(storage: S) -> Self {
-        Self(storage)
-    }
-}
-
-impl<S: Storage> Loader<u64> for ContractActionsByTransactionIdLoader<S> {
-    type Value = Vec<domain::ContractAction>;
-    type Error = Arc<sqlx::Error>;
-
-    async fn load(
-        &self,
-        keys: &[u64],
-    ) -> Result<HashMap<u64, Vec<domain::ContractAction>>, Arc<sqlx::Error>> {
-        self.get_contract_actions_by_transaction_ids(keys)
-            .await
-            .map_err(Arc::new)
-            .map(|actions| {
-                actions
-                    .into_iter()
-                    .fold(HashMap::<_, Vec<_>>::new(), |mut map, action| {
-                        map.entry(action.transaction_id).or_default().push(action);
-                        map
-                    })
-            })
-    }
-}
-
-// ---- TransactionsByBlockIdLoader ----
-
-#[derive(Deref)]
-pub struct TransactionsByBlockIdLoader<S>(S);
-
-impl<S: Storage> TransactionsByBlockIdLoader<S> {
-    pub fn new(storage: S) -> Self {
-        Self(storage)
-    }
-}
-
-impl<S: Storage> Loader<u64> for TransactionsByBlockIdLoader<S> {
-    type Value = Vec<domain::Transaction>;
-    type Error = Arc<sqlx::Error>;
-
-    async fn load(
-        &self,
-        keys: &[u64],
-    ) -> Result<HashMap<u64, Vec<domain::Transaction>>, Arc<sqlx::Error>> {
-        self.get_transactions_by_block_ids(keys)
-            .await
-            .map_err(Arc::new)
-            .map(|pairs| {
-                pairs
-                    .into_iter()
-                    .fold(HashMap::<_, Vec<_>>::new(), |mut map, (block_id, tx)| {
-                        map.entry(block_id).or_default().push(tx);
-                        map
-                    })
-            })
-    }
-}
-
-// ---- BlockByHashLoader ----
 
 #[derive(Deref)]
 pub struct BlockByHashLoader<S>(S);
@@ -136,9 +69,65 @@ impl<S: Storage> Loader<u64> for TransactionByIdLoader<S> {
             .await
             .map_err(Arc::new)?
             .into_iter()
-            .map(|t: domain::Transaction| (t.id(), t))
-            .collect();
+            .map(|t| (t.id(), t))
+            .collect::<HashMap<_, _>>();
 
         Ok(transactions)
+    }
+}
+
+#[derive(Deref)]
+pub struct TransactionsByBlockIdLoader<S>(S);
+
+impl<S: Storage> TransactionsByBlockIdLoader<S> {
+    pub fn new(storage: S) -> Self {
+        Self(storage)
+    }
+}
+
+impl<S: Storage> Loader<u64> for TransactionsByBlockIdLoader<S> {
+    type Value = Vec<domain::Transaction>;
+    type Error = Arc<sqlx::Error>;
+
+    async fn load(
+        &self,
+        keys: &[u64],
+    ) -> Result<HashMap<u64, Vec<domain::Transaction>>, Arc<sqlx::Error>> {
+        let transactions = self
+            .get_transactions_by_block_ids(keys)
+            .await
+            .map_err(Arc::new)?
+            .into_iter()
+            .into_group_map();
+
+        Ok(transactions)
+    }
+}
+
+#[derive(Deref)]
+pub struct ContractActionsByTransactionIdLoader<S>(S);
+
+impl<S: Storage> ContractActionsByTransactionIdLoader<S> {
+    pub fn new(storage: S) -> Self {
+        Self(storage)
+    }
+}
+
+impl<S: Storage> Loader<u64> for ContractActionsByTransactionIdLoader<S> {
+    type Value = Vec<domain::ContractAction>;
+    type Error = Arc<sqlx::Error>;
+
+    async fn load(
+        &self,
+        keys: &[u64],
+    ) -> Result<HashMap<u64, Vec<domain::ContractAction>>, Arc<sqlx::Error>> {
+        let actions = self
+            .get_contract_actions_by_transaction_ids(keys)
+            .await
+            .map_err(Arc::new)?
+            .into_iter()
+            .into_group_map_by(|action| action.transaction_id);
+
+        Ok(actions)
     }
 }

--- a/indexer-api/src/infra/storage/contract_action.rs
+++ b/indexer-api/src/infra/storage/contract_action.rs
@@ -398,9 +398,7 @@ impl Storage {
     ) -> Result<Vec<ContractAction>, sqlx::Error> {
         use sqlx::{QueryBuilder, Sqlite};
 
-        let mut qb = QueryBuilder::<Sqlite>::new(indoc! {"
-            WITH transaction_ids(id) AS (VALUES (
-        "});
+        let mut qb = QueryBuilder::<Sqlite>::new("WITH transaction_ids(id) AS (VALUES (");
         let mut sep = qb.separated("), (");
         for id in ids {
             sep.push_bind(*id as i64);

--- a/indexer-api/src/infra/storage/transaction.rs
+++ b/indexer-api/src/infra/storage/transaction.rs
@@ -91,31 +91,6 @@ impl TransactionStorage for Storage {
             AND transactions.variant = 'System'
         "};
 
-        #[cfg(feature = "standalone")]
-        let query = indoc! {"
-            SELECT
-                transactions.id as id,
-                transactions.variant,
-                transactions.hash,
-                transactions.protocol_version,
-                transactions.raw,
-                blocks.hash AS block_hash,
-                regular_transactions.transaction_result,
-                regular_transactions.zswap_merkle_tree_root,
-                regular_transactions.zswap_start_index,
-                regular_transactions.zswap_end_index,
-                regular_transactions.dust_commitment_start_index,
-                regular_transactions.dust_commitment_end_index,
-                regular_transactions.dust_generation_start_index,
-                regular_transactions.dust_generation_end_index,
-                regular_transactions.paid_fees,
-                regular_transactions.estimated_fees
-            FROM transactions
-            INNER JOIN blocks ON blocks.id = transactions.block_id
-            INNER JOIN regular_transactions ON regular_transactions.id = transactions.id
-            WHERE transactions.id IN (SELECT id FROM ids)
-        "};
-
         #[cfg(feature = "cloud")]
         let ids = ids.iter().map(|id| *id as i64).collect::<Vec<_>>();
 
@@ -130,15 +105,35 @@ impl TransactionStorage for Storage {
 
         #[cfg(feature = "standalone")]
         let mut transactions = {
-            let mut query_builder = QueryBuilder::<Sqlite>::new("WITH ids(id) AS (VALUES (");
-            let mut sep = query_builder.separated("), (");
+            let mut qb = QueryBuilder::<Sqlite>::new("WITH ids(id) AS (VALUES (");
+            let mut sep = qb.separated("), (");
             for id in ids {
                 sep.push_bind(*id as i64);
             }
-            query_builder.push(")) ");
-            query_builder.push(query);
-            query_builder.push(indoc! {"
-                 UNION ALL
+            qb.push(indoc! {"
+                ))
+                SELECT
+                    transactions.id AS id,
+                    transactions.variant,
+                    transactions.hash,
+                    transactions.protocol_version,
+                    transactions.raw,
+                    blocks.hash AS block_hash,
+                    regular_transactions.transaction_result,
+                    regular_transactions.zswap_merkle_tree_root,
+                    regular_transactions.zswap_start_index,
+                    regular_transactions.zswap_end_index,
+                    regular_transactions.dust_commitment_start_index,
+                    regular_transactions.dust_commitment_end_index,
+                    regular_transactions.dust_generation_start_index,
+                    regular_transactions.dust_generation_end_index,
+                    regular_transactions.paid_fees,
+                    regular_transactions.estimated_fees
+                FROM transactions
+                INNER JOIN blocks ON blocks.id = transactions.block_id
+                INNER JOIN regular_transactions ON regular_transactions.id = transactions.id
+                WHERE transactions.id IN (SELECT id FROM ids)
+                UNION ALL
                 SELECT
                     transactions.id AS id,
                     transactions.variant,
@@ -162,8 +157,7 @@ impl TransactionStorage for Storage {
                 AND transactions.id IN (SELECT id FROM ids)
             "});
 
-            query_builder
-                .build()
+            qb.build()
                 .fetch(&*self.pool)
                 .map_ok(make_transaction)
                 .map(|result| result.flatten())
@@ -847,9 +841,7 @@ impl Storage {
     ) -> Result<Vec<(u64, Transaction)>, sqlx::Error> {
         use sqlx::{QueryBuilder, Sqlite};
 
-        let mut qb = QueryBuilder::<Sqlite>::new(indoc! {"
-            WITH block_ids(id) AS (VALUES (
-        "});
+        let mut qb = QueryBuilder::<Sqlite>::new("WITH block_ids(id) AS (VALUES (");
         let mut sep = qb.separated("), (");
         for id in ids {
             sep.push_bind(*id as i64);


### PR DESCRIPTION
Signed-off-by: Oxide Dyn0 <oxidyn0@proton.me>

Follow-up to #1027, #1030, and the earlier DataLoader PRs — tightening style and fixing inconsistencies introduced by those additions.

**`dataloader.rs`**

- Reorder loaders to follow the data hierarchy: block → transaction (by id) → transactions (by block id) → contract actions (by transaction id). This matches the nesting structure of the GraphQL schema and makes the file easier to scan.
- Remove `// ---- ... ----` section dividers — the struct definitions are sufficient landmarks.
- Unify the `load` implementations: all loaders now use `map_err(Arc::new)?` + a named binding + `Ok(binding)` instead of the `.map_err(Arc::new).map(|...|)` chain used by the two older loaders.
- Add `itertools` and replace both `fold`-based grouping operations with `into_group_map()` (`TransactionsByBlockIdLoader`) and `into_group_map_by(|action| action.transaction_id)` (`ContractActionsByTransactionIdLoader`), which express the intent directly.
- `TransactionByIdLoader`: remove spurious `: domain::Transaction` type annotation; add `.collect::<HashMap<_, _>>()` turbofish for consistency.

**`infra/storage/transaction.rs` and `contract_action.rs`**

- Do not wrap single-line `QueryBuilder::new(...)` arguments in `indoc!` — `indoc!` is only for multi-line strings.
- Consolidate the standalone SQLite query in `get_transactions_by_ids` from three `push()` calls (close CTE, push regular-transactions SELECT, push UNION ALL) into two (open CTE + bind values, push the full query in one `indoc!` block), matching the pattern used in `fetch_transactions_by_block_ids` and `fetch_contract_actions_by_transaction_ids`.
- Rename `query_builder` → `qb` to match the rest of the file.
