### PR TITLE
test: regression for /api/v4 redirect loop (#1085)

### DIFF
--- a/qa/tests/tests/smoke/service-healthchecks.test.ts
+++ b/qa/tests/tests/smoke/service-healthchecks.test.ts
@@ -36,4 +36,45 @@ describe(`service health checks`, () => {
       expect(response.ok).toBe(true);
     });
   });
+
+  describe(`a request to an unrecognised path under /api/v4`, () => {
+    const unknownPath = '/api/v4/__regression_unknown_path';
+
+    /**
+     * Regression test for midnight-indexer#1085: unrecognised paths under
+     * /api/v4 must not respond with a 308 whose Location double-prepends
+     * /api/v4 (e.g. /api/v4/schema -> /api/v4/v4/schema), which causes any
+     * client that follows redirects to loop until its redirect cap is hit.
+     *
+     * @When a GET is sent to an unrecognised path under /api/v4
+     * @Then the response is NOT a 308 redirect whose Location starts with
+     *       /api/v4/v4 (a 404, or any non-prefix-doubling response, is fine)
+     */
+    test('should not 308 to a /api/v4-double-prefixed Location', async () => {
+      const targetUrl = baseUrl + unknownPath;
+      log.debug(`Target URL: ${targetUrl}`);
+      const response = await fetch(targetUrl, { redirect: 'manual' });
+      log.debug(`Status: ${response.status}`);
+
+      if (response.status === 308 || response.status === 301 || response.status === 302) {
+        const location = response.headers.get('location') ?? '';
+        log.debug(`Location: ${location}`);
+        expect(location.startsWith('/api/v4/v4')).toBe(false);
+      } else {
+        expect(response.status).toBeGreaterThanOrEqual(400);
+      }
+    });
+
+    /**
+     * Regression test for midnight-indexer#1085: when redirects are followed,
+     * the request must terminate (no infinite redirect loop).
+     *
+     * @When a GET to an unrecognised /api/v4 path follows redirects
+     * @Then fetch resolves without exceeding its redirect cap
+     */
+    test('should terminate when redirects are followed', async () => {
+      const targetUrl = baseUrl + unknownPath;
+      await expect(fetch(targetUrl, { redirect: 'follow' })).resolves.toBeDefined();
+    });
+  });
 });

--- a/qa/tests/tests/smoke/service-healthchecks.test.ts
+++ b/qa/tests/tests/smoke/service-healthchecks.test.ts
@@ -37,20 +37,24 @@ describe(`service health checks`, () => {
     });
   });
 
