### PR TITLE
test: cover connect startIndex (#984)

### DIFF
--- a/qa/tests/tests/integration/basic/subscriptions/wallet-connect-options.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/wallet-connect-options.test.ts
@@ -208,6 +208,8 @@ describe('wallet connect options (startIndex)', () => {
       const viewingKey = await toolkit.showViewingKey(seed);
 
       const tipIndex = await readCurrentZswapTipIndex(viewingKey);
+      // 1M past tip is well beyond any realistic chain depth: exercises the
+      // fast-forward semantics, not "near tip" semantics.
       const fastForward = tipIndex + 1_000_000;
 
       const sessionId = await indexerWsClient.openWalletSession(viewingKey, {

--- a/qa/tests/tests/integration/basic/subscriptions/wallet-connect-options.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/wallet-connect-options.test.ts
@@ -15,11 +15,7 @@
 
 import log from '@utils/logging/logger';
 import '@utils/logging/test-logging-hooks';
-import {
-  IndexerWsClient,
-  ShieldedTxSubscriptionResponse,
-  SubscriptionHandlers,
-} from '@utils/indexer/websocket-client';
+import { IndexerWsClient } from '@utils/indexer/websocket-client';
 import { ToolkitWrapper } from '@utils/toolkit/toolkit-wrapper';
 import dataProvider from '@utils/testdata-provider';
 
@@ -157,37 +153,39 @@ describe('wallet connect options (startIndex)', () => {
       });
       log.debug(`opened session with startIndex=${tipIndex}, sessionId=${sessionId}`);
 
-      const receivedEvents: ShieldedTxSubscriptionResponse[] = [];
-      const handlers: SubscriptionHandlers<ShieldedTxSubscriptionResponse> = {
-        next: (payload) => {
-          receivedEvents.push(payload);
-        },
-      };
-      const unsubscribe = indexerWsClient.subscribeToShieldedTransactionEvents(handlers, sessionId);
-
-      // Give the wallet-indexer time to emit at least one Progress.
-      await new Promise((res) => setTimeout(res, 5_000));
-      unsubscribe();
-
-      const progressEvents = receivedEvents
-        .map((m) => m.data?.shieldedTransactions)
-        .filter(
-          (
-            e,
-          ): e is {
-            __typename: 'ShieldedTransactionsProgress';
-            highestZswapEndIndex: number;
-            highestCheckedZswapEndIndex: number;
-            highestRelevantZswapEndIndex: number;
-          } => e?.__typename === 'ShieldedTransactionsProgress',
+      const firstProgress = await new Promise<{
+        __typename: 'ShieldedTransactionsProgress';
+        highestZswapEndIndex: number;
+        highestCheckedZswapEndIndex: number;
+        highestRelevantZswapEndIndex: number;
+      }>((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error('Timed out waiting for first Progress event')),
+          15_000,
         );
+        const unsubscribe = indexerWsClient.subscribeToShieldedTransactionEvents(
+          {
+            next: (payload) => {
+              if (payload.errors && payload.errors.length > 0) {
+                clearTimeout(timeout);
+                unsubscribe();
+                reject(
+                  new Error(`subscription returned errors: ${JSON.stringify(payload.errors)}`),
+                );
+                return;
+              }
+              const event = payload.data?.shieldedTransactions;
+              if (event?.__typename === 'ShieldedTransactionsProgress') {
+                clearTimeout(timeout);
+                unsubscribe();
+                resolve(event);
+              }
+            },
+          },
+          sessionId,
+        );
+      });
 
-      expect(
-        progressEvents.length,
-        'expected at least one ShieldedTransactionsProgress within 5s',
-      ).toBeGreaterThan(0);
-
-      const firstProgress = progressEvents[0];
       log.debug(`first progress = ${JSON.stringify(firstProgress)}`);
 
       // Core invariant: the indexer reports it has *checked* at least up to
@@ -219,20 +217,41 @@ describe('wallet connect options (startIndex)', () => {
       });
       expect(sessionId).toMatch(/^[a-f0-9]+$/);
 
-      const receivedEvents: ShieldedTxSubscriptionResponse[] = [];
-      const unsubscribe = indexerWsClient.subscribeToShieldedTransactionEvents(
-        {
-          next: (payload) => receivedEvents.push(payload),
-        },
-        sessionId,
-      );
-      await new Promise((res) => setTimeout(res, 5_000));
-      unsubscribe();
+      const firstProgress = await new Promise<{
+        __typename: 'ShieldedTransactionsProgress';
+        highestZswapEndIndex: number;
+        highestCheckedZswapEndIndex: number;
+        highestRelevantZswapEndIndex: number;
+      }>((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error('Timed out waiting for first Progress event')),
+          15_000,
+        );
+        const unsubscribe = indexerWsClient.subscribeToShieldedTransactionEvents(
+          {
+            next: (payload) => {
+              if (payload.errors && payload.errors.length > 0) {
+                clearTimeout(timeout);
+                unsubscribe();
+                reject(
+                  new Error(`subscription returned errors: ${JSON.stringify(payload.errors)}`),
+                );
+                return;
+              }
+              const event = payload.data?.shieldedTransactions;
+              if (event?.__typename === 'ShieldedTransactionsProgress') {
+                clearTimeout(timeout);
+                unsubscribe();
+                resolve(event);
+              }
+            },
+          },
+          sessionId,
+        );
+      });
 
-      // The worker should not have crashed; either we get progress events
-      // or none, but no GraphQL `errors` payload should appear.
-      const errored = receivedEvents.filter((m) => Array.isArray(m.errors) && m.errors.length > 0);
-      expect(errored, `subscription returned errors: ${JSON.stringify(errored)}`).toHaveLength(0);
+      // The worker emitted Progress without crashing or surfacing errors.
+      expect(firstProgress.__typename).toBe('ShieldedTransactionsProgress');
     }, 30_000);
   });
 });

