### PR TITLE
feat: avoid unnecessary scans of shielded transactions

### DIFF
--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -108,7 +108,7 @@ Options for the connect mutation.
 """
 input ConnectOptions {
 	"""
-	Since what transaction index to start searching for relevant transactions.
+	Transaction index to start searching for relevant transactions (inclusive).
 	"""
 	startIndex: Int
 }

--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -104,6 +104,16 @@ type CommitteeMember {
 }
 
 """
+Options for the connect mutation.
+"""
+input ConnectOptions {
+	"""
+	Since what transaction index to start searching for relevant transactions.
+	"""
+	startIndex: Int
+}
+
+"""
 A contract action.
 """
 interface ContractAction {
@@ -585,7 +595,7 @@ type Mutation {
 	"""
 	Connect the wallet with the given viewing key and return a session ID.
 	"""
-	connect(viewingKey: ViewingKey!): HexEncoded!
+	connect(viewingKey: ViewingKey!, options: ConnectOptions): HexEncoded!
 	"""
 	Disconnect the wallet with the given session ID.
 	"""

--- a/indexer-api/src/domain/storage/wallet.rs
+++ b/indexer-api/src/domain/storage/wallet.rs
@@ -21,7 +21,12 @@ where
     Self: Clone + Send + Sync + 'static,
 {
     /// Connect a wallet, i.e. add it to the active ones, and return a random session ID.
-    async fn connect_wallet(&self, viewing_key: &ViewingKey) -> Result<SessionId, sqlx::Error>;
+    /// If `start_index` is provided, transactions before that index are skipped.
+    async fn connect_wallet(
+        &self,
+        viewing_key: &ViewingKey,
+        start_index: Option<u64>,
+    ) -> Result<SessionId, sqlx::Error>;
 
     /// Disconnect a wallet, i.e. remove it from the active ones.
     async fn disconnect_wallet(&self, session_id: SessionId) -> Result<(), sqlx::Error>;
@@ -35,7 +40,11 @@ where
 
 #[allow(unused_variables)]
 impl WalletStorage for NoopStorage {
-    async fn connect_wallet(&self, viewing_key: &ViewingKey) -> Result<SessionId, sqlx::Error> {
+    async fn connect_wallet(
+        &self,
+        viewing_key: &ViewingKey,
+        start_index: Option<u64>,
+    ) -> Result<SessionId, sqlx::Error> {
         unimplemented!()
     }
 

--- a/indexer-api/src/infra/api/v4/mutation.rs
+++ b/indexer-api/src/infra/api/v4/mutation.rs
@@ -51,7 +51,14 @@ where
             .try_into_domain(cx.get_network_id())
             .map_err_into_client_error(|| "invalid viewing key")?;
 
-        let start_index = options.and_then(|o| o.start_index).map(|i| i as u64);
+        let start_index = options
+            .and_then(|o| o.start_index)
+            .map(|i| {
+                u64::try_from(i)
+                    .ok()
+                    .some_or_client_error(|| "startIndex must not be negative")
+            })
+            .transpose()?;
 
         let storage = cx.get_storage::<S>();
 
@@ -99,8 +106,8 @@ where
 /// Options for the connect mutation.
 #[derive(Debug, Clone, InputObject)]
 pub struct ConnectOptions {
-    /// Since what transaction index to start searching for relevant transactions.
-    start_index: Option<i32>,
+    /// Transaction index to start searching for relevant transactions (inclusive).
+    start_index: Option<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/indexer-api/src/infra/api/v4/mutation.rs
+++ b/indexer-api/src/infra/api/v4/mutation.rs
@@ -18,7 +18,7 @@ use crate::{
         v4::{HexEncodable, HexEncoded, decode_session_id, viewing_key::ViewingKey},
     },
 };
-use async_graphql::{Context, Object, scalar};
+use async_graphql::{Context, InputObject, Object, scalar};
 use fastrace::trace;
 use log::debug;
 use serde::{Deserialize, Serialize};
@@ -41,15 +41,22 @@ where
 {
     /// Connect the wallet with the given viewing key and return a session ID.
     #[trace]
-    async fn connect(&self, cx: &Context<'_>, viewing_key: ViewingKey) -> ApiResult<HexEncoded> {
+    async fn connect(
+        &self,
+        cx: &Context<'_>,
+        viewing_key: ViewingKey,
+        options: Option<ConnectOptions>,
+    ) -> ApiResult<HexEncoded> {
         let viewing_key = viewing_key
             .try_into_domain(cx.get_network_id())
             .map_err_into_client_error(|| "invalid viewing key")?;
 
+        let start_index = options.and_then(|o| o.start_index).map(|i| i as u64);
+
         let storage = cx.get_storage::<S>();
 
         let session_id = storage
-            .connect_wallet(&viewing_key)
+            .connect_wallet(&viewing_key, start_index)
             .await
             .map_err_into_server_error(|| "connect wallet")?;
 
@@ -87,6 +94,13 @@ where
 
         Ok(Unit)
     }
+}
+
+/// Options for the connect mutation.
+#[derive(Debug, Clone, InputObject)]
+pub struct ConnectOptions {
+    /// Since what transaction index to start searching for relevant transactions.
+    start_index: Option<i32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/indexer-api/src/infra/storage/wallet.rs
+++ b/indexer-api/src/infra/storage/wallet.rs
@@ -32,7 +32,10 @@ impl WalletStorage for Storage {
         let viewing_key = viewing_key
             .encrypt(id, &self.cipher)
             .map_err(|error| sqlx::Error::Encode(error.into()))?;
-        let start_index = start_index.unwrap_or(0) as i64;
+        let start_index: i64 = start_index
+            .unwrap_or(0)
+            .try_into()
+            .map_err(|error| sqlx::Error::Encode(Box::new(error)))?;
 
         let query = indoc! {"
             INSERT INTO wallets (

--- a/indexer-api/src/infra/storage/wallet.rs
+++ b/indexer-api/src/infra/storage/wallet.rs
@@ -21,31 +21,46 @@ use sqlx::types::{Uuid, time::OffsetDateTime};
 
 impl WalletStorage for Storage {
     #[trace]
-    async fn connect_wallet(&self, viewing_key: &ViewingKey) -> Result<SessionId, sqlx::Error> {
+    async fn connect_wallet(
+        &self,
+        viewing_key: &ViewingKey,
+        start_index: Option<u64>,
+    ) -> Result<SessionId, sqlx::Error> {
         let id = Uuid::now_v7();
         let viewing_key_hash = viewing_key.hash();
         let session_id = generate_session_id();
         let viewing_key = viewing_key
             .encrypt(id, &self.cipher)
             .map_err(|error| sqlx::Error::Encode(error.into()))?;
+        let start_index = start_index.unwrap_or(0) as i64;
 
         let query = indoc! {"
             INSERT INTO wallets (
                 id,
                 viewing_key_hash,
                 viewing_key,
+                wanted_start_index,
+                first_indexed_transaction_id,
+                last_indexed_transaction_id,
                 last_active,
                 session_id
             )
-            VALUES ($1, $2, $3, $4, $5)
+            VALUES ($1, $2, $3, $4, $4, $4, $5, $6)
             ON CONFLICT (viewing_key_hash)
-            DO UPDATE SET last_active = $4, session_id = $5
+            DO UPDATE SET
+                last_active = $5,
+                session_id = $6,
+                wanted_start_index = CASE
+                    WHEN wallets.wanted_start_index <= $4 THEN wallets.wanted_start_index
+                    ELSE $4
+                END
         "};
 
         sqlx::query(query)
             .bind(id)
             .bind(viewing_key_hash.as_ref())
             .bind(&viewing_key)
+            .bind(start_index)
             .bind(OffsetDateTime::now_utc())
             .bind(session_id.as_ref())
             .execute(&*self.pool)

--- a/indexer-common/migrations/postgres/001_initial.sql
+++ b/indexer-common/migrations/postgres/001_initial.sql
@@ -136,6 +136,8 @@ CREATE TABLE wallets (
   id UUID PRIMARY KEY,
   viewing_key_hash BYTEA NOT NULL UNIQUE,
   viewing_key BYTEA NOT NULL, -- Ciphertext with nonce, no longer unique!
+  wanted_start_index BIGINT NOT NULL DEFAULT 0,
+  first_indexed_transaction_id BIGINT NOT NULL DEFAULT 0,
   last_indexed_transaction_id BIGINT NOT NULL DEFAULT 0,
   last_active TIMESTAMPTZ NOT NULL,
   session_id BYTEA UNIQUE -- Random per-session ID for API authentication, NULL when disconnected.

--- a/indexer-common/migrations/sqlite/001_initial.sql
+++ b/indexer-common/migrations/sqlite/001_initial.sql
@@ -137,6 +137,8 @@ CREATE TABLE wallets (
   id BLOB PRIMARY KEY, -- UUID
   viewing_key_hash BLOB NOT NULL UNIQUE,
   viewing_key BLOB NOT NULL, -- Ciphertext with nonce, no longer unique!
+  wanted_start_index INTEGER NOT NULL DEFAULT 0,
+  first_indexed_transaction_id INTEGER NOT NULL DEFAULT 0,
   last_indexed_transaction_id INTEGER NOT NULL DEFAULT 0,
   last_active INTEGER NOT NULL,
   session_id BLOB UNIQUE -- Random per-session ID for API authentication, NULL when disconnected.

--- a/wallet-indexer/src/application.rs
+++ b/wallet-indexer/src/application.rs
@@ -226,7 +226,72 @@ async fn index_wallet(
         .await
         .with_context(|| format!("get wallet for wallet ID {wallet_id}"))?;
 
-    // Only continue if possibly needed.
+    if wallet.first_indexed_transaction_id > wallet.wanted_start_index {
+        // Scan the backward gap in descending order so that first_indexed_transaction_id
+        // can be moved down continuously without re-processing transactions.
+        let transactions = storage
+            .get_transactions_in_range(
+                wallet.wanted_start_index,
+                wallet.first_indexed_transaction_id,
+                transaction_batch_size,
+                &mut tx,
+            )
+            .await
+            .context("get backward transactions")?;
+
+        // The query returns results in descending order; .last() is the minimum ID.
+        let first_indexed_transaction_id = transactions
+            .last()
+            .map(|t| t.id)
+            .unwrap_or(wallet.wanted_start_index);
+
+        let relevant_transactions = transactions
+            .into_iter()
+            .map(|transaction| {
+                transaction
+                    .relevant(&wallet)
+                    .with_context(|| {
+                        format!("check transaction relevance for wallet ID {wallet_id}")
+                    })
+                    .map(|relevant| (relevant, transaction))
+            })
+            .filter_map_ok(|(relevant, transaction)| relevant.then_some(transaction))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        storage
+            .save_backward_relevant_transactions(
+                wallet_id,
+                &relevant_transactions,
+                first_indexed_transaction_id,
+                &mut tx,
+            )
+            .await
+            .with_context(|| {
+                format!("save backward relevant transactions for wallet ID {wallet_id}")
+            })?;
+
+        tx.commit().await.context("commit database transaction")?;
+
+        if !relevant_transactions.is_empty() {
+            publisher
+                .publish(&WalletIndexed { wallet_id })
+                .await
+                .with_context(|| {
+                    format!("publish WalletIndexed event for wallet ID {wallet_id}")
+                })?;
+        }
+
+        debug!(
+            wallet_id:%,
+            first_indexed_transaction_id,
+            relevant_transactions_len = relevant_transactions.len();
+            "wallet backward indexed"
+        );
+
+        return Ok(());
+    }
+
+    // Forward scan: only continue if possibly needed.
     if wallet.last_indexed_transaction_id < max_transaction_id.load(Ordering::Acquire) {
         let from = wallet.last_indexed_transaction_id + 1;
         let transactions = storage

--- a/wallet-indexer/src/domain.rs
+++ b/wallet-indexer/src/domain.rs
@@ -21,6 +21,8 @@ use sqlx::prelude::FromRow;
 #[derive(Debug, Clone, PartialEq, Eq, FromRow)]
 pub struct Wallet {
     pub viewing_key: ViewingKey,
+    pub wanted_start_index: u64,
+    pub first_indexed_transaction_id: u64,
     pub last_indexed_transaction_id: u64,
 }
 

--- a/wallet-indexer/src/domain/storage.rs
+++ b/wallet-indexer/src/domain/storage.rs
@@ -46,6 +46,15 @@ where
         tx: &mut SqlxTransaction<Self::Database>,
     ) -> Result<Vec<Transaction>, sqlx::Error>;
 
+    /// Get at most `limit` transactions in the range `[from, to)`.
+    async fn get_transactions_in_range(
+        &self,
+        from: u64,
+        to: u64,
+        limit: NonZeroUsize,
+        tx: &mut SqlxTransaction<Self::Database>,
+    ) -> Result<Vec<Transaction>, sqlx::Error>;
+
     /// For the given session ID, transactionally save the given relevant `transactions` and
     /// update the last indexed transaction ID.
     async fn save_relevant_transactions(
@@ -53,6 +62,15 @@ where
         viewing_key: &ViewingKey,
         transactions: &[Transaction],
         last_indexed_transaction_id: u64,
+        tx: &mut SqlxTransaction<Self::Database>,
+    ) -> Result<(), sqlx::Error>;
+
+    /// Save backward-scanned relevant transactions and update the first indexed transaction ID.
+    async fn save_backward_relevant_transactions(
+        &self,
+        wallet_id: Uuid,
+        transactions: &[Transaction],
+        first_indexed_transaction_id: u64,
         tx: &mut SqlxTransaction<Self::Database>,
     ) -> Result<(), sqlx::Error>;
 

--- a/wallet-indexer/src/infra/storage.rs
+++ b/wallet-indexer/src/infra/storage.rs
@@ -472,7 +472,11 @@ mod tests {
             .get_transactions_in_range(3, 9, limit, &mut tx)
             .await?;
         let ids = result.iter().map(|t| t.id).collect::<Vec<_>>();
-        assert_eq!(ids, vec![8, 6, 4], "half-open range + Regular filter + DESC");
+        assert_eq!(
+            ids,
+            vec![8, 6, 4],
+            "half-open range + Regular filter + DESC"
+        );
 
         // `from` is inclusive.
         let result = storage
@@ -485,10 +489,7 @@ mod tests {
         let result = storage
             .get_transactions_in_range(3, 8, limit, &mut tx)
             .await?;
-        assert!(
-            !result.iter().any(|t| t.id == 8),
-            "`to` must be exclusive"
-        );
+        assert!(!result.iter().any(|t| t.id == 8), "`to` must be exclusive");
 
         // Empty range collapses to empty result.
         let result = storage
@@ -496,18 +497,19 @@ mod tests {
             .await?;
         assert!(result.is_empty());
 
-        // Limit is respected — request 2 from [0, 11): Regular = {2,4,6,8,10}, DESC top 2 = [10, 8].
+        // Limit is respected — request 2 from [0, 11): Regular = {2,4,6,8,10}, DESC top 2 = [10,
+        // 8].
         let two = NonZeroUsize::new(2).unwrap();
-        let result = storage.get_transactions_in_range(0, 11, two, &mut tx).await?;
-        assert_eq!(
-            result.iter().map(|t| t.id).collect::<Vec<_>>(),
-            vec![10, 8]
-        );
+        let result = storage
+            .get_transactions_in_range(0, 11, two, &mut tx)
+            .await?;
+        assert_eq!(result.iter().map(|t| t.id).collect::<Vec<_>>(), vec![10, 8]);
 
         Ok(())
     }
 
-    /// With an empty `transactions` slice the cursor still advances and no relevant rows are inserted.
+    /// With an empty `transactions` slice the cursor still advances and no relevant rows are
+    /// inserted.
     #[tokio::test]
     async fn save_backward_empty_batch_advances_cursor_only() -> Result<(), Box<dyn StdError>> {
         let (storage, pool) = new_storage().await?;
@@ -532,7 +534,10 @@ mod tests {
                 .bind(wallet_id)
                 .fetch_one(&*pool)
                 .await?;
-        assert_eq!(relevant_count, 0, "no relevant rows inserted for empty batch");
+        assert_eq!(
+            relevant_count, 0,
+            "no relevant rows inserted for empty batch"
+        );
 
         Ok(())
     }
@@ -554,7 +559,10 @@ mod tests {
         let batch = storage
             .get_transactions_in_range(50, 100, NonZeroUsize::new(10).unwrap(), &mut tx)
             .await?;
-        assert_eq!(batch.iter().map(|t| t.id).collect::<Vec<_>>(), vec![90, 75, 50]);
+        assert_eq!(
+            batch.iter().map(|t| t.id).collect::<Vec<_>>(),
+            vec![90, 75, 50]
+        );
 
         let new_cursor = batch.last().map(|t| t.id).unwrap();
         storage

--- a/wallet-indexer/src/infra/storage.rs
+++ b/wallet-indexer/src/infra/storage.rs
@@ -377,6 +377,214 @@ pub struct Wallet {
     pub last_indexed_transaction_id: u64,
 }
 
+#[cfg(all(test, feature = "standalone"))]
+mod tests {
+    use crate::{domain::storage::Storage as _, infra::storage::Storage};
+    use chacha20poly1305::{ChaCha20Poly1305, Key, KeyInit};
+    use indexer_common::infra::{
+        migrations,
+        pool::sqlite::{Config, SqlitePool},
+    };
+    use indoc::indoc;
+    use sqlx::types::{Uuid, time::OffsetDateTime};
+    use std::{error::Error as StdError, num::NonZeroUsize};
+
+    // Seed a single block so that transactions can satisfy their FK.
+    async fn seed_block(pool: &SqlitePool) -> Result<i64, sqlx::Error> {
+        let query = indoc! {"
+            INSERT INTO blocks (
+                id, hash, height, protocol_version, parent_hash, author,
+                timestamp, zswap_merkle_tree_root, ledger_parameters, ledger_state_key
+            )
+            VALUES (1, X'00', 0, 1000000, X'00', NULL, 0, X'00', X'00', X'00')
+        "};
+        sqlx::query(query).execute(&**pool).await?;
+        Ok(1)
+    }
+
+    async fn seed_transaction(
+        pool: &SqlitePool,
+        id: i64,
+        block_id: i64,
+        variant: &str,
+    ) -> Result<(), sqlx::Error> {
+        let query = indoc! {"
+            INSERT INTO transactions (id, block_id, variant, hash, protocol_version, raw)
+            VALUES ($1, $2, $3, X'00', 1000000, X'00')
+        "};
+        sqlx::query(query)
+            .bind(id)
+            .bind(block_id)
+            .bind(variant)
+            .execute(&**pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn seed_wallet(
+        pool: &SqlitePool,
+        id: Uuid,
+        first_indexed: i64,
+        wanted_start: i64,
+    ) -> Result<(), sqlx::Error> {
+        let query = indoc! {"
+            INSERT INTO wallets (
+                id, viewing_key_hash, viewing_key,
+                wanted_start_index, first_indexed_transaction_id, last_indexed_transaction_id,
+                last_active, session_id
+            )
+            VALUES ($1, X'00', X'00', $2, $3, $3, $4, NULL)
+        "};
+        sqlx::query(query)
+            .bind(id)
+            .bind(wanted_start)
+            .bind(first_indexed)
+            .bind(OffsetDateTime::now_utc())
+            .execute(&**pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn new_storage() -> Result<(Storage, SqlitePool), Box<dyn StdError>> {
+        let pool = SqlitePool::new(Config::default()).await?;
+        migrations::sqlite::run(&pool).await?;
+        let cipher = ChaCha20Poly1305::new(Key::from_slice(&[0u8; 32]));
+        Ok((Storage::new(cipher, pool.clone()), pool))
+    }
+
+    /// Half-open `[from, to)` range, DESC order, filters `variant = 'Regular'`, honours limit.
+    #[tokio::test]
+    async fn get_transactions_in_range_semantics() -> Result<(), Box<dyn StdError>> {
+        let (storage, pool) = new_storage().await?;
+        let block_id = seed_block(&pool).await?;
+
+        // Transactions 1..=10: even ids are Regular, odd ids are System (interleaved).
+        for id in 1..=10 {
+            let variant = if id % 2 == 0 { "Regular" } else { "System" };
+            seed_transaction(&pool, id, block_id, variant).await?;
+        }
+
+        let limit = NonZeroUsize::new(100).unwrap();
+        let mut tx = pool.begin().await?;
+
+        // Range [3, 9) — Regular ids in that range: {4, 6, 8}, DESC.
+        let result = storage
+            .get_transactions_in_range(3, 9, limit, &mut tx)
+            .await?;
+        let ids = result.iter().map(|t| t.id).collect::<Vec<_>>();
+        assert_eq!(ids, vec![8, 6, 4], "half-open range + Regular filter + DESC");
+
+        // `from` is inclusive.
+        let result = storage
+            .get_transactions_in_range(4, 9, limit, &mut tx)
+            .await?;
+        assert_eq!(result.first().map(|t| t.id), Some(8));
+        assert!(result.iter().any(|t| t.id == 4), "`from` must be inclusive");
+
+        // `to` is exclusive.
+        let result = storage
+            .get_transactions_in_range(3, 8, limit, &mut tx)
+            .await?;
+        assert!(
+            !result.iter().any(|t| t.id == 8),
+            "`to` must be exclusive"
+        );
+
+        // Empty range collapses to empty result.
+        let result = storage
+            .get_transactions_in_range(5, 5, limit, &mut tx)
+            .await?;
+        assert!(result.is_empty());
+
+        // Limit is respected — request 2 from [0, 11): Regular = {2,4,6,8,10}, DESC top 2 = [10, 8].
+        let two = NonZeroUsize::new(2).unwrap();
+        let result = storage.get_transactions_in_range(0, 11, two, &mut tx).await?;
+        assert_eq!(
+            result.iter().map(|t| t.id).collect::<Vec<_>>(),
+            vec![10, 8]
+        );
+
+        Ok(())
+    }
+
+    /// With an empty `transactions` slice the cursor still advances and no relevant rows are inserted.
+    #[tokio::test]
+    async fn save_backward_empty_batch_advances_cursor_only() -> Result<(), Box<dyn StdError>> {
+        let (storage, pool) = new_storage().await?;
+        let wallet_id = Uuid::now_v7();
+        seed_wallet(&pool, wallet_id, 1000, 0).await?;
+
+        let mut tx = pool.begin().await?;
+        storage
+            .save_backward_relevant_transactions(wallet_id, &[], 0, &mut tx)
+            .await?;
+        tx.commit().await?;
+
+        let (first_indexed,): (i64,) =
+            sqlx::query_as("SELECT first_indexed_transaction_id FROM wallets WHERE id = $1")
+                .bind(wallet_id)
+                .fetch_one(&*pool)
+                .await?;
+        assert_eq!(first_indexed, 0, "cursor collapses to wanted_start");
+
+        let (relevant_count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM relevant_transactions WHERE wallet_id = $1")
+                .bind(wallet_id)
+                .fetch_one(&*pool)
+                .await?;
+        assert_eq!(relevant_count, 0, "no relevant rows inserted for empty batch");
+
+        Ok(())
+    }
+
+    /// With a non-empty batch the cursor advances and relevant rows are inserted atomically.
+    #[tokio::test]
+    async fn save_backward_with_batch_inserts_relevant_rows() -> Result<(), Box<dyn StdError>> {
+        let (storage, pool) = new_storage().await?;
+        let block_id = seed_block(&pool).await?;
+        for id in [50i64, 75, 90] {
+            seed_transaction(&pool, id, block_id, "Regular").await?;
+        }
+
+        let wallet_id = Uuid::now_v7();
+        seed_wallet(&pool, wallet_id, 1000, 0).await?;
+
+        // Simulate a DESC batch covering [50, 100): minimum id = 50, new cursor = 50.
+        let mut tx = pool.begin().await?;
+        let batch = storage
+            .get_transactions_in_range(50, 100, NonZeroUsize::new(10).unwrap(), &mut tx)
+            .await?;
+        assert_eq!(batch.iter().map(|t| t.id).collect::<Vec<_>>(), vec![90, 75, 50]);
+
+        let new_cursor = batch.last().map(|t| t.id).unwrap();
+        storage
+            .save_backward_relevant_transactions(wallet_id, &batch, new_cursor, &mut tx)
+            .await?;
+        tx.commit().await?;
+
+        let (first_indexed,): (i64,) =
+            sqlx::query_as("SELECT first_indexed_transaction_id FROM wallets WHERE id = $1")
+                .bind(wallet_id)
+                .fetch_one(&*pool)
+                .await?;
+        assert_eq!(first_indexed, 50);
+
+        let mut ids = sqlx::query_as::<_, (i64,)>(
+            "SELECT transaction_id FROM relevant_transactions WHERE wallet_id = $1",
+        )
+        .bind(wallet_id)
+        .fetch_all(&*pool)
+        .await?
+        .into_iter()
+        .map(|(id,)| id)
+        .collect::<Vec<_>>();
+        ids.sort();
+        assert_eq!(ids, vec![50, 75, 90]);
+
+        Ok(())
+    }
+}
+
 impl TryFrom<(Wallet, &ChaCha20Poly1305)> for domain::Wallet {
     type Error = DecryptViewingKeyError;
 

--- a/wallet-indexer/src/infra/storage.rs
+++ b/wallet-indexer/src/infra/storage.rs
@@ -131,6 +131,35 @@ impl domain::storage::Storage for Storage {
             .await
     }
 
+    #[trace(properties = { "from": "{from}", "to": "{to}", "limit": "{limit}" })]
+    async fn get_transactions_in_range(
+        &self,
+        from: u64,
+        to: u64,
+        limit: NonZeroUsize,
+        tx: &mut SqlxTransaction<Self::Database>,
+    ) -> Result<Vec<Transaction>, sqlx::Error> {
+        let query = indoc! {"
+            SELECT
+                id,
+                protocol_version,
+                raw
+            FROM transactions
+            WHERE id >= $1
+            AND id < $2
+            AND variant = 'Regular'
+            ORDER BY id DESC
+            LIMIT $3
+        "};
+
+        sqlx::query_as(query)
+            .bind(from as i64)
+            .bind(to as i64)
+            .bind(limit.get() as i32)
+            .fetch_all(&mut **tx)
+            .await
+    }
+
     #[trace]
     async fn save_relevant_transactions(
         &self,
@@ -150,10 +179,12 @@ impl domain::storage::Storage for Storage {
                 id,
                 viewing_key_hash,
                 viewing_key,
+                wanted_start_index,
+                first_indexed_transaction_id,
                 last_indexed_transaction_id,
                 last_active
             )
-            VALUES ($1, $2, $3, $4, $5)
+            VALUES ($1, $2, $3, 0, 0, $4, $5)
             ON CONFLICT (viewing_key_hash)
             DO UPDATE SET last_indexed_transaction_id = $4
             RETURNING id
@@ -168,6 +199,46 @@ impl domain::storage::Storage for Storage {
             .fetch_one(&mut **tx)
             .await?
             .try_get::<Uuid, _>("id")?;
+
+        if !transactions.is_empty() {
+            let query = indoc! {"
+                INSERT INTO relevant_transactions (
+                    wallet_id,
+                    transaction_id
+                )
+            "};
+
+            QueryBuilder::new(query)
+                .push_values(transactions, |mut q, transaction| {
+                    q.push_bind(wallet_id).push_bind(transaction.id as i64);
+                })
+                .build()
+                .execute(&mut **tx)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    #[trace]
+    async fn save_backward_relevant_transactions(
+        &self,
+        wallet_id: Uuid,
+        transactions: &[Transaction],
+        first_indexed_transaction_id: u64,
+        tx: &mut SqlxTransaction<Self::Database>,
+    ) -> Result<(), sqlx::Error> {
+        let query = indoc! {"
+            UPDATE wallets
+            SET first_indexed_transaction_id = $1
+            WHERE id = $2
+        "};
+
+        sqlx::query(query)
+            .bind(first_indexed_transaction_id as i64)
+            .bind(wallet_id)
+            .execute(&mut **tx)
+            .await?;
 
         if !transactions.is_empty() {
             let query = indoc! {"
@@ -272,6 +343,8 @@ impl domain::storage::Storage for Storage {
             SELECT
                 id,
                 viewing_key,
+                wanted_start_index,
+                first_indexed_transaction_id,
                 last_indexed_transaction_id
             FROM wallets
             WHERE id = $1
@@ -295,6 +368,12 @@ pub struct Wallet {
     pub viewing_key: ByteVec,
 
     #[sqlx(try_from = "i64")]
+    pub wanted_start_index: u64,
+
+    #[sqlx(try_from = "i64")]
+    pub first_indexed_transaction_id: u64,
+
+    #[sqlx(try_from = "i64")]
     pub last_indexed_transaction_id: u64,
 }
 
@@ -305,6 +384,8 @@ impl TryFrom<(Wallet, &ChaCha20Poly1305)> for domain::Wallet {
         let Wallet {
             id,
             viewing_key,
+            wanted_start_index,
+            first_indexed_transaction_id,
             last_indexed_transaction_id,
         } = wallet;
 
@@ -312,6 +393,8 @@ impl TryFrom<(Wallet, &ChaCha20Poly1305)> for domain::Wallet {
 
         Ok(domain::Wallet {
             viewing_key,
+            wanted_start_index,
+            first_indexed_transaction_id,
             last_indexed_transaction_id,
         })
     }


### PR DESCRIPTION
#984.

## Summary
- Added `ConnectOptions` input with optional `startIndex` to the `connect` mutation, allowing wallets to specify a transaction index below which no scanning is needed
- Added `wanted_start_index` and `first_indexed_transaction_id` columns to the `wallets` table, enabling range-based indexing with bidirectional gap filling
- Wallet-indexer now detects and fills backward gaps (when `first_indexed > wanted_start`) by scanning in descending order, one batch per cycle, before proceeding with forward indexing
- `wanted_start_index` can only decrease (never shrink the desired range), ensuring no transactions are silently skipped

## Design

Based on @kapke's bidirectional indexing proposal in #984. Three cursors track the indexing state per wallet: `wanted_start_index` (desired lower bound), `first_indexed_transaction_id` (actual lower bound), `last_indexed_transaction_id` (actual upper bound). A backward gap (`wanted_start < first_indexed`) is filled in batches before forward indexing proceeds.