### PR TITLE
test: cover shieldedNullifierTransactions (#994)

### DIFF
--- a/qa/tests/tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts
@@ -208,6 +208,8 @@ describe('shielded nullifier transactions subscription', () => {
       // surface has gained validation and this test should be reworked to
       // assert the new error message (see header comment).
       expect(settled.error).toBeNull();
+      expect(settled.eventCount).toBe(0);
+      expect(settled.completed).toBe(true);
     });
 
     /**
@@ -264,6 +266,8 @@ describe('shielded nullifier transactions subscription', () => {
 
       log.debug(`fromBlock>toBlock shielded outcome: ${JSON.stringify(settled)}`);
       expect(settled.error).toBeNull();
+      expect(settled.eventCount).toBe(0);
+      expect(settled.completed).toBe(true);
     });
   });
 });

--- a/qa/tests/tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts
@@ -1,0 +1,269 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import log from '@utils/logging/logger';
+import '@utils/logging/test-logging-hooks';
+import {
+  IndexerWsClient,
+  ShieldedNullifierTransactionSubscriptionResponse,
+} from '@utils/indexer/websocket-client';
+import { ShieldedNullifierTransactionSchema } from '@utils/indexer/graphql/schema';
+import { IndexerHttpClient } from '@utils/indexer/http-client';
+
+const indexerHttpClient = new IndexerHttpClient();
+
+/**
+ * Coverage for midnight-indexer#994 / PR #996
+ * (`feat: add shieldedNullifierTransactions subscription`).
+ *
+ * The subscription returns transaction references for any shielded (Zswap)
+ * transaction whose nullifiers match one of the provided hex prefixes, within
+ * an optional block range. It mirrors `dustNullifierTransactions` but on the
+ * shielded surface. Wallets use it to detect spends of coins they discovered
+ * via trial-decryption that the regular shielded sync wouldn't otherwise
+ * surface (the shielded sync only catches transactions with outputs for the
+ * provided viewing key, not pure nullifier-only spends).
+ *
+ * Mirrors the structure of `dust-nullifier-subscriptions.test.ts` so the two
+ * surfaces stay symmetric.
+ */
+describe('shielded nullifier transactions subscription', () => {
+  let indexerWsClient: IndexerWsClient;
+
+  beforeEach(async () => {
+    indexerWsClient = new IndexerWsClient();
+    await indexerWsClient.connectionInit();
+  }, 30_000);
+
+  afterEach(async () => {
+    await indexerWsClient.connectionClose();
+  });
+
+  describe('streaming shielded nullifier transactions with block range', () => {
+    /**
+     * @given a set of nullifier prefixes and a bounded block range
+     * @when we subscribe to shieldedNullifierTransactions
+     * @then we should receive matching transactions (if any) and the
+     *       subscription should complete once `toBlock` is reached
+     * @and each transaction should match the expected schema
+     */
+    test('should stream transactions within a block range and complete', async () => {
+      const blockResponse = await indexerHttpClient.getLatestBlock();
+      expect(blockResponse).toBeSuccess();
+      const latestHeight = blockResponse.data!.block.height;
+
+      // Use a broad prefix to maximise the chance of matches in the early
+      // window. Bounded to first 10 blocks for determinism.
+      const toBlock = Math.min(latestHeight, 10);
+      const nullifierPrefixes = ['00'];
+
+      log.debug(
+        `Subscribing to shielded nullifier transactions with prefixes=${nullifierPrefixes}, fromBlock=0, toBlock=${toBlock}`,
+      );
+
+      const received: ShieldedNullifierTransactionSubscriptionResponse[] = [];
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          subscription.unsubscribe();
+          // OK if no matches found in the range — subscription still
+          // completes; absent matches is a valid outcome.
+          resolve();
+        }, 15_000);
+
+        const subscription = indexerWsClient.subscribeToShieldedNullifierTransactions(
+          {
+            next: (payload) => {
+              received.push(payload);
+              log.debug(
+                `Received shielded nullifier transaction: ${JSON.stringify(payload.data?.shieldedNullifierTransactions)}`,
+              );
+            },
+            error: (error) => {
+              clearTimeout(timeout);
+              subscription.unsubscribe();
+              reject(new Error(`Subscription error: ${JSON.stringify(error)}`));
+            },
+            complete: () => {
+              clearTimeout(timeout);
+              resolve();
+            },
+          },
+          nullifierPrefixes,
+          0,
+          toBlock,
+        );
+      });
+
+      log.debug(`Received ${received.length} shielded nullifier transactions`);
+
+      for (const msg of received) {
+        expect(msg).toBeSuccess();
+        const tx = msg.data!.shieldedNullifierTransactions;
+        const parsed = ShieldedNullifierTransactionSchema.safeParse(tx);
+        expect(
+          parsed.success,
+          `Shielded nullifier transaction schema validation failed: ${JSON.stringify(parsed.error, null, 2)}`,
+        ).toBe(true);
+
+        // Block height should be within the requested range.
+        expect(tx.blockHeight).toBeGreaterThanOrEqual(0);
+        expect(tx.blockHeight).toBeLessThanOrEqual(toBlock);
+      }
+    });
+  });
+
+  /**
+   * Behaviour divergence vs `dustNullifierTransactions`:
+   *
+   * `dustNullifierTransactions` (since midnight-indexer#1089 / PR #1090)
+   * rejects two malformed inputs as client errors:
+   *   - empty `nullifierPrefixes` array (`[]`)
+   *   - `fromBlock > toBlock`
+   *
+   * `shieldedNullifierTransactions` does NOT enforce either guard at the time
+   * of writing. The tests below intentionally record the current behaviour
+   * (subscription accepts the input without surfacing an error) so that:
+   *   1. Future symmetric hardening on the shielded surface is caught — these
+   *      tests will start failing when validation is added, prompting an
+   *      update to mirror the dust pattern.
+   *   2. The asymmetry is visible in the QA suite rather than silently
+   *      tolerated.
+   *
+   * If/when an issue is filed to harden the shielded validation, link it
+   * here and convert the assertions to expect the matching client errors.
+   */
+  describe('input handling (currently permissive vs dust)', () => {
+    /**
+     * @given an empty array of nullifier prefixes
+     * @when we subscribe to shieldedNullifierTransactions with toBlock set
+     * @then the subscription does NOT raise a client error (recorded
+     *       behaviour; dust rejects this since #1089). It either completes
+     *       cleanly or stays open without emitting an event for the
+     *       observation window.
+     */
+    test('should not raise an error for empty nullifier prefixes (records divergence from dust)', async () => {
+      const blockResponse = await indexerHttpClient.getLatestBlock();
+      const toBlock = Math.min(blockResponse.data!.block.height, 5);
+
+      const settled = await new Promise<{
+        completed: boolean;
+        error: string | null;
+        eventCount: number;
+      }>((resolve) => {
+        let eventCount = 0;
+        const timeout = setTimeout(() => {
+          subscription.unsubscribe();
+          resolve({ completed: false, error: null, eventCount });
+        }, 8_000);
+
+        const subscription = indexerWsClient.subscribeToShieldedNullifierTransactions(
+          {
+            next: (payload) => {
+              eventCount++;
+              if (payload.errors && payload.errors.length > 0) {
+                clearTimeout(timeout);
+                subscription.unsubscribe();
+                resolve({
+                  completed: false,
+                  error: payload.errors[0].message,
+                  eventCount,
+                });
+              }
+            },
+            error: (error) => {
+              clearTimeout(timeout);
+              subscription.unsubscribe();
+              resolve({
+                completed: false,
+                error: typeof error === 'string' ? error : JSON.stringify(error),
+                eventCount,
+              });
+            },
+            complete: () => {
+              clearTimeout(timeout);
+              resolve({ completed: true, error: null, eventCount });
+            },
+          },
+          [],
+          0,
+          toBlock,
+        );
+      });
+
+      log.debug(`empty-prefix shielded outcome: ${JSON.stringify(settled)}`);
+      // Permissive: no error message surfaced. If this changes, the shielded
+      // surface has gained validation and this test should be reworked to
+      // assert the new error message (see header comment).
+      expect(settled.error).toBeNull();
+    });
+
+    /**
+     * @given fromBlock greater than toBlock
+     * @when we subscribe to shieldedNullifierTransactions
+     * @then the subscription does NOT raise a client error (recorded
+     *       behaviour; dust rejects this since #1089).
+     */
+    test('should not raise an error when fromBlock is greater than toBlock (records divergence from dust)', async () => {
+      const settled = await new Promise<{
+        completed: boolean;
+        error: string | null;
+        eventCount: number;
+      }>((resolve) => {
+        let eventCount = 0;
+        const timeout = setTimeout(() => {
+          subscription.unsubscribe();
+          resolve({ completed: false, error: null, eventCount });
+        }, 8_000);
+
+        const subscription = indexerWsClient.subscribeToShieldedNullifierTransactions(
+          {
+            next: (payload) => {
+              eventCount++;
+              if (payload.errors && payload.errors.length > 0) {
+                clearTimeout(timeout);
+                subscription.unsubscribe();
+                resolve({
+                  completed: false,
+                  error: payload.errors[0].message,
+                  eventCount,
+                });
+              }
+            },
+            error: (error) => {
+              clearTimeout(timeout);
+              subscription.unsubscribe();
+              resolve({
+                completed: false,
+                error: typeof error === 'string' ? error : JSON.stringify(error),
+                eventCount,
+              });
+            },
+            complete: () => {
+              clearTimeout(timeout);
+              resolve({ completed: true, error: null, eventCount });
+            },
+          },
+          ['00'],
+          10,
+          5,
+        );
+      });
+
+      log.debug(`fromBlock>toBlock shielded outcome: ${JSON.stringify(settled)}`);
+      expect(settled.error).toBeNull();
+    });
+  });
+});