--- a/qa/tests/tests/integration/basic/subscriptions/wallet-connect-options.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/wallet-connect-options.test.ts
@@ -1,0 +1,238 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import log from '@utils/logging/logger';
+import '@utils/logging/test-logging-hooks';
+import {
+  IndexerWsClient,
+  ShieldedTxSubscriptionResponse,
+  SubscriptionHandlers,
+} from '@utils/indexer/websocket-client';
+import { ToolkitWrapper } from '@utils/toolkit/toolkit-wrapper';
+import dataProvider from '@utils/testdata-provider';
+
+// Toolkit cold-start can be slow on the first run when the image is pulled.
+const TOOLKIT_STARTUP_TIMEOUT = 60_000;
+
+/**
+ * Coverage for midnight-indexer#984 / PR #1039
+ * (`feat: avoid unnecessary scans of shielded transactions`).
+ *
+ * The `connect` mutation accepts an optional `ConnectOptions { startIndex: Int }`
+ * input. When provided, the wallet-indexer is told to start scanning shielded
+ * transactions from the given index instead of from genesis. The intended use
+ * cases (per the issue) are:
+ *   - brand-new wallet: pass the current tip → no historical scan happens;
+ *   - wallet restoring with a known commitment-tree position: pass that index.
+ *
+ * Observable contract on `shieldedTransactions(sessionId)`:
+ *   - the wallet's `ShieldedTransactionsProgress.highestCheckedZswapEndIndex`
+ *     advances at least to `startIndex` immediately, and
+ *   - no historical `RelevantTransaction` events are emitted for transactions
+ *     with `endIndex <= startIndex` because they were never scanned.
+ */
+describe('wallet connect options (startIndex)', () => {
+  let toolkit: ToolkitWrapper;
+  let indexerWsClient: IndexerWsClient;
+
+  beforeAll(async () => {
+    toolkit = new ToolkitWrapper({});
+    await toolkit.start();
+  }, TOOLKIT_STARTUP_TIMEOUT);
+
+  afterAll(async () => {
+    await toolkit.stop();
+  });
+
+  beforeEach(async () => {
+    indexerWsClient = new IndexerWsClient();
+    await indexerWsClient.connectionInit();
+  }, 30_000);
+
+  afterEach(async () => {
+    await indexerWsClient.connectionClose();
+  });
+
+  /**
+   * Helper: open a transient session without options, wait for the first
+   * `ShieldedTransactionsProgress`, and return its `highestZswapEndIndex` —
+   * which is the exclusive upper bound on the chain's scanned transaction
+   * cursor at this moment, i.e. the "current tip" for sync purposes. The
+   * caller can pass this value as `startIndex` to a second session to make
+   * the wallet-indexer skip every transaction <= the tip.
+   *
+   * The probe relies on `connectionClose()` (in finally) to clean up. We
+   * deliberately do NOT call `closeWalletSession` here: when a session has
+   * just been told the chain tip, it is server-side-caught-up and the
+   * subsequent `disconnect` mutation race-condition'd a non-standard
+   * response shape on QANET. Closing the WS achieves the same teardown.
+   */
+  async function readCurrentZswapTipIndex(viewingKey: string): Promise<number> {
+    const probeWs = new IndexerWsClient();
+    await probeWs.connectionInit();
+    try {
+      const probeSessionId = await probeWs.openWalletSession(viewingKey);
+      return await new Promise<number>((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error('Timed out waiting for tip Progress event')),
+          15_000,
+        );
+        const unsubscribe = probeWs.subscribeToShieldedTransactionEvents(
+          {
+            next: (payload) => {
+              const event = payload.data?.shieldedTransactions;
+              if (event?.__typename === 'ShieldedTransactionsProgress') {
+                clearTimeout(timeout);
+                unsubscribe();
+                resolve(event.highestZswapEndIndex);
+              }
+            },
+          },
+          probeSessionId,
+        );
+      });
+    } finally {
+      await probeWs.connectionClose();
+    }
+  }
+
+  describe('opening a session with startIndex', () => {
+    /**
+     * @given a valid viewing key and `options.startIndex = 0`
+     * @when we open a wallet session
+     * @then the indexer returns a valid session ID — `startIndex: 0` is the
+     *       no-op equivalent of not passing options at all and must not be
+     *       rejected as malformed.
+     */
+    test('should accept startIndex = 0 (no-op equivalent of unset options)', async () => {
+      const seed = dataProvider.getFundingSeed();
+      const viewingKey = await toolkit.showViewingKey(seed);
+
+      const sessionId = await indexerWsClient.openWalletSession(viewingKey, {
+        startIndex: 0,
+      });
+
+      expect(sessionId).toMatch(/^[a-f0-9]+$/);
+      // No closeWalletSession: afterEach.connectionClose() releases the
+      // session server-side. See readCurrentZswapTipIndex docstring for why.
+    });
+
+    /**
+     * @given a valid viewing key and `options.startIndex` set to the current
+     *        chain tip (the brand-new-wallet case from the issue)
+     * @when we open a wallet session and subscribe to `shieldedTransactions`
+     * @then the first `ShieldedTransactionsProgress` event reports
+     *       `highestCheckedZswapEndIndex >= startIndex`, proving that the
+     *       wallet-indexer skipped scanning the historical portion of the
+     *       chain instead of catching up incrementally from 0.
+     */
+    test('should skip historical scan when startIndex equals the current tip', async () => {
+      const seed = dataProvider.getFundingSeed();
+      const viewingKey = await toolkit.showViewingKey(seed);
+
+      const tipIndex = await readCurrentZswapTipIndex(viewingKey);
+      log.debug(`tip zswap end index = ${tipIndex}`);
+      // The probe is only meaningful if the chain has produced shielded
+      // transactions. On an empty network the assertion below is vacuous;
+      // skip with a clear message rather than passing trivially.
+      if (tipIndex === 0) {
+        log.warn('chain has no shielded transactions; skipping startIndex optimisation check');
+        return;
+      }
+
+      const sessionId = await indexerWsClient.openWalletSession(viewingKey, {
+        startIndex: tipIndex,
+      });
+      log.debug(`opened session with startIndex=${tipIndex}, sessionId=${sessionId}`);
+
+      const receivedEvents: ShieldedTxSubscriptionResponse[] = [];
+      const handlers: SubscriptionHandlers<ShieldedTxSubscriptionResponse> = {
+        next: (payload) => {
+          receivedEvents.push(payload);
+        },
+      };
+      const unsubscribe = indexerWsClient.subscribeToShieldedTransactionEvents(handlers, sessionId);
+
+      // Give the wallet-indexer time to emit at least one Progress.
+      await new Promise((res) => setTimeout(res, 5_000));
+      unsubscribe();
+
+      const progressEvents = receivedEvents
+        .map((m) => m.data?.shieldedTransactions)
+        .filter(
+          (
+            e,
+          ): e is {
+            __typename: 'ShieldedTransactionsProgress';
+            highestZswapEndIndex: number;
+            highestCheckedZswapEndIndex: number;
+            highestRelevantZswapEndIndex: number;
+          } => e?.__typename === 'ShieldedTransactionsProgress',
+        );
+
+      expect(
+        progressEvents.length,
+        'expected at least one ShieldedTransactionsProgress within 5s',
+      ).toBeGreaterThan(0);
+
+      const firstProgress = progressEvents[0];
+      log.debug(`first progress = ${JSON.stringify(firstProgress)}`);
+
+      // Core invariant: the indexer reports it has *checked* at least up to
+      // the provided startIndex without having actually scanned earlier txs.
+      expect(
+        firstProgress.highestCheckedZswapEndIndex,
+        `highestCheckedZswapEndIndex (${firstProgress.highestCheckedZswapEndIndex}) ` +
+          `should be >= startIndex (${tipIndex}); the optimisation appears not to apply`,
+      ).toBeGreaterThanOrEqual(tipIndex);
+    }, 30_000);
+
+    /**
+     * @given a valid viewing key and `options.startIndex` past the current tip
+     * @when we open a wallet session and subscribe to `shieldedTransactions`
+     * @then the indexer accepts the connection — startIndex beyond tip is a
+     *       legitimate "fast-forward" use case (wallet pre-emptively trusts
+     *       its local commitment tree). The subscription should emit a
+     *       Progress event without crashing the worker.
+     */
+    test('should accept startIndex past the current tip (fast-forward)', async () => {
+      const seed = dataProvider.getFundingSeed();
+      const viewingKey = await toolkit.showViewingKey(seed);
+
+      const tipIndex = await readCurrentZswapTipIndex(viewingKey);
+      const fastForward = tipIndex + 1_000_000;
+
+      const sessionId = await indexerWsClient.openWalletSession(viewingKey, {
+        startIndex: fastForward,
+      });
+      expect(sessionId).toMatch(/^[a-f0-9]+$/);
+
+      const receivedEvents: ShieldedTxSubscriptionResponse[] = [];
+      const unsubscribe = indexerWsClient.subscribeToShieldedTransactionEvents(
+        {
+          next: (payload) => receivedEvents.push(payload),
+        },
+        sessionId,
+      );
+      await new Promise((res) => setTimeout(res, 5_000));
+      unsubscribe();
+
+      // The worker should not have crashed; either we get progress events
+      // or none, but no GraphQL `errors` payload should appear.
+      const errored = receivedEvents.filter((m) => Array.isArray(m.errors) && m.errors.length > 0);
+      expect(errored, `subscription returned errors: ${JSON.stringify(errored)}`).toHaveLength(0);
+    }, 30_000);
+  });
+});

