### PR TITLE
fix(indexer-api): tighten dust subscription input validation

### DIFF
--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -1113,7 +1113,7 @@ type Subscription {
 	Entries are interleaved with collapsed Merkle tree updates to fill gaps.
 	The subscription finishes after reaching the end index with a final collapsed update.
 	"""
-	dustGenerations(dustAddress: HexEncoded!, startIndex: Int!, endIndex: Int!): DustGenerationsEvent!
+	dustGenerations(dustAddress: DustAddress!, startIndex: Int!, endIndex: Int!): DustGenerationsEvent!
 	"""
 	Subscribe to dust ledger events starting at the given ID or at the very start if omitted.
 	"""

--- a/indexer-api/src/infra/api/v4/dust.rs
+++ b/indexer-api/src/infra/api/v4/dust.rs
@@ -16,12 +16,12 @@
 use crate::{
     domain,
     infra::api::v4::{
-        AddressType, CardanoNetworkId, CardanoRewardAddress, HexEncodable, HexEncoded,
-        encode_address, encode_cardano_reward_address,
+        AddressType, CardanoNetworkId, CardanoRewardAddress, DecodeAddressError, HexEncodable,
+        HexEncoded, decode_address, encode_address, encode_cardano_reward_address,
     },
 };
 use async_graphql::{SimpleObject, scalar};
-use indexer_common::domain::NetworkId;
+use indexer_common::domain::{DustPublicKey, NetworkId};
 use serde::{Deserialize, Serialize};
 
 /// Bech32m-encoded DUST address.
@@ -35,6 +35,17 @@ use serde::{Deserialize, Serialize};
 pub struct DustAddress(pub String);
 
 scalar!(DustAddress);
+
+impl DustAddress {
+    /// Bech32m-decode this dust address into its raw bytes, validating the
+    /// network-aware HRP (`mn_dust` on mainnet, `mn_dust_<network>` elsewhere).
+    pub fn try_into_domain(
+        &self,
+        network_id: &NetworkId,
+    ) -> Result<DustPublicKey, DecodeAddressError> {
+        decode_address(&self.0, AddressType::Dust, network_id)
+    }
+}
 
 /// DUST generation status for a specific Cardano reward address.
 #[derive(Debug, Clone, SimpleObject)]
@@ -65,6 +76,39 @@ pub struct DustGenerationStatus {
 
     /// Cardano UTXO output index for update/unregister operations.
     pub utxo_output_index: Option<u32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::infra::api::v4::{AddressType, dust::DustAddress, encode_address};
+    use indexer_common::domain::ByteVec;
+
+    #[test]
+    fn test_try_into_domain_round_trip() {
+        let network_id = "undeployed".try_into().unwrap();
+        let bytes = ByteVec::from(vec![1, 2, 3, 4, 5]);
+        let dust_address = DustAddress(encode_address(&bytes, AddressType::Dust, &network_id));
+
+        let decoded = dust_address.try_into_domain(&network_id).unwrap();
+        assert_eq!(decoded.as_ref(), bytes.as_ref());
+    }
+
+    #[test]
+    fn test_try_into_domain_rejects_hex() {
+        let network_id = "undeployed".try_into().unwrap();
+        let dust_address = DustAddress("1234567890abcdef".to_string());
+        assert!(dust_address.try_into_domain(&network_id).is_err());
+    }
+
+    #[test]
+    fn test_try_into_domain_rejects_wrong_network_hrp() {
+        let undeployed = "undeployed".try_into().unwrap();
+        let preview = "preview".try_into().unwrap();
+        let bytes = ByteVec::from(vec![1, 2, 3, 4, 5]);
+        let dust_address = DustAddress(encode_address(&bytes, AddressType::Dust, &undeployed));
+
+        assert!(dust_address.try_into_domain(&preview).is_err());
+    }
 }
 
 impl From<(domain::DustGenerationStatus, &NetworkId)> for DustGenerationStatus {

--- a/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
@@ -15,7 +15,10 @@ use crate::{
     domain::{LedgerStateCache, storage::Storage},
     infra::api::{
         ApiResult, ContextExt, ResultExt,
-        v4::{HexEncodable, HexEncoded, merkle_tree_collapsed_update::MerkleTreeCollapsedUpdate},
+        v4::{
+            HexEncodable, HexEncoded, dust::DustAddress,
+            merkle_tree_collapsed_update::MerkleTreeCollapsedUpdate,
+        },
     },
 };
 use async_graphql::{Context, SimpleObject, Subscription, Union};
@@ -90,7 +93,7 @@ where
     async fn dust_generations<'a>(
         &self,
         cx: &'a Context<'a>,
-        dust_address: HexEncoded,
+        dust_address: DustAddress,
         start_index: u64,
         end_index: u64,
     ) -> impl Stream<Item = ApiResult<DustGenerationsEvent>> {
@@ -98,12 +101,14 @@ where
         let subscriber = cx.get_subscriber::<B>();
         let ledger_state_cache = cx.get_ledger_state_cache();
         let batch_size = cx.get_subscription_config().dust_generations.batch_size;
+        let network_id = cx.get_network_id();
 
         let block_indexed_stream = subscriber.subscribe::<BlockIndexed>();
 
         try_stream! {
-            let dust_address_bytes = const_hex::decode(dust_address.as_ref())
-                .map_err_into_client_error(|| "invalid hex-encoded dust address")?;
+            let dust_address_bytes = dust_address
+                .try_into_domain(network_id)
+                .map_err_into_client_error(|| "invalid bech32m dust address")?;
             let mut cursor = start_index;
 
             debug!(start_index, end_index; "streaming existing dust generation entries");

--- a/indexer-api/src/infra/api/v4/subscription/dust_nullifier_transactions.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_nullifier_transactions.rs
@@ -99,6 +99,8 @@ where
             let from = from_block.unwrap_or(0);
             let to = to_block.unwrap_or(u64::MAX);
 
+            validate_block_range(from, to)?;
+
             debug!("streaming existing dust nullifier transactions");
 
             let entries = storage
@@ -174,5 +176,33 @@ where
 
             warn!("stream of BlockIndexed events completed unexpectedly");
         }
+    }
+}
+
+/// Reject `fromBlock > toBlock` with a client error so callers get a clear
+/// signal that they likely have a bug in their request rather than thinking
+/// their query just happens to match nothing (#1095).
+fn validate_block_range(from: u64, to: u64) -> ApiResult<()> {
+    (from <= to)
+        .then_some(())
+        .some_or_client_error(|| "fromBlock must not exceed toBlock")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_block_range;
+
+    #[test]
+    fn test_validate_block_range_accepts_valid_ranges() {
+        assert!(validate_block_range(0, 0).is_ok());
+        assert!(validate_block_range(5, 10).is_ok());
+        assert!(validate_block_range(0, u64::MAX).is_ok());
+    }
+
+    #[test]
+    fn test_validate_block_range_rejects_from_greater_than_to() {
+        assert!(validate_block_range(1, 0).is_err());
+        assert!(validate_block_range(10, 5).is_err());
+        assert!(validate_block_range(u64::MAX, 0).is_err());
     }
 }

--- a/indexer-api/src/infra/api/v4/subscription/dust_nullifier_transactions.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_nullifier_transactions.rs
@@ -14,7 +14,7 @@
 use crate::{
     domain::storage::Storage,
     infra::api::{
-        ApiResult, ContextExt, ResultExt,
+        ApiResult, ContextExt, OptionExt, ResultExt,
         v4::{HexEncodable, HexEncoded},
     },
 };
@@ -80,11 +80,21 @@ where
         let block_indexed_stream = subscriber.subscribe::<BlockIndexed>();
 
         try_stream! {
+            (!nullifier_prefixes.is_empty())
+                .then_some(())
+                .some_or_client_error(|| "nullifierPrefixes must not be empty")?;
+
             let prefix_bytes = nullifier_prefixes
                 .iter()
                 .map(|p| const_hex::decode(p.as_ref()))
                 .collect::<Result<Vec<_>, _>>()
                 .map_err_into_client_error(|| "invalid hex-encoded nullifier prefix")?;
+
+            prefix_bytes
+                .iter()
+                .all(|b| !b.is_empty())
+                .then_some(())
+                .some_or_client_error(|| "nullifierPrefixes elements must not be empty")?;
 
             let from = from_block.unwrap_or(0);
             let to = to_block.unwrap_or(u64::MAX);

--- a/indexer-tests/e2e.graphql
+++ b/indexer-tests/e2e.graphql
@@ -768,6 +768,24 @@ subscription ShieldedNullifierTransactionsSubscription(
     }
 }
 
+subscription DustNullifierTransactionsSubscription(
+    $nullifierPrefixes: [HexEncoded!]!
+    $fromBlock: Int
+    $toBlock: Int
+) {
+    dustNullifierTransactions(
+        nullifierPrefixes: $nullifierPrefixes
+        fromBlock: $fromBlock
+        toBlock: $toBlock
+    ) {
+        nullifier
+        commitment
+        transactionId
+        blockHeight
+        blockHash
+    }
+}
+
 query DustGenerationStatusQuery(
     $cardanoRewardAddresses: [CardanoRewardAddress!]!
 ) {

--- a/indexer-tests/src/e2e.rs
+++ b/indexer-tests/src/e2e.rs
@@ -1087,11 +1087,11 @@ async fn test_shielded_nullifier_transactions_subscription(ws_api_url: &str) -> 
     Ok(())
 }
 
-/// Test the dustNullifierTransactions subscription. Verifies the input-validation guards
-/// from #1089 (empty array and empty-string element both error) and that a valid
-/// non-matching prefix with a bounded range completes empty. Each case is wrapped in
-/// a defensive timeout so the test fails fast rather than hanging if the server
-/// doesn't behave as expected.
+/// Test the dustNullifierTransactions subscription. Verifies the input-validation
+/// guards from #1089 (empty array and empty-string element both error) and #1095
+/// (fromBlock > toBlock errors), plus a valid non-matching prefix with a bounded
+/// range completes empty. Each case is wrapped in a defensive timeout so the test
+/// fails fast rather than hanging if the server doesn't behave as expected.
 async fn test_dust_nullifier_transactions_subscription(ws_api_url: &str) -> anyhow::Result<()> {
     // Empty nullifierPrefixes array → client error per #1089.
     let variables = dust_nullifier_transactions_subscription::Variables {
@@ -1150,6 +1150,25 @@ async fn test_dust_nullifier_transactions_subscription(ws_api_url: &str) -> anyh
         .await
         .context("collect dust nullifier transactions")?;
     assert!(events.is_empty());
+
+    // fromBlock > toBlock → client error per #1095.
+    let variables = dust_nullifier_transactions_subscription::Variables {
+        nullifier_prefixes: vec!["00".to_string().try_into().unwrap()],
+        from_block: Some(10),
+        to_block: Some(5),
+    };
+    let stream = graphql_ws_client::subscribe::<DustNullifierTransactionsSubscription>(
+        ws_api_url, variables,
+    )
+    .await
+    .context("subscribe with fromBlock > toBlock")?;
+    let result = tokio::time::timeout(Duration::from_secs(3), stream.try_collect::<Vec<_>>())
+        .await
+        .context("expected client error within 3s for fromBlock > toBlock")?;
+    assert!(
+        result.is_err(),
+        "expected client error for fromBlock > toBlock, got: {result:?}"
+    );
 
     Ok(())
 }

--- a/indexer-tests/src/e2e.rs
+++ b/indexer-tests/src/e2e.rs
@@ -19,9 +19,10 @@ use crate::{
         ContractActionSubscription, DParameterHistoryQuery, DisconnectMutation,
         DustCommitmentMerkleTreeUpdateQuery, DustGenerationMerkleTreeUpdateQuery,
         DustGenerationStatusQuery, DustGenerationsQuery, DustLedgerEventsSubscription,
-        ShieldedNullifierTransactionsSubscription, ShieldedTransactionsSubscription,
-        TermsAndConditionsHistoryQuery, TransactionsQuery, UnshieldedTransactionsSubscription,
-        ZswapLedgerEventsSubscription, ZswapMerkleTreeCollapsedUpdateQuery, block_query,
+        DustNullifierTransactionsSubscription, ShieldedNullifierTransactionsSubscription,
+        ShieldedTransactionsSubscription, TermsAndConditionsHistoryQuery, TransactionsQuery,
+        UnshieldedTransactionsSubscription, ZswapLedgerEventsSubscription,
+        ZswapMerkleTreeCollapsedUpdateQuery, block_query,
         block_subscription::{
             self, BlockSubscriptionBlocks, BlockSubscriptionBlocksTransactions,
             BlockSubscriptionBlocksTransactionsContractActions,
@@ -36,8 +37,9 @@ use crate::{
         contract_action_subscription, disconnect_mutation,
         dust_commitment_merkle_tree_update_query, dust_generation_merkle_tree_update_query,
         dust_generation_status_query, dust_generations_query, dust_ledger_events_subscription,
-        shielded_nullifier_transactions_subscription, shielded_transactions_subscription,
-        transactions_query, unshielded_transactions_subscription, zswap_ledger_events_subscription,
+        dust_nullifier_transactions_subscription, shielded_nullifier_transactions_subscription,
+        shielded_transactions_subscription, transactions_query,
+        unshielded_transactions_subscription, zswap_ledger_events_subscription,
         zswap_merkle_tree_collapsed_update_query,
     },
     graphql_ws_client,
@@ -145,6 +147,9 @@ pub async fn run(network_id: NetworkId, host: &str, port: u16, secure: bool) -> 
     test_shielded_nullifier_transactions_subscription(&ws_api_url)
         .await
         .context("test shielded nullifier transactions subscription")?;
+    test_dust_nullifier_transactions_subscription(&ws_api_url)
+        .await
+        .context("test dust nullifier transactions subscription")?;
 
     println!("Successfully finished e2e testing");
 
@@ -1082,6 +1087,73 @@ async fn test_shielded_nullifier_transactions_subscription(ws_api_url: &str) -> 
     Ok(())
 }
 
+/// Test the dustNullifierTransactions subscription. Verifies the input-validation guards
+/// from #1089 (empty array and empty-string element both error) and that a valid
+/// non-matching prefix with a bounded range completes empty. Each case is wrapped in
+/// a defensive timeout so the test fails fast rather than hanging if the server
+/// doesn't behave as expected.
+async fn test_dust_nullifier_transactions_subscription(ws_api_url: &str) -> anyhow::Result<()> {
+    // Empty nullifierPrefixes array → client error per #1089.
+    let variables = dust_nullifier_transactions_subscription::Variables {
+        nullifier_prefixes: vec![],
+        from_block: Some(0),
+        to_block: Some(0),
+    };
+    let stream = graphql_ws_client::subscribe::<DustNullifierTransactionsSubscription>(
+        ws_api_url, variables,
+    )
+    .await
+    .context("subscribe with empty nullifierPrefixes")?;
+    let result = tokio::time::timeout(Duration::from_secs(3), stream.try_collect::<Vec<_>>())
+        .await
+        .context("expected client error within 3s for empty nullifierPrefixes")?;
+    assert!(
+        result.is_err(),
+        "expected client error for empty nullifierPrefixes, got: {result:?}"
+    );
+
+    // Empty-string prefix element → also client error per #1089.
+    let variables = dust_nullifier_transactions_subscription::Variables {
+        nullifier_prefixes: vec!["".to_string().try_into().unwrap()],
+        from_block: Some(0),
+        to_block: Some(0),
+    };
+    let stream = graphql_ws_client::subscribe::<DustNullifierTransactionsSubscription>(
+        ws_api_url, variables,
+    )
+    .await
+    .context("subscribe with empty-string prefix")?;
+    let result = tokio::time::timeout(Duration::from_secs(3), stream.try_collect::<Vec<_>>())
+        .await
+        .context("expected client error within 3s for empty-string prefix")?;
+    assert!(
+        result.is_err(),
+        "expected client error for empty-string prefix, got: {result:?}"
+    );
+
+    // Valid non-matching prefix with bounded range → completes empty. Per-event
+    // timeout pattern matches `test_shielded_nullifier_transactions_subscription`.
+    let variables = dust_nullifier_transactions_subscription::Variables {
+        nullifier_prefixes: vec!["00".to_string().try_into().unwrap()],
+        from_block: Some(0),
+        to_block: Some(0),
+    };
+    let events = graphql_ws_client::subscribe::<DustNullifierTransactionsSubscription>(
+        ws_api_url, variables,
+    )
+    .await
+    .context("subscribe with valid prefix")?;
+    let events = tokio_stream::StreamExt::timeout(events, Duration::from_secs(3))
+        .take_while(|timeout_result| ready(timeout_result.is_ok()))
+        .filter_map(|timeout_result| ready(timeout_result.map(Some).unwrap_or(None)))
+        .try_collect::<Vec<_>>()
+        .await
+        .context("collect dust nullifier transactions")?;
+    assert!(events.is_empty());
+
+    Ok(())
+}
+
 trait SerializeExt
 where
     Self: Serialize,
@@ -1245,6 +1317,14 @@ mod graphql {
         response_derives = "Debug, Clone, Serialize"
     )]
     pub struct ShieldedNullifierTransactionsSubscription;
+
+    #[derive(GraphQLQuery)]
+    #[graphql(
+        schema_path = "../indexer-api/graphql/schema-v4.graphql",
+        query_path = "./e2e.graphql",
+        response_derives = "Debug, Clone, Serialize"
+    )]
+    pub struct DustNullifierTransactionsSubscription;
 
     #[derive(GraphQLQuery)]
     #[graphql(


### PR DESCRIPTION
## Summary
- Closes #1084: switch `dustGenerations` subscription input from `HexEncoded!` to bech32m `DustAddress!` (hard cut per @kapke). Aligns with the WalletEngine spec and the rest of the API; query response and subscription input now use the same address format.
- Closes #1089: reject empty `nullifierPrefixes` (`[]` outer or `[""]` element) on `dustNullifierTransactions` subscription with a client error (per @kapke, events stream is the firehose surface for "every transaction" use cases).
- Closes #1095: reject `fromBlock > toBlock` on `dustNullifierTransactions` subscription with a client error (per @kapke, gives callers a clear signal of likely client-side bugs rather than silent empty completion).

Four commits: one per ticket plus an e2e smoke test for the dustNullifierTransactions subscription (which previously had no `e2e.rs` coverage).

## Test plan
- [x] Round-trip / hex-rejection / wrong-network-HRP unit tests for `DustAddress::try_into_domain` (3/3 pass)
- [x] Unit tests for `validate_block_range` covering valid + invalid ranges including `u64::MAX` boundary (2/2 pass)
- [x] E2E smoke test for `dustNullifierTransactions` subscription covering all three guards + a valid-prefix case
- [x] `cargo build` clean for `cloud` and `standalone` features
- [x] `cargo clippy --features cloud -- -D warnings` clean
- [x] Schema diff verified: `dustAddress: HexEncoded!` -> `dustAddress: DustAddress!`
- [ ] QA: re-test `dustGenerations` subscription with bech32m address from `dustGenerations` query response (the original Giuseppe repro)
- [ ] QA: confirm `dustNullifierTransactions` now errors on `[]` and `[""]` rather than silently hanging
- [ ] QA: confirm `dustNullifierTransactions` now errors on `fromBlock > toBlock` rather than silently completing
- [ ] QA: confirm valid `dustNullifierTransactions` calls (non-empty prefixes, valid ranges) still stream as expected