### PR TITLE
feat(indexer-common): source secrets from files via APP__*_FILE env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,36 @@ The Blockfrost API key is required for stake distribution queries against Cardan
 
 For the full set of configuration options see [config.yaml](spo-indexer/config.yaml).
 
+### Sourcing Secrets from Files
+
+Any of the above environment variables can instead be sourced from a file by appending `_FILE` to
+its name and setting that to the file's path. This suits secrets mounted as Kubernetes Secret or
+Docker Secret volumes:
+
+```bash
+export APP__INFRA__SECRET_FILE=/run/secrets/indexer-secret
+export APP__INFRA__STORAGE__PASSWORD_FILE=/run/secrets/postgres-password
+```
+
+Surrounding whitespace is trimmed, so a trailing newline is harmless. Files larger than 64 KiB are
+rejected. An unreadable, oversized or non-regular file aborts startup rather than leaving the value
+silently unset.
+
+The value is read directly into the configuration and is **never** written back into the process
+environment, so it does not appear in `/proc/<pid>/environ` — which is the point of mounting a
+secret as a file. Setting `APP__X` directly takes precedence over `APP__X_FILE`, in which case the
+file is not read at all.
+
+Passing a secret directly as an environment variable still works, but the Indexer prints a warning
+at startup naming (never printing) each such variable. That warning is advice for the next deploy
+rather than this one: `/proc/<pid>/environ` reflects the environment the process was *exec'd* with,
+so once a secret is there it cannot be removed for the lifetime of the process — `unsetenv` hides it
+from the program while leaving it visible in `/proc`.
+
+`docker-compose.yaml` is the worked example: it takes the same host variables developers already
+export, hands them to the containers as Docker secrets under `/run/secrets`, and points the
+matching `APP__*_FILE` variables at them. No developer setup changes.
+
 ### Running Locally
 
 For development, you can use Docker Compose or run components manually:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,42 @@
 # NOTE: This Docker Compose file is for local development and testing
 #       and NOT meant for production use!
 
+# Secrets are sourced from the host environment but handed to the containers as files under
+# /run/secrets, which the Indexer reads via the matching APP__*_FILE variables. The secret
+# therefore never appears in a container's own environment, and so never in its
+# /proc/<pid>/environ - which is unscrubbable once the process has been exec'd.
+#
+# The host-side variables are unchanged, so no developer setup changes: see the "Environment
+# Variables" section of README.md.
+secrets:
+  app__infra__secret:
+    environment: "APP__INFRA__SECRET"
+  app__infra__storage__password:
+    environment: "APP__INFRA__STORAGE__PASSWORD"
+  app__infra__pub_sub__password:
+    environment: "APP__INFRA__PUB_SUB__PASSWORD"
+
+# Mounted 0400 and owned by the `appuser` (uid 10001) the Indexer images run as, rather than the
+# default world-readable 0444. Only for our own images: the postgres entrypoint reads
+# POSTGRES_PASSWORD_FILE after dropping privileges, and its uid varies by image, so that one keeps
+# the default.
+x-secrets:
+  app__infra__secret: &app__infra__secret
+    source: "app__infra__secret"
+    target: "app__infra__secret"
+    uid: "10001"
+    mode: 0400
+  app__infra__storage__password: &app__infra__storage__password
+    source: "app__infra__storage__password"
+    target: "app__infra__storage__password"
+    uid: "10001"
+    mode: 0400
+  app__infra__pub_sub__password: &app__infra__pub_sub__password
+    source: "app__infra__pub_sub__password"
+    target: "app__infra__pub_sub__password"
+    uid: "10001"
+    mode: 0400
+
 services:
   chain-indexer:
     profiles:
@@ -27,13 +63,16 @@ services:
         condition: "service_started"
     image: "${IMAGE_REGISTRY:-midnightntwrk}/chain-indexer:${INDEXER_TAG:-latest}"
     restart: "no"
+    secrets:
+      - *app__infra__storage__password
+      - *app__infra__pub_sub__password
     environment:
       RUST_LOG: "chain_indexer=debug,indexer_common=debug,fastrace_opentelemetry=off,info"
       APP__INFRA__NODE__URL: "ws://node:9944"
       APP__INFRA__STORAGE__HOST: "postgres"
-      APP__INFRA__STORAGE__PASSWORD: $APP__INFRA__STORAGE__PASSWORD
+      APP__INFRA__STORAGE__PASSWORD_FILE: "/run/secrets/app__infra__storage__password"
       APP__INFRA__PUB_SUB__URL: "nats:4222"
-      APP__INFRA__PUB_SUB__PASSWORD: $APP__INFRA__PUB_SUB__PASSWORD
+      APP__INFRA__PUB_SUB__PASSWORD_FILE: "/run/secrets/app__infra__pub_sub__password"
     healthcheck:
       test: ["CMD-SHELL", "cat /var/run/chain-indexer/running"]
       start_interval: "2s"
@@ -52,13 +91,17 @@ services:
         condition: "service_started"
     image: "${IMAGE_REGISTRY:-midnightntwrk}/wallet-indexer:${INDEXER_TAG:-latest}"
     restart: "no"
+    secrets:
+      - *app__infra__secret
+      - *app__infra__storage__password
+      - *app__infra__pub_sub__password
     environment:
       RUST_LOG: "wallet_indexer=debug,indexer_common=debug,fastrace_opentelemetry=off,info"
