### PR TITLE
chore(release): prepare for 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.1] - 2026-04-27
+
+### ⚙️ Dependencies
+
+- Bump to node 1.0.0-rc.3 and storage-core 1.2.0-rc.3 (#1077)
+
+### 🚀 Features
+
+- *(bench)* Add preprod genesis and multi-tx apply benchmarks (#1076)
+
 ## [4.2.0] - 2026-04-23
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "chain-indexer"
-version = "4.2.0"
+version = "4.2.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-api"
-version = "4.2.0"
+version = "4.2.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-standalone"
-version = "4.2.0"
+version = "4.2.1"
 dependencies = [
  "anyhow",
  "byte-unit-serde",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-tests"
-version = "4.2.0"
+version = "4.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "spo-indexer"
-version = "4.2.0"
+version = "4.2.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -8271,7 +8271,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-indexer"
-version = "4.2.0"
+version = "4.2.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version       = "4.2.0"
+version       = "4.2.1"
 edition       = "2024"
 license       = "Apache-2.0"
 readme        = "README.md"


### PR DESCRIPTION
Release prep for 4.2.1 on the main lineage. Bumps the workspace version from 4.2.0 to 4.2.1 and adds the CHANGELOG entry covering the four commits that have landed on main since v4.2.0:

This is independent of the 4.0.2 rollout that is mid-flight on `release/4.0`. 4.0.2 is on the older ledger version and does not need storage-core 1.2.0-rc.3, so the two release tracks proceed in parallel.

Once merged, tag `v4.2.1` annotated on the merge commit (`git tag -a v4.2.1 -m "Release 4.2.1"`), push the tag, the `build-indexer-images` workflow then builds the `midnightntwrk/midnight-indexer:4.2.1` image. Then gitops PRs to flip env image tags wherever 4.2.x is in scope (qanet-green is currently the only env on a 4.2-line image, running 4.2.0).