### PR TITLE
test: dustGenerationMerkleTreeUpdate query (#1048)

### DIFF
--- a/qa/tests/tests/integration/basic/queries/dust-generation-update-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/dust-generation-update-queries.test.ts
@@ -22,6 +22,62 @@ import { TestContext } from 'vitest';
 
 const indexerHttpClient = new IndexerHttpClient();
 
+/**
+ * Returns the highest `dustGenerationEndIndex` across the regular
+ * transactions in the block at the given height, or 0 if the block has
+ * no regular transactions exposing the field (e.g. system-only blocks).
+ */
+async function getMaxDustGenerationEndIndex(blockHeight: number): Promise<number> {
+  const response = await indexerHttpClient.getBlockByOffset({ height: blockHeight });
+  expect(response).toBeSuccess();
+  const transactions = response.data!.block.transactions;
+  return transactions.reduce((max, tx) => {
+    const regularTx = tx as RegularTransaction;
+    return regularTx.dustGenerationEndIndex != null && regularTx.dustGenerationEndIndex > max
+      ? regularTx.dustGenerationEndIndex
+      : max;
+  }, 0);
+}
+
+/**
+ * Probes the indexer to find the smallest `endIndex` that lies just
+ * beyond the currently-cached dust generation tree boundary. Replaces
+ * a hard-coded magic value (e.g. `999_999_999`) that can drift into a
+ * legitimate range on long-running envs. Strategy:
+ *   - request a range; if the indexer returns a successful payload,
+ *     `endIndex` is within the cache;
+ *   - if the indexer returns a GraphQL error, `endIndex` is beyond.
+ * Exponential probe upward to bracket the boundary, then binary-search
+ * inside the bracket. Bounded to ~60 indexer calls in the worst case
+ * with the cap below; on QANET this completes in well under a second.
+ */
+async function findFirstBeyondRangeEndIndex(): Promise<number> {
+  const cap = 2_000_000_000; // safely below GraphQL Int32 max
+  let lo = 1;
+  let hi = 1;
+  while (hi < cap) {
+    const response = await indexerHttpClient.getDustGenerationMerkleTreeUpdate(0, hi);
+    if (response.errors && response.errors.length > 0) break;
+    lo = hi;
+    hi = Math.min(hi * 2, cap);
+  }
+  if (hi === cap) {
+    throw new Error(
+      `failed to find a beyond-range endIndex below ${cap}: indexer cache appears unexpectedly large for the test env`,
+    );
+  }
+  while (lo + 1 < hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    const response = await indexerHttpClient.getDustGenerationMerkleTreeUpdate(0, mid);
+    if (response.errors && response.errors.length > 0) {
+      hi = mid;
+    } else {
+      lo = mid;
+    }
+  }
+  return hi;
+}
+
 describe('dust generation merkle tree update queries', () => {
   describe('a collapsed update query with valid index range', () => {
     /**
@@ -89,17 +145,7 @@ describe('dust generation merkle tree update queries', () => {
         labels: ['Query', 'Dust', 'GenerationMerkleTree', 'CollapsedUpdate', 'FullRange'],
       };
 
-      // Get the highest dustGenerationEndIndex from genesis block transactions
-      const genesisResponse = await indexerHttpClient.getBlockByOffset({ height: 0 });
-      expect(genesisResponse).toBeSuccess();
-
-      const transactions = genesisResponse.data!.block.transactions;
-      const maxEndIndex = transactions.reduce((max, tx) => {
-        const regularTx = tx as RegularTransaction;
-        return regularTx.dustGenerationEndIndex != null && regularTx.dustGenerationEndIndex > max
-          ? regularTx.dustGenerationEndIndex
-          : max;
-      }, 0);
+      const maxEndIndex = await getMaxDustGenerationEndIndex(0);
 
       log.debug(`Highest dustGenerationEndIndex from genesis: ${maxEndIndex}`);
       expect(maxEndIndex).toBeGreaterThan(0);
@@ -222,7 +268,9 @@ describe('dust generation merkle tree update queries', () => {
     /**
      * A dust generation update query where endIndex exceeds the indexed range should return an error
      *
-     * @given we use an endIndex far beyond the current indexed range
+     * @given we use an endIndex strictly beyond the indexer's currently-indexed
+     *        dust generation tree boundary (derived from the chain tip rather
+     *        than hard-coded, so the test stays correct on long-running envs)
      * @when we query for a dust generation update
      * @then Indexer should respond with an error about invalid start_index and/or end_index
      */
@@ -231,10 +279,15 @@ describe('dust generation merkle tree update queries', () => {
         labels: ['Query', 'Dust', 'GenerationMerkleTree', 'CollapsedUpdate', 'Negative'],
       };
 
+      const beyondRangeEndIndex = await findFirstBeyondRangeEndIndex();
+
       log.debug(
-        'Requesting dust generation merkle tree update with startIndex=0, endIndex=999999999',
+        `Requesting dust generation merkle tree update with startIndex=0, endIndex=${beyondRangeEndIndex} (probed first-beyond-range boundary)`,
       );
-      const response = await indexerHttpClient.getDustGenerationMerkleTreeUpdate(0, 999999999);
+      const response = await indexerHttpClient.getDustGenerationMerkleTreeUpdate(
+        0,
+        beyondRangeEndIndex,
+      );
 
       expect(response).toBeError();
       expect(response.errors![0].message).toContain('invalid start_index and/or end_index');

--- a/qa/tests/tests/integration/basic/queries/dust-generation-update-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/dust-generation-update-queries.test.ts
@@ -1,0 +1,243 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import log from '@utils/logging/logger';
+import '@utils/logging/test-logging-hooks';
+import { MerkleTreeCollapsedUpdateSchema } from '@utils/indexer/graphql/schema';
+import { IndexerHttpClient } from '@utils/indexer/http-client';
+import type { RegularTransaction } from '@utils/indexer/indexer-types';
+import { TestContext } from 'vitest';
+
+const indexerHttpClient = new IndexerHttpClient();
+
+describe('dust generation merkle tree update queries', () => {
+  describe('a collapsed update query with valid index range', () => {
+    /**
+     * A dust generation update query with a valid index range returns the expected result
+     *
+     * @given the chain has indexed blocks with dust generation state
+     * @when we query for a dust generation update with startIndex=0 and endIndex=1
+     * @then Indexer should return a valid collapsed update
+     */
+    test('should return a collapsed update for a valid index range', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'GenerationMerkleTree', 'CollapsedUpdate'],
+      };
+
+      log.debug('Requesting dust generation merkle tree update with startIndex=0, endIndex=1');
+      const response = await indexerHttpClient.getDustGenerationMerkleTreeUpdate(0, 1);
+
+      expect(response).toBeSuccess();
+      expect(response.data?.dustGenerationMerkleTreeUpdate).toBeDefined();
+
+      const collapsedUpdate = response.data!.dustGenerationMerkleTreeUpdate;
+      expect(collapsedUpdate.startIndex).toBe(0);
+      expect(collapsedUpdate.endIndex).toBe(1);
+      expect(collapsedUpdate.update).toBeDefined();
+      expect(collapsedUpdate.protocolVersion).toBeDefined();
+    });
+
+    /**
+     * A dust generation update query responds with the expected schema
+     *
+     * @given the chain has indexed blocks with dust generation state
+     * @when we query for a dust generation update with a valid index range
+     * @then the response should match the expected schema
+     */
+    test('should respond with a collapsed update according to the expected schema', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'GenerationMerkleTree', 'CollapsedUpdate', 'SchemaValidation'],
+      };
+
+      log.debug('Requesting dust generation merkle tree update with startIndex=0, endIndex=1');
+      const response = await indexerHttpClient.getDustGenerationMerkleTreeUpdate(0, 1);
+
+      expect(response).toBeSuccess();
+      expect(response.data?.dustGenerationMerkleTreeUpdate).toBeDefined();
+
+      log.debug('Validating collapsed update schema');
+      const parsed = MerkleTreeCollapsedUpdateSchema.safeParse(
+        response.data!.dustGenerationMerkleTreeUpdate,
+      );
+      expect(
+        parsed.success,
+        `Collapsed update schema validation failed ${JSON.stringify(parsed.error, null, 2)}`,
+      ).toBe(true);
+    });
+
+    /**
+     * A dust generation update query covering the full genesis dust range returns a valid result
+     *
+     * @given the genesis block has indexed dust generation state
+     * @when we query for a dust generation update covering the full range from genesis
+     * @then Indexer should return a valid collapsed update spanning the entire range
+     */
+    test('should return a collapsed update for the full genesis dust range', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'GenerationMerkleTree', 'CollapsedUpdate', 'FullRange'],
+      };
+
+      // Get the highest dustGenerationEndIndex from genesis block transactions
+      const genesisResponse = await indexerHttpClient.getBlockByOffset({ height: 0 });
+      expect(genesisResponse).toBeSuccess();
+
+      const transactions = genesisResponse.data!.block.transactions;
+      const maxEndIndex = transactions.reduce((max, tx) => {
+        const regularTx = tx as RegularTransaction;
+        return regularTx.dustGenerationEndIndex != null && regularTx.dustGenerationEndIndex > max
+          ? regularTx.dustGenerationEndIndex
+          : max;
+      }, 0);
+
+      log.debug(`Highest dustGenerationEndIndex from genesis: ${maxEndIndex}`);
+      expect(maxEndIndex).toBeGreaterThan(0);
+
+      // dustGenerationEndIndex is exclusive, collapsed update endIndex is inclusive
+      const endIndex = maxEndIndex - 1;
+
+      log.debug(`Requesting dust generation update with startIndex=0, endIndex=${endIndex}`);
+      const response = await indexerHttpClient.getDustGenerationMerkleTreeUpdate(0, endIndex);
+
+      expect(response).toBeSuccess();
+      expect(response.data?.dustGenerationMerkleTreeUpdate).toBeDefined();
+
+      const collapsedUpdate = response.data!.dustGenerationMerkleTreeUpdate;
+      expect(collapsedUpdate.startIndex).toBe(0);
+      expect(collapsedUpdate.endIndex).toBe(endIndex);
+      expect(collapsedUpdate.update).toBeDefined();
+      expect(collapsedUpdate.protocolVersion).toBeDefined();
+    });
+  });
+
+  describe('a collapsed update query with equal start and end indices', () => {
+    /**
+     * A collapsed update query where startIndex === endIndex returns a valid trivial update
+     *
+     * @given we use startIndex equal to endIndex
+     * @when we query for a collapsed update
+     * @then Indexer should return a valid collapsed update with matching indices
+     */
+    test('should return a valid update when startIndex equals endIndex', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'GenerationMerkleTree', 'CollapsedUpdate', 'EdgeCase'],
+      };
+
+      log.debug('Requesting dust generation merkle tree update with startIndex=0, endIndex=0');
+      const response = await indexerHttpClient.getDustGenerationMerkleTreeUpdate(0, 0);
+
+      expect(response).toBeSuccess();
+      expect(response.data?.dustGenerationMerkleTreeUpdate).toBeDefined();
+
+      const collapsedUpdate = response.data!.dustGenerationMerkleTreeUpdate;
+      expect(collapsedUpdate.startIndex).toBe(0);
+      expect(collapsedUpdate.endIndex).toBe(0);
+      expect(collapsedUpdate.update).toBeDefined();
+      expect(collapsedUpdate.protocolVersion).toBeDefined();
+    });
+  });
+
+  describe('a collapsed update query idempotency', () => {
+    /**
+     * Two identical dust generation update queries should return the same result
+     *
+     * @given we query the same index range twice
+     * @when the chain head has not changed between calls
+     * @then both responses should be identical
+     */
+    test('should return identical results for the same query parameters', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'GenerationMerkleTree', 'CollapsedUpdate', 'Idempotency'],
+      };
+
+      log.debug(
+        'Requesting dust generation merkle tree update twice with startIndex=0, endIndex=1',
+      );
+      const response1 = await indexerHttpClient.getDustGenerationMerkleTreeUpdate(0, 1);
+      const response2 = await indexerHttpClient.getDustGenerationMerkleTreeUpdate(0, 1);
+
+      expect(response1).toBeSuccess();
+      expect(response2).toBeSuccess();
+
+      const update1 = response1.data!.dustGenerationMerkleTreeUpdate;
+      const update2 = response2.data!.dustGenerationMerkleTreeUpdate;
+
+      expect(update1.startIndex).toBe(update2.startIndex);
+      expect(update1.endIndex).toBe(update2.endIndex);
+      expect(update1.update).toBe(update2.update);
+      expect(update1.protocolVersion).toBe(update2.protocolVersion);
+    });
+  });
+
+  describe('a collapsed update query with invalid index range', () => {
+    /**
+     * A dust generation update query where startIndex > endIndex should return an error
+     *
+     * @given we use an invalid index range where startIndex > endIndex
+     * @when we query for a dust generation update
+     * @then Indexer should respond with an error about invalid start_index and/or end_index
+     */
+    test('should return an error when startIndex is greater than endIndex', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'GenerationMerkleTree', 'CollapsedUpdate', 'Negative'],
+      };
+
+      log.debug('Requesting dust generation merkle tree update with startIndex=10, endIndex=5');
+      const response = await indexerHttpClient.getDustGenerationMerkleTreeUpdate(10, 5);
+
+      expect(response).toBeError();
+      expect(response.errors![0].message).toContain('invalid start_index and/or end_index');
+    });
+
+    /**
+     * A dust generation update query with negative indices should return a parse error
+     *
+     * @given we use negative indices
+     * @when we query for a dust generation update
+     * @then Indexer should respond with an error about invalid number parsing
+     */
+    test('should return an error when indices are negative', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'GenerationMerkleTree', 'CollapsedUpdate', 'Negative'],
+      };
+
+      log.debug('Requesting dust generation merkle tree update with startIndex=-1, endIndex=1');
+      const response = await indexerHttpClient.getDustGenerationMerkleTreeUpdate(-1, 1);
+
+      expect(response).toBeError();
+      expect(response.errors![0].message).toContain('Invalid number');
+    });
+
+    /**
+     * A dust generation update query where endIndex exceeds the indexed range should return an error
+     *
+     * @given we use an endIndex far beyond the current indexed range
+     * @when we query for a dust generation update
+     * @then Indexer should respond with an error about invalid start_index and/or end_index
+     */
+    test('should return an error when endIndex is beyond the indexed range', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Dust', 'GenerationMerkleTree', 'CollapsedUpdate', 'Negative'],
+      };
+
+      log.debug(
+        'Requesting dust generation merkle tree update with startIndex=0, endIndex=999999999',
+      );
+      const response = await indexerHttpClient.getDustGenerationMerkleTreeUpdate(0, 999999999);
+
+      expect(response).toBeError();
+      expect(response.errors![0].message).toContain('invalid start_index and/or end_index');
+    });
+  });
+});

