### PR TITLE
feat(indexer-api): add dustGenerationMerkleTreeUpdate query

### DIFF
--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -674,6 +674,10 @@ type Query {
 	"""
 	dustCommitmentMerkleTreeUpdate(startIndex: Int!, endIndex: Int!): MerkleTreeCollapsedUpdate!
 	"""
+	Get a collapsed Merkle tree update for the dust generation tree.
+	"""
+	dustGenerationMerkleTreeUpdate(startIndex: Int!, endIndex: Int!): MerkleTreeCollapsedUpdate!
+	"""
 	Get the full history of D-parameter changes for governance auditability.
 	"""
 	dParameterHistory: [DParameterChange!]!

--- a/indexer-api/src/infra/api/v4/query.rs
+++ b/indexer-api/src/infra/api/v4/query.rs
@@ -338,6 +338,35 @@ where
             .map(MerkleTreeCollapsedUpdate::from)
     }
 
+    /// Get a collapsed Merkle tree update for the dust generation tree.
+    #[trace(properties = { "start_index": "{start_index}", "end_index": "{end_index}" })]
+    async fn dust_generation_merkle_tree_update(
+        &self,
+        cx: &Context<'_>,
+        start_index: u64,
+        end_index: u64,
+    ) -> ApiResult<MerkleTreeCollapsedUpdate> {
+        let storage = cx.get_storage::<S>();
+
+        let (protocol_version, _) = storage
+            .get_highest_ledger_state()
+            .await
+            .map_err_into_server_error(|| "get highest ledger state")?
+            .some_or_server_error(|| "no ledger state available")?;
+
+        cx.get_ledger_state_cache()
+            .dust_generations_collapsed_update(start_index, end_index, storage, protocol_version)
+            .await
+            .map_err(|error| match error {
+                error @ LedgerStateCacheError::Ledger(ledger::Error::InvalidUpdate(_)) => {
+                    ApiError::client("invalid start_index and/or end_index", error)
+                }
+
+                error => ApiError::server("create dust generation collapsed update", error),
+            })
+            .map(MerkleTreeCollapsedUpdate::from)
+    }
+
     /// Get the full history of D-parameter changes for governance auditability.
     #[trace]
     async fn d_parameter_history(&self, cx: &Context<'_>) -> ApiResult<Vec<DParameterChange>> {

--- a/indexer-tests/e2e.graphql
+++ b/indexer-tests/e2e.graphql
@@ -821,6 +821,15 @@ query DustCommitmentMerkleTreeUpdateQuery($startIndex: Int!, $endIndex: Int!) {
     }
 }
 
+query DustGenerationMerkleTreeUpdateQuery($startIndex: Int!, $endIndex: Int!) {
+    dustGenerationMerkleTreeUpdate(startIndex: $startIndex, endIndex: $endIndex) {
+        startIndex
+        endIndex
+        update
+        protocolVersion
+    }
+}
+
 query DParameterHistoryQuery {
     dParameterHistory {
         blockHeight

--- a/indexer-tests/src/e2e.rs
+++ b/indexer-tests/src/e2e.rs
@@ -17,11 +17,11 @@ use crate::{
     e2e::graphql::{
         BlockQuery, BlockSubscription, ConnectMutation, ContractActionQuery,
         ContractActionSubscription, DParameterHistoryQuery, DisconnectMutation,
-        DustCommitmentMerkleTreeUpdateQuery, DustGenerationStatusQuery, DustGenerationsQuery,
-        DustLedgerEventsSubscription, ShieldedNullifierTransactionsSubscription,
-        ShieldedTransactionsSubscription, TermsAndConditionsHistoryQuery, TransactionsQuery,
-        UnshieldedTransactionsSubscription, ZswapLedgerEventsSubscription,
-        ZswapMerkleTreeCollapsedUpdateQuery, block_query,
+        DustCommitmentMerkleTreeUpdateQuery, DustGenerationMerkleTreeUpdateQuery,
+        DustGenerationStatusQuery, DustGenerationsQuery, DustLedgerEventsSubscription,
+        ShieldedNullifierTransactionsSubscription, ShieldedTransactionsSubscription,
+        TermsAndConditionsHistoryQuery, TransactionsQuery, UnshieldedTransactionsSubscription,
+        ZswapLedgerEventsSubscription, ZswapMerkleTreeCollapsedUpdateQuery, block_query,
         block_subscription::{
             self, BlockSubscriptionBlocks, BlockSubscriptionBlocksTransactions,
             BlockSubscriptionBlocksTransactionsContractActions,
@@ -34,8 +34,8 @@ use crate::{
         connect_mutation,
         contract_action_query::{self},
         contract_action_subscription, disconnect_mutation,
-        dust_commitment_merkle_tree_update_query, dust_generation_status_query,
-        dust_generations_query, dust_ledger_events_subscription,
+        dust_commitment_merkle_tree_update_query, dust_generation_merkle_tree_update_query,
+        dust_generation_status_query, dust_generations_query, dust_ledger_events_subscription,
         shielded_nullifier_transactions_subscription, shielded_transactions_subscription,
         transactions_query, unshielded_transactions_subscription, zswap_ledger_events_subscription,
         zswap_merkle_tree_collapsed_update_query,
@@ -116,6 +116,9 @@ pub async fn run(network_id: NetworkId, host: &str, port: u16, secure: bool) -> 
     test_dust_commitment_merkle_tree_update_query(&api_client, &api_url)
         .await
         .context("test dust commitment merkle tree update query")?;
+    test_dust_generation_merkle_tree_update_query(&api_client, &api_url)
+        .await
+        .context("test dust generation merkle tree update query")?;
     test_governance_queries(&api_client, &api_url)
         .await
         .context("test governance queries")?;
@@ -748,6 +751,22 @@ async fn test_dust_commitment_merkle_tree_update_query(
     Ok(())
 }
 
+/// Test the dustGenerationMerkleTreeUpdate query.
+async fn test_dust_generation_merkle_tree_update_query(
+    api_client: &Client,
+    api_url: &str,
+) -> anyhow::Result<()> {
+    let variables = dust_generation_merkle_tree_update_query::Variables {
+        start_index: 0,
+        end_index: 0,
+    };
+    let response =
+        send_query::<DustGenerationMerkleTreeUpdateQuery>(api_client, api_url, variables).await?;
+    assert!(response.dust_generation_merkle_tree_update.start_index >= 0);
+
+    Ok(())
+}
+
 /// Test governance queries (D-Parameter and Terms & Conditions history).
 async fn test_governance_queries(api_client: &Client, api_url: &str) -> anyhow::Result<()> {
     use crate::e2e::graphql::{d_parameter_history_query, terms_and_conditions_history_query};
@@ -1258,6 +1277,14 @@ mod graphql {
         response_derives = "Debug, Clone, Serialize"
     )]
     pub struct DustCommitmentMerkleTreeUpdateQuery;
+
+    #[derive(GraphQLQuery)]
+    #[graphql(
+        schema_path = "../indexer-api/graphql/schema-v4.graphql",
+        query_path = "./e2e.graphql",
+        response_derives = "Debug, Clone, Serialize"
+    )]
+    pub struct DustGenerationMerkleTreeUpdateQuery;
 
     #[derive(GraphQLQuery)]
     #[graphql(


### PR DESCRIPTION
Closes #1048.

Adds a standalone GraphQL query `dustGenerationMerkleTreeUpdate(startIndex: Int!, endIndex: Int!): MerkleTreeCollapsedUpdate!` that mirrors the existing `dustCommitmentMerkleTreeUpdate` query but operates on the dust generation tree.

## Why

Wallets doing one-shot initial sync via ledger 8.1's `applyGenerationCollapsedUpdate()` need a standalone query for generation-tree collapsed updates, in symmetry with `applyCommitmentCollapsedUpdate()` already served by `dustCommitmentMerkleTreeUpdate`. Currently the only way to obtain a generation-tree update is through the streaming `dustGenerations` subscription, which is overkill for clients that just need a one-shot fetch.

## Scope

The internal capability already exists (`LedgerStateCache::dust_generations_collapsed_update`), used by the `dustGenerations` subscription. This PR exposes it via a new resolver method that mirrors `dust_commitment_merkle_tree_update` exactly (same `#[trace]` properties, same error mapping, same `MerkleTreeCollapsedUpdate::from`).

## Limitation (same as commitment query)
The indexer caches only the latest ledger state, so the query fails if `endIndex` exceeds `dust_generations_first_free()` of the cached state. Inherent to the current design, not a regression.

## Test plan

- [x] e2e tests pass (new `test_dust_generation_merkle_tree_update_query`)
- [ ] Wallet integration confirms it satisfies the one-shot sync use case