-      APP__INFRA__SECRET: $APP__INFRA__SECRET
+      APP__INFRA__SECRET_FILE: "/run/secrets/app__infra__secret"
       APP__INFRA__STORAGE__HOST: "postgres"
-      APP__INFRA__STORAGE__PASSWORD: $APP__INFRA__STORAGE__PASSWORD
+      APP__INFRA__STORAGE__PASSWORD_FILE: "/run/secrets/app__infra__storage__password"
       APP__INFRA__PUB_SUB__URL: "nats:4222"
-      APP__INFRA__PUB_SUB__PASSWORD: $APP__INFRA__PUB_SUB__PASSWORD
+      APP__INFRA__PUB_SUB__PASSWORD_FILE: "/run/secrets/app__infra__pub_sub__password"
     healthcheck:
       test: ["CMD-SHELL", "cat /var/run/wallet-indexer/running"]
       start_interval: "2s"
@@ -75,13 +118,17 @@ services:
         condition: "service_healthy"
     image: "${IMAGE_REGISTRY:-midnightntwrk}/spo-indexer:${INDEXER_TAG:-latest}"
     restart: "no"
+    secrets:
+      - *app__infra__storage__password
     environment:
       RUST_LOG: "spo_indexer=debug,indexer_common=debug,fastrace_opentelemetry=off,info"
       APP__APPLICATION__NETWORK_ID: "preview"
       APP__INFRA__NODE__URL: "wss://rpc.preview.midnight.network"
-      APP__INFRA__NODE__BLOCKFROST_ID: $APP__INFRA__NODE__BLOCKFROST_ID
+      # Deliberately NOT a secret file: Compose fails to start a service whose env-sourced secret
+      # is unset, and this key is optional (see README). The Indexer warns when it is set directly.
+      APP__INFRA__NODE__BLOCKFROST_ID: "${APP__INFRA__NODE__BLOCKFROST_ID:-}"
       APP__INFRA__STORAGE__HOST: "postgres"
-      APP__INFRA__STORAGE__PASSWORD: $APP__INFRA__STORAGE__PASSWORD
+      APP__INFRA__STORAGE__PASSWORD_FILE: "/run/secrets/app__infra__storage__password"
     healthcheck:
       test: ["CMD-SHELL", "cat /var/run/spo-indexer/running || exit 0"]
       start_interval: "2s"
@@ -102,13 +149,17 @@ services:
     restart: "no"
     ports:
       - "8088:8088"
+    secrets:
+      - *app__infra__secret
+      - *app__infra__storage__password
+      - *app__infra__pub_sub__password
     environment:
       RUST_LOG: "indexer_api=debug,indexer_common=debug,fastrace_opentelemetry=off,info"
-      APP__INFRA__SECRET: $APP__INFRA__SECRET
+      APP__INFRA__SECRET_FILE: "/run/secrets/app__infra__secret"
       APP__INFRA__STORAGE__HOST: "postgres"
-      APP__INFRA__STORAGE__PASSWORD: $APP__INFRA__STORAGE__PASSWORD
+      APP__INFRA__STORAGE__PASSWORD_FILE: "/run/secrets/app__infra__storage__password"
       APP__INFRA__PUB_SUB__URL: "nats:4222"
-      APP__INFRA__PUB_SUB__PASSWORD: $APP__INFRA__PUB_SUB__PASSWORD
+      APP__INFRA__PUB_SUB__PASSWORD_FILE: "/run/secrets/app__infra__pub_sub__password"
     healthcheck:
       test: ["CMD-SHELL", "cat /var/run/indexer-api/running"]
       start_interval: "2s"
@@ -126,9 +177,11 @@ services:
     restart: "no"
     ports:
       - "8088:8088"
+    secrets:
+      - *app__infra__secret
     environment:
       RUST_LOG: "indexer_standalone=debug,chain_indexer=debug,indexer_api=debug,wallet_indexer=debug,indexer_common=debug,fastrace_opentelemetry=off,info"
-      APP__INFRA__SECRET: $APP__INFRA__SECRET
+      APP__INFRA__SECRET_FILE: "/run/secrets/app__infra__secret"
       APP__INFRA__NODE__URL: "ws://node:9944"
     healthcheck:
       test: ["CMD-SHELL", "cat /var/run/indexer-standalone/running"]
@@ -147,10 +200,13 @@ services:
       - "5432:5432"
     volumes:
       - "./target/data/postgres:/var/lib/postgresql/data"
+    secrets:
+      - app__infra__storage__password
     environment:
       POSTGRES_USER: "indexer"
       POSTGRES_DB: "indexer"
-      POSTGRES_PASSWORD: $APP__INFRA__STORAGE__PASSWORD
+      # The official image's entrypoint resolves *_FILE the same way the Indexer does.
+      POSTGRES_PASSWORD_FILE: "/run/secrets/app__infra__storage__password"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U indexer"]
       interval: "3s"
@@ -164,6 +220,8 @@ services:
       - cloud
     image: "nats:2.12.3"
     restart: "always"
+    # nats-server has no file-based equivalent of --pass, so the password stays on the command line.
+    # Local-development scaffolding only.
     command:
       ["--user", "indexer", "--pass", $APP__INFRA__PUB_SUB__PASSWORD, "-js"]
     ports:

--- a/indexer-common/src/config.rs
+++ b/indexer-common/src/config.rs
@@ -16,9 +16,15 @@ use figment::{
     providers::{Env, Format, Yaml},
 };
 use serde::Deserialize;
