### PR TITLE
chore(api): add fee field and deprecate estimatedFees and fees wrapper

### DIFF
--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -843,9 +843,13 @@ type RegularTransaction implements Transaction {
 	"""
 	dustGenerationEndIndex: Int!
 	"""
+	The fee for this transaction in SPECK (atomic unit of DUST).
+	"""
+	fee: String!
+	"""
 	Fee information for this transaction.
 	"""
-	fees: TransactionFees!
+	fees: TransactionFees! @deprecated(reason: "Use fee instead")
 	"""
 	The block for this transaction.
 	"""
@@ -1237,17 +1241,17 @@ interface Transaction {
 }
 
 """
-Fees information for a transaction, including both paid and estimated fees.
+Fees information for a transaction.
 """
 type TransactionFees {
 	"""
-	The actual fees paid for this transaction in DUST.
+	The fees for this transaction in SPECK (atomic unit of DUST).
 	"""
 	paidFees: String!
 	"""
-	The estimated fees that was calculated for this transaction in DUST.
+	The fees for this transaction in SPECK (atomic unit of DUST).
 	"""
-	estimatedFees: String!
+	estimatedFees: String! @deprecated(reason: "Use paidFees instead")
 }
 
 """

--- a/indexer-api/src/infra/api/v4/transaction.rs
+++ b/indexer-api/src/infra/api/v4/transaction.rs
@@ -135,7 +135,11 @@ where
     /// The dust generation tree end index.
     dust_generation_end_index: u64,
 
+    /// The fee for this transaction in SPECK (atomic unit of DUST).
+    fee: String,
+
     /// Fee information for this transaction.
+    #[graphql(deprecation = "Use fee instead")]
     fees: TransactionFees,
 
     #[graphql(skip)]
@@ -210,12 +214,13 @@ where
 
         let zswap_merkle_tree_root = zswap_merkle_tree_root.hex_encode();
 
-        // Use fees information from database (calculated by chain-indexer)
+        let fee = transaction
+            .paid_fees
+            .map(|f| f.to_string())
+            .unwrap_or_else(|| "0".to_owned());
+
         let fees = TransactionFees {
-            paid_fees: transaction
-                .paid_fees
-                .map(|f| f.to_string())
-                .unwrap_or_else(|| "0".to_owned()),
+            paid_fees: fee.clone(),
             estimated_fees: transaction
                 .estimated_fees
                 .map(|f| f.to_string())
@@ -229,6 +234,7 @@ where
             raw: raw.hex_encode(),
             block_hash,
             transaction_result: transaction_result.into(),
+            fee,
             fees,
             identifiers: identifiers
                 .into_iter()
@@ -383,12 +389,14 @@ pub struct Segment {
     success: bool,
 }
 
-/// Fees information for a transaction, including both paid and estimated fees.
+/// Fees information for a transaction.
 #[derive(Debug, Clone, PartialEq, Eq, SimpleObject)]
 pub struct TransactionFees {
-    /// The actual fees paid for this transaction in DUST.
+    /// The fees for this transaction in SPECK (atomic unit of DUST).
     paid_fees: String,
-    /// The estimated fees that was calculated for this transaction in DUST.
+
+    /// The fees for this transaction in SPECK (atomic unit of DUST).
+    #[graphql(deprecation = "Use paidFees instead")]
     estimated_fees: String,
 }
 

--- a/indexer-tests/e2e.graphql
+++ b/indexer-tests/e2e.graphql
@@ -48,10 +48,7 @@ query BlockQuery($block_offset: BlockOffset) {
                         identifiers
                         zswapStartIndex
                         zswapEndIndex
-                        fees {
-                            paidFees
-                            estimatedFees
-                        }
+                        fee
                     }
                 }
                 unshieldedBalances {
@@ -88,10 +85,7 @@ query BlockQuery($block_offset: BlockOffset) {
                         identifiers
                         zswapStartIndex
                         zswapEndIndex
-                        fees {
-                            paidFees
-                            estimatedFees
-                        }
+                        fee
                     }
                 }
                 spentAtTransaction {
@@ -108,10 +102,7 @@ query BlockQuery($block_offset: BlockOffset) {
                         identifiers
                         zswapStartIndex
                         zswapEndIndex
-                        fees {
-                            paidFees
-                            estimatedFees
-                        }
+                        fee
                     }
                 }
             }
