### PR TITLE
feat(cli): support --version without confg

### DIFF
--- a/chain-indexer/src/main.rs
+++ b/chain-indexer/src/main.rs
@@ -17,6 +17,9 @@ fn main() {
     use log::error;
     use std::panic;
 
+    // Handle `--version` before anything else so it works without a config file.
+    indexer_common::handle_version_flag!();
+
     // Initialize logging.
     telemetry::init_logging();
 

--- a/chain-indexer/tests/version.rs
+++ b/chain-indexer/tests/version.rs
@@ -1,0 +1,43 @@
+// This file is part of midnight-indexer.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(feature = "cloud")]
+
+use std::process::Command;
+
+/// `--version` must work without a config file and report the workspace version.
+#[test]
+fn prints_version_without_config() {
+    let bin = env!("CARGO_BIN_EXE_chain-indexer");
+    for flag in ["--version", "-v"] {
+        let output = Command::new(bin)
+            .arg(flag)
+            .env_remove("CONFIG_FILE")
+            .output()
+            .expect("spawn chain-indexer");
+
+        assert!(
+            output.status.success(),
+            "exit status was {:?} for {flag}: stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stdout = String::from_utf8(output.stdout).expect("stdout utf-8");
+        let first_line = stdout.lines().next().unwrap_or_default();
+        assert!(
+            first_line.starts_with(&format!("chain-indexer {}", env!("CARGO_PKG_VERSION"))),
+            "unexpected output for {flag}: {first_line:?}"
+        );
+    }
+}

--- a/indexer-api/src/bin/indexer-api-cli.rs
+++ b/indexer-api/src/bin/indexer-api-cli.rs
@@ -18,6 +18,7 @@ use clap::{Parser, Subcommand};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    indexer_common::handle_version_flag!();
     Cli::parse().run()
 }
 

--- a/indexer-api/src/main.rs
+++ b/indexer-api/src/main.rs
@@ -17,6 +17,9 @@ fn main() {
     use log::error;
     use std::panic;
 
+    // Handle `--version` before anything else so it works without a config file.
+    indexer_common::handle_version_flag!();
+
     // Initialize logging.
     telemetry::init_logging();
 

--- a/indexer-common/build.rs
+++ b/indexer-common/build.rs
@@ -1,0 +1,60 @@
+// This file is part of midnight-indexer.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Best-effort population of build-time metadata consumed by
+//! `indexer-common::version`. Both pieces are optional; reproducible Nix
+//! builds without git or `date` simply omit them.
+
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=MIDNIGHT_INDEXER_GIT_SHA");
+    println!("cargo:rerun-if-env-changed=MIDNIGHT_INDEXER_BUILD_DATE");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    if let Some(sha) = pick("MIDNIGHT_INDEXER_GIT_SHA", git_sha) {
+        println!("cargo:rustc-env=MIDNIGHT_INDEXER_GIT_SHA={sha}");
+    }
+    if let Some(date) = pick("MIDNIGHT_INDEXER_BUILD_DATE", build_date) {
+        println!("cargo:rustc-env=MIDNIGHT_INDEXER_BUILD_DATE={date}");
+    }
+}
+
+/// External env var wins; otherwise fall back to `compute`. Empty/whitespace
+/// values are treated as missing so callers can clear via `VAR=`.
+fn pick(env_var: &str, compute: fn() -> Option<String>) -> Option<String> {
+    std::env::var(env_var)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .or_else(compute)
+}
+
+fn git_sha() -> Option<String> {
+    run("git", &["rev-parse", "--short=8", "HEAD"])
+}
+
+fn build_date() -> Option<String> {
+    run("date", &["-u", "+%Y-%m-%d"])
+}
+
+fn run(cmd: &str, args: &[&str]) -> Option<String> {
+    Command::new(cmd)
+        .args(args)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}

--- a/indexer-common/src/lib.rs
+++ b/indexer-common/src/lib.rs
@@ -22,3 +22,4 @@ pub mod error;
 pub mod infra;
 pub mod stream;
 pub mod telemetry;
+pub mod version;

--- a/indexer-common/src/version.rs
+++ b/indexer-common/src/version.rs
@@ -1,0 +1,160 @@
+// This file is part of midnight-indexer.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Static version reporting for binaries.
+//!
+//! Every binary entry point should invoke [`handle_version_flag!`] before any
+//! configuration loading so that `--version` / `-v` works without a
+//! `config.yaml` on disk. The version is baked in at compile time via
+//! `CARGO_PKG_VERSION` (inherited from the workspace `version`); the optional
+//! git SHA and build date come from `indexer-common/build.rs` and are simply
+//! omitted on systems where neither `git` nor `date` is available.
+
+const GIT_SHA: Option<&str> = option_env!("MIDNIGHT_INDEXER_GIT_SHA");
+const BUILD_DATE: Option<&str> = option_env!("MIDNIGHT_INDEXER_BUILD_DATE");
+
+#[derive(Debug, PartialEq, Eq)]
+enum Action {
+    Continue,
+    PrintVersionAndExit,
+}
+
+/// Print the version line to stdout and exit 0 if argv contains a version
+/// flag; otherwise return so the caller can continue normal startup.
+///
+/// Prefer the [`handle_version_flag!`] macro at the call site — it captures
+/// the *caller's* `CARGO_BIN_NAME` and `CARGO_PKG_VERSION` automatically so
+/// each binary's `main` is a single line.
+pub fn handle_version_flag(bin_name: &str, version: &str) {
+    if action_for(std::env::args().skip(1)) == Action::PrintVersionAndExit {
+        println!("{}", format_version_line(bin_name, version));
+        std::process::exit(0);
+    }
+}
+
+/// One-liner wrapper around [`handle_version_flag`] that fills in the
+/// caller's `CARGO_BIN_NAME` and `CARGO_PKG_VERSION` at compile time.
+#[macro_export]
+macro_rules! handle_version_flag {
+    () => {
+        $crate::version::handle_version_flag(
+            env!("CARGO_BIN_NAME"),
+            env!("CARGO_PKG_VERSION"),
+        )
+    };
+}
+
+/// Cargo-style version line, optionally appending git SHA and build date in
+/// parentheses when the build provided them.
+pub fn format_version_line(bin_name: &str, version: &str) -> String {
+    format_version_line_with(bin_name, version, GIT_SHA, BUILD_DATE)
+}
+
+fn format_version_line_with(
+    bin_name: &str,
+    version: &str,
+    git_sha: Option<&str>,
+    build_date: Option<&str>,
+) -> String {
+    match (git_sha, build_date) {
+        (Some(sha), Some(date)) => format!("{bin_name} {version} ({sha} {date})"),
+        (Some(sha), None) => format!("{bin_name} {version} ({sha})"),
+        (None, Some(date)) => format!("{bin_name} {version} ({date})"),
+        (None, None) => format!("{bin_name} {version}"),
+    }
+}
+
+fn action_for<I, S>(args: I) -> Action
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let found = args
+        .into_iter()
+        .any(|a| matches!(a.as_ref(), "-v" | "--version"));
+    if found {
+        Action::PrintVersionAndExit
+    } else {
+        Action::Continue
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_no_metadata() {
+        assert_eq!(
+            format_version_line_with("standalone", "4.2.1", None, None),
+            "standalone 4.2.1"
+        );
+    }
+
+    #[test]
+    fn format_sha_only() {
+        assert_eq!(
+            format_version_line_with("standalone", "4.2.1", Some("abc12345"), None),
+            "standalone 4.2.1 (abc12345)"
+        );
+    }
+
+    #[test]
+    fn format_date_only() {
+        assert_eq!(
+            format_version_line_with("standalone", "4.2.1", None, Some("2026-04-28")),
+            "standalone 4.2.1 (2026-04-28)"
+        );
+    }
+
+    #[test]
+    fn format_sha_and_date() {
+        assert_eq!(
+            format_version_line_with("standalone", "4.2.1", Some("abc12345"), Some("2026-04-28")),
+            "standalone 4.2.1 (abc12345 2026-04-28)"
+        );
+    }
+
+    #[test]
+    fn detects_long_flag() {
+        assert_eq!(action_for(["--version"]), Action::PrintVersionAndExit);
+    }
+
+    #[test]
+    fn detects_short_flag() {
+        assert_eq!(action_for(["-v"]), Action::PrintVersionAndExit);
+    }
+
+    #[test]
+    fn upper_v_is_not_a_version_flag() {
+        assert_eq!(action_for(["-V"]), Action::Continue);
+    }
+
+    #[test]
+    fn detects_flag_among_other_args() {
+        assert_eq!(
+            action_for(["--config", "x.yaml", "--version"]),
+            Action::PrintVersionAndExit
+        );
+    }
+
+    #[test]
+    fn no_flag_means_continue() {
+        assert_eq!(action_for(["--config", "x.yaml"]), Action::Continue);
+    }
+
+    #[test]
+    fn empty_args_means_continue() {
+        assert_eq!(action_for(Vec::<&str>::new()), Action::Continue);
+    }
+}

--- a/indexer-common/src/version.rs
+++ b/indexer-common/src/version.rs
@@ -13,8 +13,8 @@
 
 //! Static version reporting for binaries.
 //!
-//! Every binary entry point should invoke [`handle_version_flag!`] before any
-//! configuration loading so that `--version` / `-v` works without a
+//! Every binary entry point should invoke [`crate::handle_version_flag!`]
+//! before any configuration loading so that `--version` / `-v` works without a
 //! `config.yaml` on disk. The version is baked in at compile time via
 //! `CARGO_PKG_VERSION` (inherited from the workspace `version`); the optional
 //! git SHA and build date come from `indexer-common/build.rs` and are simply
@@ -32,9 +32,9 @@ enum Action {
 /// Print the version line to stdout and exit 0 if argv contains a version
 /// flag; otherwise return so the caller can continue normal startup.
 ///
-/// Prefer the [`handle_version_flag!`] macro at the call site — it captures
-/// the *caller's* `CARGO_BIN_NAME` and `CARGO_PKG_VERSION` automatically so
-/// each binary's `main` is a single line.
+/// Prefer the [`crate::handle_version_flag!`] macro at the call site, which
+/// captures the *caller's* `CARGO_BIN_NAME` and `CARGO_PKG_VERSION`
+/// automatically so each binary's `main` is a single line.
 pub fn handle_version_flag(bin_name: &str, version: &str) {
     if action_for(std::env::args().skip(1)) == Action::PrintVersionAndExit {
         println!("{}", format_version_line(bin_name, version));
@@ -47,10 +47,7 @@ pub fn handle_version_flag(bin_name: &str, version: &str) {
 #[macro_export]
 macro_rules! handle_version_flag {
     () => {
-        $crate::version::handle_version_flag(
-            env!("CARGO_BIN_NAME"),
-            env!("CARGO_PKG_VERSION"),
-        )
+        $crate::version::handle_version_flag(env!("CARGO_BIN_NAME"), env!("CARGO_PKG_VERSION"))
     };
 }
 

--- a/indexer-standalone/src/main.rs
+++ b/indexer-standalone/src/main.rs
@@ -20,6 +20,9 @@ fn main() {
     use log::error;
     use std::panic;
 
+    // Handle `--version` before anything else so it works without a config file.
+    indexer_common::handle_version_flag!();
+
     // Initialize logging.
     telemetry::init_logging();
 

--- a/indexer-tests/src/main.rs
+++ b/indexer-tests/src/main.rs
@@ -18,6 +18,7 @@ use indexer_tests::e2e;
 /// e2e tests against the Indexer API.
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    indexer_common::handle_version_flag!();
     Cli::parse().run().await
 }
 

--- a/spo-indexer/src/main.rs
+++ b/spo-indexer/src/main.rs
@@ -18,6 +18,9 @@ async fn main() {
     use log::error;
     use std::panic;
 
+    // Handle `--version` before anything else so it works without a config file.
+    indexer_common::handle_version_flag!();
+
     // Initialize logging.
     telemetry::init_logging();
 

--- a/wallet-indexer/src/main.rs
+++ b/wallet-indexer/src/main.rs
@@ -18,6 +18,9 @@ async fn main() {
     use log::error;
     use std::panic;
 
+    // Handle `--version` before anything else so it works without a config file.
+    indexer_common::handle_version_flag!();
+
     // Initialize logging.
     telemetry::init_logging();
 


### PR DESCRIPTION
Hey, small quality-of-life thing I bumped into.

Right now running any of the binaries with `-v` or `--version` errors out
trying to load config:

    $ /nix/store/.../bin/standalone --version
    {"level":"ERROR",...,"error":"load configuration: No such file or
     directory (os error 2) in config.yaml YAML file"}

Which is awkward when you're sshing into a box and just want to know what
version is deployed.

This PR adds a tiny version helper in `indexer-common` that every binary
calls as the first line of `main`, before any config loading. So now:

    $ indexer-standalone --version
    indexer-standalone 4.2.1 (5503a07c 2026-04-28)

Format is cargo-style: `<bin> <version>` plus an optional `(sha date)`
suffix when the build had that info available.

A few notes on the design:

- Version comes from `CARGO_PKG_VERSION`, which all crates inherit from
  the workspace `version` field. So it tracks releases automatically and
  can't drift from whatever `chore(release):` bumps.
- Git SHA and build date are best-effort. If `MIDNIGHT_INDEXER_GIT_SHA`
  or `MIDNIGHT_INDEXER_BUILD_DATE` env vars are set at build time
  (CI, Nix derivations, etc.) they win. Otherwise `build.rs` tries
  `git rev-parse` and `date -u` as fallbacks. If neither is available,
  the parens just get omitted, no failure. So Nix builds without git
  context still work fine.
- Each call site is one line: `indexer_common::handle_version_flag!();`.
  The macro fills in the caller's bin name and version automatically.
- Recognized flags are `--version` and `-v`. Skipped `-V` to keep things
  simple, happy to add it back if you'd rather match cargo exactly.

Wired into all 7 binaries: chain-indexer, wallet-indexer, indexer-api,
indexer-api-cli, indexer-standalone, spo-indexer, indexer-tests.

Tests:
- Unit tests in `indexer-common::version` for the format strings and
  arg parsing.
- Integration tests in each binary crate's `tests/version.rs` that spawn
  the real binary and check exit code + output. Had to put these in
  `tests/` rather than alongside the code in `src/` because that's the
  only place Cargo sets `CARGO_BIN_EXE_<name>` so the test can find the
  binary on disk.
- One gap: `indexer-standalone` is excluded from nextest in the
  justfile, so its integration test isn't actually run by `just test`.
  The shared helper is exercised by the other 6 though, so the wiring
  is covered.

Low priority on my end, no rush. Happy to tweak any of the choices above
if they don't match how you'd want it.