--- a/qa/tests/utils/indexer/graphql/dust-queries.ts
+++ b/qa/tests/utils/indexer/graphql/dust-queries.ts
@@ -62,3 +62,13 @@ query GetDustCommitmentMerkleTreeUpdate($START_INDEX: Int!, $END_INDEX: Int!) {
     protocolVersion
   }
 }`;
+
+export const GET_DUST_GENERATION_MERKLE_TREE_UPDATE = `
+query GetDustGenerationMerkleTreeUpdate($START_INDEX: Int!, $END_INDEX: Int!) {
+  dustGenerationMerkleTreeUpdate(startIndex: $START_INDEX, endIndex: $END_INDEX) {
+    startIndex
+    endIndex
+    update
+    protocolVersion
+  }
+}`;

--- a/qa/tests/utils/indexer/http-client.ts
+++ b/qa/tests/utils/indexer/http-client.ts
@@ -32,6 +32,8 @@ import type {
   DustGenerationsResponse,
   DustCommitmentMerkleTreeUpdateResult,
   DustCommitmentMerkleTreeUpdateResponse,
+  DustGenerationMerkleTreeUpdateResult,
+  DustGenerationMerkleTreeUpdateResponse,
   ZswapMerkleTreeCollapsedUpdateResponse,
   ZswapMerkleTreeCollapsedUpdateResult,
 } from './indexer-types';
@@ -46,6 +48,7 @@ import {
   GET_DUST_GENERATION_STATUS,
   GET_DUST_GENERATIONS,
   GET_DUST_COMMITMENT_MERKLE_TREE_UPDATE,
+  GET_DUST_GENERATION_MERKLE_TREE_UPDATE,
 } from './graphql/dust-queries';
 
 /**
@@ -304,6 +307,35 @@ export class IndexerHttpClient {
 
     const response = await this.client.rawRequest<{
       dustCommitmentMerkleTreeUpdate: DustCommitmentMerkleTreeUpdateResult;
+    }>(query, variables);
+
+    log.debug(`Raw indexer response\n${JSON.stringify(response, null, 2)}`);
+
+    return response;
+  }
+
+  /**
+   * Retrieves a collapsed Merkle tree update for the dust generation tree
+   * @param startIndex - Start index of the range
+   * @param endIndex - Optional end index of the range
+   * @param queryOverride - Optional custom GraphQL query
+   * @returns Promise resolving to the hex-encoded collapsed update
+   */
+  async getDustGenerationMerkleTreeUpdate(
+    startIndex: number,
+    endIndex: number,
+    queryOverride?: string,
+  ): Promise<DustGenerationMerkleTreeUpdateResponse> {
+    log.debug(`Target URL endpoint ${this.getTargetUrl()}`);
+
+    const query = queryOverride || GET_DUST_GENERATION_MERKLE_TREE_UPDATE;
+    const variables = { START_INDEX: startIndex, END_INDEX: endIndex };
+
+    log.debug(`Using query\n${query}`);
+    log.debug(`Using variables\n${JSON.stringify(variables, null, 2)}`);
+
+    const response = await this.client.rawRequest<{
+      dustGenerationMerkleTreeUpdate: DustGenerationMerkleTreeUpdateResult;
     }>(query, variables);
 
     log.debug(`Raw indexer response\n${JSON.stringify(response, null, 2)}`);

--- a/qa/tests/utils/indexer/http-client.ts
+++ b/qa/tests/utils/indexer/http-client.ts
@@ -317,7 +317,7 @@ export class IndexerHttpClient {
   /**
    * Retrieves a collapsed Merkle tree update for the dust generation tree
    * @param startIndex - Start index of the range
-   * @param endIndex - Optional end index of the range
+   * @param endIndex - End index of the range (inclusive)
    * @param queryOverride - Optional custom GraphQL query
    * @returns Promise resolving to the hex-encoded collapsed update
    */

--- a/qa/tests/utils/indexer/indexer-types.ts
+++ b/qa/tests/utils/indexer/indexer-types.ts
@@ -319,6 +319,17 @@ export type DustCommitmentMerkleTreeUpdateResponse = GraphQLResponse<{
   dustCommitmentMerkleTreeUpdate: DustCommitmentMerkleTreeUpdateResult;
 }>;
 
+export interface DustGenerationMerkleTreeUpdateResult {
+  startIndex: number;
+  endIndex: number;
+  update: string;
+  protocolVersion: number;
+}
+
+export type DustGenerationMerkleTreeUpdateResponse = GraphQLResponse<{
+  dustGenerationMerkleTreeUpdate: DustGenerationMerkleTreeUpdateResult;
+}>;
+
 export interface CollapsedMerkleTree {
   startIndex: number;
   endIndex: number;


### PR DESCRIPTION
## Summary

Adds QA integration coverage for the new `dustGenerationMerkleTreeUpdate(startIndex, endIndex)` query (introduced in midnight-indexer#1048 / PR #1062). The resolver mirrors `dustCommitmentMerkleTreeUpdate` 1:1, so the test suite mirrors `dust-commitment-update-queries.test.ts` to give parity with what was previously the only covered side. Closes the gap flagged by the QA coverage report (`Query.dustGenerationMerkleTreeUpdate — missing — no supporting tests detected`).

### Scenarios covered (8 tests)

- Valid range `[0, 1]` — indices echoed back, `update`/`protocolVersion` populated.
- Response shape validates against `MerkleTreeCollapsedUpdateSchema` (Zod).
- Full genesis dust-generation range — read `dustGenerationEndIndex` from genesis transactions, query `[0, max-1]`.
- Equal `startIndex == endIndex` returns trivial valid update.
- Idempotency — two identical calls yield identical results.
- Error: `startIndex > endIndex` → `invalid start_index and/or end_index`.
- Error: negative indices → `Invalid number`.
- Error: `endIndex` beyond indexed range → `invalid start_index and/or end_index`.

### Plumbing additions

- `qa/tests/utils/indexer/graphql/dust-queries.ts` — `GET_DUST_GENERATION_MERKLE_TREE_UPDATE`
- `qa/tests/utils/indexer/indexer-types.ts` — `DustGenerationMerkleTreeUpdateResult` / `Response`
- `qa/tests/utils/indexer/http-client.ts` — `getDustGenerationMerkleTreeUpdate()`

## Test plan

- [x] `cd qa/tests && yarn format` — clean
- [x] `cd qa/tests && yarn lint` — clean
- [x] `TARGET_ENV=qanet yarn test:smoke` — 5 passed, 1 skipped (baseline)
- [x] `TARGET_ENV=qanet yarn test:integration ...dust-generation-update-queries.test.ts ...dust-commitment-update-queries.test.ts` — 16 passed (8 new + 8 sibling regression)