### PR TITLE
chore(deps): bump Rust to 1.95.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.94.1"
+channel = "1.95.0"


### PR DESCRIPTION
- Bumps Rust toolchain from 1.94.1 to 1.95.0.