@@ -137,10 +128,7 @@ query BlockQuery($block_offset: BlockOffset) {
                         identifiers
                         zswapStartIndex
                         zswapEndIndex
-                        fees {
-                            paidFees
-                            estimatedFees
-                        }
+                        fee
                     }
                 }
                 spentAtTransaction {
@@ -157,10 +145,7 @@ query BlockQuery($block_offset: BlockOffset) {
                         identifiers
                         zswapStartIndex
                         zswapEndIndex
-                        fees {
-                            paidFees
-                            estimatedFees
-                        }
+                        fee
                     }
                 }
             }
@@ -188,10 +173,7 @@ query BlockQuery($block_offset: BlockOffset) {
                 identifiers
                 zswapStartIndex
                 zswapEndIndex
-                fees {
-                    paidFees
-                    estimatedFees
-                }
+                fee
             }
         }
     }
@@ -225,10 +207,7 @@ query TransactionsQuery($transaction_offset: TransactionOffset!) {
                     identifiers
                     zswapStartIndex
                     zswapEndIndex
-                    fees {
-                        paidFees
-                        estimatedFees
-                    }
+                    fee
                 }
             }
             unshieldedBalances {
@@ -265,10 +244,7 @@ query TransactionsQuery($transaction_offset: TransactionOffset!) {
                     identifiers
                     zswapStartIndex
                     zswapEndIndex
-                    fees {
-                        paidFees
-                        estimatedFees
-                    }
+                    fee
                 }
             }
             spentAtTransaction {
@@ -285,10 +261,7 @@ query TransactionsQuery($transaction_offset: TransactionOffset!) {
                     identifiers
                     zswapStartIndex
                     zswapEndIndex
-                    fees {
-                        paidFees
-                        estimatedFees
-                    }
+                    fee
                 }
             }
         }
@@ -314,10 +287,7 @@ query TransactionsQuery($transaction_offset: TransactionOffset!) {
                     identifiers
                     zswapStartIndex
                     zswapEndIndex
-                    fees {
-                        paidFees
-                        estimatedFees
-                    }
+                    fee
                 }
             }
             spentAtTransaction {
@@ -334,10 +304,7 @@ query TransactionsQuery($transaction_offset: TransactionOffset!) {
                     identifiers
                     zswapStartIndex
                     zswapEndIndex
-                    fees {
-                        paidFees
-                        estimatedFees
-                    }
+                    fee
                 }
             }
         }
@@ -365,10 +332,7 @@ query TransactionsQuery($transaction_offset: TransactionOffset!) {
             identifiers
             zswapStartIndex
             zswapEndIndex
-            fees {
-                paidFees
-                estimatedFees
-            }
+            fee
         }
     }
 }
@@ -398,10 +362,7 @@ query ContractActionQuery(
                 identifiers
                 zswapStartIndex
                 zswapEndIndex
-                fees {
-                    paidFees
-                    estimatedFees
-                }
+                fee
             }
         }
         unshieldedBalances {
@@ -476,10 +437,7 @@ subscription BlockSubscription($block_offset: BlockOffset) {
                         identifiers
                         zswapStartIndex
                         zswapEndIndex
-                        fees {
-                            paidFees
-                            estimatedFees
-                        }
+                        fee
                     }
                 }
                 unshieldedBalances {
@@ -516,10 +474,7 @@ subscription BlockSubscription($block_offset: BlockOffset) {
                         identifiers
                         zswapStartIndex
                         zswapEndIndex
-                        fees {
-                            paidFees
-                            estimatedFees
-                        }
+                        fee
                     }
                 }
                 spentAtTransaction {
@@ -536,10 +491,7 @@ subscription BlockSubscription($block_offset: BlockOffset) {
                         identifiers
                         zswapStartIndex
                         zswapEndIndex
-                        fees {
-                            paidFees
-                            estimatedFees
-                        }
+                        fee
                     }
                 }
             }
