### PR TITLE
chore(ci): bump upload-sarif-github-action to containerised scanners

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -27,4 +27,4 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  #v6.0.2
 
       - name: Scan code
-        uses: midnightntwrk/upload-sarif-github-action@07dad711370cc5985885ebcf07cb8c9264bc4167
+        uses: midnightntwrk/upload-sarif-github-action@47a6b67fb94c6d8385cfe3cd336152dfd49bbcf2

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -27,4 +27,4 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  #v6.0.2
 
       - name: Scan code
-        uses: midnightntwrk/upload-sarif-github-action@47a6b67fb94c6d8385cfe3cd336152dfd49bbcf2
+        uses: midnightntwrk/upload-sarif-github-action@37e5a0a03dc65fdbbab4cdc8ba264328c15e9657


### PR DESCRIPTION
## Summary

Bump the `upload-sarif-github-action` pin in `scan.yaml` from `07dad711` to `47a6b67f` to pick up the containerised parallel scanning from [upload-sarif PR #64](https://github.com/midnightntwrk/upload-sarif-github-action/pull/64) (merged).

## What changes

The scan action now runs each scanner in an isolated container via EarthBuild instead of directly on the runner:

| Before | After |
|--------|-------|
| 6 steps running on the runner | 2 steps: install EarthBuild, run `earth +scan` |
| OpenGrep + Scorecard + KICS (disabled) + Trivy (disabled) | OpenGrep + Scorecard + **Checkov** (new IaC scanner) |
| Scanners have access to runner secrets | Each runs in isolated container, no secret access |
| Scanners run as root | Scanners run as non-root `scanner` user |
| Sequential execution | Parallel execution via EarthBuild |

## Context

- KICS was disabled due to supply chain compromise (checkmarx/kics-github-action, ~2026-03-23)
- Trivy removed precautionarily
- Checkov replaces KICS as the IaC misconfiguration scanner
- All binaries hash-verified, base images pinned by digest, Checkov's 90+ Python deps locked with SHA256 hashes

## Expected findings

Checkov will scan IaC files (Dockerfiles, docker-compose). Likely new findings on the per-crate Dockerfiles (missing USER, healthchecks, etc.). OpenGrep/Scorecard results should be similar to before.