--- a/qa/tests/utils/indexer/graphql/schema.ts
+++ b/qa/tests/utils/indexer/graphql/schema.ts
@@ -411,3 +411,10 @@ export const DustNullifierTransactionSchema = z.object({
   blockHeight: z.number(),
   blockHash: Hash64,
 });
+
+export const ShieldedNullifierTransactionSchema = z.object({
+  transactionId: z.number(),
+  blockHash: Hash64,
+  blockHeight: z.number(),
+  nullifier: VarLenghtHex,
+});

--- a/qa/tests/utils/indexer/graphql/subscriptions.ts
+++ b/qa/tests/utils/indexer/graphql/subscriptions.ts
@@ -395,3 +395,14 @@ export const DUST_NULLIFIER_TRANSACTIONS_SUBSCRIPTION = `
     }
   }
 `;
+
+export const SHIELDED_NULLIFIER_TRANSACTIONS_SUBSCRIPTION = `
+  subscription ShieldedNullifierTransactions($nullifierPrefixes: [HexEncoded!]!, $fromBlock: Int, $toBlock: Int) {
+    shieldedNullifierTransactions(nullifierPrefixes: $nullifierPrefixes, fromBlock: $fromBlock, toBlock: $toBlock) {
+      transactionId
+      blockHash
+      blockHeight
+      nullifier
+    }
+  }
+`;

