### PR TITLE
chore: bump midnight-storage-core to 1.2.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4153,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "midnight-storage-core"
 version = "1.2.0"
-source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.1#b23837b2dacc2284bb18853bc37148448b04d419"
+source = "git+https://github.com/midnightntwrk/midnight-ledger?tag=storage-core-1.2.0-rc.2#cdfa4f94dedbe5a6b68fa196b9dda0a195c3aa72"
 dependencies = [
  "archery",
  "crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,4 +103,4 @@ midnight-onchain-vm       = { git = "https://github.com/midnightntwrk/midnight-l
 midnight-onchain-state    = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "onchain-state-3.1.0-rc.1" }
 midnight-onchain-runtime  = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "onchain-runtime-3.1.0-rc.1" }
 midnight-serialize        = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "serialize-1.1.0-rc.1" }
-midnight-storage-core     = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.1" }
+midnight-storage-core     = { git = "https://github.com/midnightntwrk/midnight-ledger", tag = "storage-core-1.2.0-rc.2" }


### PR DESCRIPTION
## Summary

Bump the `[patch.crates-io]` entry for `midnight-storage-core` from `storage-core-1.2.0-rc.1` to `storage-core-1.2.0-rc.2`.

`storage-core-1.2.0-rc.2` includes the `StorageBackend::get()` fix (midnightntwrk/midnight-ledger#433), which resolves the `cache_insert_new_key` panic hit on qanet-blue at block 11074 and the related symptom class from midnight-indexer #987.

Thomas announced the release in #topic-ledger on 17 Apr 16:00 BST. Changelog:
- feat: allow shared parity_db backend through generic Deref
- fix: remove pending Update from memory before cache_insert_new_key in get()

## Test plan

- [x] `just check` passes locally
- [ ] qanet-blue deployment reset + re-sync, verify chain-indexer passes block 11074
- [ ] QA validation of #987, #1024, #1026
