### PR TITLE
fix: correct paidFees computation (backport of #1031 and #1061)

### DIFF
--- a/.github/actions/init-env/action.yml
+++ b/.github/actions/init-env/action.yml
@@ -1,0 +1,11 @@
+name: Init Env Vars
+description: Initialize certain environment variables (secrets) with random values
+runs:
+  using: composite
+  steps:
+    - name: Generate random Env Vars
+      shell: bash
+      run: |
+        echo "APP__INFRA__PUB_SUB__PASSWORD=$(openssl rand -hex 32)" >> "$GITHUB_ENV"
+        echo "APP__INFRA__SECRET=$(openssl rand -hex 32)" >> "$GITHUB_ENV"
+        echo "APP__INFRA__STORAGE__PASSWORD=$(openssl rand -hex 32)" >> "$GITHUB_ENV"

--- a/.github/workflows/ci-cloud.yaml
+++ b/.github/workflows/ci-cloud.yaml
@@ -52,16 +52,15 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
+      - name: Init Env Vars
+        uses: ./.github/actions/init-env
+
       - name: just check
         run: |
           . ./.envrc
           git config --global url."https://@github.com".insteadOf "ssh://git@github.com"
           rustup override set ${{needs.toolchain.outputs.toolchain}}
           just feature=cloud check
-        env:
-          APP__INFRA__STORAGE__PASSWORD: ${{ secrets.APP__INFRA__STORAGE__PASSWORD }}
-          APP__INFRA__PUB_SUB__PASSWORD: ${{ secrets.APP__INFRA__PUB_SUB__PASSWORD }}
-          APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
 
   fmt-check:
     runs-on: ubuntu-latest
@@ -108,16 +107,15 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
+      - name: Init Env Vars
+        uses: ./.github/actions/init-env
+
       - name: just lint
         run: |
           . ./.envrc
           git config --global url."https://@github.com".insteadOf "ssh://git@github.com"
           rustup override set ${{needs.toolchain.outputs.toolchain}}
           just feature=cloud lint
-        env:
-          APP__INFRA__STORAGE__PASSWORD: ${{ secrets.APP__INFRA__STORAGE__PASSWORD }}
-          APP__INFRA__PUB_SUB__PASSWORD: ${{ secrets.APP__INFRA__PUB_SUB__PASSWORD }}
-          APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
 
   test:
     runs-on: ubuntu-latest-8-core-x64
@@ -153,16 +151,15 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
+      - name: Init Env Vars
+        uses: ./.github/actions/init-env
+
       - name: just test
         run: |
           . ./.envrc
           git config --global url."https://@github.com".insteadOf "ssh://git@github.com"
           rustup override set ${{needs.toolchain.outputs.toolchain}}
           just feature=cloud test
-        env:
-          APP__INFRA__STORAGE__PASSWORD: ${{ secrets.APP__INFRA__STORAGE__PASSWORD }}
-          APP__INFRA__PUB_SUB__PASSWORD: ${{ secrets.APP__INFRA__PUB_SUB__PASSWORD }}
-          APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
 
   doc:
     runs-on: ubuntu-latest-8-core-x64

--- a/.github/workflows/ci-standalone.yaml
+++ b/.github/workflows/ci-standalone.yaml
@@ -52,14 +52,15 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
+      - name: Init Env Vars
+        uses: ./.github/actions/init-env
+
       - name: just check
         run: |
           . ./.envrc
           git config --global url."https://@github.com".insteadOf "ssh://git@github.com"
           rustup override set ${{needs.toolchain.outputs.toolchain}}
           just feature=standalone check
-        env:
-          APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
 
   fmt-check:
     runs-on: ubuntu-latest
@@ -106,14 +107,15 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
+      - name: Init Env Vars
+        uses: ./.github/actions/init-env
+
       - name: just lint
         run: |
           . ./.envrc
           git config --global url."https://@github.com".insteadOf "ssh://git@github.com"
           rustup override set ${{needs.toolchain.outputs.toolchain}}
           just feature=standalone lint
-        env:
-          APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
 
   test:
     runs-on: ubuntu-latest-8-core-x64
@@ -149,14 +151,15 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
+      - name: Init Env Vars
+        uses: ./.github/actions/init-env
+
       - name: just test
         run: |
           . ./.envrc
           git config --global url."https://@github.com".insteadOf "ssh://git@github.com"
           rustup override set ${{needs.toolchain.outputs.toolchain}}
           just feature=standalone test
-        env:
-          APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
 
   doc:
     runs-on: ubuntu-latest-8-core-x64

--- a/chain-indexer/src/domain/ledger_state.rs
+++ b/chain-indexer/src/domain/ledger_state.rs
@@ -121,6 +121,7 @@ impl LedgerState {
             created_unshielded_utxos,
             spent_unshielded_utxos,
             ledger_events,
+            fees,
         } = self
             .0
             .apply_regular_transaction(
@@ -142,6 +143,8 @@ impl LedgerState {
         transaction.created_unshielded_utxos = created_unshielded_utxos;
         transaction.spent_unshielded_utxos = spent_unshielded_utxos;
         transaction.ledger_events = ledger_events;
+        transaction.paid_fees = fees;
+        transaction.estimated_fees = fees;
 
         // Update contract actions.
         for contract_action in transaction.contract_actions.iter_mut() {

--- a/indexer-common/src/domain.rs
+++ b/indexer-common/src/domain.rs
@@ -155,6 +155,7 @@ pub struct ApplyRegularTransactionOutcome {
     pub created_unshielded_utxos: Vec<UnshieldedUtxo>,
     pub spent_unshielded_utxos: Vec<UnshieldedUtxo>,
     pub ledger_events: Vec<LedgerEvent>,
+    pub fees: u128,
 }
 
 /// The outcome of applying a system transaction to the ledger state along with extracted data.

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 use fastrace::trace;
 use itertools::Itertools;
-use log::info;
+use log::{error, info};
 use midnight_base_crypto::{
     cost_model::{FixedPoint, NormalizedCost, SyntheticCost},
     hash::{HashOutput, persistent_commit},
@@ -386,6 +386,9 @@ impl LedgerState {
                 let cost = transaction
                     .cost(&ledger_state.parameters, true)
                     .map_err(|error| Error::TransactionCost(error.into()))?;
+                let fees = transaction
+                    .fees(&ledger_state.parameters, true)
+                    .map_err(|error| Error::TransactionCost(error.into()))?;
                 let verified_ledger_transaction = transaction
                     .well_formed(&cx.ref_state, *STRICTNESS_V7, cx.block_context.tblock)
                     .map_err(|error| Error::MalformedTransaction(error.into()))?;
@@ -434,6 +437,7 @@ impl LedgerState {
                     created_unshielded_utxos,
                     spent_unshielded_utxos,
                     ledger_events,
+                    fees,
                 })
             }
 
@@ -458,6 +462,9 @@ impl LedgerState {
 
                 let cost = transaction
                     .cost(&ledger_state.parameters, true)
+                    .map_err(|error| Error::TransactionCost(error.into()))?;
+                let fees = transaction
+                    .fees(&ledger_state.parameters, true)
                     .map_err(|error| Error::TransactionCost(error.into()))?;
                 let verified_ledger_transaction = transaction
                     .well_formed(&cx.ref_state, *STRICTNESS_V8, cx.block_context.tblock)
@@ -507,6 +514,7 @@ impl LedgerState {
                     created_unshielded_utxos,
                     spent_unshielded_utxos,
                     ledger_events,
+                    fees,
                 })
             }
         }
@@ -682,9 +690,9 @@ impl LedgerState {
                 block_fullness,
             } => {
                 let timestamp = timestamp(block_timestamp);
-                let normalized_fullness = block_fullness
-                    .normalize(ledger_state.parameters.limits.block_limits)
-                    .unwrap_or(NormalizedCost::ZERO);
+                let block_limits = ledger_state.parameters.limits.block_limits;
+                let normalized_fullness =
+                    clamp_and_normalize(block_fullness, &block_limits, "post_block_update_v7");
                 let overall_fullness = FixedPoint::max(
                     FixedPoint::max(
                         FixedPoint::max(
@@ -718,9 +726,9 @@ impl LedgerState {
                 block_fullness,
             } => {
                 let timestamp = timestamp(block_timestamp);
-                let normalized_fullness = block_fullness
-                    .normalize(ledger_state.parameters.limits.block_limits)
-                    .unwrap_or(NormalizedCost::ZERO);
+                let block_limits = ledger_state.parameters.limits.block_limits;
+                let normalized_fullness =
+                    clamp_and_normalize(block_fullness, &block_limits, "post_block_update_v8");
                 let overall_fullness = FixedPoint::max(
                     FixedPoint::max(
                         FixedPoint::max(
@@ -1645,6 +1653,31 @@ where
         .utxos
         .get(utxo)
         .map(|meta| meta.ctime.to_secs())
+}
+
+/// Matches the node's `clamp_and_normalize`: falling back to `NormalizedCost::ZERO` on
+/// overflow would drive `overall_price` opposite to the node and compound drift.
+fn clamp_and_normalize(
+    cost: &SyntheticCost,
+    limits: &SyntheticCost,
+    context: &str,
+) -> NormalizedCost {
+    let clamped = SyntheticCost {
+        read_time: cost.read_time.min(limits.read_time),
+        compute_time: cost.compute_time.min(limits.compute_time),
+        block_usage: cost.block_usage.min(limits.block_usage),
+        bytes_written: cost.bytes_written.min(limits.bytes_written),
+        bytes_churned: cost.bytes_churned.min(limits.bytes_churned),
+    };
+    if clamped != *cost {
+        error!(
+            original:? = *cost,
+            limits:? = *limits,
+            context;
+            "block fullness exceeded limits, clamping"
+        );
+    }
+    clamped.normalize(*limits).expect("clamped cost normalises")
 }
 
 #[cfg(test)]

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -1687,6 +1687,7 @@ mod tests {
         error::BoxError,
     };
     use anyhow::Context;
+    use midnight_base_crypto::cost_model::SyntheticCost;
 
     #[cfg(any(feature = "cloud", feature = "standalone"))]
     #[tokio::test(flavor = "multi_thread")]
@@ -1786,5 +1787,67 @@ mod tests {
         assert!(result.is_err());
 
         Ok(())
+    }
+
+    /// Overflow in any dimension clamps to the corresponding limit; resulting `NormalizedCost`
+    /// has each dim = 1.0. Regression guard: previously we used
+    /// `.normalize().unwrap_or(NormalizedCost::ZERO)` which flipped the sign of the price
+    /// adjustment relative to the node.
+    #[test]
+    fn test_clamp_and_normalize_overflow_normalises_to_one() {
+        use super::clamp_and_normalize;
+        use midnight_base_crypto::cost_model::{CostDuration, FixedPoint};
+
+        let limits = SyntheticCost {
+            read_time: CostDuration::from_picoseconds(1_000),
+            compute_time: CostDuration::from_picoseconds(1_000),
+            block_usage: 1_000,
+            bytes_written: 1_000,
+            bytes_churned: 1_000,
+        };
+        let overfull = SyntheticCost {
+            read_time: limits.read_time,
+            compute_time: limits.compute_time,
+            block_usage: limits.block_usage + 1,
+            bytes_written: limits.bytes_written,
+            bytes_churned: limits.bytes_churned,
+        };
+
+        let normalized = clamp_and_normalize(&overfull, &limits, "test");
+        assert_eq!(normalized.read_time, FixedPoint::ONE);
+        assert_eq!(normalized.compute_time, FixedPoint::ONE);
+        assert_eq!(normalized.block_usage, FixedPoint::ONE);
+        assert_eq!(normalized.bytes_written, FixedPoint::ONE);
+        assert_eq!(normalized.bytes_churned, FixedPoint::ONE);
+    }
+
+    /// Non-overfull cost normalises to the expected ratios.
+    #[test]
+    fn test_clamp_and_normalize_below_limits_preserves_ratios() {
+        use super::clamp_and_normalize;
+        use midnight_base_crypto::cost_model::{CostDuration, FixedPoint};
+
+        let limits = SyntheticCost {
+            read_time: CostDuration::from_picoseconds(1_000),
+            compute_time: CostDuration::from_picoseconds(1_000),
+            block_usage: 1_000,
+            bytes_written: 1_000,
+            bytes_churned: 1_000,
+        };
+        let cost = SyntheticCost {
+            read_time: CostDuration::from_picoseconds(500),
+            compute_time: CostDuration::from_picoseconds(500),
+            block_usage: 500,
+            bytes_written: 500,
+            bytes_churned: 500,
+        };
+
+        let normalized = clamp_and_normalize(&cost, &limits, "test");
+        let half = FixedPoint::from_u64_div(1, 2);
+        assert_eq!(normalized.read_time, half);
+        assert_eq!(normalized.compute_time, half);
+        assert_eq!(normalized.block_usage, half);
+        assert_eq!(normalized.bytes_written, half);
+        assert_eq!(normalized.bytes_churned, half);
     }
 }


### PR DESCRIPTION
# Overview

Backports two fixes from `main` onto `release/4.0`, targeting a 4.0.2 point release that fixes `paidFees` returned by the GraphQL API.

- `#1031` (main, `6c36ef0e`) switched `paidFees` from the node's `get_transaction_cost()` RPC (Substrate weight) to the ledger's `Transaction::fees(params, true)` (SPECKs). The `fees` field is now computed in `indexer-common::LedgerState::apply_regular_transaction` and plumbed through to the chain-indexer's transaction record.
- `#1061` (main, `7fd1fe98`, closes #1060) replaces `.normalize(limits).unwrap_or(NormalizedCost::ZERO)` in `finalize_apply_transactions` with a `clamp_and_normalize` helper mirroring the node's version 1:1. Without this, overfull blocks drove the indexer's `fee_prices.overall_price` in the opposite direction to the node's, decaying it to `MIN_COST = FixedPoint(100)`.

Together they produce correct on-chain fees in SPECKs via `Transaction::fees(fee_prices, true)`, with the `fee_prices` no longer drifting. Applied to both V7 and V8 ledger arms (v4.0.1 supports both; main only has V8).

The backport deliberately skips the cleanup from #1031 (delete `transaction_fees.rs`, remove unused `get_transaction_cost` RPC bindings, remove unused fee fields from `node::RegularTransaction`) to keep the diff minimal. The old RPC path still runs and writes a weight value, which is then overwritten by the ledger-computed `fees` in `apply_regular_transaction`. Dead but harmless.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (two regression tests for `clamp_and_normalize`, backported from #1061)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [ ] Update README.md file (if relevant)
- [ ] Update documentation (if relevant)
- [x] No new todos introduced

## Rollout

Historical `block.ledger_parameters` on deployed envs reflects the drifted pre-fix state. Once 4.0.2 is deployed, each env needs an **indexer reset** (drop indexer DB and re-sync from the node); node chain state is unaffected. For mainnet, the blue/green deployment allows rolling this on the secondary namespace, re-syncing there, and cutting over when ready.

## Links

Closes #1060
Cherry-picks behaviour from #1031 and #1061