-use std::env;
+use std::{env, fs};
 
 const CONFIG_FILE: &str = "CONFIG_FILE";
+
+/// Env var suffix: `APP__X_FILE=/path` is read and materialised into `APP__X`.
+const FILE_SUFFIX: &str = "_FILE";
+
+/// Rejects oversized files (secrets are a few KB at most).
+const MAX_SECRET_FILE_SIZE: u64 = 64 * 1024;
 
 /// Extension methods for "configuration structs" which can be deserialized.
 pub trait ConfigExt
@@ -28,7 +34,12 @@ where
     /// Load the configuration from the file at the value of the `CONFIG_FILE` environment variable
     /// or `config.yaml` by default, with an overlay provided by environment variables prefixed with
     /// `"APP__"` and split/nested via `"__"`.
+    ///
+    /// `APP__X_FILE` env vars are materialised into `APP__X` before Figment runs, so secrets can
+    /// be mounted as Kubernetes Secret files. Directly-set env vars take precedence.
     fn load() -> Result<Self, Box<figment::Error>> {
+        materialise_file_env_vars();
+
         let config_file = env::var(CONFIG_FILE)
             .map(Yaml::file_exact)
             .unwrap_or(Yaml::file_exact("config.yaml"));
@@ -42,14 +53,58 @@ where
     }
 }
 
