### PR TITLE
test: dustGenerations DtimeUpdate variant (#1078)

### DIFF
--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -21,7 +21,10 @@ import {
   IndexerWsClient,
   DustGenerationsSubscriptionResponse,
 } from '@utils/indexer/websocket-client';
-import { DustGenerationsEventSchema } from '@utils/indexer/graphql/schema';
+import {
+  DustGenerationsEventSchema,
+  DustGenerationDtimeUpdateItemSchema,
+} from '@utils/indexer/graphql/schema';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
 import { env } from 'environment/model';
 import dataProvider from '@utils/testdata-provider';
@@ -159,6 +162,25 @@ describe('dust generations subscription', () => {
       // The last event should be a DustGenerationsProgress
       const lastEvent = received[received.length - 1].data!.dustGenerations;
       expect(lastEvent.__typename).toBe('DustGenerationsProgress');
+
+      // Wire-format coverage for DustGenerationDtimeUpdateItem (issue #1078).
+      // Presence is environment-dependent (requires the wallet's backing
+      // NIGHT/cNIGHT UTXO to have been spent on chain, and `startIndex` to be
+      // past the wallet's first owned entry to trigger historical replay).
+      // When no event arrives we just record a debug line; when at least one
+      // arrives we validate its shape with the dedicated schema, which acts as
+      // a regression guard on the new union variant's field set.
+      const dtimeUpdates = received.filter(
+        (msg) => msg.data?.dustGenerations?.__typename === 'DustGenerationDtimeUpdateItem',
+      );
+      log.debug(`Received ${dtimeUpdates.length} DustGenerationDtimeUpdateItem event(s)`);
+      for (const msg of dtimeUpdates) {
+        const parsed = DustGenerationDtimeUpdateItemSchema.safeParse(msg.data!.dustGenerations);
+        expect(
+          parsed.success,
+          `DustGenerationDtimeUpdateItem shape validation failed: ${JSON.stringify(parsed.error, null, 2)}`,
+        ).toBe(true);
+      }
     }, 30_000);
   });
 

--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -21,10 +21,7 @@ import {
   IndexerWsClient,
   DustGenerationsSubscriptionResponse,
 } from '@utils/indexer/websocket-client';
-import {
-  DustGenerationsEventSchema,
-  DustGenerationDtimeUpdateItemSchema,
-} from '@utils/indexer/graphql/schema';
+import { DustGenerationsEventSchema } from '@utils/indexer/graphql/schema';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
 import { env } from 'environment/model';
 import dataProvider from '@utils/testdata-provider';
@@ -164,23 +161,19 @@ describe('dust generations subscription', () => {
       expect(lastEvent.__typename).toBe('DustGenerationsProgress');
 
       // Wire-format coverage for DustGenerationDtimeUpdateItem (issue #1078).
-      // Presence is environment-dependent (requires the wallet's backing
-      // NIGHT/cNIGHT UTXO to have been spent on chain, and `startIndex` to be
-      // past the wallet's first owned entry to trigger historical replay).
-      // When no event arrives we just record a debug line; when at least one
-      // arrives we validate its shape with the dedicated schema, which acts as
-      // a regression guard on the new union variant's field set.
-      const dtimeUpdates = received.filter(
+      // The discriminated-union schema above (DustGenerationsEventSchema) is
+      // the actual regression guard: any payload whose `__typename` is
+      // `DustGenerationDtimeUpdateItem` is validated against
+      // DustGenerationDtimeUpdateItemSchema as part of the union match, so a
+      // drift in the new variant's field set would already have failed there.
+      // Here we only count occurrences for visibility — presence is
+      // environment-dependent (requires the wallet's backing NIGHT/cNIGHT UTXO
+      // to have been spent on chain, and `startIndex` past the wallet's first
+      // owned entry to trigger historical replay).
+      const dtimeUpdateCount = received.filter(
         (msg) => msg.data?.dustGenerations?.__typename === 'DustGenerationDtimeUpdateItem',
-      );
-      log.debug(`Received ${dtimeUpdates.length} DustGenerationDtimeUpdateItem event(s)`);
-      for (const msg of dtimeUpdates) {
-        const parsed = DustGenerationDtimeUpdateItemSchema.safeParse(msg.data!.dustGenerations);
-        expect(
-          parsed.success,
-          `DustGenerationDtimeUpdateItem shape validation failed: ${JSON.stringify(parsed.error, null, 2)}`,
-        ).toBe(true);
-      }
+      ).length;
+      log.debug(`Received ${dtimeUpdateCount} DustGenerationDtimeUpdateItem event(s)`);
     }, 30_000);
   });
 

