### PR TITLE
chore(ci): make cargo-deny advisories block CI

### DIFF
--- a/.github/workflows/rust-security-scan.yaml
+++ b/.github/workflows/rust-security-scan.yaml
@@ -44,16 +44,22 @@ jobs:
           username: MidnightCI
           password: ${{ secrets.MIDNIGHTCI_REPO }}
 
-      - name: Run cargo-deny
-        # cargo-deny 0.19.0+ includes fix for empty locations in SARIF output
-        # shell: bash forces `bash --noprofile --norc -eo pipefail`, so the
-        # pipeline propagates cargo-deny's exit code instead of `tee`'s.
-        # Without pipefail, cargo-deny advisory failures are silently swallowed.
-        shell: bash
+      - name: Run cargo-deny (produce SARIF for Security tab)
+        # cargo-deny 0.19.0+ includes fix for empty locations in SARIF output.
+        # `-f sarif` always exits 0 (failures are encoded in the SARIF, not the
+        # exit code), so this step never fails CI. Gating happens below.
         run: cargo deny -f sarif check -Aduplicate -Aunmaintained -Alicense-not-encountered -Aparse-error -Asource-not-allowed -Aunlicensed | tee scan.sarif
-        # TODO: once everything's open sourced remove -Aunlicensed
+        # `-Aunlicensed` covers upstream ledger crates without `license = ...`
+        # fields (e.g. midnight-circuits, midnight-zk-stdlib). Drop once those
+        # crates ship with explicit license fields.
 
       - name: Upload SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@7273f08caa1dcf2c2837f362f1982de0ab4dc344
         with:
           sarif_file: scan.sarif
+
+      - name: Run cargo-deny (gate CI on advisories)
+        # Re-run without `-f sarif` so cargo-deny exits non-zero on findings.
+        # `--disable-fetch` reuses the advisory DB cached by the previous step.
+        # Same `-Aunlicensed` rationale as above.
+        run: cargo deny check --disable-fetch -Aduplicate -Aunmaintained -Alicense-not-encountered -Aparse-error -Asource-not-allowed -Aunlicensed

--- a/.github/workflows/rust-security-scan.yaml
+++ b/.github/workflows/rust-security-scan.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run cargo-deny
         # cargo-deny 0.19.0+ includes fix for empty locations in SARIF output
-        run: cargo deny -f sarif check -Aduplicate -Aunmaintained -Alicense-not-encountered -Aparse-error -Asource-not-allowed -Aunlicensed | tee scan.sarif || true
+        run: cargo deny -f sarif check -Aduplicate -Aunmaintained -Alicense-not-encountered -Aparse-error -Asource-not-allowed -Aunlicensed | tee scan.sarif
         # TODO: once everything's open sourced remove -Aunlicensed
 
       - name: Upload SARIF to GitHub Security

--- a/.github/workflows/rust-security-scan.yaml
+++ b/.github/workflows/rust-security-scan.yaml
@@ -46,6 +46,10 @@ jobs:
 
       - name: Run cargo-deny
         # cargo-deny 0.19.0+ includes fix for empty locations in SARIF output
+        # shell: bash forces `bash --noprofile --norc -eo pipefail`, so the
+        # pipeline propagates cargo-deny's exit code instead of `tee`'s.
+        # Without pipefail, cargo-deny advisory failures are silently swallowed.
+        shell: bash
         run: cargo deny -f sarif check -Aduplicate -Aunmaintained -Alicense-not-encountered -Aparse-error -Asource-not-allowed -Aunlicensed | tee scan.sarif
         # TODO: once everything's open sourced remove -Aunlicensed
 

--- a/.github/workflows/rust-security-scan.yaml
+++ b/.github/workflows/rust-security-scan.yaml
@@ -45,13 +45,11 @@ jobs:
           password: ${{ secrets.MIDNIGHTCI_REPO }}
 
       - name: Run cargo-deny (produce SARIF for Security tab)
-        # cargo-deny 0.19.0+ includes fix for empty locations in SARIF output.
-        # `-f sarif` always exits 0 (failures are encoded in the SARIF, not the
-        # exit code), so this step never fails CI. Gating happens below.
+        # `-f sarif` always exits 0 since findings are encoded in the SARIF, not the exit code.
+        # So this step never fails CI; advisory gating is in the second cargo-deny invocation below.
         run: cargo deny -f sarif check -Aduplicate -Aunmaintained -Alicense-not-encountered -Aparse-error -Asource-not-allowed -Aunlicensed | tee scan.sarif
-        # `-Aunlicensed` covers upstream ledger crates without `license = ...`
-        # fields (e.g. midnight-circuits, midnight-zk-stdlib). Drop once those
-        # crates ship with explicit license fields.
+        # `-Aunlicensed` allows upstream ledger crates without `license = ...` fields (e.g. midnight-circuits, midnight-zk-stdlib).
+        # Remove this flag once those upstream crates ship with explicit license fields.
 
       - name: Upload SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@7273f08caa1dcf2c2837f362f1982de0ab4dc344
@@ -59,7 +57,6 @@ jobs:
           sarif_file: scan.sarif
 
       - name: Run cargo-deny (gate CI on advisories)
-        # Re-run without `-f sarif` so cargo-deny exits non-zero on findings.
-        # `--disable-fetch` reuses the advisory DB cached by the previous step.
-        # Same `-Aunlicensed` rationale as above.
+        # Re-runs cargo-deny without `-f sarif` so it exits non-zero on findings, gating CI.
+        # `--disable-fetch` reuses the cached advisory DB; `-Aunlicensed` rationale as above.
         run: cargo deny check --disable-fetch -Aduplicate -Aunmaintained -Alicense-not-encountered -Aparse-error -Asource-not-allowed -Aunlicensed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
+checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
 dependencies = [
  "filetime",
  "futures-core",
@@ -2023,7 +2023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3432,7 +3432,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5378,7 +5378,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5846,7 +5846,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5926,7 +5926,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7453,7 +7453,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
 dependencies = [
  "filetime",
  "futures-core",
@@ -1272,7 +1272,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2023,7 +2023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3432,7 +3432,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5378,7 +5378,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5846,7 +5846,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5926,7 +5926,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7453,7 +7453,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8575,7 +8575,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
 dependencies = [
  "filetime",
  "futures-core",
@@ -2023,7 +2023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3432,7 +3432,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5378,7 +5378,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5846,7 +5846,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5926,7 +5926,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7453,7 +7453,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Closes the gap where cargo-deny detected RustSec advisories but didn't gate CI (engineering standup, 1 May). Brings indexer to parity with ledger.

## Workflow change

`cargo deny -f sarif check` always exits 0 (findings encoded in the SARIF, not the exit code). Splits into two invocations:

1. With `-f sarif`: produces SARIF, uploaded to the Security tab.
2. Without `-f sarif` (with `--disable-fetch` to reuse the cached DB): exits non-zero on findings, gates CI.

## Verification

Downgraded `astral-tokio-tar` (dev-dep via testcontainers) back to 0.6.0 on this branch; CI failed with RUSTSEC-2026-0112 and RUSTSEC-2026-0113 in the gate-step log (see PR check-run history). Restored to 0.6.1 for merge.