### PR TITLE
feat: dust generations QDO fields and generation tree index

### DIFF
--- a/chain-indexer/src/infra/storage.rs
+++ b/chain-indexer/src/infra/storage.rs
@@ -701,7 +701,7 @@ async fn save_dust_generation_info(
             LedgerEventAttributes::DustInitialUtxo {
                 output,
                 generation_info,
-                ..
+                generation_index,
             } => {
                 let query = indoc! {"
                     INSERT INTO dust_generation_info (
@@ -711,10 +711,13 @@ async fn save_dust_generation_info(
                         nonce,
                         ctime,
                         merkle_index,
+                        generation_index,
+                        backing_night,
+                        initial_value,
                         dtime,
                         transaction_id
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
                 "};
 
                 let dtime = if generation_info.dtime == u64::MAX {
@@ -730,6 +733,9 @@ async fn save_dust_generation_info(
                     .bind(generation_info.nonce.as_ref())
                     .bind(generation_info.ctime as i64)
                     .bind(output.mt_index as i64)
+                    .bind(*generation_index as i64)
+                    .bind(output.backing_night.as_ref())
+                    .bind(U128BeBytes::from(&output.initial_value))
                     .bind(dtime)
                     .bind(transaction_id)
                     .execute(&mut **tx)

--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -387,10 +387,6 @@ type DustGenerationsItem {
 	"""
 	initialValue: String!
 	"""
-	The hex-encoded nonce.
-	"""
-	nonce: HexEncoded!
-	"""
 	Hex-encoded hash of the NIGHT UTXO that backs this dust output.
 	"""
 	backingNight: HexEncoded!

--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -367,21 +367,38 @@ A dust generations item with optional collapsed Merkle tree update.
 """
 type DustGenerationsItem {
 	"""
-	The Merkle tree index.
+	Deprecated alias of `commitmentMtIndex`. Scheduled for removal in a
+	follow-up release.
 	"""
-	merkleIndex: Int!
+	merkleIndex: Int! @deprecated(reason: "Use `commitmentMtIndex` or `generationMtIndex` to disambiguate which tree. This field mirrors `commitmentMtIndex`.")
+	"""
+	Index of this output in the dust commitment Merkle tree.
+	"""
+	commitmentMtIndex: Int!
+	"""
+	Index of this output in the dust generation Merkle tree.
+	"""
+	generationMtIndex: Int!
 	"""
 	The hex-encoded owner (dust address).
 	"""
 	owner: HexEncoded!
 	"""
-	The NIGHT value in STAR.
+	The NIGHT value backing this output, in STAR.
 	"""
 	value: String!
+	"""
+	The DUST value at creation, in SPECK.
+	"""
+	initialValue: String!
 	"""
 	The hex-encoded nonce.
 	"""
 	nonce: HexEncoded!
+	"""
+	Hex-encoded hash of the NIGHT UTXO that backs this dust output.
+	"""
+	backingNight: HexEncoded!
 	"""
 	The creation timestamp.
 	"""

--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -367,11 +367,6 @@ A dust generations item with optional collapsed Merkle tree update.
 """
 type DustGenerationsItem {
 	"""
-	Deprecated alias of `commitmentMtIndex`. Scheduled for removal in a
-	follow-up release.
-	"""
-	merkleIndex: Int! @deprecated(reason: "Use `commitmentMtIndex` or `generationMtIndex` to disambiguate which tree. This field mirrors `commitmentMtIndex`.")
-	"""
 	Index of this output in the dust commitment Merkle tree.
 	"""
 	commitmentMtIndex: Int!

--- a/indexer-api/src/domain/dust.rs
+++ b/indexer-api/src/domain/dust.rs
@@ -11,8 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use indexer_common::domain::{ByteVec, CardanoRewardAddress, DustPublicKey};
+use indexer_common::{
+    domain::{ByteVec, CardanoRewardAddress, DustPublicKey},
+    infra::sqlx::U128BeBytes,
+};
 use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
 
 /// DUST generation status for a specific Cardano reward address.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -66,13 +70,36 @@ pub struct DustRegistration {
 }
 
 /// A dust generation entry for the subscription stream.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, FromRow)]
 pub struct DustGenerationEntry {
-    pub merkle_index: u64,
+    /// Commitment-tree index from QualifiedDustOutput.mt_index.
+    /// (DB column is named `merkle_index`; SELECT uses an alias.)
+    #[sqlx(try_from = "i64")]
+    pub commitment_mt_index: u64,
+
+    /// Generation-tree index from DustInitialUtxo.generation_index.
+    #[sqlx(try_from = "i64")]
+    pub generation_mt_index: u64,
+
     pub owner: ByteVec,
+
+    /// NIGHT amount backing this dust output, in STAR.
+    #[sqlx(try_from = "U128BeBytes")]
     pub value: u128,
+
+    /// DUST amount at creation, in SPECK, from QualifiedDustOutput.initial_value.
+    #[sqlx(try_from = "U128BeBytes")]
+    pub initial_value: u128,
+
     pub nonce: ByteVec,
+
+    /// Hash of the NIGHT UTXO that backs this dust output (InitialNonce).
+    pub backing_night: ByteVec,
+
+    #[sqlx(try_from = "i64")]
     pub ctime: u64,
+
+    #[sqlx(try_from = "i64")]
     pub transaction_id: u64,
 }
 

--- a/indexer-api/src/domain/dust.rs
+++ b/indexer-api/src/domain/dust.rs
@@ -91,8 +91,6 @@ pub struct DustGenerationEntry {
     #[sqlx(try_from = "U128BeBytes")]
     pub initial_value: u128,
 
-    pub nonce: ByteVec,
-
     /// Hash of the NIGHT UTXO that backs this dust output (InitialNonce).
     pub backing_night: ByteVec,
 

--- a/indexer-api/src/domain/storage/dust_generations.rs
+++ b/indexer-api/src/domain/storage/dust_generations.rs
@@ -32,7 +32,11 @@ where
         ledger_version: LedgerVersion,
     ) -> Result<Vec<DustGenerations>, sqlx::Error>;
 
-    /// Get dust generation entries for a dust address within an index range.
+    /// Get dust generation entries for a dust address within a generation-tree
+    /// index range. `start_index` and `end_index` are interpreted as positions
+    /// in the dust generation Merkle tree (NOT the commitment tree). Entries
+    /// inserted before the dust generation/commitment split was tracked
+    /// (legacy rows with NULL `generation_index`) are skipped.
     async fn get_dust_generation_entries(
         &self,
         dust_address: &[u8],

--- a/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
@@ -59,8 +59,6 @@ pub struct DustGenerationsItem {
     pub value: String,
     /// The DUST value at creation, in SPECK.
     pub initial_value: String,
-    /// The hex-encoded nonce.
-    pub nonce: HexEncoded,
     /// Hex-encoded hash of the NIGHT UTXO that backs this dust output.
     pub backing_night: HexEncoded,
     /// The creation timestamp.
@@ -134,7 +132,6 @@ where
                     owner: entry.owner.hex_encode(),
                     value: entry.value.to_string(),
                     initial_value: entry.initial_value.to_string(),
-                    nonce: entry.nonce.hex_encode(),
                     backing_night: entry.backing_night.hex_encode(),
                     ctime: entry.ctime,
                     transaction_id: entry.transaction_id,
@@ -187,7 +184,6 @@ where
                         owner: entry.owner.hex_encode(),
                         value: entry.value.to_string(),
                         initial_value: entry.initial_value.to_string(),
-                        nonce: entry.nonce.hex_encode(),
                         backing_night: entry.backing_night.hex_encode(),
                         ctime: entry.ctime,
                         transaction_id: entry.transaction_id,

--- a/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
@@ -49,14 +49,25 @@ impl<S, B> Default for DustGenerationsSubscription<S, B> {
 /// A dust generations item with optional collapsed Merkle tree update.
 #[derive(Debug, Clone, SimpleObject)]
 pub struct DustGenerationsItem {
-    /// The Merkle tree index.
+    /// Deprecated alias of `commitmentMtIndex`. Scheduled for removal in a
+    /// follow-up release.
+    #[graphql(deprecation = "Use `commitmentMtIndex` or `generationMtIndex` \
+        to disambiguate which tree. This field mirrors `commitmentMtIndex`.")]
     pub merkle_index: u64,
+    /// Index of this output in the dust commitment Merkle tree.
+    pub commitment_mt_index: u64,
+    /// Index of this output in the dust generation Merkle tree.
+    pub generation_mt_index: u64,
     /// The hex-encoded owner (dust address).
     pub owner: HexEncoded,
-    /// The NIGHT value in STAR.
+    /// The NIGHT value backing this output, in STAR.
     pub value: String,
+    /// The DUST value at creation, in SPECK.
+    pub initial_value: String,
     /// The hex-encoded nonce.
     pub nonce: HexEncoded,
+    /// Hex-encoded hash of the NIGHT UTXO that backs this dust output.
+    pub backing_night: HexEncoded,
     /// The creation timestamp.
     pub ctime: u64,
     /// The originating transaction ID.
@@ -115,18 +126,22 @@ where
             {
                 let collapsed_merkle_tree = make_collapsed_update(
                     cursor,
-                    entry.merkle_index,
+                    entry.generation_mt_index,
                     storage,
                     ledger_state_cache,
                 ).await?;
 
-                cursor = entry.merkle_index + 1;
+                cursor = entry.generation_mt_index + 1;
 
                 yield DustGenerationsEvent::DustGenerationsItem(DustGenerationsItem {
-                    merkle_index: entry.merkle_index,
+                    merkle_index: entry.commitment_mt_index,
+                    commitment_mt_index: entry.commitment_mt_index,
+                    generation_mt_index: entry.generation_mt_index,
                     owner: entry.owner.hex_encode(),
                     value: entry.value.to_string(),
+                    initial_value: entry.initial_value.to_string(),
                     nonce: entry.nonce.hex_encode(),
+                    backing_night: entry.backing_night.hex_encode(),
                     ctime: entry.ctime,
                     transaction_id: entry.transaction_id,
                     collapsed_merkle_tree,
@@ -165,18 +180,22 @@ where
                 {
                     let collapsed_merkle_tree = make_collapsed_update(
                         cursor,
-                        entry.merkle_index,
+                        entry.generation_mt_index,
                         storage,
                         ledger_state_cache,
                     ).await?;
 
-                    cursor = entry.merkle_index + 1;
+                    cursor = entry.generation_mt_index + 1;
 
                     yield DustGenerationsEvent::DustGenerationsItem(DustGenerationsItem {
-                        merkle_index: entry.merkle_index,
+                        merkle_index: entry.commitment_mt_index,
+                        commitment_mt_index: entry.commitment_mt_index,
+                        generation_mt_index: entry.generation_mt_index,
                         owner: entry.owner.hex_encode(),
                         value: entry.value.to_string(),
+                        initial_value: entry.initial_value.to_string(),
                         nonce: entry.nonce.hex_encode(),
+                        backing_night: entry.backing_night.hex_encode(),
                         ctime: entry.ctime,
                         transaction_id: entry.transaction_id,
                         collapsed_merkle_tree,

--- a/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
@@ -49,11 +49,6 @@ impl<S, B> Default for DustGenerationsSubscription<S, B> {
 /// A dust generations item with optional collapsed Merkle tree update.
 #[derive(Debug, Clone, SimpleObject)]
 pub struct DustGenerationsItem {
-    /// Deprecated alias of `commitmentMtIndex`. Scheduled for removal in a
-    /// follow-up release.
-    #[graphql(deprecation = "Use `commitmentMtIndex` or `generationMtIndex` \
-        to disambiguate which tree. This field mirrors `commitmentMtIndex`.")]
-    pub merkle_index: u64,
     /// Index of this output in the dust commitment Merkle tree.
     pub commitment_mt_index: u64,
     /// Index of this output in the dust generation Merkle tree.
@@ -134,7 +129,6 @@ where
                 cursor = entry.generation_mt_index + 1;
 
                 yield DustGenerationsEvent::DustGenerationsItem(DustGenerationsItem {
-                    merkle_index: entry.commitment_mt_index,
                     commitment_mt_index: entry.commitment_mt_index,
                     generation_mt_index: entry.generation_mt_index,
                     owner: entry.owner.hex_encode(),
@@ -188,7 +182,6 @@ where
                     cursor = entry.generation_mt_index + 1;
 
                     yield DustGenerationsEvent::DustGenerationsItem(DustGenerationsItem {
-                        merkle_index: entry.commitment_mt_index,
                         commitment_mt_index: entry.commitment_mt_index,
                         generation_mt_index: entry.generation_mt_index,
                         owner: entry.owner.hex_encode(),

--- a/indexer-api/src/infra/storage/dust_generations.rs
+++ b/indexer-api/src/infra/storage/dust_generations.rs
@@ -143,42 +143,46 @@ impl DustGenerationsStorage for Storage {
 
         try_stream! {
             loop {
+                // `generation_index >= $2` implicitly filters out legacy rows
+                // (inserted before the 002 migration) whose generation_index
+                // is NULL. Those rows also lack backing_night / initial_value,
+                // so skipping them keeps the stream well-typed without having
+                // to plumb Option fields through the domain layer.
                 let query = indoc! {"
-                    SELECT merkle_index, owner, value, nonce, ctime, transaction_id
+                    SELECT
+                        merkle_index AS commitment_mt_index,
+                        generation_index AS generation_mt_index,
+                        owner,
+                        value,
+                        initial_value,
+                        nonce,
+                        backing_night,
+                        ctime,
+                        transaction_id
                     FROM dust_generation_info
                     WHERE owner = $1
-                    AND merkle_index >= $2
-                    AND merkle_index <= $3
-                    ORDER BY merkle_index
+                    AND generation_index >= $2
+                    AND generation_index <= $3
+                    ORDER BY generation_index
                     LIMIT $4
                 "};
 
-                let entries = sqlx::query_as::<_, (i64, ByteVec, U128BeBytes, ByteVec, i64, i64)>(
-                    query,
-                )
-                .bind(&dust_address[..])
-                .bind(start_index as i64)
-                .bind(end_index as i64)
-                .bind(batch_size.get() as i64)
-                .fetch_all(&*pool)
-                .await?;
+                let entries = sqlx::query_as::<_, DustGenerationEntry>(query)
+                    .bind(&dust_address[..])
+                    .bind(start_index as i64)
+                    .bind(end_index as i64)
+                    .bind(batch_size.get() as i64)
+                    .fetch_all(&*pool)
+                    .await?;
 
-                if entries.is_empty() {
+                let Some(last_index) = entries.last().map(|e| e.generation_mt_index) else {
                     break;
+                };
+
+                for entry in entries {
+                    yield entry;
                 }
 
-                for (merkle_index, owner, value, nonce, ctime, transaction_id) in &entries {
-                    yield DustGenerationEntry {
-                        merkle_index: *merkle_index as u64,
-                        owner: owner.clone(),
-                        value: u128::from(*value),
-                        nonce: nonce.clone(),
-                        ctime: *ctime as u64,
-                        transaction_id: *transaction_id as u64,
-                    };
-                }
-
-                let last_index = entries.last().unwrap().0 as u64;
                 if last_index >= end_index {
                     break;
                 }

--- a/indexer-api/src/infra/storage/dust_generations.rs
+++ b/indexer-api/src/infra/storage/dust_generations.rs
@@ -155,7 +155,6 @@ impl DustGenerationsStorage for Storage {
                         owner,
                         value,
                         initial_value,
-                        nonce,
                         backing_night,
                         ctime,
                         transaction_id

--- a/indexer-common/migrations/postgres/002_dust_generations_qdo_fields.sql
+++ b/indexer-common/migrations/postgres/002_dust_generations_qdo_fields.sql
@@ -1,0 +1,15 @@
+-- Expose QualifiedDustOutput fields and the generation-tree index on
+-- dust_generation_info.
+--
+-- Columns are added nullable so the migration runs cleanly on a populated
+-- database. Rows inserted before this migration have NULL for the new
+-- fields and are auto-skipped by the dustGenerations subscription's
+-- `WHERE generation_index >= $cursor` clause (NULL fails the comparison).
+
+--------------------------------------------------------------------------------
+-- dust_generation_info
+--------------------------------------------------------------------------------
+ALTER TABLE dust_generation_info ADD COLUMN generation_index BIGINT;
+ALTER TABLE dust_generation_info ADD COLUMN backing_night BYTEA;
+ALTER TABLE dust_generation_info ADD COLUMN initial_value BYTEA;
+CREATE INDEX ON dust_generation_info (owner, generation_index);

--- a/indexer-common/migrations/sqlite/002_dust_generations_qdo_fields.sql
+++ b/indexer-common/migrations/sqlite/002_dust_generations_qdo_fields.sql
@@ -1,0 +1,15 @@
+-- Expose QualifiedDustOutput fields and the generation-tree index on
+-- dust_generation_info.
+--
+-- Columns are added nullable so the migration runs cleanly on a populated
+-- database. Rows inserted before this migration have NULL for the new
+-- fields and are auto-skipped by the dustGenerations subscription's
+-- `WHERE generation_index >= $cursor` clause (NULL fails the comparison).
+
+--------------------------------------------------------------------------------
+-- dust_generation_info
+--------------------------------------------------------------------------------
+ALTER TABLE dust_generation_info ADD COLUMN generation_index INTEGER;
+ALTER TABLE dust_generation_info ADD COLUMN backing_night BLOB;
+ALTER TABLE dust_generation_info ADD COLUMN initial_value BLOB;
+CREATE INDEX dust_generation_info_owner_generation_index_idx ON dust_generation_info (owner, generation_index);


### PR DESCRIPTION
Closes #1053. Locked design from #efficient-wallet-syncing with @jsidorenko and @tkerber (16 to 21 Apr).

## Summary

1. **QDO field exposure** on `DustGenerationsItem`: added `commitmentMtIndex`, `generationMtIndex`, `backingNight`, `initialValue`.
2. **Generation tree index fix**: subscription cursor and collapsed update boundaries now advance on `DustInitialUtxo.generation_index`, not the commitment tree index. The two diverge once dust spending begins.

## Final `DustGenerationsItem` shape

```graphql
type DustGenerationsItem {
  commitmentMtIndex: Int!
  generationMtIndex: Int!
  owner: HexEncoded!
  value: String!                  # NIGHT in STAR
  initialValue: String!           # DUST in SPECK
  backingNight: HexEncoded!
  ctime: Int!
  transactionId: Int!
  collapsedMerkleTree: MerkleTreeCollapsedUpdate
}
```

## Breaking changes

- `merkleIndex` removed, replaced by `commitmentMtIndex` + `generationMtIndex`. Wallet hadn't integrated it.
- `nonce` removed. It held `gen_info.nonce`, which equals `qdo.backing_night` per ledger `fresh_dust_output`, so `backingNight` carries the same bytes. Wallet derives `qdo.nonce` locally from `backingNight + owner + seq=0` (per @tkerber's anonymity-set preference).

## Test plan

- [ ] Wallet integrates against image `4.1.0-f8c55de0` (the subsequent removals are strict reductions; no fresh image cut since the old one is a schema superset)
- [ ] QA updates subscription tests for the new field set (#1034, Giuseppe)
- [ ] No chain reset required on deploy (nullable migration, legacy rows auto-skipped)
