### PR TITLE
fix: replace remaining production panics with error returns

### DIFF
--- a/chain-indexer/src/infra/subxt_node.rs
+++ b/chain-indexer/src/infra/subxt_node.rs
@@ -173,7 +173,7 @@ impl SubxtNode {
         let parent_hash = header.parent_hash.0.into();
         let protocol_version = header
             .protocol_version()?
-            .expect("protocol version header is present");
+            .ok_or(SubxtNodeError::MissingProtocolVersionHeader)?;
         let node_version = protocol_version.node_version();
         let ledger_version = protocol_version.ledger_version();
 
@@ -545,6 +545,9 @@ pub enum SubxtNodeError {
 
     #[error("cannot get block header")]
     GetBlockHeader(#[source] Box<subxt::error::BlockError>),
+
+    #[error("protocol version header missing from block")]
+    MissingProtocolVersionHeader,
 
     #[error("cannot get next extrinsic")]
     GetNextExtrinsic(#[source] Box<subxt::error::ExtrinsicDecodeErrorAt>),

--- a/indexer-api/src/infra/api/v4/contract_action.rs
+++ b/indexer-api/src/infra/api/v4/contract_action.rs
@@ -201,12 +201,23 @@ where
             .map_err_into_server_error(|| {
                 format!("get contract deploy by address {}", self.raw_address)
             })?
-            .expect("contract call has contract deploy");
+            .some_or_server_error(|| {
+                format!(
+                    "no contract deploy for contract call address {}",
+                    self.raw_address
+                )
+            })?;
 
         let deploy = match ContractAction::from(action) {
-            ContractAction::Deploy(deploy) => deploy,
-            _ => panic!("unexpected contract action"),
-        };
+            ContractAction::Deploy(deploy) => Some(deploy),
+            _ => None,
+        }
+        .some_or_server_error(|| {
+            format!(
+                "expected ContractDeploy variant for contract call address {}",
+                self.raw_address
+            )
+        })?;
 
         Ok(deploy)
     }

--- a/indexer-common/src/domain/ledger.rs
+++ b/indexer-common/src/domain/ledger.rs
@@ -89,6 +89,9 @@ pub enum Error {
 
     #[error("cannot translate ledger state from {0} to {1}")]
     LedgerStateTranslation(LedgerVersion, LedgerVersion, #[source] io::Error),
+
+    #[error("unsupported EventDetailsV8 variant: {0}")]
+    UnsupportedEventVariant(String),
 }
 
 /// Extension methods for `Serializable` implementations.

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -634,7 +634,7 @@ where
                 commitment.0.0.to_bytes_le().to_vec().into(),
             ))),
 
-            other => panic!("unexpected EventDetailsV8 variant {other:?}"),
+            other => Some(Err(Error::UnsupportedEventVariant(format!("{other:?}")))),
         })
         .flatten()
         .collect::<Result<_, _>>()


### PR DESCRIPTION
## Summary

Three production sites where `panic!`/`expect` was reachable via external runtime data, each converted to return a structured error so the host process surfaces a recoverable error rather than crashing.

- `chain-indexer/src/infra/subxt_node.rs:176`, replace the protocol version `expect` with `ok_or` returning a new `SubxtNodeError::MissingProtocolVersionHeader`. Crashed when a connected node's block header was missing the field.
- `indexer-common/src/domain/ledger/ledger_state.rs:637`, replace the exhaustiveness panic on unmatched `EventDetailsV8` variants with an `Error::UnsupportedEventVariant` return inside `make_ledger_events_v8`. Crashed if the upstream ledger crate added a new variant before the indexer extended the match.
- `indexer-api/src/infra/api/v4/contract_action.rs:204,208`, replace `expect("contract call has contract deploy")` and the `unexpected contract action` panic with the `OptionExt::some_or_server_error` pattern. Crashed the API server if the contract deploy row was missing or its variant didn't match.

## Test plan

- [x] `cargo check --features cloud --workspace --tests`
- [x] `cargo clippy --features cloud -p indexer-common -p chain-indexer -p indexer-api --tests -- -D warnings`
- [x] `cargo clippy --features standalone -p indexer-common -p chain-indexer -p indexer-api --tests -- -D warnings`
- [x] `cargo +nightly fmt --check`
- [x] GraphQL schema unchanged (`indexer-api/graphql/schema-v4.graphql` still matches)