### PR TITLE
test: block scanner to have lightweight transaction

### DIFF
--- a/qa/tools/block-scanner/.gitignore
+++ b/qa/tools/block-scanner/.gitignore
@@ -13,7 +13,7 @@ logs/
 # Runtime data
 tmp_scan/
 *.jsonl
-qanet_stats.json
+stats/*_stats.json
 
 # Environment variables
 .env

--- a/qa/tools/block-scanner/src/block-subscription.graphql
+++ b/qa/tools/block-scanner/src/block-subscription.graphql
@@ -45,8 +45,6 @@ subscription BlocksSubscription($OFFSET: BlockOffset) {
         contractActions {
           __typename
           address
-          state
-          zswapState
         }
         unshieldedCreatedOutputs {
           owner
@@ -78,12 +76,10 @@ subscription BlocksSubscription($OFFSET: BlockOffset) {
       ... on SystemTransaction {
         zswapLedgerEvents {
           id
-          raw
           maxId
         }
         dustLedgerEvents {
           id
-          raw
           maxId
         }
       }

--- a/qa/tools/block-scanner/src/indexer-types.ts
+++ b/qa/tools/block-scanner/src/indexer-types.ts
@@ -92,30 +92,30 @@ export type ContractAction = ContractDeploy | ContractCall | ContractUpdate;
 export interface ContractDeploy {
   __typename: "ContractDeploy";
   address: string;
-  state: string;
-  zswapState: string;
-  transaction: Transaction;
-  unshieldedBalances: ContractBalance[];
+  state?: string;
+  zswapState?: string;
+  transaction?: Transaction;
+  unshieldedBalances?: ContractBalance[];
 }
 
 export interface ContractCall {
   __typename: "ContractCall";
   address: string;
-  state: string;
-  zswapState: string;
-  transaction: Transaction;
-  entryPoint: string;
-  deploy: ContractDeploy;
-  unshieldedBalances: ContractBalance[];
+  state?: string;
+  zswapState?: string;
+  transaction?: Transaction;
+  entryPoint?: string;
+  deploy?: ContractDeploy;
+  unshieldedBalances?: ContractBalance[];
 }
 
 export interface ContractUpdate {
   __typename: "ContractUpdate";
   address: string;
-  state: string;
-  zswapState: string;
-  transaction: Transaction;
-  unshieldedBalances: ContractBalance[];
+  state?: string;
+  zswapState?: string;
+  transaction?: Transaction;
+  unshieldedBalances?: ContractBalance[];
 }
 
 export interface ContractBalance {
@@ -125,12 +125,12 @@ export interface ContractBalance {
 
 export interface ZswapLedgerEvent {
   id: number;
-  raw: string;
+  raw?: string;
   maxId: number;
 }
 
 export interface DustLedgerEvent {
   id: number;
-  raw: string;
+  raw?: string;
   maxId: number;
 }


### PR DESCRIPTION
The block scanner purpose is to provide test data to the qa test framework. That hardly looks into the details of a transaction so the raw fields have been removed as they tend to be heavy