### PR TITLE
fix(indexer-common): keep in-memory pub/sub drain tasks alive after lag

### DIFF
--- a/indexer-common/src/infra/pub_sub/in_mem.rs
+++ b/indexer-common/src/infra/pub_sub/in_mem.rs
@@ -124,4 +124,45 @@ mod tests {
 
         Ok(())
     }
+
+    /// Regression test: when no external subscriber is attached, the drain
+    /// task is the sole receiver keeping the channel alive. If it broke on
+    /// `RecvError::Lagged` (the pre-fix behavior), the receiver would be
+    /// dropped and subsequent `publish` calls would fail with `SendError`
+    /// because the broadcast channel has no active receivers.
+    ///
+    /// To force the drain task to lag, we publish far more messages than the
+    /// channel capacity (42) in a tight loop. `publish` contains no await
+    /// points, so on a current-thread runtime the drain task cannot be
+    /// scheduled until we explicitly yield, guaranteeing overflow.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_drain_survives_lag() -> Result<(), Box<dyn StdError>> {
+        let pub_sub = InMemPubSub::default();
+        let publisher = pub_sub.publisher();
+
+        for height in 0..1000 {
+            publisher
+                .publish(&BlockIndexed {
+                    height,
+                    max_transaction_id: None,
+                    caught_up: false,
+                })
+                .await?;
+        }
+
+        // Let the drain task observe the lag.
+        sleep(Duration::from_millis(50)).await;
+
+        // If the drain task broke on lag, this publish would fail with
+        // `SendError` because no receivers remain.
+        publisher
+            .publish(&BlockIndexed {
+                height: 9999,
+                max_transaction_id: None,
+                caught_up: false,
+            })
+            .await?;
+
+        Ok(())
+    }
 }

--- a/indexer-common/src/infra/pub_sub/in_mem.rs
+++ b/indexer-common/src/infra/pub_sub/in_mem.rs
@@ -15,10 +15,10 @@ pub mod publisher;
 pub mod subscriber;
 
 use crate::infra::pub_sub::in_mem::{publisher::InMemPublisher, subscriber::InMemSubscriber};
-use log::error;
+use log::warn;
 use serde_json::Value;
 use tokio::{
-    sync::broadcast::{self, Sender, error::RecvError},
+    sync::broadcast::{self, Receiver, Sender, error::RecvError},
     task,
 };
 
