### PR TITLE
feat(indexer-api): add transactionHash to event subscription response types

### DIFF
--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -323,9 +323,13 @@ type DustGenerationDtimeUpdateItem {
 	"""
 	newDtime: Int!
 	"""
-	The originating transaction ID.
+	The originating transaction ID (indexer-internal BIGSERIAL).
 	"""
 	transactionId: Int!
+	"""
+	The hex-encoded originating transaction hash (32-byte chain identifier).
+	"""
+	transactionHash: HexEncoded!
 	"""
 	Hex-encoded tagged-serialised `TreeInsertionPath<DustGenerationInfo>`
 	from the originating ledger event. Wallets deserialise this and hand
@@ -428,9 +432,13 @@ type DustGenerationsItem {
 	"""
 	ctime: Int!
 	"""
-	The originating transaction ID.
+	The originating transaction ID (indexer-internal BIGSERIAL).
 	"""
 	transactionId: Int!
+	"""
+	The hex-encoded originating transaction hash (32-byte chain identifier).
+	"""
+	transactionHash: HexEncoded!
 	"""
 	Collapsed Merkle tree update filling the gap before this entry.
 	"""
@@ -497,9 +505,13 @@ type DustNullifierTransaction {
 	"""
 	commitment: HexEncoded!
 	"""
-	The transaction ID (use to query full transaction via `transaction` query).
+	The transaction ID (indexer-internal BIGSERIAL, use as resumption cursor).
 	"""
 	transactionId: Int!
+	"""
+	The hex-encoded transaction hash (32-byte chain identifier).
+	"""
+	transactionHash: HexEncoded!
 	"""
 	The block height containing this transaction.
 	"""
@@ -972,9 +984,13 @@ A transaction containing a shielded (zswap) nullifier match with block context.
 """
 type ShieldedNullifierTransaction {
 	"""
-	The transaction ID (use to query full transaction via `transaction` query).
+	The transaction ID (indexer-internal BIGSERIAL, use as resumption cursor).
 	"""
 	transactionId: Int!
+	"""
+	The hex-encoded transaction hash (32-byte chain identifier).
+	"""
+	transactionHash: HexEncoded!
 	"""
 	The hex-encoded block hash (use to query block with ledger parameters).
 	"""

--- a/indexer-api/src/domain/dust.rs
+++ b/indexer-api/src/domain/dust.rs
@@ -12,7 +12,10 @@
 // limitations under the License.
 
 use indexer_common::{
-    domain::{ByteVec, CardanoRewardAddress, DustPublicKey, SerializedDustTreeInsertionPath},
+    domain::{
+        ByteVec, CardanoRewardAddress, DustPublicKey, SerializedDustTreeInsertionPath,
+        TransactionHash,
+    },
     infra::sqlx::U128BeBytes,
 };
 use serde::{Deserialize, Serialize};
@@ -99,6 +102,8 @@ pub struct DustGenerationEntry {
 
     #[sqlx(try_from = "i64")]
     pub transaction_id: u64,
+
+    pub transaction_hash: TransactionHash,
 }
 
 /// A dust generation dtime update entry for the subscription stream.
@@ -126,6 +131,8 @@ pub struct DustGenerationDtimeUpdateEntry {
 
     pub transaction_id: u64,
 
+    pub transaction_hash: TransactionHash,
+
     /// Tagged-serialised `TreeInsertionPath<DustGenerationInfo>` from the
     /// originating ledger event. Surfaced verbatim on the GraphQL API so
     /// wallets can hand it to `generating_tree.update_from_evidence(...)`.
@@ -138,6 +145,7 @@ pub struct DustNullifierTransaction {
     pub nullifier: ByteVec,
     pub commitment: ByteVec,
     pub transaction_id: u64,
+    pub transaction_hash: TransactionHash,
     pub block_height: u32,
     pub block_hash: ByteVec,
 }

--- a/indexer-api/src/domain/shielded_nullifier.rs
+++ b/indexer-api/src/domain/shielded_nullifier.rs
@@ -11,12 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use indexer_common::domain::ByteVec;
+use indexer_common::domain::{ByteVec, TransactionHash};
 
 /// A shielded nullifier transaction for the subscription stream.
 #[derive(Debug, Clone)]
 pub struct ShieldedNullifierTransaction {
     pub transaction_id: u64,
+    pub transaction_hash: TransactionHash,
     pub block_hash: ByteVec,
     pub block_height: u32,
     pub nullifier: ByteVec,

--- a/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
@@ -70,8 +70,10 @@ pub struct DustGenerationsItem {
     pub backing_night: HexEncoded,
     /// The creation timestamp.
     pub ctime: u64,
-    /// The originating transaction ID.
+    /// The originating transaction ID (indexer-internal BIGSERIAL).
     pub transaction_id: u64,
+    /// The hex-encoded originating transaction hash (32-byte chain identifier).
+    pub transaction_hash: HexEncoded,
     /// Collapsed Merkle tree update filling the gap before this entry.
     pub collapsed_merkle_tree: Option<MerkleTreeCollapsedUpdate>,
 }
@@ -97,8 +99,10 @@ pub struct DustGenerationDtimeUpdateItem {
     pub night_utxo_hash: HexEncoded,
     /// The decay time as observed in this ledger event.
     pub new_dtime: u64,
-    /// The originating transaction ID.
+    /// The originating transaction ID (indexer-internal BIGSERIAL).
     pub transaction_id: u64,
+    /// The hex-encoded originating transaction hash (32-byte chain identifier).
+    pub transaction_hash: HexEncoded,
     /// Hex-encoded tagged-serialised `TreeInsertionPath<DustGenerationInfo>`
     /// from the originating ledger event. Wallets deserialise this and hand
     /// it to `generating_tree.update_from_evidence(...)`.
@@ -201,6 +205,7 @@ where
                     backing_night: entry.backing_night.hex_encode(),
                     ctime: entry.ctime,
                     transaction_id: entry.transaction_id,
+                    transaction_hash: entry.transaction_hash.hex_encode(),
                     collapsed_merkle_tree,
                 });
             }
@@ -253,6 +258,7 @@ where
                         backing_night: entry.backing_night.hex_encode(),
                         ctime: entry.ctime,
                         transaction_id: entry.transaction_id,
+                        transaction_hash: entry.transaction_hash.hex_encode(),
                         collapsed_merkle_tree,
                     });
                 }
@@ -364,6 +370,7 @@ fn dtime_update_item(update: DustGenerationDtimeUpdateEntry) -> DustGenerationDt
         night_utxo_hash: update.night_utxo_hash.hex_encode(),
         new_dtime: update.new_dtime,
         transaction_id: update.transaction_id,
+        transaction_hash: update.transaction_hash.hex_encode(),
         tree_insertion_path: update.tree_insertion_path.hex_encode(),
     }
 }

--- a/indexer-api/src/infra/api/v4/subscription/dust_nullifier_transactions.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_nullifier_transactions.rs
@@ -46,8 +46,10 @@ pub struct DustNullifierTransaction {
     pub nullifier: HexEncoded,
     /// The hex-encoded commitment.
     pub commitment: HexEncoded,
-    /// The transaction ID (use to query full transaction via `transaction` query).
+    /// The transaction ID (indexer-internal BIGSERIAL, use as resumption cursor).
     pub transaction_id: u64,
+    /// The hex-encoded transaction hash (32-byte chain identifier).
+    pub transaction_hash: HexEncoded,
     /// The block height containing this transaction.
     pub block_height: u32,
     /// The hex-encoded block hash (use to query block with ledger parameters).
@@ -116,6 +118,7 @@ where
                     nullifier: entry.nullifier.hex_encode(),
                     commitment: entry.commitment.hex_encode(),
                     transaction_id: entry.transaction_id,
+                    transaction_hash: entry.transaction_hash.hex_encode(),
                     block_height: entry.block_height,
                     block_hash: entry.block_hash.hex_encode(),
                 };
@@ -155,6 +158,7 @@ where
                         nullifier: entry.nullifier.hex_encode(),
                         commitment: entry.commitment.hex_encode(),
                         transaction_id: entry.transaction_id,
+                        transaction_hash: entry.transaction_hash.hex_encode(),
                         block_height: entry.block_height,
                         block_hash: entry.block_hash.hex_encode(),
                     };

--- a/indexer-api/src/infra/api/v4/subscription/shielded_nullifier_transactions.rs
+++ b/indexer-api/src/infra/api/v4/subscription/shielded_nullifier_transactions.rs
@@ -42,8 +42,10 @@ impl<S, B> Default for ShieldedNullifierTransactionsSubscription<S, B> {
 /// A transaction containing a shielded (zswap) nullifier match with block context.
 #[derive(Debug, Clone, SimpleObject)]
 pub struct ShieldedNullifierTransaction {
-    /// The transaction ID (use to query full transaction via `transaction` query).
+    /// The transaction ID (indexer-internal BIGSERIAL, use as resumption cursor).
     pub transaction_id: u64,
+    /// The hex-encoded transaction hash (32-byte chain identifier).
+    pub transaction_hash: HexEncoded,
     /// The hex-encoded block hash (use to query block with ledger parameters).
     pub block_hash: HexEncoded,
     /// The block height containing this transaction.
@@ -56,6 +58,7 @@ impl From<crate::domain::ShieldedNullifierTransaction> for ShieldedNullifierTran
     fn from(t: crate::domain::ShieldedNullifierTransaction) -> Self {
         Self {
             transaction_id: t.transaction_id,
+            transaction_hash: t.transaction_hash.hex_encode(),
             block_hash: t.block_hash.hex_encode(),
             block_height: t.block_height,
             nullifier: t.nullifier.hex_encode(),

--- a/indexer-api/src/infra/storage/dust_generations.rs
+++ b/indexer-api/src/infra/storage/dust_generations.rs
@@ -27,7 +27,7 @@ use futures::Stream;
 use indexer_common::{
     domain::{
         ByteVec, CardanoRewardAddress, LedgerEventAttributes, LedgerVersion, TimestampMs,
-        TimestampSecs, ledger,
+        TimestampSecs, TransactionHash, ledger,
     },
     infra::sqlx::U128BeBytes,
 };
@@ -157,19 +157,21 @@ impl DustGenerationsStorage for Storage {
                 // to plumb Option fields through the domain layer.
                 let query = indoc! {"
                     SELECT
-                        merkle_index AS commitment_mt_index,
-                        generation_index AS generation_mt_index,
-                        owner,
-                        value,
-                        initial_value,
-                        backing_night,
-                        ctime,
-                        transaction_id
+                        dust_generation_info.merkle_index AS commitment_mt_index,
+                        dust_generation_info.generation_index AS generation_mt_index,
+                        dust_generation_info.owner,
+                        dust_generation_info.value,
+                        dust_generation_info.initial_value,
+                        dust_generation_info.backing_night,
+                        dust_generation_info.ctime,
+                        dust_generation_info.transaction_id,
+                        transactions.hash AS transaction_hash
                     FROM dust_generation_info
-                    WHERE owner = $1
-                    AND generation_index >= $2
-                    AND generation_index <= $3
-                    ORDER BY generation_index
+                    INNER JOIN transactions ON transactions.id = dust_generation_info.transaction_id
+                    WHERE dust_generation_info.owner = $1
+                    AND dust_generation_info.generation_index >= $2
+                    AND dust_generation_info.generation_index <= $3
+                    ORDER BY dust_generation_info.generation_index
                     LIMIT $4
                 "};
 
@@ -258,7 +260,8 @@ impl DustGenerationsStorage for Storage {
                         dgi.owner,
                         dgi.night_utxo_hash,
                         le.attributes,
-                        le.transaction_id
+                        le.transaction_id,
+                        t.hash AS transaction_hash
                     FROM ledger_events le
                     JOIN transactions t ON t.id = le.transaction_id
                     JOIN dust_generation_info dgi
@@ -297,7 +300,8 @@ impl DustGenerationsStorage for Storage {
                         dgi.owner,
                         dgi.night_utxo_hash,
                         e.attributes,
-                        e.transaction_id
+                        e.transaction_id,
+                        t.hash AS transaction_hash
                     FROM dtime_events e
                     JOIN transactions t ON t.id = e.transaction_id
                     JOIN dust_generation_info dgi
@@ -331,6 +335,7 @@ impl DustGenerationsStorage for Storage {
                         night_utxo_hash,
                         attributes,
                         transaction_id,
+                        transaction_hash,
                     } = row;
 
                     let LedgerEventAttributes::DustGenerationDtimeUpdate {
@@ -353,6 +358,7 @@ impl DustGenerationsStorage for Storage {
                         night_utxo_hash,
                         new_dtime: generation_info.dtime,
                         transaction_id: transaction_id as u64,
+                        transaction_hash,
                         tree_insertion_path,
                     };
                 }
@@ -387,7 +393,7 @@ impl DustGenerationsStorage for Storage {
 
                 loop {
                     let query = indoc! {"
-                        SELECT dn.id, dn.nullifier, dn.commitment, t.id, b.height, b.hash
+                        SELECT dn.id, dn.nullifier, dn.commitment, t.id, t.hash, b.height, b.hash
                         FROM dust_nullifiers dn
                         JOIN transactions t ON t.id = dn.transaction_id
                         JOIN blocks b ON b.id = dn.block_id
@@ -399,7 +405,7 @@ impl DustGenerationsStorage for Storage {
                         LIMIT $6
                     "};
 
-                    let rows = sqlx::query_as::<_, (i64, ByteVec, ByteVec, i64, i64, ByteVec)>(query)
+                    let rows = sqlx::query_as::<_, (i64, ByteVec, ByteVec, i64, TransactionHash, i64, ByteVec)>(query)
                         .bind(&prefix[..])
                         .bind(&next_prefix[..])
                         .bind(from_block as i64)
@@ -414,11 +420,12 @@ impl DustGenerationsStorage for Storage {
                         None => break,
                     }
 
-                    for (_, nullifier, commitment, transaction_id, block_height, block_hash) in rows {
+                    for (_, nullifier, commitment, transaction_id, transaction_hash, block_height, block_hash) in rows {
                         yield DustNullifierTransaction {
                             nullifier,
                             commitment,
                             transaction_id: transaction_id as u64,
+                            transaction_hash,
                             block_height: block_height as u32,
                             block_hash,
                         };
@@ -444,4 +451,5 @@ struct DtimeUpdateRow {
     #[sqlx(json)]
     attributes: LedgerEventAttributes,
     transaction_id: i64,
+    transaction_hash: TransactionHash,
 }

--- a/indexer-api/src/infra/storage/shielded_nullifiers.rs
+++ b/indexer-api/src/infra/storage/shielded_nullifiers.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use async_stream::try_stream;
 use futures::Stream;
-use indexer_common::domain::ByteVec;
+use indexer_common::domain::{ByteVec, TransactionHash};
 use indoc::indoc;
 use std::num::NonZeroU32;
 
@@ -50,7 +50,7 @@ impl ShieldedNullifiersStorage for Storage {
 
                 loop {
                     let query = indoc! {"
-                        SELECT zn.id, zn.nullifier, t.id, b.height, b.hash
+                        SELECT zn.id, zn.nullifier, t.id, t.hash, b.height, b.hash
                         FROM zswap_nullifiers zn
                         JOIN transactions t ON t.id = zn.transaction_id
                         JOIN blocks b ON b.id = zn.block_id
@@ -62,7 +62,7 @@ impl ShieldedNullifiersStorage for Storage {
                         LIMIT $6
                     "};
 
-                    let rows = sqlx::query_as::<_, (i64, ByteVec, i64, i64, ByteVec)>(query)
+                    let rows = sqlx::query_as::<_, (i64, ByteVec, i64, TransactionHash, i64, ByteVec)>(query)
                         .bind(&prefix[..])
                         .bind(&next_prefix[..])
                         .bind(from_block as i64)
@@ -77,9 +77,10 @@ impl ShieldedNullifiersStorage for Storage {
                         None => break,
                     }
 
-                    for (_, nullifier, transaction_id, block_height, block_hash) in rows {
+                    for (_, nullifier, transaction_id, transaction_hash, block_height, block_hash) in rows {
                         yield ShieldedNullifierTransaction {
                             transaction_id: transaction_id as u64,
+                            transaction_hash,
                             block_hash,
                             block_height: block_height as u32,
                             nullifier,


### PR DESCRIPTION
## Summary

Adds `transactionHash: HexEncoded!` to four GraphQL subscription response types that previously exposed only `transactionId` (the indexer's BIGSERIAL primary key, an indexer-internal integer that can't be used to look up transactions or reference them across indexer instances).

The new field gives consumers the chain-stable 32-byte transaction hash needed for:
- Constructing on-chain references (immediate use case: Jegor's new `DustStateChanges` object in the wallet)
- Looking up the full transaction via `transactions(offset: { hash: ... })`
- Cross-indexer references (BIGSERIAL ids differ across instances, hashes don't)

## Affected types

- `DustGenerationsItem`
- `DustGenerationDtimeUpdateItem`
- `DustNullifierTransaction`
- `ShieldedNullifierTransaction`

`transactionId` remains unchanged on each, it's still useful as the resumption cursor in `dustLedgerEvents(id)`, `zswapLedgerEvents(id)`, and `unshieldedTransactions(transactionId)` subscriptions where wallets track last-seen position within an indexer instance. The two fields are complementary, not alternatives.

## Implementation

- SQL queries now JOIN the `transactions` table to fetch `t.hash` (the existing `get_dust_generation_dtime_cutoff_block_id` query already used this JOIN pattern)
- Domain entry structs use the `TransactionHash` type alias (`= ByteArray<32>`), consistent with `Transaction.hash` / `Block.parent_hash`
- GraphQL types call `.hex_encode()` at the API boundary, output is `HexEncoded!`

## Verification
- Live introspection on a local indexer-api confirmed all 4 types expose `transactionHash: HexEncoded!`

## Backwards compatibility
Additive only, no existing fields removed or changed in shape. Existing consumers continue to work; new consumers can opt into requesting `transactionHash` when they need it.

## Related
- Closes #1114
- Follow-up consideration tracked at #1115 (`feat: add transaction reference field for event subscription navigation`, broader 2.0 design that may add `transaction: Transaction!` reference fields for full Transaction navigation)
- Design discussion: [#efficient-wallet-syncing slack thread "Adding transactionHash to DustGenerationsItem" with Jegor and Andrzej](https://shielded.slack.com/archives/C0AQ3N6HM7B/p1778244382628559)