### PR TITLE
perf(chain-indexer): avoid double header fetch in catch-up forward phase

### DIFF
--- a/chain-indexer/src/infra/subxt_node.rs
+++ b/chain-indexer/src/infra/subxt_node.rs
@@ -346,18 +346,18 @@ impl Node for SubxtNode {
                     }
                     let block = self.block_at_height(height).await?;
                     let block_hash = block.block_hash();
-                    if let Some(expected_parent) = last_forward_hash {
-                        let parent_hash = block_header(&block).await?.parent_hash;
-                        if parent_hash != expected_parent {
-                            Err(SubxtNodeError::ParentHashMismatch(
-                                height,
-                                expected_parent,
-                                parent_hash,
-                            ))?;
-                        }
+                    let made_block = self.make_block(&mut authorities, block).await?;
+                    if let Some(expected_parent) = last_forward_hash
+                        && made_block.parent_hash.0 != expected_parent.0
+                    {
+                        Err(SubxtNodeError::ParentHashMismatch(
+                            height,
+                            expected_parent,
+                            H256(made_block.parent_hash.0),
+                        ))?;
                     }
                     last_forward_hash = Some(block_hash);
-                    yield self.make_block(&mut authorities, block).await?;
+                    yield made_block;
                 }
 
                 let stop_hash = last_forward_hash.unwrap_or(H256(after_hash.0));


### PR DESCRIPTION
Follow-up to #1038.

## Summary

The parent hash verification added in #1038 was triggering an extra `block_header()` RPC per block in the forward phase, since `make_block` already fetches the header internally to extract `parent_hash`. This change moves the verification to use the `parent_hash` already extracted by `make_block`, eliminating the duplicate fetch on the success path.

## Trade-off

On verification failure, `make_block`'s work is wasted (it ran fully before we detected the mismatch). On the success path (the common case), we save one RPC per Phase 1 block. Verification failure is only triggered by node misbehaviour or lag, so this is a net positive.