--- a/qa/tests/utils/indexer/graphql/schema.ts
+++ b/qa/tests/utils/indexer/graphql/schema.ts
@@ -388,9 +388,20 @@ export const DustGenerationsProgressSchema = z.object({
   collapsedMerkleTree: CollapsedMerkleTreeSchema.nullable(),
 });
 
+export const DustGenerationDtimeUpdateItemSchema = z.object({
+  __typename: z.literal('DustGenerationDtimeUpdateItem'),
+  generationMtIndex: z.number(),
+  owner: VarLenghtHex,
+  nightUtxoHash: VarLenghtHex,
+  newDtime: z.number(),
+  transactionId: z.number(),
+  treeInsertionPath: VarLenghtHex,
+});
+
 export const DustGenerationsEventSchema = z.discriminatedUnion('__typename', [
   DustGenerationsItemSchema,
   DustGenerationsProgressSchema,
+  DustGenerationDtimeUpdateItemSchema,
 ]);
 
 export const DustNullifierTransactionSchema = z.object({

--- a/qa/tests/utils/indexer/graphql/subscriptions.ts
+++ b/qa/tests/utils/indexer/graphql/subscriptions.ts
@@ -371,6 +371,15 @@ export const DUST_GENERATIONS_SUBSCRIPTION = `
           protocolVersion
         }
       }
+      ... on DustGenerationDtimeUpdateItem {
+        __typename
+        generationMtIndex
+        owner
+        nightUtxoHash
+        newDtime
+        transactionId
+        treeInsertionPath
+      }
     }
   }
 `;

--- a/qa/tests/utils/indexer/indexer-types.ts
+++ b/qa/tests/utils/indexer/indexer-types.ts
@@ -345,7 +345,20 @@ export interface DustGenerationsProgress {
   collapsedMerkleTree: CollapsedMerkleTree | null;
 }
 
-export type DustGenerationsEvent = DustGenerationsItem | DustGenerationsProgress;
+export interface DustGenerationDtimeUpdateItem {
+  __typename: 'DustGenerationDtimeUpdateItem';
+  generationMtIndex: number;
+  owner: string;
+  nightUtxoHash: string;
+  newDtime: number;
+  transactionId: number;
+  treeInsertionPath: string;
+}
+
+export type DustGenerationsEvent =
+  | DustGenerationsItem
+  | DustGenerationsProgress
+  | DustGenerationDtimeUpdateItem;
 
 export interface DustNullifierTransaction {
   nullifier: string;


### PR DESCRIPTION
## Summary

Adds wire-format regression coverage for the new `DustGenerationDtimeUpdateItem` variant on the `dustGenerations` subscription (introduced in midnight-indexer#1078 / PR #1080).

- Extends `DUST_GENERATIONS_SUBSCRIPTION` to select the new variant's fields (`generationMtIndex`, `owner`, `nightUtxoHash`, `newDtime`, `transactionId`, `treeInsertionPath`).
- Adds `DustGenerationDtimeUpdateItemSchema` to the Zod-discriminated union and the matching TypeScript interface.
- Soft-validates any `DustGenerationDtimeUpdateItem` events received in the existing streaming test against the dedicated schema (presence is environment-dependent — requires the wallet's backing NIGHT/cNIGHT to have been spent on chain — so absence is logged, not asserted).

## What this catches vs. what it doesn't

- Catches: **wire-format regressions** in deployed environments — a renamed/dropped field on the new variant fails the discriminated-union check immediately.
- Doesn't catch: **functional emission** of `DustGenerationDtimeUpdateItem`. The event only fires when the backing UTXO is spent, which is not deterministically driven by the QA suite (it runs against deployed envs). That path is exercised by the wallet integration on the consumer side and a manual spot-check on long-running envs.

## Test plan

- [x] `cd qa/tests && yarn format` — clean
- [x] `cd qa/tests && yarn lint` — clean
- [x] `TARGET_ENV=qanet yarn test:smoke` — 5 passed, 1 skipped (unrelated baseline)
- [x] `TARGET_ENV=qanet yarn test:integration tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts` — 3 error-handling tests pass; the streaming test times out **identically on clean main** (verified by stashing changes and rerunning) — pre-existing env data flake, separate from this PR