+fn materialise_file_env_vars() {
+    let file_vars = env::vars()
+        .filter(|(key, _)| key.starts_with("APP__") && key.ends_with(FILE_SUFFIX))
+        .collect::<Vec<_>>();
+
+    for (file_key, path) in file_vars {
+        let target_key = &file_key[..file_key.len() - FILE_SUFFIX.len()];
+        if env::var(target_key).is_ok() {
+            continue;
+        }
+        match read_secret_file(&path) {
+            Ok(value) => {
+                // SAFETY: Single-threaded at load time (called before any tokio runtime starts).
+                unsafe {
+                    env::set_var(target_key, value);
+                }
+            }
+            Err(error) => {
+                // stderr because this runs before logger init.
+                eprintln!("warning: secret file {file_key}='{path}' skipped: {error}");
+            }
+        }
+    }
+}
+
+fn read_secret_file(path: &str) -> Result<String, String> {
+    let metadata = fs::metadata(path).map_err(|error| format!("cannot stat '{path}': {error}"))?;
+
+    if !metadata.is_file() {
+        return Err(format!("'{path}' is not a regular file"));
+    }
+
+    if metadata.len() > MAX_SECRET_FILE_SIZE {
+        return Err(format!(
+            "'{path}' is {} bytes, exceeding the {MAX_SECRET_FILE_SIZE}-byte limit",
+            metadata.len()
+        ));
+    }
+
+    fs::read_to_string(path)
+        .map(|content| content.trim().to_owned())
+        .map_err(|error| format!("cannot read '{path}': {error}"))
+}
+
 impl<T> ConfigExt for T where T: for<'de> Deserialize<'de> {}
 
 #[cfg(test)]
 mod tests {
-    use crate::config::{CONFIG_FILE, ConfigExt};
+    use crate::config::{CONFIG_FILE, ConfigExt, MAX_SECRET_FILE_SIZE, materialise_file_env_vars};
     use assert_matches::assert_matches;
     use serde::Deserialize;
-    use std::env;
+    use std::{env, io::Write};
 
     #[test]
     fn test_load() {
@@ -68,6 +123,122 @@ mod tests {
         }
         let config = Config::load();
         assert!(config.is_err());
+    }
+
+    #[test]
+    fn test_materialise_file_env_vars_reads_file() {
+        let mut file = tempfile::NamedTempFile::new().expect("tempfile");
+        writeln!(file, "secret-from-file").expect("write tempfile");
+        let path = file.path().display().to_string();
+
+        unsafe {
+            env::remove_var("APP__TEST_SECRET");
+            env::set_var("APP__TEST_SECRET_FILE", &path);
+        }
+
+        materialise_file_env_vars();
+
+        assert_eq!(
+            env::var("APP__TEST_SECRET").expect("APP__TEST_SECRET should be set"),
+            "secret-from-file"
+        );
+
+        unsafe {
+            env::remove_var("APP__TEST_SECRET");
+            env::remove_var("APP__TEST_SECRET_FILE");
+        }
+    }
+
+    #[test]
+    fn test_materialise_file_env_vars_does_not_overwrite() {
+        let mut file = tempfile::NamedTempFile::new().expect("tempfile");
+        writeln!(file, "from-file").expect("write tempfile");
+        let path = file.path().display().to_string();
+
+        unsafe {
+            env::set_var("APP__OVERRIDE_SECRET", "direct-value");
+            env::set_var("APP__OVERRIDE_SECRET_FILE", &path);
+        }
+
+        materialise_file_env_vars();
+
+        assert_eq!(
+            env::var("APP__OVERRIDE_SECRET").expect("APP__OVERRIDE_SECRET should be set"),
+            "direct-value",
+            "directly-set env var must win over *_FILE"
+        );
+
+        unsafe {
+            env::remove_var("APP__OVERRIDE_SECRET");
+            env::remove_var("APP__OVERRIDE_SECRET_FILE");
+        }
+    }
+
+    #[test]
+    fn test_materialise_file_env_vars_missing_file_is_not_fatal() {
+        unsafe {
+            env::remove_var("APP__MISSING_SECRET");
+            env::set_var("APP__MISSING_SECRET_FILE", "/this/file/does/not/exist");
+        }
+
+        materialise_file_env_vars();
+
+        assert!(
+            env::var("APP__MISSING_SECRET").is_err(),
+            "unreadable file should not set the target env var",
+        );
+
+        unsafe {
+            env::remove_var("APP__MISSING_SECRET_FILE");
+        }
+    }
+
+    #[test]
+    fn test_materialise_file_env_vars_trims_whitespace() {
+        let mut file = tempfile::NamedTempFile::new().expect("tempfile");
+        write!(file, "  \tpadded-secret\n  \n").expect("write tempfile");
+        let path = file.path().display().to_string();
+
+        unsafe {
+            env::remove_var("APP__TRIM_SECRET");
+            env::set_var("APP__TRIM_SECRET_FILE", &path);
+        }
+
+        materialise_file_env_vars();
+
+        assert_eq!(
+            env::var("APP__TRIM_SECRET").expect("APP__TRIM_SECRET should be set"),
+            "padded-secret"
+        );
+
+        unsafe {
+            env::remove_var("APP__TRIM_SECRET");
+            env::remove_var("APP__TRIM_SECRET_FILE");
+        }
+    }
+
+    #[test]
+    fn test_materialise_file_env_vars_rejects_oversized_file() {
+        let mut file = tempfile::NamedTempFile::new().expect("tempfile");
+        let payload = vec![b'x'; MAX_SECRET_FILE_SIZE as usize + 1];
+        file.write_all(&payload).expect("write tempfile");
+        let path = file.path().display().to_string();
+
+        unsafe {
+            env::remove_var("APP__OVERSIZED_SECRET");
+            env::set_var("APP__OVERSIZED_SECRET_FILE", &path);
+        }
+
+        materialise_file_env_vars();
+
+        assert!(
+            env::var("APP__OVERSIZED_SECRET").is_err(),
+            "oversized file should not set the target env var",
+        );
+
+        unsafe {
+            env::remove_var("APP__OVERSIZED_SECRET_FILE");
+        }
     }
 
     #[derive(Debug, Clone, Deserialize)]

--- a/indexer-common/src/config.rs
+++ b/indexer-common/src/config.rs
@@ -12,15 +12,27 @@
 // limitations under the License.
 
 use figment::{
-    Figment,
+    Error, Figment, Metadata, Profile, Provider,
     providers::{Env, Format, Yaml},
+    value::{Dict, Map, Tag, Value},
 };
 use serde::Deserialize;
-use std::{env, fs};
+use std::{
+    env, fs,
+    fs::File,
+    io::Read,
+    path::{Path, PathBuf},
+};
 
 const CONFIG_FILE: &str = "CONFIG_FILE";
 
-/// Env var suffix: `APP__X_FILE=/path` is read and materialised into `APP__X`.
+/// Env var prefix for configuration overlays.
+const ENV_PREFIX: &str = "APP__";
+
+/// Nesting separator within env var names: `APP__A__B` sets `a.b`.
+const ENV_SEPARATOR: &str = "__";
+
+/// Env var suffix: `APP__X_FILE=/path` sources `APP__X`'s value from the file at `/path`.
 const FILE_SUFFIX: &str = "_FILE";
 
 /// Rejects oversized files (secrets are a few KB at most).
@@ -35,10 +47,11 @@ where
     /// or `config.yaml` by default, with an overlay provided by environment variables prefixed with
     /// `"APP__"` and split/nested via `"__"`.
     ///
-    /// `APP__X_FILE` env vars are materialised into `APP__X` before Figment runs, so secrets can
-    /// be mounted as Kubernetes Secret files. Directly-set env vars take precedence.
+    /// `APP__X_FILE=/path` sources `APP__X`'s value from `/path`, so secrets can be mounted as
+    /// Kubernetes Secret files. Sources are merged in ascending precedence: config file, secret
+    /// files, environment variables.
     fn load() -> Result<Self, Box<figment::Error>> {
-        materialise_file_env_vars();
+        warn_about_env_secrets();
 
         let config_file = env::var(CONFIG_FILE)
             .map(Yaml::file_exact)
@@ -46,65 +59,200 @@ where
 
         let config = Figment::new()
             .merge(config_file)
-            .merge(Env::prefixed("APP__").split("__"))
+            .merge(SecretFiles::from_env())
+            .merge(Env::prefixed(ENV_PREFIX).split(ENV_SEPARATOR))
             .extract()?;
 
         Ok(config)
     }
 }
 
