### PR TITLE
Fix sqlite deadlocks and socket bloat in standalone mode

### DIFF
--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -1097,11 +1097,9 @@ mod tests {
                 .display()
                 .to_string();
 
-            let pool = SqlitePool::new(pool::sqlite::Config {
-                cnn_url: sqlite_file,
-            })
-            .await
-            .context("create pool")?;
+            let pool = SqlitePool::new(pool::sqlite::Config::with_url(sqlite_file))
+                .await
+                .context("create pool")?;
             migrations::sqlite::run(&pool)
                 .await
                 .context("run migrations")?;

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -2591,11 +2591,9 @@ mod tests {
                 .display()
                 .to_string();
 
-            let pool = SqlitePool::new(pool::sqlite::Config {
-                cnn_url: sqlite_file,
-            })
-            .await
-            .context("create pool")?;
+            let pool = SqlitePool::new(pool::sqlite::Config::with_url(sqlite_file))
+                .await
+                .context("create pool")?;
             migrations::sqlite::run(&pool)
                 .await
                 .context("run migrations")?;

--- a/indexer-common/src/domain/ledger/transaction.rs
+++ b/indexer-common/src/domain/ledger/transaction.rs
@@ -309,11 +309,9 @@ mod tests {
                 .display()
                 .to_string();
 
-            let pool = SqlitePool::new(pool::sqlite::Config {
-                cnn_url: sqlite_file,
-            })
-            .await
-            .context("create pool")?;
+            let pool = SqlitePool::new(pool::sqlite::Config::with_url(sqlite_file))
+                .await
+                .context("create pool")?;
             migrations::sqlite::run(&pool)
                 .await
                 .context("run migrations")?;

--- a/indexer-common/src/domain/ledger/transaction.rs
+++ b/indexer-common/src/domain/ledger/transaction.rs
@@ -458,11 +458,9 @@ mod tests {
                 .display()
                 .to_string();
 
-            let pool = SqlitePool::new(pool::sqlite::Config {
-                cnn_url: sqlite_file,
-            })
-            .await
-            .context("create pool")?;
+            let pool = SqlitePool::new(pool::sqlite::Config::with_url(sqlite_file))
+                .await
+                .context("create pool")?;
             migrations::sqlite::run(&pool)
                 .await
                 .context("run migrations")?;

--- a/indexer-common/src/infra/ledger_db.rs
+++ b/indexer-common/src/infra/ledger_db.rs
@@ -36,7 +36,7 @@ pub async fn init(config: Config) -> Result<(), Error> {
         cnn_url,
     } = config;
 
-    let pool = sqlite::SqlitePool::new(sqlite::Config { cnn_url }).await?;
+    let pool = sqlite::SqlitePool::new(sqlite::Config::with_url(cnn_url)).await?;
     migrations::sqlite::run_for_ledger_db(&pool).await?;
 
     let db = v1_1::LedgerDb::new(pool);

--- a/indexer-common/src/infra/ledger_db.rs
+++ b/indexer-common/src/infra/ledger_db.rs
@@ -36,7 +36,16 @@ pub async fn init(config: Config) -> Result<(), Error> {
         cnn_url,
     } = config;
 
-    let pool = sqlite::SqlitePool::new(sqlite::Config::with_url(cnn_url)).await?;
+    // storage-core assumes a single writer: `flush_*` reads root counts and
+    // then writes new ones, and that read-then-write must observe its own
+    // in-progress state. With max_connections > 1, sqlx can route the read to
+    // a different connection whose WAL snapshot predates the writer, breaking
+    // the invariant and producing "roots counts can't be negative" panics.
+    let pool = sqlite::SqlitePool::new(sqlite::Config {
+        cnn_url,
+        max_connections: 1,
+    })
+    .await?;
     migrations::sqlite::run_for_ledger_db(&pool).await?;
 
     let db = v1_1::LedgerDb::new(pool);

--- a/indexer-common/src/infra/ledger_db.rs
+++ b/indexer-common/src/infra/ledger_db.rs
@@ -41,9 +41,17 @@ pub async fn init(config: Config) -> Result<(), Error> {
     // in-progress state. With max_connections > 1, sqlx can route the read to
     // a different connection whose WAL snapshot predates the writer, breaking
     // the invariant and producing "roots counts can't be negative" panics.
+    //
+    // `synchronous_full`: chain-indexer commits the ledger state BEFORE the block row in the
+    // main DB and the resume path relies on the on-disk ledger DB being at least as new as
+    // the main DB. With NORMAL both files fsync independently at checkpoints, so a power
+    // loss could keep block N in the main DB while dropping N's ledger state here - the
+    // startup filter would then silently seed from an older state and diverge. FULL keeps
+    // the cross-file ordering: a ledger state is durable before its block row can be.
     let pool = sqlite::SqlitePool::new(sqlite::Config {
         cnn_url,
         max_connections: 1,
+        synchronous_full: true,
     })
     .await?;
     migrations::sqlite::run_for_ledger_db(&pool).await?;

--- a/indexer-common/src/infra/pool/sqlite.rs
+++ b/indexer-common/src/infra/pool/sqlite.rs
@@ -14,8 +14,11 @@
 use derive_more::Into;
 use log::debug;
 use serde::Deserialize;
-use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
-use std::ops::Deref;
+use sqlx::{
+    Sqlite, Transaction,
+    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous},
+};
+use std::{ops::Deref, time::Duration};
 use thiserror::Error;
 
 /// New type for `sqlx::SqlitePool`, allowing for some custom extensions as well as security.
@@ -28,16 +31,33 @@ pub struct SqlitePool(sqlx::SqlitePool);
 impl SqlitePool {
     /// Try to create a new [SqlitePool] with the given config.
     pub async fn new(config: Config) -> Result<Self, Error> {
+        let max_connections = config.max_connections;
         let connect_options =
             SqliteConnectOptions::try_from(config).map_err(Error::ConvertConfig)?;
         let inner = SqlitePoolOptions::new()
-            .max_connections(1)
+            .max_connections(max_connections)
             .connect_with(connect_options)
             .await?;
         let pool = SqlitePool(inner);
         debug!(pool:?; "created pool");
 
         Ok(pool)
+    }
+
+    /// Begin a transaction with `BEGIN IMMEDIATE` semantics, claiming the
+    /// writer lock up front.
+    ///
+    /// SQLite's default `BEGIN DEFERRED` transaction stays a reader until its
+    /// first write statement. When multiple connections run in WAL mode, a
+    /// deferred reader that later tries to upgrade to a writer (while another
+    /// connection has committed in between) gets `SQLITE_BUSY_SNAPSHOT` (517),
+    /// which is not retryable via `busy_timeout`. Every caller in this
+    /// codebase that starts a transaction does so to write, so taking the
+    /// write lock immediately is both correct and avoids the race. Shadowing
+    /// `sqlx::Pool::begin` via inherent method makes the existing
+    /// `self.pool.begin()` call sites pick up the new behavior transparently.
+    pub async fn begin(&self) -> Result<Transaction<'static, Sqlite>, sqlx::Error> {
+        self.0.begin_with("BEGIN IMMEDIATE").await
     }
 }
 
@@ -63,14 +83,45 @@ pub enum Error {
 #[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     pub cnn_url: String,
+
+    #[serde(default = "default_max_connections")]
+    pub max_connections: u32,
+}
+
+impl Config {
+    /// Build a [Config] for the given connection URL using defaults for the
+    /// remaining fields.
+    pub fn with_url(cnn_url: impl Into<String>) -> Self {
+        Self {
+            cnn_url: cnn_url.into(),
+            ..Default::default()
+        }
+    }
+}
+
+fn default_max_connections() -> u32 {
+    8
 }
 
 impl TryFrom<Config> for SqliteConnectOptions {
     type Error = sqlx::Error;
 
     fn try_from(config: Config) -> Result<Self, Self::Error> {
-        let mut options = config.cnn_url.parse::<SqliteConnectOptions>()?;
-        options = options.create_if_missing(true);
+        // WAL lets readers run concurrent with a single writer; without it the
+        // default `DELETE` journal mode serializes all access on a single file.
+        // `busy_timeout` lets SQLite itself retry on lock contention instead of
+        // immediately returning `SQLITE_BUSY`. It needs to cover the worst-case
+        // writer hold time: on mainnet, chain-indexer's per-block write
+        // transaction (many inserts across several tables) can exceed a few
+        // seconds, so a short timeout causes concurrent writes (e.g. an API
+        // `disconnect_wallet` UPDATE) to spuriously fail.
+        let options = config
+            .cnn_url
+            .parse::<SqliteConnectOptions>()?
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .synchronous(SqliteSynchronous::Normal)
+            .busy_timeout(Duration::from_secs(30));
         Ok(options)
     }
 }
@@ -79,6 +130,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             cnn_url: "sqlite::memory:".to_string(),
+            max_connections: default_max_connections(),
         }
     }
 }
