### PR TITLE
chore(release): prepare for 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.0] - 2026-04-30
+
+### 🚀 Features
+
+- *(indexer-standalone)* Run spo indexer in standalone sqlite mode (#979)
+- *(cli)* Support --version without confg (#1083)
+- *(indexer-api)* Include DustGenerationDtimeUpdate in dustGenerations subscription (#1080)
+
+### 🐛 Bug Fixes
+
+- *(indexer-common)* Keep in-memory pub/sub drain tasks alive after lag (#1063)
+- *(indexer-api)* Tighten dust subscription input validation (#1090)
+- *(indexer-api)* Avoid infinite redirect loop on unknown /api/v3 and /api/v4 paths (#1093)
+
 ## [4.2.1] - 2026-04-27
 
 ### ⚙️ Dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "chain-indexer"
-version = "4.2.1"
+version = "4.3.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-api"
-version = "4.2.1"
+version = "4.3.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-standalone"
-version = "4.2.1"
+version = "4.3.0"
 dependencies = [
  "anyhow",
  "byte-unit-serde",
@@ -3276,7 +3276,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-tests"
-version = "4.2.1"
+version = "4.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -6775,7 +6775,7 @@ dependencies = [
 
 [[package]]
 name = "spo-indexer"
-version = "4.2.1"
+version = "4.3.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -8270,7 +8270,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-indexer"
-version = "4.2.1"
+version = "4.3.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version       = "4.2.1"
+version       = "4.3.0"
 edition       = "2024"
 license       = "Apache-2.0"
 readme        = "README.md"


### PR DESCRIPTION
## Summary

Bumps workspace version `4.2.1` -> `4.3.0` and prepends the changelog entry generated by `git cliff --unreleased --tag v4.3.0`.

Six PRs land in 4.3.0:

### Features
- `feat(indexer-standalone)`: run spo indexer in standalone sqlite mode (#979)
- `feat(cli)`: support `--version` without config (#1083)
- `feat(indexer-api)`: include `DustGenerationDtimeUpdate` in `dustGenerations` subscription (#1080)

### Bug fixes
- `fix(indexer-common)`: keep in-memory pub/sub drain tasks alive after lag (#1063)
- `fix(indexer-api)`: tighten dust subscription input validation, bech32m + empty-prefix + fromBlock-greater-than-toBlock guards (#1090)
- `fix(indexer-api)`: avoid infinite redirect loop on unknown `/api/v3` and `/api/v4` paths (#1093)

## Test plan

- [x] `cargo check --features cloud` clean (`Cargo.lock` regenerated)
- [x] CHANGELOG entry generated cleanly via `git cliff --unreleased --tag v4.3.0`
- [ ] All check jobs of CI succeed
- [ ] After merge: tag `v4.3.0` on the merge commit and push, then watch `build-indexer-images` workflow cut the image