### PR TITLE
chore(release): prepare for 4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.2] - 2026-04-23
+
+### 🐛 Bug Fixes
+
+- Correct paidFees computation (backport of #1031 and #1061) (#1068)
+
 ## [4.0.1] - 2026-03-25
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "chain-indexer"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3004,7 +3004,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6756,7 +6756,7 @@ dependencies = [
 
 [[package]]
 name = "spo-indexer"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "anyhow",
  "blake2",
@@ -8243,7 +8243,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-indexer"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version       = "4.0.1"
+version       = "4.0.2"
 edition       = "2024"
 license       = "Apache-2.0"
 readme        = "README.md"


### PR DESCRIPTION
# Overview

Release prep for 4.0.2. Bumps the workspace version from 4.0.1 to 4.0.2 and adds the CHANGELOG entry for the paidFees fix that landed in #1068.

Once merged, I'll tag `v4.0.2` on the merge commit (annotated, message `Release 4.0.2`) so the `build-indexer-images` workflow cuts the image. Rollout goes lower envs to higher envs: devnet and qanet-blue first to validate, then preprod and preview, then mainnet (blue/green cutover on the last three). Each env needs an indexer reset (drop indexer DB and re-sync from the node), chain state on the node stays as is.

## Changes

- `Cargo.toml`: `version = "4.0.1"` → `"4.0.2"`
- `Cargo.lock`: workspace member versions regenerated
- `CHANGELOG.md`: new `[4.0.2] - 2026-04-23` section via `git cliff --unreleased --tag v4.0.2 --prepend CHANGELOG.md`

## Links

- Fix PR: #1068 (paidFees correction, backport of #1031 and #1061)
- Issue: #1060