@@ -100,10 +152,7 @@ mod tests {
         }
         assert!(!Path::new(db_path).exists());
 
-        let pool = SqlitePool::new(Config {
-            cnn_url: format!("sqlite://{db_path}"),
-        })
-        .await;
+        let pool = SqlitePool::new(Config::with_url(format!("sqlite://{db_path}"))).await;
 
         assert!(pool.is_ok());
         assert!(Path::new(db_path).exists());

--- a/indexer-common/src/infra/pool/sqlite.rs
+++ b/indexer-common/src/infra/pool/sqlite.rs
@@ -56,9 +56,34 @@ impl SqlitePool {
     /// write lock immediately is both correct and avoids the race. Shadowing
     /// `sqlx::Pool::begin` via inherent method makes the existing
     /// `self.pool.begin()` call sites pick up the new behavior transparently.
+    ///
+    /// `busy_timeout` bounds a single lock wait, but SQLite's busy handler is unfair polling,
+    /// not a queue: under back-to-back writers (chain-indexer catching up) a waiter can lose
+    /// every retry window and starve past the timeout. A begin failure is fatal to the whole
+    /// standalone process (components propagate it and main exits), so retry a few times
+    /// before giving up.
     pub async fn begin(&self) -> Result<Transaction<'static, Sqlite>, sqlx::Error> {
-        self.0.begin_with("BEGIN IMMEDIATE").await
+        const ATTEMPTS: u32 = 4;
+
+        let mut attempt = 1;
+        loop {
+            match self.0.begin_with("BEGIN IMMEDIATE").await {
+                Err(error) if is_busy_error(&error) && attempt < ATTEMPTS => {
+                    log::warn!(attempt; "sqlite writer starved past busy_timeout, retrying begin");
+                    attempt += 1;
+                }
+
+                other => return other,
+            }
+        }
     }