-  describe(`a request to an unrecognised path under /api/v4`, () => {
-    const unknownPath = '/api/v4/__regression_unknown_path';
-
+  describe.each([
+    ['/api/v3/__regression_unknown_path', '/api/v3/v3'],
+    ['/api/v4/__regression_unknown_path', '/api/v4/v4'],
+  ])(`a request to an unrecognised path %s`, (unknownPath, doubledPrefix) => {
     /**
      * Regression test for midnight-indexer#1085: unrecognised paths under
-     * /api/v4 must not respond with a 308 whose Location double-prepends
-     * /api/v4 (e.g. /api/v4/schema -> /api/v4/v4/schema), which causes any
-     * client that follows redirects to loop until its redirect cap is hit.
+     * a versioned prefix must not respond with a 308 whose Location
+     * double-prepends that prefix (e.g. /api/v4/schema -> /api/v4/v4/schema),
+     * which causes any client that follows redirects to loop until its
+     * redirect cap is hit. The fix in #1093 covers both /api/v3 and /api/v4,
+     * so this regression suite asserts the same on both.
      *
-     * @When a GET is sent to an unrecognised path under /api/v4
-     * @Then the response is NOT a 308 redirect whose Location contains
-     *       /api/v4/v4 (a 404, or any non-prefix-doubling response, is fine)
+     * @When a GET is sent to an unrecognised path under /api/vN
+     * @Then the response is NOT a 308 redirect whose Location contains the
+     *       doubled version prefix (a 404, or any non-prefix-doubling
+     *       response, is fine)
      */
-    test('should not 308 to a /api/v4-double-prefixed Location', async () => {
+    test('should not 308 to a version-double-prefixed Location', async () => {
       const targetUrl = baseUrl + unknownPath;
       log.debug(`Target URL: ${targetUrl}`);
       const response = await fetch(targetUrl, { redirect: 'manual' });
@@ -59,7 +63,7 @@ describe(`service health checks`, () => {
       if (response.status === 308 || response.status === 301 || response.status === 302) {
         const location = response.headers.get('location') ?? '';
         log.debug(`Location: ${location}`);
-        expect(location.includes('/api/v4/v4')).toBe(false);
+        expect(location.includes(doubledPrefix)).toBe(false);
       } else {
         expect(response.status).toBeGreaterThanOrEqual(400);
       }
@@ -69,7 +73,7 @@ describe(`service health checks`, () => {
      * Regression test for midnight-indexer#1085: when redirects are followed,
      * the request must terminate (no infinite redirect loop).
      *
-     * @When a GET to an unrecognised /api/v4 path follows redirects
+     * @When a GET to an unrecognised /api/vN path follows redirects
      * @Then fetch resolves with a 4xx (no redirect-cap exhaustion)
      */
     test('should terminate when redirects are followed', async () => {

--- a/qa/tests/tests/smoke/service-healthchecks.test.ts
+++ b/qa/tests/tests/smoke/service-healthchecks.test.ts
@@ -47,7 +47,7 @@ describe(`service health checks`, () => {
      * client that follows redirects to loop until its redirect cap is hit.
      *
      * @When a GET is sent to an unrecognised path under /api/v4
-     * @Then the response is NOT a 308 redirect whose Location starts with
+     * @Then the response is NOT a 308 redirect whose Location contains
      *       /api/v4/v4 (a 404, or any non-prefix-doubling response, is fine)
      */
     test('should not 308 to a /api/v4-double-prefixed Location', async () => {
@@ -59,7 +59,7 @@ describe(`service health checks`, () => {
       if (response.status === 308 || response.status === 301 || response.status === 302) {
         const location = response.headers.get('location') ?? '';
         log.debug(`Location: ${location}`);
-        expect(location.startsWith('/api/v4/v4')).toBe(false);
+        expect(location.includes('/api/v4/v4')).toBe(false);
       } else {
         expect(response.status).toBeGreaterThanOrEqual(400);
       }
@@ -70,11 +70,13 @@ describe(`service health checks`, () => {
      * the request must terminate (no infinite redirect loop).
      *
      * @When a GET to an unrecognised /api/v4 path follows redirects
-     * @Then fetch resolves without exceeding its redirect cap
+     * @Then fetch resolves with a 4xx (no redirect-cap exhaustion)
      */
     test('should terminate when redirects are followed', async () => {
       const targetUrl = baseUrl + unknownPath;
-      await expect(fetch(targetUrl, { redirect: 'follow' })).resolves.toBeDefined();
+      const response = await fetch(targetUrl, { redirect: 'follow' });
+      log.debug(`Status (after redirects): ${response.status}`);
+      expect(response.status).toBeGreaterThanOrEqual(400);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds two smoke regression tests covering midnight-indexer#1085 (`indexer-standalone` 4.2.1 308 redirect loop on unrecognised `/api/v4/*` paths).
- First test asserts that any unknown `/api/v4/*` path does **not** return a 308/301/302 whose `Location` header starts with `/api/v4/v4` (the prefix-doubling shape that caused the infinite loop). A 4xx is also accepted.
- Second test asserts that following redirects on the same path **terminates** (no exhaustion of `fetch`'s redirect cap).

## Test plan

- [x] `TARGET_ENV=qanet yarn test:smoke` — 7 passed, 1 skipped (schema-stability, unrelated)
- [x] `cd qa/tests && yarn format` — clean
- [x] `cd qa/tests && yarn lint` — clean