--- a/qa/tests/utils/indexer/indexer-types.ts
+++ b/qa/tests/utils/indexer/indexer-types.ts
@@ -379,4 +379,11 @@ export interface DustNullifierTransaction {
   blockHash: string;
 }
 
+export interface ShieldedNullifierTransaction {
+  transactionId: number;
+  blockHash: string;
+  blockHeight: number;
+  nullifier: string;
+}
+
 export type ViewingKey = string & { __brand: 'ViewingKey' };

--- a/qa/tests/utils/indexer/websocket-client.ts
+++ b/qa/tests/utils/indexer/websocket-client.ts
@@ -23,6 +23,7 @@ import type {
   DustLedgerEvent,
   DustGenerationsEvent,
   DustNullifierTransaction,
+  ShieldedNullifierTransaction,
   ZswapLedgerEvent,
   ShieldedTransactionsEvent,
   UnshieldedTransactionEvent,
@@ -41,6 +42,7 @@ import {
   DUST_LEDGER_EVENTS_SUBSCRIPTION_FROM_ID,
   DUST_GENERATIONS_SUBSCRIPTION,
   DUST_NULLIFIER_TRANSACTIONS_SUBSCRIPTION,
+  SHIELDED_NULLIFIER_TRANSACTIONS_SUBSCRIPTION,
   ZSWAP_LEDGER_EVENTS_SUBSCRIPTION_DEFAULT,
   ZSWAP_LEDGER_EVENTS_SUBSCRIPTION_FROM_ID,
 } from './graphql/subscriptions';
@@ -69,6 +71,10 @@ export type DustGenerationsSubscriptionResponse = GraphQLResponse<{
 
 export type DustNullifierTransactionSubscriptionResponse = GraphQLResponse<{
   dustNullifierTransactions: DustNullifierTransaction;
+}>;
+
+export type ShieldedNullifierTransactionSubscriptionResponse = GraphQLResponse<{
+  shieldedNullifierTransactions: ShieldedNullifierTransaction;
 }>;
 
 export type ZswapLedgerEventSubscriptionResponse = GraphQLResponse<{
@@ -1036,6 +1042,64 @@ export class IndexerWsClient {
     };
 
     log.debug(`Dust Nullifier Transactions payload:\n${JSON.stringify(payload, null, 2)}`);
+
+    this.handlersMap.set(subscriptionId, handlers as SubscriptionHandlers<unknown>);
+    this.getWs().send(JSON.stringify(payload));
+
+    return {
+      id: subscriptionId,
+      unsubscribe: () => {
+        const stopMessage: GraphQLStopMessage = {
+          id: subscriptionId,
+          type: 'stop',
+        };
+        this.getWs().send(JSON.stringify(stopMessage));
+        this.handlersMap.delete(subscriptionId);
+      },
+    };
+  }
+
+  /**
+   * Subscribes to transactions containing shielded (Zswap) nullifiers matching
+   * the provided prefixes.
+   *
+   * Mirrors `subscribeToDustNullifierTransactions` but operates on the shielded
+   * nullifier surface. Returns transaction and block references the wallet can
+   * use to fetch the full transaction. If `toBlock` is supplied, the
+   * subscription completes once that block is reached.
+   *
+   * @param handlers - Callback functions for handling incoming nullifier
+   *   transaction events
+   * @param nullifierPrefixes - Array of hex-encoded nullifier prefixes to match
+   * @param fromBlock - Optional starting block height
+   * @param toBlock - Optional ending block height (subscription finishes after
+   *   this)
+   * @param queryOverride - Optional custom GraphQL subscription query
+   *
+   * @returns An object with subscription ID and unsubscribe function
+   */
+  subscribeToShieldedNullifierTransactions(
+    handlers: SubscriptionHandlers<ShieldedNullifierTransactionSubscriptionResponse>,
+    nullifierPrefixes: string[],
+    fromBlock?: number,
+    toBlock?: number,
+    queryOverride?: string,
+  ): { unsubscribe: () => void; id: string } {
+    const query = queryOverride || SHIELDED_NULLIFIER_TRANSACTIONS_SUBSCRIPTION;
+    const variables = { nullifierPrefixes, fromBlock, toBlock };
+
+    const subscriptionId = this.getNextId();
+
+    const payload: GraphQLStartMessage = {
+      id: subscriptionId,
+      type: 'start',
+      payload: {
+        query,
+        variables,
+      },
+    };
+
+    log.debug(`Shielded Nullifier Transactions payload:\n${JSON.stringify(payload, null, 2)}`);
 
     this.handlersMap.set(subscriptionId, handlers as SubscriptionHandlers<unknown>);
     this.getWs().send(JSON.stringify(payload));


### PR DESCRIPTION
## Scope

Adds QA integration coverage for [midnight-indexer#994](https://github.com/midnightntwrk/midnight-indexer/issues/994) (`feat: add shieldedNullifierTransactions subscription`, PR #996). The subscription returns transaction references for any shielded (Zswap) transaction whose nullifiers match a hex prefix, within an optional block range. Wallets use it to detect spends of coins discovered via trial-decryption that the regular shielded sync wouldn't otherwise surface.

## Why

`qa/tests/integration/basic/subscriptions/` had no exercise of `shieldedNullifierTransactions`. Without coverage, a regression on the new subscription would not be caught here.

## What changed

Two logical commits:

1. **`test: add shielded nullifier subscription helper`** — adds the `ShieldedNullifierTransaction` type, the zod schema validator, the `SHIELDED_NULLIFIER_TRANSACTIONS_SUBSCRIPTION` GraphQL string, and a `subscribeToShieldedNullifierTransactions` wrapper on `IndexerWsClient`. Mirrors the existing `dustNullifierTransactions` surface 1:1, with the schema shape adjusted to drop `commitment` (not present on the shielded variant). Purely additive.
2. **`test: cover shieldedNullifierTransactions (#994)`** — new file `qa/tests/tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts` with three cases:
   - **Streaming with bounded range** — emits matching transactions (or completes when none match), each payload validates against the schema, `blockHeight` falls within `[0, toBlock]`.
   - **Empty `nullifierPrefixes` array** — accepted without an error (records divergence from `dustNullifierTransactions`, which rejects this since #1089 / PR #1090).
   - **`fromBlock > toBlock`** — accepted without an error (same divergence).

## Behaviour divergence flagged

`dustNullifierTransactions` rejects empty `nullifierPrefixes` and `fromBlock > toBlock` with client errors after #1089 / PR #1090. `shieldedNullifierTransactions` does not. The two divergence cases here are intentionally framed as **behaviour-recording**: if validation parity is added on the shielded surface later, the tests will fail and need updating to expect the matching client errors. The header comment in the test file flags this for whoever does the eventual hardening. Slack thread with @cosmir17 to confirm whether the asymmetry is intentional.

## Validation

- `TARGET_ENV=qanet yarn test:smoke` — 9 passed / 1 skipped, 1.57s.
- `TARGET_ENV=qanet yarn test:integration` — 150 passed / 2 failed (152 total). +3 passing vs `main`, no new regressions.
- `yarn lint` clean. `yarn format` reports all files unchanged (already formatted).

## Residual

Two failures present on `main` reproduce identically here, **independent of this change**:

- `block-subscriptions > regular transaction fees > should report ledger paidFees and estimatedFees` — 50s timeout (related to fee-drift work in #1060/#1068).
- `dust-generations-subscriptions > streaming dust generation entries > should stream dust generation events for a valid dust address in bech32m format` — 25s timeout, data-dependent.

Flagging here so the failing run is not misread as a regression from this PR.