+}
+
+/// Whether the error is SQLite's `SQLITE_BUSY` family ("database is locked"), i.e. lock
+/// contention that outlasted `busy_timeout` - transient by nature and safe to retry or skip
+/// for housekeeping writes.
+pub fn is_busy_error(error: &sqlx::Error) -> bool {
+    matches!(error, sqlx::Error::Database(db) if db.message().contains("database is locked"))
 }
 
 impl Deref for SqlitePool {
@@ -86,6 +111,12 @@ pub struct Config {
 
     #[serde(default = "default_max_connections")]
     pub max_connections: u32,
+
+    /// `synchronous=FULL` instead of `NORMAL`: every commit fsyncs the WAL. Not exposed to
+    /// operators - set in code for DBs whose commits must hit disk in order relative to
+    /// other files (the ledger DB; see `infra::ledger_db::init`).
+    #[serde(skip)]
+    pub synchronous_full: bool,
 }
 
 impl Config {
@@ -115,12 +146,22 @@ impl TryFrom<Config> for SqliteConnectOptions {
         // transaction (many inserts across several tables) can exceed a few
         // seconds, so a short timeout causes concurrent writes (e.g. an API
         // `disconnect_wallet` UPDATE) to spuriously fail.
+        //
+        // `synchronous=NORMAL` fsyncs the WAL only at checkpoints: a power loss can drop the
+        // last commits (never corrupt), all of which the indexer recomputes from the node -
+        // except wallet sessions, which clients re-establish by reconnecting. DBs that cannot
+        // accept tail loss opt into FULL via `synchronous_full`.
+        let synchronous = if config.synchronous_full {
+            SqliteSynchronous::Full
+        } else {
+            SqliteSynchronous::Normal
+        };
         let options = config
             .cnn_url
             .parse::<SqliteConnectOptions>()?
             .create_if_missing(true)
             .journal_mode(SqliteJournalMode::Wal)
-            .synchronous(SqliteSynchronous::Normal)
+            .synchronous(synchronous)
             .busy_timeout(Duration::from_secs(30));
         Ok(options)
     }
@@ -131,6 +172,7 @@ impl Default for Config {
         Self {
             cnn_url: "sqlite::memory:".to_string(),
             max_connections: default_max_connections(),
+            synchronous_full: false,
         }
     }
 }
@@ -171,5 +213,70 @@ mod tests {
             .execute(pool.deref())
             .await;
         assert!(result.is_ok());
+    }
+
+    /// Regression test for the PM-15038 failure shape: many concurrent write transactions on
+    /// one file-backed DB, each also reading inside its transaction like wallet-indexer's
+    /// read-modify-write. With DEFERRED transactions this dies with `database is locked`
+    /// (SQLITE_BUSY, 5) or `SQLITE_BUSY_SNAPSHOT` (517, not retried by busy_timeout);
+    /// `BEGIN IMMEDIATE` + WAL + busy_timeout must let every writer through.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn concurrent_write_transactions_never_hit_busy_errors() {
+        const WRITERS: usize = 8;
+        const WRITES_PER_WRITER: usize = 25;
+
+        let temp_dir = tempfile::tempdir().expect("create tempdir");
+        let db_path = temp_dir
+            .path()
+            .join("contention.sqlite")
+            .display()
+            .to_string();
+        let pool = SqlitePool::new(Config::with_url(format!("sqlite://{db_path}")))
+            .await
+            .expect("create pool");
+
+        sqlx::query("CREATE TABLE wallet_txs (id INTEGER PRIMARY KEY, wallet INTEGER, n INTEGER)")
+            .execute(pool.deref())
+            .await
+            .expect("create table");
+
+        let writers = (0..WRITERS)
+            .map(|wallet| {
+                let pool = pool.clone();
+                tokio::spawn(async move {
+                    for n in 0..WRITES_PER_WRITER {
+                        let mut tx = pool.begin().await?;
+                        // Read BEFORE writing: with a DEFERRED transaction this pins a WAL
+                        // snapshot as a reader, and the later INSERT's lock upgrade fails
+                        // with SQLITE_BUSY_SNAPSHOT once any other writer commits in
+                        // between. This read-then-write order is what makes the test able
+                        // to fail at all.
+                        sqlx::query_scalar::<_, i64>("SELECT count(*) FROM wallet_txs")
+                            .fetch_one(&mut *tx)
+                            .await?;
+                        sqlx::query("INSERT INTO wallet_txs (wallet, n) VALUES ($1, $2)")
+                            .bind(wallet as i64)
+                            .bind(n as i64)
+                            .execute(&mut *tx)
+                            .await?;
+                        tx.commit().await?;
+                    }
+                    Ok::<_, sqlx::Error>(())
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for writer in writers {
+            writer
+                .await
+                .expect("writer task panicked")
+                .expect("writer hit an sqlite error");
+        }
+
+        let rows = sqlx::query_scalar::<_, i64>("SELECT count(*) FROM wallet_txs")
+            .fetch_one(pool.deref())
+            .await
+            .expect("count rows");
+        assert_eq!(rows as usize, WRITERS * WRITES_PER_WRITER);
     }
 }

--- a/indexer-standalone/config.yaml
+++ b/indexer-standalone/config.yaml
@@ -38,6 +38,13 @@ infra:
     url: "ws://localhost:9944"
     reconnect_max_delay: "10s"
     reconnect_max_attempts: 30
+    # Tuning for the Blockfrost HTTP connection pools. Applied to both the
+    # direct client and the one owned by the blockfrost crate. Omit to use
+    # defaults (max_idle_per_host=4, idle_timeout=30s, tcp_keepalive=60s).
+    # http_pool:
+    #   max_idle_per_host: 4
+    #   idle_timeout: "30s"
+    #   tcp_keepalive: "60s"
 
   api:
     address: "0.0.0.0"

--- a/indexer-standalone/config.yaml
+++ b/indexer-standalone/config.yaml
@@ -46,6 +46,12 @@ infra:
     # APP__INFRA__SPO_NODE__BLOCKFROST_ID env var. If you are not exercising
     # SPO features locally, any non-empty placeholder is accepted at startup,
     # e.g. APP__INFRA__SPO_NODE__BLOCKFROST_ID=dummy-not-using-spo
+    #
+    # Optional Blockfrost HTTP pool tuning (defaults: 4 / 30s / 60s).
+    # http_pool:
+    #   max_idle_per_host: 4
+    #   idle_timeout: "30s"
+    #   tcp_keepalive: "60s"
 
   api:
     address: "0.0.0.0"

--- a/indexer-standalone/config.yaml
+++ b/indexer-standalone/config.yaml
@@ -47,7 +47,6 @@ infra:
     # SPO features locally, any non-empty placeholder is accepted at startup,
     # e.g. APP__INFRA__SPO_NODE__BLOCKFROST_ID=dummy-not-using-spo
     #
-    # Optional Blockfrost HTTP pool tuning (defaults: 4 / 30s / 60s).
     # http_pool:
     #   max_idle_per_host: 4
     #   idle_timeout: "30s"

--- a/indexer-standalone/src/config.rs
+++ b/indexer-standalone/src/config.rs
@@ -17,7 +17,7 @@ use indexer_common::{domain::NetworkId, infra::pool, telemetry};
 use serde::Deserialize;
 use spo_indexer::{
     application::{self as spo_app, StakeRefreshConfig},
-    infra::spo_client,
+    infra::spo_client::{self, HttpPoolConfig},
 };
 use std::{num::NonZeroUsize, time::Duration};
 use wallet_indexer::application as wallet_app;
@@ -157,6 +157,8 @@ pub struct SpoNodeConfig {
     #[serde(with = "humantime_serde")]
     pub reconnect_max_delay: Duration,
     pub reconnect_max_attempts: usize,
+    #[serde(default)]
+    pub http_pool: HttpPoolConfig,
 }
 
 impl From<SpoNodeConfig> for spo_client::Config {
@@ -166,6 +168,7 @@ impl From<SpoNodeConfig> for spo_client::Config {
             blockfrost_id: secrecy::SecretString::from(config.blockfrost_id),
             reconnect_max_delay: config.reconnect_max_delay,
             reconnect_max_attempts: config.reconnect_max_attempts,
+            http_pool: config.http_pool,
         }
     }
 }

--- a/indexer-standalone/src/config.rs
+++ b/indexer-standalone/src/config.rs
@@ -17,7 +17,7 @@ use indexer_common::{domain::NetworkId, infra::pool, telemetry};
 use serde::Deserialize;
 use spo_indexer::{
     application::{self as spo_app, StakeRefreshConfig},
-    infra::spo_client,
+    infra::spo_client::{self, HttpPoolConfig},
 };
 use std::{num::NonZeroUsize, time::Duration};
 use wallet_indexer::application as wallet_app;
@@ -173,6 +173,8 @@ pub struct SpoNodeConfig {
     #[serde(with = "humantime_serde")]
     pub reconnect_max_delay: Duration,
     pub reconnect_max_attempts: usize,
+    #[serde(default)]
+    pub http_pool: HttpPoolConfig,
 }
 
 impl From<SpoNodeConfig> for spo_client::Config {
@@ -182,6 +184,7 @@ impl From<SpoNodeConfig> for spo_client::Config {
             blockfrost_id: secrecy::SecretString::from(config.blockfrost_id),
             reconnect_max_delay: config.reconnect_max_delay,
             reconnect_max_attempts: config.reconnect_max_attempts,
+            http_pool: config.http_pool,
         }
     }
 }

--- a/spo-indexer/src/application.rs
+++ b/spo-indexer/src/application.rs
@@ -20,13 +20,18 @@ use crate::{
     infra::spo_client::{SLOT_DURATION, SPOClient},
     utils::{hex_to_bytes, remove_hex_prefix},
 };
+use anyhow::Context;
 use blake2::{
     Blake2bVar,
     digest::{Update, VariableOutput},
 };
 use log::{debug, error, info, warn};
 use serde::Deserialize;
-use std::{cmp, collections::HashMap, time::Duration};
+use std::{
+    cmp,
+    collections::{HashMap, hash_map::Entry},
+    time::{Duration, Instant},
+};
 use subxt::utils::to_hex;
 use tokio::{
     select,
@@ -99,31 +104,62 @@ async fn process_next_epoch(
     };
     info!(epoch_no = epoch.epoch_no; "processing epoch");
 
-    let mut tx = storage.create_tx().await?;
+    // Fetch everything from the network before opening a transaction. Holding
+    // the SQLite writer across HTTP calls starves concurrent writers (e.g. the
+    // chain-indexer or the stake-refresh task) beyond `busy_timeout` and trips
+    // `database is locked` errors.
+    let prefetch_started = Instant::now();
     let committee = client.get_committee(epoch.epoch_no).await?;
     let raw_spos = client.get_spo_registrations(epoch.epoch_no).await?;
     let membership = committee_to_membership(client, &committee);
 
-    storage.save_epoch(&epoch, &mut tx).await?;
-    storage.save_membership(&membership, &mut tx).await?;
+    let entries = raw_spos
+        .candidate_registrations
+        .values()
+        .flatten()
+        .map(|reg| (get_cardano_id(&reg.mainchain_pub_key), reg.clone()))
+        .collect::<Vec<_>>();
 
     let mut blocks_produced: HashMap<String, u32> = HashMap::new();
     let mut val_to_registration: HashMap<String, CandidateRegistration> = HashMap::new();
+    let mut pool_metadata: HashMap<String, PoolMetadata> = HashMap::new();
 
-    for (_, registrations) in raw_spos.candidate_registrations {
-        for raw_spo in &registrations {
-            let cardano_id = get_cardano_id(&raw_spo.mainchain_pub_key);
-            // Normalize all keys by stripping optional 0x prefix for consistency with DB values.
-            let spo_sk = remove_hex_prefix(&raw_spo.sidechain_pub_key).to_owned();
+    for (cardano_id, raw_spo) in &entries {
+        // Normalize all keys by stripping optional 0x prefix for consistency with DB values.
+        let spo_sk = remove_hex_prefix(&raw_spo.sidechain_pub_key).to_owned();
+        val_to_registration.insert(spo_sk.clone(), raw_spo.clone());
+        *blocks_produced.entry(spo_sk).or_insert(0) += 1;
 
-            val_to_registration.insert(spo_sk.clone(), raw_spo.clone());
-            save_pool_metadata(client, storage, &mut tx, cardano_id.clone()).await?;
-            save_spo_identity(storage, raw_spo, cardano_id, &mut tx).await?;
-            save_spo_history(storage, raw_spo, epoch.epoch_no.into(), &mut tx).await?;
-
-            let count_mk = blocks_produced.entry(spo_sk).or_insert(0);
-            *count_mk += 1;
+        if let Entry::Vacant(slot) = pool_metadata.entry(cardano_id.clone()) {
+            let meta = client
+                .get_pool_metadata(cardano_id.clone())
+                .await
+                .unwrap_or_else(|_| PoolMetadata::placeholder(cardano_id.clone()));
+            slot.insert(meta);
         }
+    }
+
+    debug!(
+        epoch_no = epoch.epoch_no,
+        registrations = val_to_registration.len(),
+        unique_pools = pool_metadata.len(),
+        prefetch_ms = elapsed_ms(prefetch_started);
+        "spo: network pre-fetch complete"
+    );
+
+    // All network work is done; now persist in a single short transaction.
+    let tx_started = Instant::now();
+    let mut tx = storage.create_tx().await?;
+    storage.save_epoch(&epoch, &mut tx).await?;
+    storage.save_membership(&membership, &mut tx).await?;
+
+    for (cardano_id, raw_spo) in &entries {
+        let meta = pool_metadata
+            .get(cardano_id)
+            .expect("metadata inserted for every entry above");
+        storage.save_pool_meta(meta, &mut tx).await?;
+        save_spo_identity(storage, raw_spo, cardano_id.clone(), &mut tx).await?;
+        save_spo_history(storage, raw_spo, epoch.epoch_no.into(), &mut tx).await?;
     }
 
     debug!(committee_size = committee.len(); "committee");
@@ -161,7 +197,11 @@ async fn process_next_epoch(
     }
 
     tx.commit().await?;
-    info!(epoch_no = epoch.epoch_no; "processed epoch");
+    info!(
+        epoch_no = epoch.epoch_no,
+        tx_ms = elapsed_ms(tx_started);
+        "processed epoch"
+    );
     Ok(())
 }
 
@@ -205,10 +245,17 @@ async fn refresh_stake_snapshots(
         (1000 / cfg.max_rps.max(1)) as u64
     };
 
-    let mut tx = storage.create_tx().await?;
+    // Use one transaction per pool so the shared SQLite writer is not held
+    // across Blockfrost HTTP calls and rate-limit sleeps, which would otherwise
+    // starve the connection pool for concurrent readers/writers.
     for pid in pool_ids.iter() {
         match client.get_pool_data(pid).await {
             Ok(pd) => {
+                let tx_started = Instant::now();
+                let mut tx = storage
+                    .create_tx()
+                    .await
+                    .with_context(|| format!("begin tx for pool {pid}"))?;
                 storage
                     .save_stake_snapshot(
                         pid,
@@ -220,7 +267,8 @@ async fn refresh_stake_snapshots(
                         pd.live_pledge,
                         &mut tx,
                     )
-                    .await?;
+                    .await
+                    .with_context(|| format!("save_stake_snapshot for pool {pid}"))?;
                 storage
                     .insert_stake_history(
                         pid,
@@ -233,7 +281,15 @@ async fn refresh_stake_snapshots(
                         pd.live_pledge,
                         &mut tx,
                     )
-                    .await?;
+                    .await
+                    .with_context(|| format!("insert_stake_history for pool {pid}"))?;
+                tx.commit()
+                    .await
+                    .with_context(|| format!("commit tx for pool {pid}"))?;
+                let tx_ms = elapsed_ms(tx_started);
+                if tx_ms > 1_000 {
+                    warn!(pid, tx_ms; "spo: stake snapshot tx held > 1s");
+                }
                 total_updated += 1;
             }
             Err(error) => {
@@ -244,7 +300,6 @@ async fn refresh_stake_snapshots(
             sleep(Duration::from_millis(sleep_per_req_ms)).await;
         }
     }
-    tx.commit().await?;
 
     // Persist cursor at the last processed id
     let last_id = pool_ids.last().map(|s| s.as_str());
@@ -299,28 +354,6 @@ async fn save_spo_identity(
     };
 
     storage.save_spo(&spo, tx).await?;
-    Ok(())
-}
-
-async fn save_pool_metadata(
-    client: &SPOClient,
-    storage: &impl Storage,
-    tx: &mut SqlxTransaction,
-    cardano_id: String,
-) -> anyhow::Result<()> {
-    let saved_meta = client
-        .get_pool_metadata(cardano_id.clone())
-        .await
-        .unwrap_or_else(|_| PoolMetadata {
-            pool_id: cardano_id.clone(),
-            hex_id: cardano_id,
-            name: String::new(),
-            ticker: String::new(),
-            homepage_url: String::new(),
-            url: String::new(),
-        });
-
-    storage.save_pool_meta(&saved_meta, tx).await?;
     Ok(())
 }
 
@@ -387,6 +420,10 @@ async fn get_epoch_to_process(
             ends_at: current_epoch.ends_at - time_offset,
         }))
     }
+}
+
+fn elapsed_ms(t: Instant) -> u64 {
+    u64::try_from(t.elapsed().as_millis()).unwrap_or(u64::MAX)
 }
 
 fn get_cardano_id(mainchain_pk: &str) -> String {

--- a/spo-indexer/src/application.rs
+++ b/spo-indexer/src/application.rs
@@ -117,7 +117,7 @@ async fn process_next_epoch(
         .candidate_registrations
         .values()
         .flatten()
-        .map(|reg| (get_cardano_id(&reg.mainchain_pub_key), reg.clone()))
+        .map(|reg| (get_cardano_id(&reg.mainchain_pub_key), reg))
         .collect::<Vec<_>>();
 
     let mut blocks_produced: HashMap<String, u32> = HashMap::new();
@@ -127,7 +127,7 @@ async fn process_next_epoch(
     for (cardano_id, raw_spo) in &entries {
         // Normalize all keys by stripping optional 0x prefix for consistency with DB values.
         let spo_sk = remove_hex_prefix(&raw_spo.sidechain_pub_key).to_owned();
-        val_to_registration.insert(spo_sk.clone(), raw_spo.clone());
+        val_to_registration.insert(spo_sk.clone(), (*raw_spo).clone());
         *blocks_produced.entry(spo_sk).or_insert(0) += 1;
 
         if let Entry::Vacant(slot) = pool_metadata.entry(cardano_id.clone()) {
@@ -296,17 +296,22 @@ async fn refresh_stake_snapshots(
                 error!("stake refresh for {pid} failed: {error:?}");
             }
         }
+
+        // Advance the cursor per pool, not once after the loop: pools committed so far stay
+        // committed when a later pool fails, and re-reading them on the next cycle would
+        // append duplicate spo_stake_history rows (the table has no unique key).
+        storage
+            .set_stake_refresh_cursor(Some(pid.as_str()))
+            .await
+            .with_context(|| format!("advance stake refresh cursor to {pid}"))?;
+
         if sleep_per_req_ms > 0 {
             sleep(Duration::from_millis(sleep_per_req_ms)).await;
         }
     }
 
-    // Persist cursor at the last processed id
-    let last_id = pool_ids.last().map(|s| s.as_str());
-    storage.set_stake_refresh_cursor(last_id).await?;
-
     if total_updated > 0 {
-        info!(total_updated, cursor:? = last_id; "stake refresh completed");
+        info!(total_updated, cursor:? = pool_ids.last(); "stake refresh completed");
     }
     Ok(())
 }
@@ -423,7 +428,7 @@ async fn get_epoch_to_process(
 }
 
 fn elapsed_ms(t: Instant) -> u64 {
-    u64::try_from(t.elapsed().as_millis()).unwrap_or(u64::MAX)
+    t.elapsed().as_millis() as u64
 }
 
 fn get_cardano_id(mainchain_pk: &str) -> String {

--- a/spo-indexer/src/domain/pool.rs
+++ b/spo-indexer/src/domain/pool.rs
@@ -20,3 +20,18 @@ pub struct PoolMetadata {
     pub homepage_url: String,
     pub url: String,
 }
+
+impl PoolMetadata {
+    /// Placeholder used when the upstream metadata fetch fails so we still
+    /// persist a row keyed by `cardano_id`.
+    pub fn placeholder(cardano_id: String) -> Self {
+        Self {
+            pool_id: cardano_id.clone(),
+            hex_id: cardano_id,
+            name: String::new(),
+            ticker: String::new(),
+            homepage_url: String::new(),
+            url: String::new(),
+        }
+    }
+}

--- a/spo-indexer/src/infra/spo_client.rs
+++ b/spo-indexer/src/infra/spo_client.rs
@@ -24,10 +24,10 @@ use http::{
     header::{InvalidHeaderValue, USER_AGENT},
 };
 use indexer_common::error::BoxError;
-use reqwest::Client as HttpClient;
+use reqwest::{Client as HttpClient, ClientBuilder};
 use secrecy::{ExposeSecret, SecretString};
 use serde_json::value::RawValue;
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 use subxt::{
     OnlineClient, PolkadotConfig,
     config::RpcConfigFor,
@@ -51,9 +51,36 @@ pub struct Config {
     pub blockfrost_id: SecretString,
 
     #[serde(with = "humantime_serde")]
-    pub reconnect_max_delay: std::time::Duration,
+    pub reconnect_max_delay: Duration,
 
     pub reconnect_max_attempts: usize,
+
+    #[serde(default)]
+    pub http_pool: HttpPoolConfig,
+}
+
+/// Pool tuning applied to every `reqwest::Client` SPOClient owns (its own direct
+/// Blockfrost client and the one wrapped by `BlockfrostAPI`). Both clients use the
+/// same values so the total idle socket count is bounded.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct HttpPoolConfig {
+    pub max_idle_per_host: usize,
+
+    #[serde(with = "humantime_serde")]
+    pub idle_timeout: Duration,
+
+    #[serde(with = "humantime_serde")]
+    pub tcp_keepalive: Duration,
+}
+
+impl Default for HttpPoolConfig {
+    fn default() -> Self {
+        Self {
+            max_idle_per_host: 4,
+            idle_timeout: Duration::from_secs(30),
+            tcp_keepalive: Duration::from_secs(60),
+        }
+    }
 }
 
 /// A [Node] implementation based on subxt.
@@ -77,6 +104,7 @@ impl SPOClient {
             blockfrost_id,
             reconnect_max_delay,
             reconnect_max_attempts,
+            http_pool,
         } = config;
 
         if blockfrost_id.expose_secret().is_empty() {
@@ -94,14 +122,19 @@ impl SPOClient {
             .build(&url)
             .await
             .map_err(|error| SPOClientError::Subtx(error.into()))?;
+
         let online_client = OnlineClient::<PolkadotConfig>::from_rpc_client(rpc_client.clone())
             .await
             .map_err(|error| SPOClientError::UnexpectedResponse(error.to_string()))?;
 
-        let blockfrost = BlockfrostAPI::new(blockfrost_id.expose_secret(), Default::default());
+        let blockfrost = BlockfrostAPI::new_with_client(
+            blockfrost_id.expose_secret(),
+            Default::default(),
+            tuned_client_builder(&http_pool),
+        )
+        .map_err(|error| SPOClientError::UnexpectedResponse(error.to_string()))?;
 
-        let http = HttpClient::builder()
-            .user_agent("midnight-spo-indexer/1.0")
+        let http = tuned_client_builder(&http_pool)
             .build()
             .map_err(|error| SPOClientError::UnexpectedResponse(error.to_string()))?;
 
@@ -400,6 +433,15 @@ fn parse_lovelace(v: &serde_json::Value, field: &str) -> Option<i64> {
             None
         }
     }
+}
+
+fn tuned_client_builder(http_pool: &HttpPoolConfig) -> ClientBuilder {
+    let user_agent = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
+    ClientBuilder::new()
+        .user_agent(user_agent)
+        .pool_max_idle_per_host(http_pool.max_idle_per_host)
+        .pool_idle_timeout(http_pool.idle_timeout)
+        .tcp_keepalive(http_pool.tcp_keepalive)
 }
 
 async fn get_epoch_duration(

--- a/spo-indexer/src/infra/spo_client.rs
+++ b/spo-indexer/src/infra/spo_client.rs
@@ -64,21 +64,34 @@ pub struct Config {
 /// same values so the total idle socket count is bounded.
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct HttpPoolConfig {
+    #[serde(default = "default_max_idle_per_host")]
     pub max_idle_per_host: usize,
 
-    #[serde(with = "humantime_serde")]
+    #[serde(default = "default_idle_timeout", with = "humantime_serde")]
     pub idle_timeout: Duration,
 
-    #[serde(with = "humantime_serde")]
+    #[serde(default = "default_tcp_keepalive", with = "humantime_serde")]
     pub tcp_keepalive: Duration,
+}
+
+fn default_max_idle_per_host() -> usize {
+    4
+}
+
+fn default_idle_timeout() -> Duration {
+    Duration::from_secs(30)
+}
+
+fn default_tcp_keepalive() -> Duration {
+    Duration::from_secs(60)
 }
 
 impl Default for HttpPoolConfig {
     fn default() -> Self {
         Self {
-            max_idle_per_host: 4,
-            idle_timeout: Duration::from_secs(30),
-            tcp_keepalive: Duration::from_secs(60),
+            max_idle_per_host: default_max_idle_per_host(),
+            idle_timeout: default_idle_timeout(),
+            tcp_keepalive: default_tcp_keepalive(),
         }
     }
 }
@@ -127,10 +140,11 @@ impl SPOClient {
             .await
             .map_err(|error| SPOClientError::UnexpectedResponse(error.to_string()))?;
 
+        // Keep the user agent Blockfrost has seen from this client since day one.
         let blockfrost = BlockfrostAPI::new_with_client(
             blockfrost_id.expose_secret(),
             Default::default(),
-            tuned_client_builder(&http_pool),
+            tuned_client_builder(&http_pool).user_agent("midnight-spo-indexer/1.0"),
         )
         .map_err(|error| SPOClientError::UnexpectedResponse(error.to_string()))?;
 

--- a/wallet-indexer/src/infra/storage.rs
+++ b/wallet-indexer/src/infra/storage.rs
@@ -317,11 +317,22 @@ impl domain::storage::Storage for Storage {
                     AND last_active < $2
                 "};
 
-                sqlx::query(query)
+                // Housekeeping: if the shared writer is starved past busy_timeout, skip this
+                // wallet instead of failing the poll (which would take down the whole
+                // standalone process); the next poll retries.
+                let result = sqlx::query(query)
                     .bind(id)
                     .bind(min_last_active)
                     .execute(&*self.pool)
-                    .await?;
+                    .await;
+                match result {
+                    Err(error) if indexer_common::infra::pool::sqlite::is_busy_error(&error) => {
+                        log::warn!("skipping wallet session cleanup, sqlite writer is busy");
+                    }
+                    other => {
+                        other?;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Running indexer-standalone in prod, we've seen some issues, like database is locked errors during stake refresh, GraphQL queries timing out while chain-indexer was committing a block, and the box piling up way more open sockets than feels right for talking to one node.

What this changes:

SQLite is now WAL with a 30s busy timeout and 8 connections, so readers don't queue behind the single writer. Every tx opens with BEGIN IMMEDIATE so we don't hit SQLITE_BUSY_SNAPSHOT (517) which busy_timeout doesn't retry, by the way.
spo-indexer stops holding a tx across HTTP calls. Both the per-epoch path and stake refresh now prefetch from Blockfrost first, then write in short transactions (per-pool for stake refresh).
HTTP pool is configurable and shared between SPOClient's direct reqwest client and the one inside BlockfrostAPI, so the blockfrost crate's untuned default pool isn't sitting next to ours leaking idle sockets.
Without these you can hit:

a slow Blockfrost call during stake refresh blocks every other writer for the duration of that call (chain-indexer can't commit, wallet disconnect mutations stall)
chain-indexer's per-block tx (multi-second on mainnet) times out concurrent API writes with no retry
SQLITE_BUSY_SNAPSHOT errors that look transient but aren't retried, they just fail the request
idle sockets from two reqwest pools per SPOClient, which is easy to hit fd limits on with small VMs
Defaults are conservative (max_idle_per_host=4, idle_timeout=30s, tcp_keepalive=60s) and existing configs keep working untouched.