--- a/qa/tests/tests/integration/basic/subscriptions/wallet-connect-options.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/wallet-connect-options.test.ts
@@ -35,9 +35,7 @@ const TOOLKIT_STARTUP_TIMEOUT = 60_000;
  *
  * Observable contract on `shieldedTransactions(sessionId)`:
  *   - the wallet's `ShieldedTransactionsProgress.highestCheckedZswapEndIndex`
- *     advances at least to `startIndex` immediately, and
- *   - no historical `RelevantTransaction` events are emitted for transactions
- *     with `endIndex <= startIndex` because they were never scanned.
+ *     advances at least to `startIndex` immediately.
  */
 describe('wallet connect options (startIndex)', () => {
   let toolkit: ToolkitWrapper;

--- a/qa/tests/tests/integration/basic/subscriptions/wallet-connect-options.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/wallet-connect-options.test.ts
@@ -138,7 +138,7 @@ describe('wallet connect options (startIndex)', () => {
      *       wallet-indexer skipped scanning the historical portion of the
      *       chain instead of catching up incrementally from 0.
      */
-    test('should skip historical scan when startIndex equals the current tip', async () => {
+    test('should skip historical scan when startIndex equals the current tip', async (ctx) => {
       const seed = dataProvider.getFundingSeed();
       const viewingKey = await toolkit.showViewingKey(seed);
 
@@ -149,7 +149,7 @@ describe('wallet connect options (startIndex)', () => {
       // skip with a clear message rather than passing trivially.
       if (tipIndex === 0) {
         log.warn('chain has no shielded transactions; skipping startIndex optimisation check');
-        return;
+        ctx.skip();
       }
 
       const sessionId = await indexerWsClient.openWalletSession(viewingKey, {

--- a/qa/tests/utils/indexer/websocket-client.ts
+++ b/qa/tests/utils/indexer/websocket-client.ts
@@ -612,14 +612,19 @@ export class IndexerWsClient {
    * when starting a subscription
    *
    * @param viewingKey - The viewing key for the wallet
+   * @param options - Optional `ConnectOptions`. `startIndex` lets the wallet skip
+   *   historical transaction scanning by telling the indexer to begin scanning from
+   *   the given transaction index (see midnight-indexer#984 / PR #1039).
    *
    * @returns A session ID in case of success
    */
-  async openWalletSession(viewingKey: string): Promise<string> {
+  async openWalletSession(viewingKey: string, options?: { startIndex?: number }): Promise<string> {
     const id = this.getNextId();
 
+    const optionsClause =
+      options?.startIndex !== undefined ? `, options: { startIndex: ${options.startIndex} }` : '';
     const connectMutation = `mutation OpenWalletSession {
-      connect (viewingKey: "${viewingKey}")
+      connect (viewingKey: "${viewingKey}"${optionsClause})
     }`;
 
     const payload: GraphQLStartMessage = {


### PR DESCRIPTION
## Scope

Adds QA integration coverage for [midnight-indexer#984](https://github.com/midnightntwrk/midnight-indexer/issues/984) (`feat: avoid unnecessary scans of shielded transactions`, PR #1039). The `connect` mutation accepts `ConnectOptions { startIndex: Int }` so a wallet can tell the wallet-indexer to start scanning shielded transactions from a known index instead of from genesis.

## Why

`qa/tests/integration/basic/subscriptions/` had no exercise of `connect(viewingKey, options)`. Existing wallet-session tests use only the no-options form. Without coverage, a regression silently undoing the optimisation would not be caught here.

## What changed

Two logical commits:

1. **`test: support ConnectOptions in openWalletSession`** — extends the WS helper at `qa/tests/utils/indexer/websocket-client.ts` to accept an optional `options: { startIndex?: number }` parameter. Additive: existing call sites unchanged.
2. **`test: cover connect startIndex (#984)`** — new file `qa/tests/tests/integration/basic/subscriptions/wallet-connect-options.test.ts` with three cases:
   - `startIndex = 0` — accepted as no-op equivalent of unset options.
   - `startIndex = current chain tip` (brand-new-wallet case) — first `ShieldedTransactionsProgress` event has `highestCheckedZswapEndIndex >= startIndex`, proving historical scan was skipped.
   - `startIndex` past tip (fast-forward) — accepted without GraphQL errors on the subscription.

The tip-probe helper relies on `connectionClose()` rather than `closeWalletSession` to avoid a server-side teardown race when the session is already caught up.

## Validation

- `TARGET_ENV=qanet yarn test:smoke` — 5 passed / 1 skipped, 1.57s.
- `TARGET_ENV=qanet yarn test:integration` — 150 passed / 2 failed (152 total). +1 passing vs `main`.
- `yarn lint` clean. `yarn format` applied.

## Residual

Two failures are present on `main` and reproduce identically here, **independent of this change**:

- `block-subscriptions > regular transaction fees > should report ledger paidFees and estimatedFees` — 50s timeout on QANET (related to fee-drift work in #1060/#1068).
- `dust-generations-subscriptions > streaming dust generation entries > should stream dust generation events for a valid dust address in bech32m format` — 25s timeout, data-dependent.

Tracked separately; flagging here so the failing run is not misread as a regression from this PR.