### PR TITLE
feat: bridge async-graphql tracing to fastrace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,8 @@ dependencies = [
  "static_assertions_next",
  "tempfile",
  "thiserror 2.0.18",
+ "tracing",
+ "tracing-futures",
  "uuid",
 ]
 
@@ -1201,7 +1203,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1917,7 +1919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2050,6 +2052,19 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "pollster",
+]
+
+[[package]]
+name = "fastrace-tracing"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26ee74fc06c6a7b49cce575ccd4e4ce2c8992c35d83e5c2f41babcbef862712"
+dependencies = [
+ "fastrace",
+ "take_mut",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3083,6 +3098,7 @@ dependencies = [
  "derive_more 2.1.1",
  "fastrace",
  "fastrace-opentelemetry",
+ "fastrace-tracing",
  "figment",
  "futures",
  "humantime-serde",
@@ -3117,6 +3133,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "tracing",
+ "tracing-subscriber",
  "trait-variant",
  "uuid",
 ]
@@ -3296,7 +3314,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4472,7 +4490,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5274,7 +5292,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5725,7 +5743,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5805,7 +5823,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7311,6 +7329,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7326,7 +7350,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7755,6 +7779,18 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "futures",
+ "futures-task",
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -8455,7 +8491,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ fake                        = { version = "2.10" }
 fastrace                    = { version = "0.7" }
 fastrace-axum               = { version = "0.2" }
 fastrace-opentelemetry      = { version = "0.16" }
+fastrace-tracing            = { version = "0.1" }
 figment                     = { version = "0.10" }
 fs_extra                    = { version = "1.3" }
 futures                     = { version = "0.3" }
@@ -87,6 +88,8 @@ thiserror                   = { version = "2.0" }
 tokio                       = { version = "1" }
 tokio-stream                = { version = "0.1" }
 tokio-tungstenite           = { version = "0.29" }
+tracing                     = { version = "0.1" }
+tracing-subscriber          = { version = "0.3" }
 tower                       = { version = "0.5" }
 tower-http                  = { version = "0.6" }
 trait-variant               = { version = "0.1" }

--- a/indexer-api/Cargo.toml
+++ b/indexer-api/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = [ "--cfg", "docsrs" ]
 
 [dependencies]
 anyhow             = { workspace = true }
-async-graphql      = { workspace = true, features = [ "dataloader", "uuid" ] }
+async-graphql      = { workspace = true, features = [ "dataloader", "tracing", "uuid" ] }
 async-graphql-axum = { workspace = true }
 async-stream       = { workspace = true }
 axum               = { workspace = true, features = [ "http2" ] }

--- a/indexer-api/src/infra/api/v4.rs
+++ b/indexer-api/src/infra/api/v4.rs
@@ -425,6 +425,7 @@ where
         Mutation::<S>::default(),
         Subscription::<S, B>::default(),
     )
+    .extension(async_graphql::extensions::Tracing)
 }
 
 fn decode_session_id(session_id: HexEncoded) -> Result<SessionId, DecodeSessionIdError> {

--- a/indexer-common/Cargo.toml
+++ b/indexer-common/Cargo.toml
@@ -31,6 +31,7 @@ const-hex                   = { workspace = true, features = [ "serde" ] }
 derive_more                 = { workspace = true, features = [ "as_ref", "debug", "deref", "display", "from", "into" ] }
 fastrace                    = { workspace = true }
 fastrace-opentelemetry      = { workspace = true }
+fastrace-tracing            = { workspace = true }
 figment                     = { workspace = true, features = [ "env", "yaml" ] }
 futures                     = { workspace = true }
 humantime-serde             = { workspace = true }
@@ -51,6 +52,8 @@ sha2                        = { workspace = true }
 sqlx                        = { workspace = true, features = [ "runtime-tokio", "uuid" ] }
 thiserror                   = { workspace = true }
 tokio                       = { workspace = true, features = [ "time" ] }
+tracing                     = { workspace = true }
+tracing-subscriber          = { workspace = true, features = [ "registry" ] }
 tokio-stream                = { workspace = true, features = [ "sync" ] }
 trait-variant               = { workspace = true }
 uuid                        = { workspace = true }

--- a/indexer-common/src/telemetry.rs
+++ b/indexer-common/src/telemetry.rs
@@ -33,6 +33,7 @@ use fastrace::{
     prelude::SpanRecord,
 };
 use fastrace_opentelemetry::OpenTelemetryReporter;
+use fastrace_tracing::FastraceCompatLayer;
 use logforth::{
     append::{FastraceEvent, Stdout},
     diagnostic::FastraceDiagnostic,
@@ -45,6 +46,7 @@ use opentelemetry_otlp::{SpanExporter, WithExportConfig};
 use opentelemetry_sdk::Resource;
 use serde::Deserialize;
 use std::{borrow::Cow, net::IpAddr};
+use tracing_subscriber::layer::SubscriberExt;
 
 /// Telemetry (tracing, metrics) configuration.
 #[derive(Debug, Clone, Deserialize)]
@@ -153,6 +155,9 @@ pub fn init_tracing(config: TracingConfig) {
         };
 
         fastrace::set_reporter(reporter, fastrace::collector::Config::default());
+
+        let subscriber = tracing_subscriber::Registry::default().with(FastraceCompatLayer::new());
+        tracing::subscriber::set_global_default(subscriber).expect("tracing subscriber can be set");
     }
 }
 


### PR DESCRIPTION
#1028

## Summary

- Enabled `tracing` feature on `async-graphql` so it emits tokio-tracing spans for resolver execution
- Added `fastrace-tracing` bridge in `init_tracing()` to propagate tokio-tracing spans into the fastrace trace tree
- GraphQL resolver spans (including DataLoader batch calls) now appear in the existing tracing pipeline when a fastrace root span is active
