### PR TITLE
chore(release): prepare for 4.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.1] - 2026-05-11
+
+### 🚀 Features
+
+- *(indexer-api)* Add transactionHash to event subscription response types (#1116)
+
+### 🐛 Bug Fixes
+
+- Replace remaining production panics with error returns (#1105)
+
 ## [4.3.0] - 2026-04-30
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "chain-indexer"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-api"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-standalone"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "anyhow",
  "byte-unit-serde",
@@ -3276,7 +3276,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-tests"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -6784,7 +6784,7 @@ dependencies = [
 
 [[package]]
 name = "spo-indexer"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -8279,7 +8279,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-indexer"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version       = "4.3.0"
+version       = "4.3.1"
 edition       = "2024"
 license       = "Apache-2.0"
 readme        = "README.md"


### PR DESCRIPTION
## Summary
Prepares 4.3.1 patch release on top of v4.3.0.

### What's in this release

#### 🚀 Features
- *(indexer-api)* Add `transactionHash` to event subscription response types (#1116)

#### 🐛 Bug Fixes
- Replace remaining production panics with error returns (#1105)

### Changes in this PR
- Bump workspace version `4.3.0` → `4.3.1` in `Cargo.toml`
- Update `Cargo.lock` for 6 workspace members
- Add `[4.3.1] - 2026-05-11` section to `CHANGELOG.md` via `git cliff`
