### PR TITLE
chore(release): prepare for 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.0] - 2026-04-23
+
+### 🚀 Features
+
+- *(indexer-api)* Add dustGenerationMerkleTreeUpdate query (#1062)
+- Dust generations QDO fields and generation tree index (#1059)
+
+### 🐛 Bug Fixes
+
+- *(indexer-common)* Clamp block_fullness on post_block_update to match node (#1061)
+
+### ⚡ Performance
+
+- *(chain-indexer)* Replace backward traversal with forward iteration by block height (#1038)
+
 ## [4.1.0] - 2026-04-20
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "chain-indexer"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3061,7 +3061,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-api"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3153,7 +3153,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-standalone"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "byte-unit-serde",
@@ -3170,7 +3170,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-tests"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -6608,7 +6608,7 @@ dependencies = [
 
 [[package]]
 name = "spo-indexer"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -8093,7 +8093,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-indexer"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version       = "4.1.0"
+version       = "4.2.0"
 edition       = "2024"
 license       = "Apache-2.0"
 readme        = "README.md"


### PR DESCRIPTION
Release prep for 4.2.0.

## Changes
- Bump workspace version from 4.1.0 to 4.2.0 in `Cargo.toml`
- Regenerate `Cargo.lock` for the version bump
- Add `[4.2.0]` CHANGELOG entry via `git-cliff --unreleased --tag v4.2.0`
- Tidy CHANGELOG: removed superseded `[4.1.0-rc.1]`, `[4.1.0-alpha.0]`, and the duplicate `[4.1.0]` (incremental rc.1→final) entries; kept the consolidated `[4.1.0]`

## What's in 4.2.0 (since v4.1.0)

### 🚀 Features
- *(indexer-api)* Add dustGenerationMerkleTreeUpdate query (#1062)
- Dust generations QDO fields and generation tree index (#1059)

### 🐛 Bug Fixes
- *(indexer-common)* Clamp block_fullness on post_block_update to match node (#1061)

### ⚡ Performance
- *(chain-indexer)* Replace backward traversal with forward iteration by block height (#1038)

(Plus dependency bumps and CI tooling updates filtered out by `git-cliff` config.)

## Rollout (after merge)

1. Tag `v4.2.0` annotated on the merge commit, push the tag → `build-indexer-images` workflow builds `midnightntwrk/midnight-indexer:4.2.0`

## Notes
- Wallet team is currently integrating against the `4.1.0-f8c55de0` WIP image (PR #1059's branch image). Once 4.2.0 ships, they can move to the tagged version.
- 4.0.2 is a separate parallel release on `release/4.0` for the paidFees fix (PR #1068, in progress); this 4.2.0 is the main-branch release that includes #1061 (the same fix), among other things.