@@ -44,9 +44,9 @@ impl InMemPubSub {
 
 impl Default for InMemPubSub {
     fn default() -> Self {
-        let (block_indexed_sender, mut block_indexed_receiver) = broadcast::channel(42);
-        let (wallet_indexed_sender, mut wallet_indexed_receiver) = broadcast::channel(42);
-        let (unshielded_utxo_sender, mut unshielded_utxo_receiver) = broadcast::channel(42);
+        let (block_indexed_sender, block_indexed_receiver) = broadcast::channel(42);
+        let (wallet_indexed_sender, wallet_indexed_receiver) = broadcast::channel(42);
+        let (unshielded_utxo_sender, unshielded_utxo_receiver) = broadcast::channel(42);
 
         let pub_sub = InMemPubSub {
             block_indexed_sender,
@@ -54,59 +54,35 @@ impl Default for InMemPubSub {
             unshielded_utxo_sender,
         };
 
-        task::spawn(async move {
-            loop {
-                match block_indexed_receiver.recv().await {
-                    Ok(_) => continue,
-
-                    Err(RecvError::Lagged(_)) => {
-                        error!("cannot drain block_indexed_receiver");
-                        break;
-                    }
-
-                    Err(RecvError::Closed) => {
-                        break;
-                    }
-                }
-            }
-        });
-
-        task::spawn(async move {
-            loop {
-                match wallet_indexed_receiver.recv().await {
-                    Ok(_) => continue,
-
-                    Err(RecvError::Lagged(_)) => {
-                        error!("cannot drain wallet_indexed_receiver");
-                        break;
-                    }
-
-                    Err(RecvError::Closed) => {
-                        break;
-                    }
-                }
-            }
-        });
-
-        task::spawn(async move {
-            loop {
-                match unshielded_utxo_receiver.recv().await {
-                    Ok(_) => continue,
-
-                    Err(RecvError::Lagged(_)) => {
-                        error!("cannot drain unshielded_utxo_receiver");
-                        break;
-                    }
-
-                    Err(RecvError::Closed) => {
-                        break;
-                    }
-                }
-            }
-        });
+        // Keep one receiver alive per topic for as long as the `InMemPubSub`
+        // lives. This guarantees that `broadcast::Sender::send` always has at
+        // least one active receiver, so publishers do not see spurious
+        // "channel closed" errors when no external subscriber happens to be
+        // attached. `RecvError::Lagged` does not invalidate the receiver —
+        // `recv` just skips ahead — so we must keep looping, not break.
+        spawn_drain("block_indexed_receiver", block_indexed_receiver);
+        spawn_drain("wallet_indexed_receiver", wallet_indexed_receiver);
+        spawn_drain("unshielded_utxo_receiver", unshielded_utxo_receiver);
 
         pub_sub
     }
+}
+
+fn spawn_drain(name: &'static str, mut receiver: Receiver<Value>) {
+    task::spawn(async move {
+        loop {
+            match receiver.recv().await {
+                Ok(_) => continue,
+
+                Err(RecvError::Lagged(skipped)) => {
+                    warn!(receiver = name, skipped; "drain receiver lagged");
+                    continue;
+                }
+
+                Err(RecvError::Closed) => break,
+            }
+        }
+    });
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### What was happening

In standalone mode we use `tokio::sync::broadcast` channels (capacity 42) for pub/sub. For each topic (`BlockIndexed`, `WalletIndexed`, `UnshieldedUtxoIndexed`) we spawn a background "drain" task whose whole purpose is to keep at least one receiver alive, so that publishers never see `SendError` just because no GraphQL client happens to be subscribed at that moment.

The drain task had a bug: on `RecvError::Lagged(_)` it logged an error and broke out of its loop, which dropped the receiver. The moment that happened, if no external subscriber (GraphQL client) was attached to that topic, the sender had zero active receivers, and the very next `send` returned `SendError`. Publishers treat this as fatal and propagate it up with `?`.

On our nodes we saw this as:

```
ERROR indexer_standalone: chain-indexer exited with ERROR
  error: index_blocks_task failed: publish UnshieldedUtxoIndexed event:
         cannot send message: channel closed
```

The process would then shut down and systemd would restart it. Sporadic, always hit `UnshieldedUtxoIndexed`, never `BlockIndexed` or `WalletIndexed` in practice.

### Why `UnshieldedUtxoIndexed` specifically

Chain-indexer publishes one `UnshieldedUtxoIndexed` per unique owner address affected by a block. A single block with many unshielded owners fans out into a burst of N events all dispatched in the same tight loop. The 42-slot ring buffer can overflow before the drain task gets a chance to pull from it, and the drain lags. `BlockIndexed` and `WalletIndexed` are one-per-block / one-per-wallet-session, much less bursty, so in practice they never tripped the same ceiling even though the bug was identical in all three drain loops.

### Why `Lagged` is not fatal

`broadcast::Receiver::recv()` returning `Lagged(n)` does not invalidate the receiver. It just tells you "you missed n messages, the next recv will resume at the oldest slot still in the ring." The correct response in a drain-only task is to keep looping. Breaking out of the loop is exactly the wrong move because it destroys the very thing the drain task exists to guarantee (at least one receiver on the channel).

### The fix

Change the three drain loops so that `Lagged` falls through to `continue`. Only `Closed` ends the loop, and that only happens if `InMemPubSub` itself is dropped, which by construction does not happen while the process is running. Pulled the three identical loops into one `spawn_drain` helper. Downgraded the log to `warn!` with the skipped-count so we still notice lag without pretending it is fatal.

Before:

```rust
Err(RecvError::Lagged(_)) => {
    error!("cannot drain block_indexed_receiver");
    break;
}
```

After:

```rust
Err(RecvError::Lagged(skipped)) => {
    warn!(receiver = name, skipped; "drain receiver lagged");
    continue;
}
```