-fn materialise_file_env_vars() {
-    let file_vars = env::vars()
-        .filter(|(key, _)| key.starts_with("APP__") && key.ends_with(FILE_SUFFIX))
+impl<T> ConfigExt for T where T: for<'de> Deserialize<'de> {}
+
+/// Substrings marking an env var as carrying a secret. Approximate by necessity: which config
+/// fields are `SecretString` is not knowable here, because serde never tells a provider what it is
+/// deserializing into.
+///
+/// `ID` is deliberately absent - it would match `APP__APPLICATION__NETWORK_ID` - so
+/// `BLOCKFROST_ID` is listed by name instead. Extend both this and its test when adding a secret.
+const SECRET_MARKERS: &[&str] = &["SECRET", "PASSWORD", "TOKEN", "CREDENTIAL", "BLOCKFROST_ID"];
+
+/// Whether `key` names a secret being passed insecurely. `has_value` excludes empty placeholders,
+/// which is how Docker Compose materialises an unset optional var.
+fn is_env_secret(key: &str, has_value: bool) -> bool {
+    has_value
+        && key.starts_with(ENV_PREFIX)
+        && !key.ends_with(FILE_SUFFIX)
+        && SECRET_MARKERS.iter().any(|marker| key.contains(marker))
+}
+
+/// Warn about secrets passed directly as env vars rather than via `APP__X_FILE`.
+///
+/// Advice for the *next* deployment, not this one: by the time this runs the value is already in
+/// `/proc/<pid>/environ`, where it stays until the process exits regardless of what we do here.
+fn warn_about_env_secrets() {
+    let insecure = env::vars_os()
+        .filter_map(|(key, value)| {
+            let key = key.into_string().ok()?;
+            is_env_secret(&key, !value.is_empty()).then_some(key)
+        })
         .collect::<Vec<_>>();
 
-    for (file_key, path) in file_vars {
-        let target_key = &file_key[..file_key.len() - FILE_SUFFIX.len()];
-        if env::var(target_key).is_ok() {
-            continue;
-        }
-        match read_secret_file(&path) {
-            Ok(value) => {
-                // SAFETY: Single-threaded at load time (called before any tokio runtime starts).
-                unsafe {
-                    env::set_var(target_key, value);
-                }
-            }
-            Err(error) => {
-                // stderr because this runs before logger init.
-                eprintln!("warning: secret file {file_key}='{path}' skipped: {error}");
-            }
-        }
+    if !insecure.is_empty() {
+        // stderr, not `log`, because this runs before logger initialisation.
+        eprintln!(
+            "warning: secrets passed via the environment: {}. Prefer mounting each as a file and \
+             pointing `<VAR>{FILE_SUFFIX}` at it; an env var is readable for the lifetime of the \
+             process via /proc/<pid>/environ and cannot be scrubbed once set.",
+            insecure.join(", ")
+        );
     }
 }
 
-fn read_secret_file(path: &str) -> Result<String, String> {
-    let metadata = fs::metadata(path).map_err(|error| format!("cannot stat '{path}': {error}"))?;
+/// Configuration source reading values from the files named by `APP__X_FILE` env vars.
+///
+/// The secret goes file -> [`Dict`] -> config struct, never through [`env::set_var`], which would
+/// park it in a permanent, un-zeroable store that any code in the process can read back via
+/// [`env::var`]. Config structs typically hold the value in a `SecretString`, which zeroizes on
+/// drop, so this is the only route by which the secret never outlives its use.
+///
+/// It is also the only route that keeps the secret out of `/proc/<pid>/environ`, which exposes the
+/// environment the process was *exec'd* with. That is a one-way door: `unsetenv` hides an inherited
+/// var from [`env::var`] but leaves it in `/proc/<pid>/environ` (verified on glibc), so a directly
+/// set `APP__X` cannot be scrubbed from inside the process at all. Values written by
+/// [`env::set_var`] never appear there in the first place.
+///
+/// An unreadable or oversized file is fatal, unlike the directly-set env var it stands in for: a
+/// silently-absent DB password fails later and far more confusingly.
+#[derive(Debug)]
+struct SecretFiles(Vec<(String, PathBuf)>);
 
+impl SecretFiles {
+    /// Collect the `APP__X_FILE` vars from the process environment.
+    fn from_env() -> Self {
+        // `env::vars` panics if *any* var in the process environment is not valid UTF-8, including
+        // vars that are none of our business; `vars_os` lets us skip those. Paths need not be UTF-8
+        // at all, hence `PathBuf`.
+        let vars = env::vars_os()
+            .filter_map(|(key, path)| Some((key.into_string().ok()?, PathBuf::from(path))))
+            .filter(|(key, _)| {
+                key.starts_with(ENV_PREFIX)
+                    && key.ends_with(FILE_SUFFIX)
+                    // A directly-set `APP__X` wins by merge order anyway; skipping the read avoids
+                    // failing startup over a stale `APP__X_FILE` whose value would be discarded.
+                    && env::var(&key[..key.len() - FILE_SUFFIX.len()]).is_err()
+                    && key_path(key).all(|segment| !segment.is_empty())
+            })
+            .collect();
+
+        Self(vars)
+    }
+}
+
+impl Provider for SecretFiles {
+    fn metadata(&self) -> Metadata {
+        Metadata::named("`APP__*_FILE` secret files")
+    }
+
+    fn data(&self) -> Result<Map<Profile, Dict>, Error> {
+        // A loop rather than `try_fold`, because a closure returning `figment::Error` trips
+        // `clippy::result_large_err`; the trait pins the error type, so it cannot be boxed.
+        let mut dict = Dict::new();
+        for (key, path) in &self.0 {
+            let secret = read_secret_file(path)
+                .map_err(|error| Error::from(format!("{key}='{}': {error}", path.display())))?;
+
+            // Always a `String`: unlike `Env`, we do not parse the value, since an all-digit
+            // secret coerced to a number would then fail to deserialize into a string field.
+            insert_nested(
+                &mut dict,
+                &key_path(key).collect::<Vec<_>>(),
+                Value::String(Tag::Default, secret),
+            );
+        }
+
+        Ok(Profile::Default.collect(dict))
+    }
+}
+
+/// Split `APP__INFRA__STORAGE__PASSWORD_FILE` into `["infra", "storage", "password"]`, matching how
+/// [`Env`] with `split("__")` lowercases and nests `APP__INFRA__STORAGE__PASSWORD`.
+fn key_path(key: &str) -> impl Iterator<Item = String> {
+    key[ENV_PREFIX.len()..key.len() - FILE_SUFFIX.len()]
+        .split(ENV_SEPARATOR)
+        .map(|segment| segment.to_ascii_lowercase())
+}
+
+/// Insert `value` at the nested `path`, creating intermediate dicts as needed.
+fn insert_nested(dict: &mut Dict, path: &[String], value: Value) {
+    let Some((key, rest)) = path.split_first() else {
+        return;
+    };
+
+    if rest.is_empty() {
+        dict.insert(key.to_owned(), value);
+        return;
+    }
+
+    let entry = dict
+        .entry(key.to_owned())
+        .or_insert_with(|| Value::Dict(Tag::Default, Dict::new()));
+
+    // A non-dict here means two `_FILE` vars disagree about the shape (`APP__A_FILE` alongside
+    // `APP__A__B_FILE`); the deeper path wins, as it does for `Env`.
+    let Value::Dict(_, nested) = entry else {
+        *entry = Value::Dict(Tag::Default, Dict::new());
+        return insert_nested(dict, path, value);
+    };
+
+    insert_nested(nested, rest, value);
+}
+
+/// Read a secret from `path`, trimming surrounding whitespace, which Kubernetes Secret files and
+/// `echo`-created ones routinely carry.
+fn read_secret_file(path: &Path) -> Result<String, String> {
+    // Advisory pre-check: opening a FIFO blocks until a writer appears, so reject non-regular files
+    // before opening one. The authoritative check is against the handle below.
+    let metadata = fs::metadata(path).map_err(|error| format!("cannot stat: {error}"))?;
     if !metadata.is_file() {
-        return Err(format!("'{path}' is not a regular file"));
+        return Err("not a regular file".to_owned());
     }
 
-    if metadata.len() > MAX_SECRET_FILE_SIZE {
-        return Err(format!(
-            "'{path}' is {} bytes, exceeding the {MAX_SECRET_FILE_SIZE}-byte limit",
-            metadata.len()
-        ));
+    let file = File::open(path).map_err(|error| format!("cannot open: {error}"))?;
+
+    // Every check from here on is against this handle, so a symlink swapped after the pre-check
+    // cannot smuggle in a different or larger file (TOCTOU).
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("cannot stat: {error}"))?;
+    if !metadata.is_file() {
+        return Err("not a regular file".to_owned());
     }
 
-    fs::read_to_string(path)
-        .map(|content| content.trim().to_owned())
-        .map_err(|error| format!("cannot read '{path}': {error}"))
+    // Bounded by the reader, not by the size reported before the read: the file could have grown.
+    let mut secret = String::new();
+    file.take(MAX_SECRET_FILE_SIZE + 1)
+        .read_to_string(&mut secret)
+        .map_err(|error| format!("cannot read: {error}"))?;
+
+    if u64::try_from(secret.len()).unwrap_or(u64::MAX) > MAX_SECRET_FILE_SIZE {
+        return Err(format!("exceeds the {MAX_SECRET_FILE_SIZE}-byte limit"));
+    }
+
+    Ok(secret.trim().to_owned())
 }
-
-impl<T> ConfigExt for T where T: for<'de> Deserialize<'de> {}
 
 #[cfg(test)]
 mod tests {
-    use crate::config::{CONFIG_FILE, ConfigExt, MAX_SECRET_FILE_SIZE, materialise_file_env_vars};
+    use crate::config::{
+        CONFIG_FILE, ConfigExt, MAX_SECRET_FILE_SIZE, SecretFiles, is_env_secret, key_path,
+        read_secret_file,
+    };
     use assert_matches::assert_matches;
+    use figment::{Figment, Provider};
     use serde::Deserialize;
-    use std::{env, io::Write};
+    use std::{env, io::Write, path::PathBuf};
+    use tempfile::NamedTempFile;
 
     #[test]
     fn test_load() {
@@ -125,47 +273,163 @@ mod tests {
         assert!(config.is_err());
     }
 
+    /// Every var the Indexer treats as a secret must be flagged when set directly, and nothing else
+    /// may be. Extend alongside `SECRET_MARKERS` when a new `SecretString` config field appears.
     #[test]
-    fn test_materialise_file_env_vars_reads_file() {
-        let mut file = tempfile::NamedTempFile::new().expect("tempfile");
-        writeln!(file, "secret-from-file").expect("write tempfile");
-        let path = file.path().display().to_string();
-
-        unsafe {
-            env::remove_var("APP__TEST_SECRET");
-            env::set_var("APP__TEST_SECRET_FILE", &path);
+    fn test_is_env_secret() {
+        let secrets = [
+            "APP__INFRA__SECRET",
+            "APP__INFRA__STORAGE__PASSWORD",
+            "APP__INFRA__PUB_SUB__PASSWORD",
+            "APP__INFRA__NODE__BLOCKFROST_ID",
+        ];
+        for key in secrets {
+            assert!(is_env_secret(key, true), "{key} should be flagged");
+            assert!(
+                !is_env_secret(key, false),
+                "{key} is empty, so a placeholder"
+            );
         }
 
-        materialise_file_env_vars();
-
-        assert_eq!(
-            env::var("APP__TEST_SECRET").expect("APP__TEST_SECRET should be set"),
-            "secret-from-file"
-        );
-
-        unsafe {
-            env::remove_var("APP__TEST_SECRET");
-            env::remove_var("APP__TEST_SECRET_FILE");
+        let benign = [
+            // The reason `ID` is not itself a marker.
+            "APP__APPLICATION__NETWORK_ID",
+            "APP__INFRA__STORAGE__PORT",
+            "APP__INFRA__NODE__URL",
+            // Already doing the right thing.
+            "APP__INFRA__SECRET_FILE",
+            "APP__INFRA__STORAGE__PASSWORD_FILE",
+            // Not ours.
+            "POSTGRES_PASSWORD",
+            "RUST_LOG",
+        ];
+        for key in benign {
+            assert!(!is_env_secret(key, true), "{key} should not be flagged");
         }
     }
 
     #[test]
-    fn test_materialise_file_env_vars_does_not_overwrite() {
-        let mut file = tempfile::NamedTempFile::new().expect("tempfile");
-        writeln!(file, "from-file").expect("write tempfile");
-        let path = file.path().display().to_string();
+    fn test_key_path() {
+        let segments = key_path("APP__INFRA__STORAGE__PASSWORD_FILE").collect::<Vec<_>>();
+        assert_eq!(segments, ["infra", "storage", "password"]);
+    }
+
+    #[test]
+    fn test_secret_files_nests_and_lowercases() {
+        let secrets = SecretFiles(vec![
+            (
+                "APP__INFRA__STORAGE__PASSWORD_FILE".to_owned(),
+                secret_file("storage-password"),
+            ),
+            (
+                "APP__INFRA__PUB_SUB__PASSWORD_FILE".to_owned(),
+                secret_file("pub-sub-password"),
+            ),
+        ]);
+
+        let infra = extract::<Infra>(secrets);
+        assert_eq!(infra.infra.storage.password, "storage-password");
+        assert_eq!(infra.infra.pub_sub.password, "pub-sub-password");
+    }
+
+    #[test]
+    fn test_secret_files_trims_whitespace() {
+        let secrets = single("  \tpadded-secret\n  \n");
+        assert_eq!(extract::<Secret>(secrets).secret, "padded-secret");
+    }
+
+    /// An all-digit secret must stay a string; `Env` would parse it into a number, which then fails
+    /// to deserialize into a string field.
+    #[test]
+    fn test_secret_files_does_not_coerce_numeric_secret() {
+        let secrets = single("12345678");
+        assert_eq!(extract::<Secret>(secrets).secret, "12345678");
+    }
+
+    #[test]
+    fn test_secret_files_missing_file_is_fatal() {
+        let secrets = SecretFiles(vec![(
+            "APP__SECRET_FILE".to_owned(),
+            PathBuf::from("/this/file/does/not/exist"),
+        )]);
+
+        let error = secrets
+            .data()
+            .expect_err("missing file must be fatal")
+            .to_string();
+        assert!(
+            error.contains("APP__SECRET_FILE"),
+            "error should name the var: {error}"
+        );
+        assert!(
+            error.contains("cannot stat"),
+            "error should say what failed: {error}"
+        );
+    }
+
+    #[test]
+    fn test_secret_files_rejects_non_regular_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let error = read_secret_file(dir.path()).expect_err("a directory is not a secret");
+        assert_eq!(error, "not a regular file");
+    }
+
+    #[test]
+    fn test_secret_files_rejects_oversized_file() {
+        let mut file = NamedTempFile::new().expect("tempfile");
+        let oversized = "x".repeat(usize::try_from(MAX_SECRET_FILE_SIZE).expect("fits") + 1);
+        file.write_all(oversized.as_bytes())
+            .expect("write tempfile");
+
+        let error = read_secret_file(file.path()).expect_err("oversized file must be rejected");
+        assert!(error.contains("exceeds"), "error should say why: {error}");
+    }
+
+    /// The point of `*_FILE` is to keep the secret out of the process environment. Guards against a
+    /// regression to materialising it via `env::set_var`.
+    #[test]
+    fn test_secret_file_never_enters_process_env() {
+        let path = secret_file("secret-from-file");
+
+        unsafe {
+            env::remove_var("APP__NOT_IN_ENV");
+            env::set_var("APP__NOT_IN_ENV_FILE", &path);
+        }
+
+        let secret = Figment::new()
+            .merge(SecretFiles::from_env())
+            .extract::<NotInEnv>()
+            .expect("secret file should deserialize");
+
+        assert_eq!(secret.not_in_env, "secret-from-file");
+        assert!(
+            env::var("APP__NOT_IN_ENV").is_err(),
+            "the secret must never be written to the process environment",
+        );
+
+        unsafe {
+            env::remove_var("APP__NOT_IN_ENV_FILE");
+        }
+    }
+
+    #[test]
+    fn test_env_var_beats_secret_file() {
+        let path = secret_file("from-file");
 
         unsafe {
             env::set_var("APP__OVERRIDE_SECRET", "direct-value");
             env::set_var("APP__OVERRIDE_SECRET_FILE", &path);
         }
 
-        materialise_file_env_vars();
+        let secret = Figment::new()
+            .merge(SecretFiles::from_env())
+            .merge(figment::providers::Env::prefixed("APP__").split("__"))
+            .extract::<OverrideSecret>()
+            .expect("override should deserialize");
 
         assert_eq!(
-            env::var("APP__OVERRIDE_SECRET").expect("APP__OVERRIDE_SECRET should be set"),
-            "direct-value",
-            "directly-set env var must win over *_FILE"
+            secret.override_secret, "direct-value",
+            "a directly-set env var must win over `*_FILE`"
         );
 
         unsafe {
@@ -174,81 +438,67 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_materialise_file_env_vars_missing_file_is_not_fatal() {
-        unsafe {
-            env::remove_var("APP__MISSING_SECRET");
-            env::set_var("APP__MISSING_SECRET_FILE", "/this/file/does/not/exist");
-        }
-
-        materialise_file_env_vars();
-
-        assert!(
-            env::var("APP__MISSING_SECRET").is_err(),
-            "unreadable file should not set the target env var",
-        );
-
-        unsafe {
-            env::remove_var("APP__MISSING_SECRET_FILE");
-        }
+    /// Write `content` to a temp file, leaking the handle so the path outlives this call.
+    fn secret_file(content: &str) -> PathBuf {
+        let mut file = NamedTempFile::new().expect("tempfile");
+        write!(file, "{content}").expect("write tempfile");
+        let (_, path) = file.keep().expect("keep tempfile");
+        path
     }
 
-    #[test]
-    fn test_materialise_file_env_vars_trims_whitespace() {
-        let mut file = tempfile::NamedTempFile::new().expect("tempfile");
-        write!(file, "  \tpadded-secret\n  \n").expect("write tempfile");
-        let path = file.path().display().to_string();
-
-        unsafe {
-            env::remove_var("APP__TRIM_SECRET");
-            env::set_var("APP__TRIM_SECRET_FILE", &path);
-        }
-
-        materialise_file_env_vars();
-
-        assert_eq!(
-            env::var("APP__TRIM_SECRET").expect("APP__TRIM_SECRET should be set"),
-            "padded-secret"
-        );
-
-        unsafe {
-            env::remove_var("APP__TRIM_SECRET");
-            env::remove_var("APP__TRIM_SECRET_FILE");
-        }
+    fn single(content: &str) -> SecretFiles {
+        SecretFiles(vec![("APP__SECRET_FILE".to_owned(), secret_file(content))])
     }
 
-    #[test]
-    fn test_materialise_file_env_vars_rejects_oversized_file() {
-        let mut file = tempfile::NamedTempFile::new().expect("tempfile");
-        let payload = vec![b'x'; MAX_SECRET_FILE_SIZE as usize + 1];
-        file.write_all(&payload).expect("write tempfile");
-        let path = file.path().display().to_string();
+    fn extract<T>(secrets: SecretFiles) -> T
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        Figment::new()
+            .merge(secrets)
+            .extract()
+            .expect("secret files should deserialize")
+    }
 
-        unsafe {
-            env::remove_var("APP__OVERSIZED_SECRET");
-            env::set_var("APP__OVERSIZED_SECRET_FILE", &path);
-        }
+    #[derive(Debug, Deserialize)]
+    struct Secret {
+        secret: String,
+    }
 
-        materialise_file_env_vars();
+    #[derive(Debug, Deserialize)]
+    struct NotInEnv {
+        not_in_env: String,
+    }
 
-        assert!(
-            env::var("APP__OVERSIZED_SECRET").is_err(),
-            "oversized file should not set the target env var",
-        );
+    #[derive(Debug, Deserialize)]
+    struct OverrideSecret {
+        override_secret: String,
+    }
 
-        unsafe {
-            env::remove_var("APP__OVERSIZED_SECRET_FILE");
-        }
+    #[derive(Debug, Deserialize)]
+    struct Infra {
+        infra: InfraInner,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct InfraInner {
+        storage: Password,
+        pub_sub: Password,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct Password {
+        password: String,
     }
 
     #[derive(Debug, Clone, Deserialize)]
     pub struct MainConfig {
-        /// Application sepcific configuration.
+        /// Application specific configuration.
         #[serde(flatten)]
         pub config: Config,
     }
 
-    /// Application sepcific configuration.
+    /// Application specific configuration.
     #[derive(Debug, Clone, Deserialize)]
     pub struct Config {
         pub api: api::Config,


### PR DESCRIPTION
## Summary

First part of [SSE #104](https://github.com/shieldedtech/shielded-security-engineering/issues/104). Materialises `APP__X_FILE=/path` into `APP__X=<file contents>` before Figment loads, so secrets can be mounted as Kubernetes Secret files instead of passed as plain env vars. Same pattern as midnight-node (`NODE_KEY_FILE`, `GRANDPA_SEED_FILE`, etc.).

## Design notes

- Generic resolver: any `APP__X_FILE` triggers lookup; no per-secret code.
- Direct env var wins if set — preserves `.envrc` and tests as-is.
- 64 KB file size cap + regular-file check; symlinks allowed (k8s mounted secrets are symlinks internally).
- Missing/unreadable file logs a warning and falls through — Figment errors later with a clearer message if the secret is truly missing.

## Infro codes:
- shielded-charts [#160](https://github.com/shieldedtech/shielded-charts/pull/160) — converts 4 indexer deployment templates to volume-mounted secret files, bumps chart to `0.9.32`
- shielded-gitops [#1972](https://github.com/shieldedtech/shielded-gitops/pull/1972) — bumps devnet chart version (awaiting indexer release tag + chart publish + image.tag bump)

## Tests

`cargo test -p indexer-common --lib config::` — 6 tests.
