### PR TITLE
feat(indexer-api): include DustGenerationDtimeUpdate in dustGenerations subscription

### DIFF
--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -302,6 +302,46 @@ type DustGenerationDtimeUpdate implements DustLedgerEvent {
 }
 
 """
+A dust generation dtime update emitted when the backing Night UTXO is
+spent and the entry's decay time is set.
+"""
+type DustGenerationDtimeUpdateItem {
+	"""
+	Generation-tree index of the entry whose dtime changed.
+	"""
+	generationMtIndex: Int!
+	"""
+	The hex-encoded owner (dust address).
+	"""
+	owner: HexEncoded!
+	"""
+	Hex-encoded hash of the NIGHT UTXO that backs this dust output.
+	"""
+	nightUtxoHash: HexEncoded!
+	"""
+	The decay time as observed in this ledger event.
+	"""
+	newDtime: Int!
+	"""
+	The originating transaction ID.
+	"""
+	transactionId: Int!
+	"""
+	Collapsed Merkle tree update covering the gap between the wallet's
+	current cursor and this entry. `null` when the wallet has already
+	passed this entry's index, which is the typical case for dtime
+	updates on already-seen entries.
+	"""
+	collapsedMerkleTree: MerkleTreeCollapsedUpdate
+	"""
+	Path from the updated leaf to the root of the dust generation tree,
+	matching the ledger's `TreeInsertionPath<DustGenerationInfo>`.
+	Wallets apply this via `generating_tree.update_from_evidence(...)`.
+	"""
+	merklePath: [DustMerklePathEntry!]!
+}
+
+"""
 DUST generation status for a specific Cardano reward address.
 """
 type DustGenerationStatus {
@@ -360,7 +400,7 @@ type DustGenerations {
 """
 An event of the dust generations subscription.
 """
-union DustGenerationsEvent = DustGenerationsItem | DustGenerationsProgress
+union DustGenerationsEvent = DustGenerationsItem | DustGenerationsProgress | DustGenerationDtimeUpdateItem
 
 """
 A dust generations item with optional collapsed Merkle tree update.
@@ -449,6 +489,24 @@ interface DustLedgerEvent {
 	raw: HexEncoded!
 	maxId: Int!
 	protocolVersion: Int!
+}
+
+"""
+One entry in a `DustGenerationDtimeUpdateItem.merklePath`. Mirrors the
+ledger's `TreeInsertionPathEntry`: the hash is the node along the path
+from leaf to root (not the sibling), and may be `null` if the tree was
+not fully rehashed at the point the update was constructed.
+"""
+type DustMerklePathEntry {
+	"""
+	Hex-encoded hash of the node along the path. `null` when the
+	upstream `TreeInsertionPathEntry.hash` was `None`.
+	"""
+	hash: HexEncoded
+	"""
+	Whether the path went left at this branch.
+	"""
+	goesLeft: Boolean!
 }
 
 """
@@ -1109,9 +1167,16 @@ type Subscription {
 	"""
 	contractActions(address: HexEncoded!, offset: BlockOffset): ContractAction!
 	"""
-	Subscribe to dust generation entries for a dust address within an index range.
-	Entries are interleaved with collapsed Merkle tree updates to fill gaps.
-	The subscription finishes after reaching the end index with a final collapsed update.
+	Subscribe to dust generation entries for a dust address within an index
+	range, interleaved with collapsed Merkle tree updates and
+	`DustGenerationDtimeUpdateItem` events for entries the subscriber owns.
+	Finishes at end_index with a final collapsed update.
+	
+	On reconnect, historical dtime updates after the wallet's last fully-
+	synced block (derived from the entry below `startIndex`) are replayed
+	before entry backfill. Fresh subscriptions skip historical dtime
+	backfill; the wallet learns of pre-existing spends primarily via block
+	sync and `dustNullifierTransactions`.
 	"""
 	dustGenerations(dustAddress: DustAddress!, startIndex: Int!, endIndex: Int!): DustGenerationsEvent!
 	"""

--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -334,11 +334,11 @@ type DustGenerationDtimeUpdateItem {
 	"""
 	collapsedMerkleTree: MerkleTreeCollapsedUpdate
 	"""
-	Path from the updated leaf to the root of the dust generation tree,
-	matching the ledger's `TreeInsertionPath<DustGenerationInfo>`.
-	Wallets apply this via `generating_tree.update_from_evidence(...)`.
+	Hex-encoded tagged-serialised `TreeInsertionPath<DustGenerationInfo>`
+	from the originating ledger event. Wallets deserialise this and hand
+	it to `generating_tree.update_from_evidence(...)`.
 	"""
-	merklePath: [DustMerklePathEntry!]!
+	treeInsertionPath: HexEncoded!
 }
 
 """
@@ -489,24 +489,6 @@ interface DustLedgerEvent {
 	raw: HexEncoded!
 	maxId: Int!
 	protocolVersion: Int!
-}
-
-"""
-One entry in a `DustGenerationDtimeUpdateItem.merklePath`. Mirrors the
-ledger's `TreeInsertionPathEntry`: the hash is the node along the path
-from leaf to root (not the sibling), and may be `null` if the tree was
-not fully rehashed at the point the update was constructed.
-"""
-type DustMerklePathEntry {
-	"""
-	Hex-encoded hash of the node along the path. `null` when the
-	upstream `TreeInsertionPathEntry.hash` was `None`.
-	"""
-	hash: HexEncoded
-	"""
-	Whether the path went left at this branch.
-	"""
-	goesLeft: Boolean!
 }
 
 """
@@ -1167,16 +1149,10 @@ type Subscription {
 	"""
 	contractActions(address: HexEncoded!, offset: BlockOffset): ContractAction!
 	"""
-	Subscribe to dust generation entries for a dust address within an index
-	range, interleaved with collapsed Merkle tree updates and
+	Subscribe to dust generation entries for a dust address within an index range.
+	Entries are interleaved with collapsed Merkle tree updates and
 	`DustGenerationDtimeUpdateItem` events for entries the subscriber owns.
-	Finishes at end_index with a final collapsed update.
-	
-	On reconnect, historical dtime updates after the wallet's last fully-
-	synced block (derived from the entry below `startIndex`) are replayed
-	before entry backfill. Fresh subscriptions skip historical dtime
-	backfill; the wallet learns of pre-existing spends primarily via block
-	sync and `dustNullifierTransactions`.
+	The subscription finishes after reaching the end index with a final collapsed update.
 	"""
 	dustGenerations(dustAddress: DustAddress!, startIndex: Int!, endIndex: Int!): DustGenerationsEvent!
 	"""

--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -327,13 +327,6 @@ type DustGenerationDtimeUpdateItem {
 	"""
 	transactionId: Int!
 	"""
-	Collapsed Merkle tree update covering the gap between the wallet's
-	current cursor and this entry. `null` when the wallet has already
-	passed this entry's index, which is the typical case for dtime
-	updates on already-seen entries.
-	"""
-	collapsedMerkleTree: MerkleTreeCollapsedUpdate
-	"""
 	Hex-encoded tagged-serialised `TreeInsertionPath<DustGenerationInfo>`
 	from the originating ledger event. Wallets deserialise this and hand
 	it to `generating_tree.update_from_evidence(...)`.

--- a/indexer-api/src/domain/dust.rs
+++ b/indexer-api/src/domain/dust.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use indexer_common::{
-    domain::{ByteVec, CardanoRewardAddress, DustPublicKey, dust::DustMerklePathEntry},
+    domain::{ByteVec, CardanoRewardAddress, DustPublicKey, SerializedDustTreeInsertionPath},
     infra::sqlx::U128BeBytes,
 };
 use serde::{Deserialize, Serialize};
@@ -104,7 +104,7 @@ pub struct DustGenerationEntry {
 /// A dust generation dtime update entry for the subscription stream.
 ///
 /// Built from the row by the storage layer, not directly via `FromRow`,
-/// because `merkle_path` is sourced by deserialising
+/// because `tree_insertion_path` is sourced by deserialising
 /// `LedgerEventAttributes::DustGenerationDtimeUpdate` from the row's
 /// JSONB `attributes` column.
 #[derive(Debug, Clone)]
@@ -126,10 +126,10 @@ pub struct DustGenerationDtimeUpdateEntry {
 
     pub transaction_id: u64,
 
-    /// Path from the updated leaf to the root of the dust generation tree,
-    /// as emitted by the ledger in `TreeInsertionPath<DustGenerationInfo>`.
-    /// Wallets apply this via `generating_tree.update_from_evidence(...)`.
-    pub merkle_path: Vec<DustMerklePathEntry>,
+    /// Tagged-serialised `TreeInsertionPath<DustGenerationInfo>` from the
+    /// originating ledger event. Surfaced verbatim on the GraphQL API so
+    /// wallets can hand it to `generating_tree.update_from_evidence(...)`.
+    pub tree_insertion_path: SerializedDustTreeInsertionPath,
 }
 
 /// A dust nullifier transaction for the subscription stream.

--- a/indexer-api/src/domain/dust.rs
+++ b/indexer-api/src/domain/dust.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use indexer_common::{
-    domain::{ByteVec, CardanoRewardAddress, DustPublicKey},
+    domain::{ByteVec, CardanoRewardAddress, DustPublicKey, dust::DustMerklePathEntry},
     infra::sqlx::U128BeBytes,
 };
 use serde::{Deserialize, Serialize};
@@ -99,6 +99,37 @@ pub struct DustGenerationEntry {
 
     #[sqlx(try_from = "i64")]
     pub transaction_id: u64,
+}
+
+/// A dust generation dtime update entry for the subscription stream.
+///
+/// Built from the row by the storage layer, not directly via `FromRow`,
+/// because `merkle_path` is sourced by deserialising
+/// `LedgerEventAttributes::DustGenerationDtimeUpdate` from the row's
+/// JSONB `attributes` column.
+#[derive(Debug, Clone)]
+pub struct DustGenerationDtimeUpdateEntry {
+    /// Ledger event id of this dtime update. Internal cursor for advancing
+    /// between live-tail polls; not exposed on the GraphQL surface.
+    pub ledger_event_id: u64,
+
+    /// Generation-tree index of the entry whose dtime changed.
+    pub generation_mt_index: u64,
+
+    pub owner: ByteVec,
+
+    /// Hash of the NIGHT UTXO that backs this dust output.
+    pub night_utxo_hash: ByteVec,
+
+    /// New decay time as observed in this ledger event.
+    pub new_dtime: u64,
+
+    pub transaction_id: u64,
+
+    /// Path from the updated leaf to the root of the dust generation tree,
+    /// as emitted by the ledger in `TreeInsertionPath<DustGenerationInfo>`.
+    /// Wallets apply this via `generating_tree.update_from_evidence(...)`.
+    pub merkle_path: Vec<DustMerklePathEntry>,
 }
 
 /// A dust nullifier transaction for the subscription stream.

--- a/indexer-api/src/domain/storage/dust_generations.rs
+++ b/indexer-api/src/domain/storage/dust_generations.rs
@@ -12,7 +12,10 @@
 // limitations under the License.
 
 use crate::domain::{
-    dust::{DustGenerationEntry, DustGenerations, DustNullifierTransaction},
+    dust::{
+        DustGenerationDtimeUpdateEntry, DustGenerationEntry, DustGenerations,
+        DustNullifierTransaction,
+    },
     storage::NoopStorage,
 };
 use futures::{Stream, stream};
@@ -45,6 +48,28 @@ where
         batch_size: NonZeroU32,
     ) -> impl Stream<Item = Result<DustGenerationEntry, sqlx::Error>> + Send;
 
+    /// Look up the block_id of the wallet's most recent owned entry below
+    /// `start_index`. Returns `None` for fresh subscriptions or wallets with
+    /// no prior entries (in which case dtime backfill is skipped entirely).
+    async fn get_dust_generation_dtime_cutoff_block_id(
+        &self,
+        dust_address: &[u8],
+        start_index: u64,
+    ) -> Result<Option<u64>, sqlx::Error>;
+
+    /// Get dust generation dtime update events for a dust address whose
+    /// transaction's block_id exceeds the cutoff and whose ledger event id
+    /// exceeds `after_event_id`. Used both for initial backfill (with the
+    /// cutoff derived above) and live tail (with the cutoff being the latest
+    /// processed block). The stream is ordered by ledger event id.
+    async fn get_dust_generation_dtime_updates(
+        &self,
+        dust_address: &[u8],
+        cutoff_block_id: u64,
+        after_event_id: u64,
+        batch_size: NonZeroU32,
+    ) -> impl Stream<Item = Result<DustGenerationDtimeUpdateEntry, sqlx::Error>> + Send;
+
     /// Get transactions containing dust nullifiers matching a prefix.
     async fn get_dust_nullifier_transactions(
         &self,
@@ -72,6 +97,24 @@ impl DustGenerationsStorage for NoopStorage {
         end_index: u64,
         batch_size: NonZeroU32,
     ) -> impl Stream<Item = Result<DustGenerationEntry, sqlx::Error>> + Send {
+        stream::empty()
+    }
+
+    async fn get_dust_generation_dtime_cutoff_block_id(
+        &self,
+        dust_address: &[u8],
+        start_index: u64,
+    ) -> Result<Option<u64>, sqlx::Error> {
+        Ok(None)
+    }
+
+    async fn get_dust_generation_dtime_updates(
+        &self,
+        dust_address: &[u8],
+        cutoff_block_id: u64,
+        after_event_id: u64,
+        batch_size: NonZeroU32,
+    ) -> impl Stream<Item = Result<DustGenerationDtimeUpdateEntry, sqlx::Error>> + Send {
         stream::empty()
     }
 

--- a/indexer-api/src/infra/api/v4/dust.rs
+++ b/indexer-api/src/infra/api/v4/dust.rs
@@ -78,6 +78,31 @@ pub struct DustGenerationStatus {
     pub utxo_output_index: Option<u32>,
 }
 
+impl From<(domain::DustGenerationStatus, &NetworkId)> for DustGenerationStatus {
+    fn from((status, network_id): (domain::DustGenerationStatus, &NetworkId)) -> Self {
+        let cardano_network_id = CardanoNetworkId::from(network_id);
+        let cardano_reward_address = CardanoRewardAddress(encode_cardano_reward_address(
+            status.cardano_reward_address,
+            cardano_network_id,
+        ));
+        let dust_address = status
+            .dust_address
+            .map(|addr| DustAddress(encode_address(addr, AddressType::Dust, network_id)));
+
+        Self {
+            cardano_reward_address,
+            dust_address,
+            registered: status.registered,
+            night_balance: status.night_balance.to_string(),
+            generation_rate: status.generation_rate.to_string(),
+            max_capacity: status.max_capacity.to_string(),
+            current_capacity: status.current_capacity.to_string(),
+            utxo_tx_hash: status.utxo_tx_hash.map(|h| h.hex_encode()),
+            utxo_output_index: status.utxo_output_index,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::infra::api::v4::{AddressType, dust::DustAddress, encode_address};
@@ -108,30 +133,5 @@ mod tests {
         let dust_address = DustAddress(encode_address(&bytes, AddressType::Dust, &undeployed));
 
         assert!(dust_address.try_into_domain(&preview).is_err());
-    }
-}
-
-impl From<(domain::DustGenerationStatus, &NetworkId)> for DustGenerationStatus {
-    fn from((status, network_id): (domain::DustGenerationStatus, &NetworkId)) -> Self {
-        let cardano_network_id = CardanoNetworkId::from(network_id);
-        let cardano_reward_address = CardanoRewardAddress(encode_cardano_reward_address(
-            status.cardano_reward_address,
-            cardano_network_id,
-        ));
-        let dust_address = status
-            .dust_address
-            .map(|addr| DustAddress(encode_address(addr, AddressType::Dust, network_id)));
-
-        Self {
-            cardano_reward_address,
-            dust_address,
-            registered: status.registered,
-            night_balance: status.night_balance.to_string(),
-            generation_rate: status.generation_rate.to_string(),
-            max_capacity: status.max_capacity.to_string(),
-            current_capacity: status.current_capacity.to_string(),
-            utxo_tx_hash: status.utxo_tx_hash.map(|h| h.hex_encode()),
-            utxo_output_index: status.utxo_output_index,
-        }
     }
 }

--- a/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
@@ -99,11 +99,6 @@ pub struct DustGenerationDtimeUpdateItem {
     pub new_dtime: u64,
     /// The originating transaction ID.
     pub transaction_id: u64,
-    /// Collapsed Merkle tree update covering the gap between the wallet's
-    /// current cursor and this entry. `null` when the wallet has already
-    /// passed this entry's index, which is the typical case for dtime
-    /// updates on already-seen entries.
-    pub collapsed_merkle_tree: Option<MerkleTreeCollapsedUpdate>,
     /// Hex-encoded tagged-serialised `TreeInsertionPath<DustGenerationInfo>`
     /// from the originating ledger event. Wallets deserialise this and hand
     /// it to `generating_tree.update_from_evidence(...)`.
@@ -171,14 +166,8 @@ where
                     .map_err_into_server_error(|| "get next dtime update")?
                 {
                     dtime_after_event_id = update.ledger_event_id;
-                    let collapsed_merkle_tree = make_collapsed_update(
-                        cursor,
-                        update.generation_mt_index,
-                        storage,
-                        ledger_state_cache,
-                    ).await?;
                     yield DustGenerationsEvent::DustGenerationDtimeUpdateItem(
-                        dtime_update_item(update, collapsed_merkle_tree),
+                        dtime_update_item(update),
                     );
                 }
             }
@@ -287,14 +276,8 @@ where
                         .map_err_into_server_error(|| "get next dtime update")?
                     {
                         dtime_after_event_id = update.ledger_event_id;
-                        let collapsed_merkle_tree = make_collapsed_update(
-                            cursor,
-                            update.generation_mt_index,
-                            storage,
-                            ledger_state_cache,
-                        ).await?;
                         yield DustGenerationsEvent::DustGenerationDtimeUpdateItem(
-                            dtime_update_item(update, collapsed_merkle_tree),
+                            dtime_update_item(update),
                         );
                     }
                 }
@@ -373,19 +356,14 @@ async fn make_final_collapsed_update<S: Storage>(
     }
 }
 
-/// Convert a domain dtime update entry into the GraphQL item, attaching a
-/// caller-computed `collapsed_merkle_tree`.
-fn dtime_update_item(
-    update: DustGenerationDtimeUpdateEntry,
-    collapsed_merkle_tree: Option<MerkleTreeCollapsedUpdate>,
-) -> DustGenerationDtimeUpdateItem {
+/// Convert a domain dtime update entry into the GraphQL item.
+fn dtime_update_item(update: DustGenerationDtimeUpdateEntry) -> DustGenerationDtimeUpdateItem {
     DustGenerationDtimeUpdateItem {
         generation_mt_index: update.generation_mt_index,
         owner: update.owner.hex_encode(),
         night_utxo_hash: update.night_utxo_hash.hex_encode(),
         new_dtime: update.new_dtime,
         transaction_id: update.transaction_id,
-        collapsed_merkle_tree,
         tree_insertion_path: update.tree_insertion_path.hex_encode(),
     }
 }

--- a/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
@@ -24,7 +24,7 @@ use crate::{
 use async_graphql::{Context, SimpleObject, Subscription, Union};
 use async_stream::try_stream;
 use futures::{Stream, TryStreamExt};
-use indexer_common::domain::{BlockIndexed, ByteVec, Subscriber};
+use indexer_common::domain::{BlockIndexed, Subscriber};
 use log::{debug, warn};
 use std::{marker::PhantomData, pin::pin};
 
@@ -104,23 +104,10 @@ pub struct DustGenerationDtimeUpdateItem {
     /// passed this entry's index, which is the typical case for dtime
     /// updates on already-seen entries.
     pub collapsed_merkle_tree: Option<MerkleTreeCollapsedUpdate>,
-    /// Path from the updated leaf to the root of the dust generation tree,
-    /// matching the ledger's `TreeInsertionPath<DustGenerationInfo>`.
-    /// Wallets apply this via `generating_tree.update_from_evidence(...)`.
-    pub merkle_path: Vec<DustMerklePathEntry>,
-}
-
-/// One entry in a `DustGenerationDtimeUpdateItem.merklePath`. Mirrors the
-/// ledger's `TreeInsertionPathEntry`: the hash is the node along the path
-/// from leaf to root (not the sibling), and may be `null` if the tree was
-/// not fully rehashed at the point the update was constructed.
-#[derive(Debug, Clone, SimpleObject)]
-pub struct DustMerklePathEntry {
-    /// Hex-encoded hash of the node along the path. `null` when the
-    /// upstream `TreeInsertionPathEntry.hash` was `None`.
-    pub hash: Option<HexEncoded>,
-    /// Whether the path went left at this branch.
-    pub goes_left: bool,
+    /// Hex-encoded tagged-serialised `TreeInsertionPath<DustGenerationInfo>`
+    /// from the originating ledger event. Wallets deserialise this and hand
+    /// it to `generating_tree.update_from_evidence(...)`.
+    pub tree_insertion_path: HexEncoded,
 }
 
 #[Subscription]
@@ -129,16 +116,10 @@ where
     S: Storage,
     B: Subscriber,
 {
-    /// Subscribe to dust generation entries for a dust address within an index
-    /// range, interleaved with collapsed Merkle tree updates and
+    /// Subscribe to dust generation entries for a dust address within an index range.
+    /// Entries are interleaved with collapsed Merkle tree updates and
     /// `DustGenerationDtimeUpdateItem` events for entries the subscriber owns.
-    /// Finishes at end_index with a final collapsed update.
-    ///
-    /// On reconnect, historical dtime updates after the wallet's last fully-
-    /// synced block (derived from the entry below `startIndex`) are replayed
-    /// before entry backfill. Fresh subscriptions skip historical dtime
-    /// backfill; the wallet learns of pre-existing spends primarily via block
-    /// sync and `dustNullifierTransactions`.
+    /// The subscription finishes after reaching the end index with a final collapsed update.
     async fn dust_generations<'a>(
         &self,
         cx: &'a Context<'a>,
@@ -393,23 +374,11 @@ async fn make_final_collapsed_update<S: Storage>(
 }
 
 /// Convert a domain dtime update entry into the GraphQL item, attaching a
-/// caller-computed `collapsed_merkle_tree`. The `merkle_path` entries are
-/// converted from raw bytes to `HexEncoded` here.
+/// caller-computed `collapsed_merkle_tree`.
 fn dtime_update_item(
     update: DustGenerationDtimeUpdateEntry,
     collapsed_merkle_tree: Option<MerkleTreeCollapsedUpdate>,
 ) -> DustGenerationDtimeUpdateItem {
-    let merkle_path = update
-        .merkle_path
-        .into_iter()
-        .map(|entry| DustMerklePathEntry {
-            hash: entry
-                .sibling_hash
-                .map(|bytes| ByteVec::from(bytes).hex_encode()),
-            goes_left: entry.goes_left,
-        })
-        .collect();
-
     DustGenerationDtimeUpdateItem {
         generation_mt_index: update.generation_mt_index,
         owner: update.owner.hex_encode(),
@@ -417,6 +386,6 @@ fn dtime_update_item(
         new_dtime: update.new_dtime,
         transaction_id: update.transaction_id,
         collapsed_merkle_tree,
-        merkle_path,
+        tree_insertion_path: update.tree_insertion_path.hex_encode(),
     }
 }

--- a/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use crate::{
-    domain::{LedgerStateCache, storage::Storage},
+    domain::{LedgerStateCache, dust::DustGenerationDtimeUpdateEntry, storage::Storage},
     infra::api::{
         ApiResult, ContextExt, ResultExt,
         v4::{
@@ -24,15 +24,19 @@ use crate::{
 use async_graphql::{Context, SimpleObject, Subscription, Union};
 use async_stream::try_stream;
 use futures::{Stream, TryStreamExt};
-use indexer_common::domain::{BlockIndexed, Subscriber};
+use indexer_common::domain::{BlockIndexed, ByteVec, Subscriber};
 use log::{debug, warn};
 use std::{marker::PhantomData, pin::pin};
 
 /// An event of the dust generations subscription.
+// The `Dust*` prefix on every variant matches the existing GraphQL type
+// names; renaming would change the public union members.
+#[allow(clippy::enum_variant_names)]
 #[derive(Union)]
 pub enum DustGenerationsEvent {
     DustGenerationsItem(DustGenerationsItem),
     DustGenerationsProgress(DustGenerationsProgress),
+    DustGenerationDtimeUpdateItem(DustGenerationDtimeUpdateItem),
 }
 
 pub struct DustGenerationsSubscription<S, B> {
@@ -81,15 +85,60 @@ pub struct DustGenerationsProgress {
     pub collapsed_merkle_tree: Option<MerkleTreeCollapsedUpdate>,
 }
 
+/// A dust generation dtime update emitted when the backing Night UTXO is
+/// spent and the entry's decay time is set.
+#[derive(Debug, Clone, SimpleObject)]
+pub struct DustGenerationDtimeUpdateItem {
+    /// Generation-tree index of the entry whose dtime changed.
+    pub generation_mt_index: u64,
+    /// The hex-encoded owner (dust address).
+    pub owner: HexEncoded,
+    /// Hex-encoded hash of the NIGHT UTXO that backs this dust output.
+    pub night_utxo_hash: HexEncoded,
+    /// The decay time as observed in this ledger event.
+    pub new_dtime: u64,
+    /// The originating transaction ID.
+    pub transaction_id: u64,
+    /// Collapsed Merkle tree update covering the gap between the wallet's
+    /// current cursor and this entry. `null` when the wallet has already
+    /// passed this entry's index, which is the typical case for dtime
+    /// updates on already-seen entries.
+    pub collapsed_merkle_tree: Option<MerkleTreeCollapsedUpdate>,
+    /// Path from the updated leaf to the root of the dust generation tree,
+    /// matching the ledger's `TreeInsertionPath<DustGenerationInfo>`.
+    /// Wallets apply this via `generating_tree.update_from_evidence(...)`.
+    pub merkle_path: Vec<DustMerklePathEntry>,
+}
+
+/// One entry in a `DustGenerationDtimeUpdateItem.merklePath`. Mirrors the
+/// ledger's `TreeInsertionPathEntry`: the hash is the node along the path
+/// from leaf to root (not the sibling), and may be `null` if the tree was
+/// not fully rehashed at the point the update was constructed.
+#[derive(Debug, Clone, SimpleObject)]
+pub struct DustMerklePathEntry {
+    /// Hex-encoded hash of the node along the path. `null` when the
+    /// upstream `TreeInsertionPathEntry.hash` was `None`.
+    pub hash: Option<HexEncoded>,
+    /// Whether the path went left at this branch.
+    pub goes_left: bool,
+}
+
 #[Subscription]
 impl<S, B> DustGenerationsSubscription<S, B>
 where
     S: Storage,
     B: Subscriber,
 {
-    /// Subscribe to dust generation entries for a dust address within an index range.
-    /// Entries are interleaved with collapsed Merkle tree updates to fill gaps.
-    /// The subscription finishes after reaching the end index with a final collapsed update.
+    /// Subscribe to dust generation entries for a dust address within an index
+    /// range, interleaved with collapsed Merkle tree updates and
+    /// `DustGenerationDtimeUpdateItem` events for entries the subscriber owns.
+    /// Finishes at end_index with a final collapsed update.
+    ///
+    /// On reconnect, historical dtime updates after the wallet's last fully-
+    /// synced block (derived from the entry below `startIndex`) are replayed
+    /// before entry backfill. Fresh subscriptions skip historical dtime
+    /// backfill; the wallet learns of pre-existing spends primarily via block
+    /// sync and `dustNullifierTransactions`.
     async fn dust_generations<'a>(
         &self,
         cx: &'a Context<'a>,
@@ -110,6 +159,48 @@ where
                 .try_into_domain(network_id)
                 .map_err_into_client_error(|| "invalid bech32m dust address")?;
             let mut cursor = start_index;
+
+            // Derive the dtime cutoff from the wallet's most recent owned
+            // entry below `start_index`. `None` for fresh subscriptions; we
+            // skip historical dtime backfill in that case.
+            let dtime_cutoff_block_id = storage
+                .get_dust_generation_dtime_cutoff_block_id(&dust_address_bytes, start_index)
+                .await
+                .map_err_into_server_error(|| "get dtime cutoff block id")?;
+
+            // Single dtime cursor across initial backfill and live tail. It
+            // advances past every emitted DustGenerationDtimeUpdateItem so
+            // subsequent block-driven polls don't re-emit.
+            let mut dtime_after_event_id = 0u64;
+
+            if let Some(cutoff) = dtime_cutoff_block_id {
+                debug!(cutoff; "replaying dtime updates after cutoff");
+                let updates = storage
+                    .get_dust_generation_dtime_updates(
+                        &dust_address_bytes,
+                        cutoff,
+                        dtime_after_event_id,
+                        batch_size,
+                    )
+                    .await;
+                let mut updates = pin!(updates);
+                while let Some(update) = updates
+                    .try_next()
+                    .await
+                    .map_err_into_server_error(|| "get next dtime update")?
+                {
+                    dtime_after_event_id = update.ledger_event_id;
+                    let collapsed_merkle_tree = make_collapsed_update(
+                        cursor,
+                        update.generation_mt_index,
+                        storage,
+                        ledger_state_cache,
+                    ).await?;
+                    yield DustGenerationsEvent::DustGenerationDtimeUpdateItem(
+                        dtime_update_item(update, collapsed_merkle_tree),
+                    );
+                }
+            }
 
             debug!(start_index, end_index; "streaming existing dust generation entries");
 
@@ -196,6 +287,37 @@ where
                     });
                 }
 
+                // Drain any new dtime updates for entries the subscriber
+                // owns. Reuses the same cutoff (initial entry-block anchor)
+                // and the running event cursor so we don't re-emit.
+                if let Some(cutoff) = dtime_cutoff_block_id {
+                    let updates = storage
+                        .get_dust_generation_dtime_updates(
+                            &dust_address_bytes,
+                            cutoff,
+                            dtime_after_event_id,
+                            batch_size,
+                        )
+                        .await;
+                    let mut updates = pin!(updates);
+                    while let Some(update) = updates
+                        .try_next()
+                        .await
+                        .map_err_into_server_error(|| "get next dtime update")?
+                    {
+                        dtime_after_event_id = update.ledger_event_id;
+                        let collapsed_merkle_tree = make_collapsed_update(
+                            cursor,
+                            update.generation_mt_index,
+                            storage,
+                            ledger_state_cache,
+                        ).await?;
+                        yield DustGenerationsEvent::DustGenerationDtimeUpdateItem(
+                            dtime_update_item(update, collapsed_merkle_tree),
+                        );
+                    }
+                }
+
                 // Check if we've now reached end_index.
                 if cursor > end_index {
                     let final_update = make_final_collapsed_update(
@@ -267,5 +389,34 @@ async fn make_final_collapsed_update<S: Storage>(
     match update {
         Ok(update) => Ok(Some(update.into())),
         Err(_) => Ok(None),
+    }
+}
+
+/// Convert a domain dtime update entry into the GraphQL item, attaching a
+/// caller-computed `collapsed_merkle_tree`. The `merkle_path` entries are
+/// converted from raw bytes to `HexEncoded` here.
+fn dtime_update_item(
+    update: DustGenerationDtimeUpdateEntry,
+    collapsed_merkle_tree: Option<MerkleTreeCollapsedUpdate>,
+) -> DustGenerationDtimeUpdateItem {
+    let merkle_path = update
+        .merkle_path
+        .into_iter()
+        .map(|entry| DustMerklePathEntry {
+            hash: entry
+                .sibling_hash
+                .map(|bytes| ByteVec::from(bytes).hex_encode()),
+            goes_left: entry.goes_left,
+        })
+        .collect();
+
+    DustGenerationDtimeUpdateItem {
+        generation_mt_index: update.generation_mt_index,
+        owner: update.owner.hex_encode(),
+        night_utxo_hash: update.night_utxo_hash.hex_encode(),
+        new_dtime: update.new_dtime,
+        transaction_id: update.transaction_id,
+        collapsed_merkle_tree,
+        merkle_path,
     }
 }

--- a/indexer-api/src/infra/storage/dust_generations.rs
+++ b/indexer-api/src/infra/storage/dust_generations.rs
@@ -13,7 +13,10 @@
 
 use crate::{
     domain::{
-        dust::{DustGenerationEntry, DustGenerations, DustNullifierTransaction, DustRegistration},
+        dust::{
+            DustGenerationDtimeUpdateEntry, DustGenerationEntry, DustGenerations,
+            DustNullifierTransaction, DustRegistration,
+        },
         storage::dust_generations::DustGenerationsStorage,
     },
     infra::storage::Storage,
@@ -22,10 +25,14 @@ use async_stream::try_stream;
 use fastrace::trace;
 use futures::Stream;
 use indexer_common::{
-    domain::{ByteVec, CardanoRewardAddress, LedgerVersion, TimestampMs, TimestampSecs, ledger},
+    domain::{
+        ByteVec, CardanoRewardAddress, LedgerEventAttributes, LedgerVersion, TimestampMs,
+        TimestampSecs, ledger,
+    },
     infra::sqlx::U128BeBytes,
 };
 use indoc::indoc;
+use sqlx::FromRow;
 use std::num::NonZeroU32;
 
 impl DustGenerationsStorage for Storage {
@@ -190,6 +197,171 @@ impl DustGenerationsStorage for Storage {
         }
     }
 
+    #[trace(properties = { "start_index": "{start_index}" })]
+    async fn get_dust_generation_dtime_cutoff_block_id(
+        &self,
+        dust_address: &[u8],
+        start_index: u64,
+    ) -> Result<Option<u64>, sqlx::Error> {
+        // Highest owned entry strictly below `start_index` gives the block we
+        // last fully synced through. `generation_index < start_index` also
+        // implicitly skips legacy NULL rows (NULL fails the comparison).
+        let query = indoc! {"
+            SELECT t.block_id
+            FROM dust_generation_info dgi
+            JOIN transactions t ON t.id = dgi.transaction_id
+            WHERE dgi.owner = $1
+            AND dgi.generation_index < $2
+            ORDER BY dgi.generation_index DESC
+            LIMIT 1
+        "};
+
+        sqlx::query_as::<_, (i64,)>(query)
+            .bind(dust_address)
+            .bind(start_index as i64)
+            .fetch_optional(&*self.pool)
+            .await
+            .map(|row| row.map(|(block_id,)| block_id as u64))
+    }
+
+    async fn get_dust_generation_dtime_updates(
+        &self,
+        dust_address: &[u8],
+        cutoff_block_id: u64,
+        mut after_event_id: u64,
+        batch_size: NonZeroU32,
+    ) -> impl Stream<Item = Result<DustGenerationDtimeUpdateEntry, sqlx::Error>> + Send {
+        let pool = self.pool.clone();
+        let dust_address = dust_address.to_vec();
+
+        try_stream! {
+            loop {
+                // Filter by indexed `variant` (Postgres LEDGER_EVENT_VARIANT
+                // enum, SQLite TEXT-with-CHECK). Join `dust_generation_info`
+                // via `night_utxo_hash`, which is stored inside the
+                // attributes as a hex string (ByteVec uses
+                // #[serde(with = "const_hex")] which serialises with a `0x`
+                // prefix). Strip the prefix only if present (anchored, not
+                // global) so any malformed input fails loudly at decode
+                // time rather than being silently rewritten. The indexed
+                // BYTEA/BLOB equality predicate on dgi then fires. The full
+                // attributes blob (JSONB on Postgres, TEXT on SQLite) is
+                // also returned so the caller can deserialise
+                // `LedgerEventAttributes::DustGenerationDtimeUpdate` to
+                // recover the merkle_path (and dtime) without further SQL
+                // extraction.
+                #[cfg(feature = "cloud")]
+                let query = indoc! {"
+                    SELECT
+                        le.id AS ledger_event_id,
+                        dgi.generation_index AS generation_mt_index,
+                        dgi.owner,
+                        dgi.night_utxo_hash,
+                        le.attributes,
+                        le.transaction_id
+                    FROM ledger_events le
+                    JOIN transactions t ON t.id = le.transaction_id
+                    JOIN dust_generation_info dgi
+                      ON dgi.night_utxo_hash = decode(
+                           regexp_replace(
+                               le.attributes -> 'DustGenerationDtimeUpdate'
+                                             -> 'generation_info'
+                                            ->> 'night_utxo_hash',
+                               '^0x', ''),
+                           'hex')
+                    WHERE le.variant = 'DustGenerationDtimeUpdate'
+                    AND t.block_id > $1
+                    AND dgi.owner = $2
+                    AND le.id > $3
+                    ORDER BY le.id
+                    LIMIT $4
+                "};
+
+                #[cfg(feature = "standalone")]
+                let query = indoc! {"
+                    WITH dtime_events AS (
+                        SELECT
+                            le.id AS ledger_event_id,
+                            le.transaction_id,
+                            le.attributes,
+                            json_extract(le.attributes,
+                                '$.DustGenerationDtimeUpdate.generation_info.night_utxo_hash')
+                                AS hash_hex
+                        FROM ledger_events le
+                        WHERE le.variant = 'DustGenerationDtimeUpdate'
+                        AND le.id > $3
+                    )
+                    SELECT
+                        e.ledger_event_id,
+                        dgi.generation_index AS generation_mt_index,
+                        dgi.owner,
+                        dgi.night_utxo_hash,
+                        e.attributes,
+                        e.transaction_id
+                    FROM dtime_events e
+                    JOIN transactions t ON t.id = e.transaction_id
+                    JOIN dust_generation_info dgi
+                      ON dgi.night_utxo_hash = unhex(iif(
+                            substr(e.hash_hex, 1, 2) = '0x',
+                            substr(e.hash_hex, 3),
+                            e.hash_hex))
+                    WHERE t.block_id > $1
+                    AND dgi.owner = $2
+                    ORDER BY e.ledger_event_id
+                    LIMIT $4
+                "};
+
+                let rows = sqlx::query_as::<_, DtimeUpdateRow>(query)
+                    .bind(cutoff_block_id as i64)
+                    .bind(&dust_address[..])
+                    .bind(after_event_id as i64)
+                    .bind(batch_size.get() as i64)
+                    .fetch_all(&*pool)
+                    .await?;
+
+                let Some(last_event_id) = rows.last().map(|row| row.ledger_event_id) else {
+                    break;
+                };
+
+                for row in rows {
+                    let DtimeUpdateRow {
+                        ledger_event_id,
+                        generation_mt_index,
+                        owner,
+                        night_utxo_hash,
+                        attributes,
+                        transaction_id,
+                    } = row;
+
+                    let LedgerEventAttributes::DustGenerationDtimeUpdate {
+                        generation_info,
+                        merkle_path,
+                        ..
+                    } = attributes
+                    else {
+                        // The `WHERE le.variant = 'DustGenerationDtimeUpdate'`
+                        // filter above means every row matches this variant.
+                        // A mismatch here would be DB corruption; skip rather
+                        // than panic.
+                        continue;
+                    };
+
+                    yield DustGenerationDtimeUpdateEntry {
+                        ledger_event_id: ledger_event_id as u64,
+                        generation_mt_index: generation_mt_index as u64,
+                        owner,
+                        night_utxo_hash,
+                        new_dtime: generation_info.dtime,
+                        transaction_id: transaction_id as u64,
+                        merkle_path,
+                    };
+                }
+
+                after_event_id = last_event_id as u64;
+            }
+        }
+    }
+
     async fn get_dust_nullifier_transactions(
         &self,
         nullifier_prefixes: &[Vec<u8>],
@@ -255,4 +427,20 @@ impl DustGenerationsStorage for Storage {
             }
         }
     }
+}
+
+/// Row shape returned by the dtime-updates query. The `attributes` JSONB
+/// blob is deserialised into the `LedgerEventAttributes` enum so the caller
+/// can extract the merkle_path (and dtime) without further SQL extraction.
+#[derive(FromRow)]
+struct DtimeUpdateRow {
+    #[sqlx(rename = "ledger_event_id")]
+    ledger_event_id: i64,
+    #[sqlx(rename = "generation_mt_index")]
+    generation_mt_index: i64,
+    owner: ByteVec,
+    night_utxo_hash: ByteVec,
+    #[sqlx(json)]
+    attributes: LedgerEventAttributes,
+    transaction_id: i64,
 }

--- a/indexer-api/src/infra/storage/dust_generations.rs
+++ b/indexer-api/src/infra/storage/dust_generations.rs
@@ -248,8 +248,8 @@ impl DustGenerationsStorage for Storage {
                 // attributes blob (JSONB on Postgres, TEXT on SQLite) is
                 // also returned so the caller can deserialise
                 // `LedgerEventAttributes::DustGenerationDtimeUpdate` to
-                // recover the merkle_path (and dtime) without further SQL
-                // extraction.
+                // recover the tree_insertion_path (and dtime) without
+                // further SQL extraction.
                 #[cfg(feature = "cloud")]
                 let query = indoc! {"
                     SELECT
@@ -335,7 +335,7 @@ impl DustGenerationsStorage for Storage {
 
                     let LedgerEventAttributes::DustGenerationDtimeUpdate {
                         generation_info,
-                        merkle_path,
+                        tree_insertion_path,
                         ..
                     } = attributes
                     else {
@@ -353,7 +353,7 @@ impl DustGenerationsStorage for Storage {
                         night_utxo_hash,
                         new_dtime: generation_info.dtime,
                         transaction_id: transaction_id as u64,
-                        merkle_path,
+                        tree_insertion_path,
                     };
                 }
 
@@ -431,7 +431,8 @@ impl DustGenerationsStorage for Storage {
 
 /// Row shape returned by the dtime-updates query. The `attributes` JSONB
 /// blob is deserialised into the `LedgerEventAttributes` enum so the caller
-/// can extract the merkle_path (and dtime) without further SQL extraction.
+/// can extract the tree_insertion_path (and dtime) without further SQL
+/// extraction.
 #[derive(FromRow)]
 struct DtimeUpdateRow {
     #[sqlx(rename = "ledger_event_id")]

--- a/indexer-common/src/domain.rs
+++ b/indexer-common/src/domain.rs
@@ -56,6 +56,7 @@ pub type SerializedZswapMerkleTreeRoot = ByteVec;
 // Tagged serialization: complex types that may evolve; tags allow version-awareness.
 pub type SerializedContractAddress = ByteVec;
 pub type SerializedContractState = ByteVec;
+pub type SerializedDustTreeInsertionPath = ByteVec;
 pub type SerializedLedgerEvent = ByteVec;
 pub type SerializedLedgerParameters = ByteVec;
 pub type SerializedTransaction = ByteVec;
@@ -279,7 +280,7 @@ impl LedgerEvent {
         raw: SerializedLedgerEvent,
         generation_info: dust::DustGenerationInfo,
         generation_index: u64,
-        merkle_path: Vec<dust::DustMerklePathEntry>,
+        tree_insertion_path: SerializedDustTreeInsertionPath,
     ) -> Self {
         Self {
             grouping: LedgerEventGrouping::Dust,
@@ -287,7 +288,7 @@ impl LedgerEvent {
             attributes: LedgerEventAttributes::DustGenerationDtimeUpdate {
                 generation_info,
                 generation_index,
-                merkle_path,
+                tree_insertion_path,
             },
         }
     }
@@ -327,7 +328,10 @@ pub enum LedgerEventAttributes {
     DustGenerationDtimeUpdate {
         generation_info: dust::DustGenerationInfo,
         generation_index: u64,
-        merkle_path: Vec<dust::DustMerklePathEntry>,
+        /// Tagged-serialised `TreeInsertionPath<DustGenerationInfo>` from the
+        /// originating ledger event. Surfaced verbatim on the GraphQL API so
+        /// wallets can hand it to `generating_tree.update_from_evidence(...)`.
+        tree_insertion_path: SerializedDustTreeInsertionPath,
     },
 
     DustSpendProcessed {

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -716,20 +716,15 @@ fn make_dust_generation_dtime_update_v8(
             }
         });
 
-    let merkle_path = update
-        .path
-        .iter()
-        .map(|entry| dust::DustMerklePathEntry {
-            sibling_hash: entry.hash.as_ref().map(|h| h.0.0.to_bytes_le().to_vec()),
-            goes_left: entry.goes_left,
-        })
-        .collect();
+    let tree_insertion_path = update
+        .tagged_serialize()
+        .map_err(|error| Error::Serialize("TreeInsertionPath<DustGenerationInfoV8>", error))?;
 
     Ok(LedgerEvent::dust_generation_dtime_update(
         raw,
         generation_info,
         mt_index,
-        merkle_path,
+        tree_insertion_path,
     ))
 }
 

--- a/indexer-tests/e2e.graphql
+++ b/indexer-tests/e2e.graphql
@@ -751,6 +751,31 @@ subscription DustLedgerEventsSubscription($id: Int) {
     }
 }
 
+subscription DustGenerationsSubscription(
+    $dustAddress: DustAddress!
+    $startIndex: Int!
+    $endIndex: Int!
+) {
+    dustGenerations(
+        dustAddress: $dustAddress
+        startIndex: $startIndex
+        endIndex: $endIndex
+    ) {
+        __typename
+        ... on DustGenerationsItem {
+            generationMtIndex
+        }
+        ... on DustGenerationsProgress {
+            highestIndex
+        }
+        ... on DustGenerationDtimeUpdateItem {
+            generationMtIndex
+            newDtime
+            treeInsertionPath
+        }
+    }
+}
+
 subscription ShieldedNullifierTransactionsSubscription(
     $nullifierPrefixes: [HexEncoded!]!
     $fromBlock: Int

--- a/indexer-tests/src/e2e.rs
+++ b/indexer-tests/src/e2e.rs
@@ -18,11 +18,11 @@ use crate::{
         BlockQuery, BlockSubscription, ConnectMutation, ContractActionQuery,
         ContractActionSubscription, DParameterHistoryQuery, DisconnectMutation,
         DustCommitmentMerkleTreeUpdateQuery, DustGenerationMerkleTreeUpdateQuery,
-        DustGenerationStatusQuery, DustGenerationsQuery, DustLedgerEventsSubscription,
-        DustNullifierTransactionsSubscription, ShieldedNullifierTransactionsSubscription,
-        ShieldedTransactionsSubscription, TermsAndConditionsHistoryQuery, TransactionsQuery,
-        UnshieldedTransactionsSubscription, ZswapLedgerEventsSubscription,
-        ZswapMerkleTreeCollapsedUpdateQuery, block_query,
+        DustGenerationStatusQuery, DustGenerationsQuery, DustGenerationsSubscription,
+        DustLedgerEventsSubscription, DustNullifierTransactionsSubscription,
+        ShieldedNullifierTransactionsSubscription, ShieldedTransactionsSubscription,
+        TermsAndConditionsHistoryQuery, TransactionsQuery, UnshieldedTransactionsSubscription,
+        ZswapLedgerEventsSubscription, ZswapMerkleTreeCollapsedUpdateQuery, block_query,
         block_subscription::{
             self, BlockSubscriptionBlocks, BlockSubscriptionBlocksTransactions,
             BlockSubscriptionBlocksTransactionsContractActions,
@@ -36,10 +36,10 @@ use crate::{
         contract_action_query::{self},
         contract_action_subscription, disconnect_mutation,
         dust_commitment_merkle_tree_update_query, dust_generation_merkle_tree_update_query,
-        dust_generation_status_query, dust_generations_query, dust_ledger_events_subscription,
-        dust_nullifier_transactions_subscription, shielded_nullifier_transactions_subscription,
-        shielded_transactions_subscription, transactions_query,
-        unshielded_transactions_subscription, zswap_ledger_events_subscription,
+        dust_generation_status_query, dust_generations_query, dust_generations_subscription,
+        dust_ledger_events_subscription, dust_nullifier_transactions_subscription,
+        shielded_nullifier_transactions_subscription, shielded_transactions_subscription,
+        transactions_query, unshielded_transactions_subscription, zswap_ledger_events_subscription,
         zswap_merkle_tree_collapsed_update_query,
     },
     graphql_ws_client,
@@ -47,7 +47,10 @@ use crate::{
 use anyhow::{Context, bail};
 use futures::{StreamExt, TryStreamExt, future::ok};
 use graphql_client::{GraphQLQuery, Response};
-use indexer_api::infra::api::v4::{HexEncodable, HexEncoded, viewing_key::ViewingKey};
+use indexer_api::infra::api::v4::{
+    AddressType, HexEncodable, HexEncoded, dust::DustAddress, encode_address,
+    viewing_key::ViewingKey,
+};
 use indexer_common::domain::NetworkId;
 use itertools::Itertools;
 use reqwest::Client;
@@ -144,6 +147,9 @@ pub async fn run(network_id: NetworkId, host: &str, port: u16, secure: bool) -> 
     test_dust_ledger_events_subscription(&indexer_data, &ws_api_url)
         .await
         .context("test dust ledger events subscription")?;
+    test_dust_generations_subscription(&ws_api_url)
+        .await
+        .context("test dust generations subscription")?;
     test_shielded_nullifier_transactions_subscription(&ws_api_url)
         .await
         .context("test shielded nullifier transactions subscription")?;
@@ -1062,6 +1068,52 @@ async fn test_dust_ledger_events_subscription(
     Ok(())
 }
 
+/// Test the dustGenerations subscription with a fresh dust address. Uses
+/// `start_index > end_index` so the resolver's `cursor > end_index` check
+/// fires on first pass (cursor starts at start_index, no entries to advance
+/// it), yielding a single final `DustGenerationsProgress` event and closing.
+/// Verifies wire-format compatibility for all three union variants and the
+/// completion-event shape on the empty case.
+async fn test_dust_generations_subscription(ws_api_url: &str) -> anyhow::Result<()> {
+    let end_index: i64 = 0;
+    let network_id: NetworkId = "undeployed".try_into().unwrap();
+    let dust_address = DustAddress(encode_address([0u8; 32], AddressType::Dust, &network_id));
+    let variables = dust_generations_subscription::Variables {
+        dust_address,
+        start_index: 1,
+        end_index,
+    };
+    let events = graphql_ws_client::subscribe::<DustGenerationsSubscription>(ws_api_url, variables)
+        .await
+        .context("subscribe to dust generations")?
+        .map_ok(|data| data.dust_generations.to_json_value())
+        .take(1)
+        .take_until(sleep(Duration::from_secs(5)))
+        .try_collect::<Vec<_>>()
+        .await
+        .context("collect dust generations events from subscription")?;
+
+    assert_eq!(
+        events.len(),
+        1,
+        "expected exactly one DustGenerationsProgress event"
+    );
+
+    let event = &events[0];
+    assert_eq!(
+        event.get("__typename").and_then(|v| v.as_str()),
+        Some("DustGenerationsProgress"),
+        "expected DustGenerationsProgress variant, got: {event:?}"
+    );
+    assert_eq!(
+        event.get("highestIndex").and_then(|v| v.as_i64()),
+        Some(end_index),
+        "highestIndex should match the requested endIndex"
+    );
+
+    Ok(())
+}
+
 /// Test the shieldedNullifierTransactions subscription with a non-matching prefix.
 async fn test_shielded_nullifier_transactions_subscription(ws_api_url: &str) -> anyhow::Result<()> {
     let variables = shielded_nullifier_transactions_subscription::Variables {
@@ -1328,6 +1380,14 @@ mod graphql {
         response_derives = "Debug, Clone, Serialize"
     )]
     pub struct DustLedgerEventsSubscription;
+
+    #[derive(GraphQLQuery)]
+    #[graphql(
+        schema_path = "../indexer-api/graphql/schema-v4.graphql",
+        query_path = "./e2e.graphql",
+        response_derives = "Debug, Clone, Serialize"
+    )]
+    pub struct DustGenerationsSubscription;
 
     #[derive(GraphQLQuery)]
     #[graphql(


### PR DESCRIPTION
Closes #1078. Agreed design from #efficient-wallet-syncing with @jsidorenko, @kapke, and @tkerber(21 Apr through 30 Apr).

# Overview

Adds a new `DustGenerationDtimeUpdateItem` variant to the `DustGenerationsEvent` union so wallets that own a dust generation entry learn about its decay-time updates on the same subscription, without having to fall back to `dustLedgerEvents` for raw bytes.

## Final shape

```graphql
union DustGenerationsEvent =
    DustGenerationsItem
  | DustGenerationsProgress
  | DustGenerationDtimeUpdateItem

type DustGenerationDtimeUpdateItem {
  generationMtIndex: Int!
  owner: HexEncoded!
  nightUtxoHash: HexEncoded!
  newDtime: Int!
  transactionId: Int!
  treeInsertionPath: HexEncoded!
}
```

`dustGenerations(dustAddress, startIndex, endIndex)` signature is unchanged. `DustGenerationsItem` and `DustGenerationsProgress` shapes are unchanged. `dustLedgerEvents` is untouched.

## Field-set evolution (per the slack thread)

The variant's field set was iterated three times in #efficient-wallet-syncing before settling:

1. **Initial proposal (22 Apr)**: structured fields + `TreeInsertionPath`. Agreed in principle.
2. **First implementation (29 Apr morning)**: per Jegor's review, added `collapsedMerkleTree` (mirroring `DustGenerationsItem`) and structured `merklePath: [DustMerklePathEntry!]!`.
3. **Second iteration (29 Apr afternoon)**: per Jegor + Thomas, replaced the structured `merklePath` array with `treeInsertionPath: HexEncoded!` carrying the chain-indexer's `tagged_serialize()` of the ledger's `TreeInsertionPath<DustGenerationInfo>`. Thomas pointed out that `TreeInsertionPath` is structurally distinct from a Merkle inclusion path (path-node hashes, not sibling hashes), so the original `DustMerklePathEntry` naming was misleading. Switching to opaque hex sidesteps the naming concern entirely and is symmetric with `MerkleTreeCollapsedUpdate.update`.
4. **Third iteration (30 Apr morning)**: per Andrzej, dropped `collapsedMerkleTree` from this variant. The dtime drain only fires for entries the wallet has already inserted (or will insert via `DustGenerationsItem`), so the gap-before-this-entry concept doesn't apply; gap-filling continues to ride on `DustGenerationsItem` and the final `DustGenerationsProgress`. Cursor model unchanged: only `DustGenerationsItem` advances the cursor.

The wallet hands `treeInsertionPath` straight to `generating_tree.update_from_evidence(...)` after deserialising via the existing wasm binding (Jegor will land the `update_from_evidence` wasm wrapper separately on the wallet side).

## Cursor / reconnect semantics (Andrzej's call)

No new client-side cursor. The dtime-update cutoff is derived server-side from the wallet's most recent owned entry below `startIndex` (its `transactions.block_id`). On reconnect, the resolver replays missed dtime updates after that block during initial backfill, then emits live dtime updates alongside new entries on each `BlockIndexed`.

Fresh subscriptions (no prior owned entry below `startIndex`) skip historical dtime backfill. Per Andrzej, "DtimeUpdate is informational; the wallet learns of spends primarily via block sync and `dustNullifierTransactions`."

## Storage (chain-indexer change, no SQL migration)

The chain-indexer's `make_dust_generation_dtime_update_v8` now `tagged_serialize()`s the `TreeInsertionPath<DustGenerationInfo>` and persists it in the JSONB `attributes` blob (new `tree_insertion_path: SerializedDustTreeInsertionPath` field on `LedgerEventAttributes::DustGenerationDtimeUpdate`). The indexer-api resolver reads it back from JSONB and hex-encodes for the GraphQL surface.

The dtime-update query joins `dust_generation_info` on the indexed `night_utxo_hash` column and filters by the indexed `ledger_events.variant = 'DustGenerationDtimeUpdate'`. The hex string in JSONB carries a `0x` prefix (`ByteVec` uses `#[serde(with = "const_hex")]`), so the join strips it (anchored at the start) before decoding:

- Postgres: `regexp_replace(..., '^0x', '')` + `decode(..., 'hex')`
- SQLite: CTE + `iif(substr(..., 1, 2) = '0x', substr(..., 3), ...)` + `unhex(...)`

Anchored so malformed input fails loudly at decode time rather than being silently rewritten. Verified empirically against qanet-green (3 valid rows returned by the join).

No SQL migration. No write-path change to `dust_generation_info.dtime` (already in place since 001 schema).

## Out of scope (intentional)

- `DustSpendProcessed` not added: per Andrzej, this is the by-nullifier subscription's role for privacy. Wallet uses `dustNullifierTransactions(nullifierPrefixes, ...)`.
- `dtime` field on `DustGenerationsItem`: dropped per Andrzej in favour of the separate-event design. The new variant is the canonical dtime channel.
- `ParamChange` placement: Andrzej and Jegor are still discussing block-data bundling vs a dedicated subscription. Tracked separately.
- Rename of the misleading `DustMerklePathEntry` / `sibling_hash` domain type in indexer-common: tracked as a follow-up PR (publicly committed in the slack thread to Thomas Kerber on 29 Apr). With this PR landing, the misnamed type is no longer on the GraphQL surface.

## Test plan

- [x] `just check`, `just lint`, `just fmt`, `just doc` pass for both `cloud` and `standalone`
- [x] `just test --features standalone`: passes (includes e2e against bundled SQLite)
- [x] `just test`: passes (includes e2e against testcontainer Postgres + NATS)
- [x] `just generate-indexer-api-schema` produces a clean diff covering the new union variant + `treeInsertionPath` field
- [x] E2E smoke test (`test_dust_generations_subscription`) added in `indexer-tests/src/e2e.rs` covering the union shape + completion-event semantics on the empty-fixture case (3 assertions: exactly one event, `__typename`, `highestIndex == endIndex`)
- [x] JSONB encoding verified empirically against qanet-green: prefix-stripped join returns matching `dust_generation_info` rows
- [ ] Wallet integration confirms the new variant satisfies the dtime tracking use case (Jegor)

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (e2e smoke test added; QA-owned tests in #1034 cover the wallet-facing surface)
- [x] Key commits have useful messages (4 commits, one per design iteration)
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [x] Update README.md file (N/A)
- [x] Update documentation (subscription docstring updated, schema regenerated)
- [x] No new todos introduced

## Links

Closes #1078

Slack thread (full conversation, 21 Apr through 30 Apr): https://shielded.slack.com/archives/C0AQ3N6HM7B/p1776862739853729

Related merged PRs in the wallet-sync work-stream: #1059 (QDO fields on `DustGenerationsItem`), #1062 (`dustGenerationMerkleTreeUpdate` query), #1090 (dust subscription input validation tightening).