@@ -565,10 +517,7 @@ subscription BlockSubscription($block_offset: BlockOffset) {
                         identifiers
                         zswapStartIndex
                         zswapEndIndex
-                        fees {
-                            paidFees
-                            estimatedFees
-                        }
+                        fee
                     }
                 }
                 spentAtTransaction {
@@ -585,10 +534,7 @@ subscription BlockSubscription($block_offset: BlockOffset) {
                         identifiers
                         zswapStartIndex
                         zswapEndIndex
-                        fees {
-                            paidFees
-                            estimatedFees
-                        }
+                        fee
                     }
                 }
             }
@@ -616,10 +562,7 @@ subscription BlockSubscription($block_offset: BlockOffset) {
                 identifiers
                 zswapStartIndex
                 zswapEndIndex
-                fees {
-                    paidFees
-                    estimatedFees
-                }
+                fee
             }
         }
     }
@@ -653,10 +596,7 @@ subscription ContractActionSubscription(
                 identifiers
                 zswapStartIndex
                 zswapEndIndex
-                fees {
-                    paidFees
-                    estimatedFees
-                }
+                fee
             }
         }
         unshieldedBalances {
@@ -713,10 +653,7 @@ subscription UnshieldedTransactionsSubscription($address: UnshieldedAddress!) {
                     identifiers
                     zswapStartIndex
                     zswapEndIndex
-                    fees {
-                        paidFees
-                        estimatedFees
-                    }
+                    fee
                 }
             }
             createdUtxos {
@@ -741,10 +678,7 @@ subscription UnshieldedTransactionsSubscription($address: UnshieldedAddress!) {
                         identifiers
                         zswapStartIndex
                         zswapEndIndex
-                        fees {
-                            paidFees
-                            estimatedFees
-                        }
+                        fee
                     }
                 }
             }
@@ -770,10 +704,7 @@ subscription UnshieldedTransactionsSubscription($address: UnshieldedAddress!) {
                         identifiers
                         zswapStartIndex
                         zswapEndIndex
-                        fees {
-                            paidFees
-                            estimatedFees
-                        }
+                        fee
                     }
                 }
                 spentAtTransaction {
@@ -790,10 +721,7 @@ subscription UnshieldedTransactionsSubscription($address: UnshieldedAddress!) {
                         identifiers
                         zswapStartIndex
                         zswapEndIndex
-                        fees {
-                            paidFees
-                            estimatedFees
-                        }
+                        fee
                     }
                 }
             }

--- a/indexer-tests/src/e2e.rs
+++ b/indexer-tests/src/e2e.rs
@@ -248,10 +248,7 @@ impl IndexerData {
             };
 
             // Verify fees.
-            assert!(
-                transaction.fees.paid_fees.parse::<u64>().is_ok()
-                    && transaction.fees.estimated_fees.parse::<u64>().is_ok()
-            );
+            assert!(transaction.fee.parse::<u64>().is_ok());
         }
 
         // Verify that contract actions of a transaction reference that transaction.


### PR DESCRIPTION
#1032.

## Summary

- Added `fee: String!` field on `RegularTransaction` returning the fee in SPECK (atomic unit of DUST)
- Deprecated `fees: TransactionFees!` wrapper with `@deprecated(reason: "Use fee instead")`
- Deprecated `estimatedFees` on `TransactionFees` with `@deprecated(reason: "Use paidFees instead")`
- Updated e2e tests to use `fee` directly

## Context

Both `estimatedFees` and `paidFees` have always had the same value (since #359). With #1031 now computing correct fees via `Transaction::fees()`, the redundant `estimatedFees` field and the `TransactionFees` wrapper can be deprecated. The new `fee` field provides direct access without the wrapper, to be flattened in a future major version bump.