### PR TITLE
fix(indexer-api): avoid infinite redirect loop on unknown /api/v3 and /api/v4 paths

### DIFF
--- a/indexer-api/src/infra/api.rs
+++ b/indexer-api/src/infra/api.rs
@@ -288,8 +288,16 @@ async fn ready(State(caught_up): State<Arc<AtomicBool>>) -> impl IntoResponse {
     }
 }
 
-async fn redirect_api_to_latest(OriginalUri(uri): OriginalUri) -> Redirect {
-    redirect_to_latest(uri, "/api")
+async fn redirect_api_to_latest(OriginalUri(uri): OriginalUri) -> Response {
+    // Avoid redirecting paths already under a known API version, otherwise the redirect prepends
+    // `/api/v4` again and the client follows itself into an infinite loop. Unrecognised paths
+    // under a known version should 404 like any other unknown route.
+    let path = uri.path();
+    if path.starts_with("/api/v3/") || path.starts_with("/api/v4/") {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+
+    redirect_to_latest(uri, "/api").into_response()
 }
 
 fn redirect_to_latest(uri: Uri, target: &str) -> Redirect {
@@ -539,3 +547,35 @@ impl StdError for ApiError {}
 #[derive(Debug, Clone, Error)]
 #[error("{0}")]
 pub struct InnerApiError(String, #[source] Option<Arc<dyn StdError + Send + Sync>>);
+
+#[cfg(test)]
+mod tests {
+    use crate::infra::api::redirect_api_to_latest;
+    use axum::{
+        extract::OriginalUri,
+        http::{StatusCode, Uri, header},
+    };
+
+    /// Regression for #1085, an unrecognised path under `/api/v4` must not redirect to a
+    /// `/api/v4/v4/...` URL (which would loop indefinitely). Same guard applies to `/api/v3`.
+    #[tokio::test]
+    async fn unknown_versioned_paths_return_404() {
+        for path in ["/api/v4/schema", "/api/v3/schema"] {
+            let uri: Uri = path.parse().unwrap();
+            let response = redirect_api_to_latest(OriginalUri(uri)).await;
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        }
+    }
+
+    /// Unversioned `/api/...` paths still get the existing redirect to the latest version.
+    #[tokio::test]
+    async fn unversioned_api_path_redirects_to_latest() {
+        let uri: Uri = "/api/foo".parse().unwrap();
+        let response = redirect_api_to_latest(OriginalUri(uri)).await;
+        assert_eq!(response.status(), StatusCode::PERMANENT_REDIRECT);
+        assert_eq!(
+            response.headers().get(header::LOCATION).unwrap(),
+            "/api/v4/foo"
+        );
+    }
+}


### PR DESCRIPTION
# Overview

Fixes #1085 (reported by @NicolasDP).

Unrecognised paths under `/api/v3` or `/api/v4` were returning a 308 whose `Location` double-prepended the version prefix (e.g. `/api/v4/schema` → `/api/v4/v4/schema` → `/api/v4/v4/v4/schema` → ...), looping until the client's redirect cap.

The catch-all `/api/{*rest}` in `indexer-api/src/infra/api.rs` was meant to redirect legacy versioned paths to the latest, but when a path under a known version fell through (because the nested router has no matching sub-route, e.g. there's no `/schema`), `replacen("/api", "/api/v4", 1)` ran against a path that already contained `/api/v4` and prepended it again.

Fix: in `redirect_api_to_latest`, return 404 if the path already starts with `/api/v3/` or `/api/v4/`. Unversioned `/api/...` paths still redirect to `/api/v4/...` as before.

## Note on the reporter's secondary claim
The ticket also asks for `/api/v4/schema` to be restored. Verified against `v4.0.0` in git that endpoint never existed; indexer-api has only ever exposed `/graphql` (POST) and `/graphql/ws`. Confirmed empirically too, qanet-blue (running 4.0.2) returns the same `308 → /api/v4/v4/schema` loop, so this is pre-existing on the 4.0.x line and not a 4.2.x regression. Introspection at `/api/v4/graphql` remains the supported way to fetch the SDL.

## Tests

- `unknown_versioned_paths_return_404`, `/api/v4/schema` and `/api/v3/schema` return 404.
- `unversioned_api_path_redirects_to_latest`, `/api/foo` still 308s to `/api/v4/foo`.

## Links

Closes #1085