### PR TITLE
test: cover transactionHash on event subscriptions (#1114)

### DIFF
--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -17,6 +17,7 @@ import log from '@utils/logging/logger';
 import { bech32m } from 'bech32';
 import { Buffer } from 'node:buffer';
 import '@utils/logging/test-logging-hooks';
+import type { TestContext } from 'vitest';
 import {
   IndexerWsClient,
   DustGenerationsSubscriptionResponse,
@@ -376,5 +377,123 @@ describe('dust generations subscription', () => {
         /(expected hrp|unexpected hrp|wrong hrp|bech32|invalid.*address)/,
       );
     });
+  });
+
+  /**
+   * Coverage for midnight-indexer#1114 / PR #1116
+   * (`feat(indexer-api): add transactionHash to event subscription response types`).
+   *
+   * `transactionHash: HexEncoded!` was added to `DustGenerationsItem` and
+   * `DustGenerationDtimeUpdateItem` so wallets can resolve the on-chain
+   * transaction from a streamed event via `transactions(offset: { hash: ... })`.
+   * The `transactionId` BIGSERIAL is indexer-internal and not portable across
+   * indexer instances; the hash is. The schema-level shape (64-hex,
+   * non-nullable) is already enforced by the discriminated-union zod schema
+   * used by the streaming test above. This block adds the round-trip check.
+   */
+  describe('transactionHash on dust generation events (#1114)', () => {
+    /**
+     * @given a registered dust address that emits at least one
+     *        `DustGenerationsItem` or `DustGenerationDtimeUpdateItem`
+     * @when we subscribe to `dustGenerations` and look up the first event's
+     *       `transactionHash` via `transactions(offset: { hash: ... })`
+     * @then the lookup resolves a single transaction whose `hash` equals the
+     *       streamed `transactionHash` — proving the field is the on-chain
+     *       identifier wallets can use to fetch the full transaction.
+     */
+    test('first item transactionHash resolves via transactions(offset)', async (ctx: TestContext) => {
+      let rewardAddress: string;
+      try {
+        rewardAddress = dataProvider.getCardanoRewardAddress('registered-with-dust');
+      } catch (error) {
+        log.warn(error);
+        ctx.skip?.(true, (error as Error).message);
+        return;
+      }
+
+      const generationsResponse = await indexerHttpClient.getDustGenerations([rewardAddress]);
+      expect(generationsResponse).toBeSuccess();
+      const dustAddress = generationsResponse.data!.dustGenerations[0].registrations[0].dustAddress;
+      log.debug(`Using dust address: ${dustAddress}`);
+
+      const firstItem = await new Promise<{
+        transactionId: number;
+        transactionHash: string;
+        __typename: 'DustGenerationsItem' | 'DustGenerationDtimeUpdateItem';
+      } | null>((resolve, reject) => {
+        let settled = false;
+        let unsubscribe = () => {};
+        const settle = (handler: () => void) => {
+          if (settled) return;
+          settled = true;
+          handler();
+        };
+
+        // Returning null (instead of rejecting) on timeout lets the caller
+        // ctx.skip when the streaming surface is in a known-flaky state on
+        // the target environment, rather than false-failing this test.
+        const timeout = setTimeout(() => {
+          safeUnsubscribe(unsubscribe);
+          settle(() => resolve(null));
+        }, 15_000);
+
+        const subscription = indexerWsClient.subscribeToDustGenerations(
+          {
+            next: (payload) => {
+              const event = payload.data?.dustGenerations;
+              if (
+                event?.__typename === 'DustGenerationsItem' ||
+                event?.__typename === 'DustGenerationDtimeUpdateItem'
+              ) {
+                clearTimeout(timeout);
+                safeUnsubscribe(unsubscribe);
+                settle(() =>
+                  resolve({
+                    transactionId: event.transactionId,
+                    transactionHash: event.transactionHash,
+                    __typename: event.__typename,
+                  }),
+                );
+              }
+            },
+            error: (error) => {
+              clearTimeout(timeout);
+              safeUnsubscribe(unsubscribe);
+              settle(() => reject(new Error(`Subscription error: ${JSON.stringify(error)}`)));
+            },
+            complete: () => {
+              clearTimeout(timeout);
+              settle(() => resolve(null));
+            },
+          },
+          dustAddress,
+          0,
+          10,
+        );
+        unsubscribe = subscription.unsubscribe;
+      });
+
+      if (firstItem === null) {
+        log.warn(
+          'no DustGenerationsItem / DtimeUpdateItem event received within the timeout — ' +
+            'streaming surface is currently flaky on this environment (round-trip skipped)',
+        );
+        ctx.skip?.(true, 'no dust generations item event in time — round-trip vacuous');
+        return;
+      }
+
+      log.debug(
+        `Round-tripping ${firstItem.__typename}.transactionHash=${firstItem.transactionHash} ` +
+          `(transactionId=${firstItem.transactionId})`,
+      );
+
+      const txResponse = await indexerHttpClient.getTransactionByOffset({
+        hash: firstItem.transactionHash,
+      });
+      expect(txResponse).toBeSuccess();
+      const transactions = txResponse.data!.transactions;
+      expect(transactions.length).toBeGreaterThanOrEqual(1);
+      expect(transactions[0].hash).toBe(firstItem.transactionHash);
+    }, 30_000);
   });
 });

--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -468,7 +468,7 @@ describe('dust generations subscription', () => {
           },
           dustAddress,
           0,
-          10,
+          2_147_483_647,
         );
         unsubscribe = subscription.unsubscribe;
       });

--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -492,7 +492,7 @@ describe('dust generations subscription', () => {
       });
       expect(txResponse).toBeSuccess();
       const transactions = txResponse.data!.transactions;
-      expect(transactions.length).toBeGreaterThanOrEqual(1);
+      expect(transactions).toHaveLength(1);
       expect(transactions[0].hash).toBe(firstItem.transactionHash);
     }, 30_000);
   });

--- a/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
@@ -15,12 +15,14 @@
 
 import log from '@utils/logging/logger';
 import '@utils/logging/test-logging-hooks';
+import type { TestContext } from 'vitest';
 import {
   IndexerWsClient,
   DustNullifierTransactionSubscriptionResponse,
 } from '@utils/indexer/websocket-client';
 import { DustNullifierTransactionSchema } from '@utils/indexer/graphql/schema';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
+import { DustNullifierTransaction } from '@utils/indexer/indexer-types';
 
 const indexerHttpClient = new IndexerHttpClient();
 
@@ -227,5 +229,96 @@ describe('dust nullifier transactions subscription', () => {
       expect(settled.completed).toBe(false);
       expect(settled.eventCount).toBeGreaterThanOrEqual(0);
     });
+  });
+
+  /**
+   * Coverage for midnight-indexer#1114 / PR #1116
+   * (`feat(indexer-api): add transactionHash to event subscription response types`).
+   *
+   * `transactionHash: HexEncoded!` was added to `DustNullifierTransaction`.
+   * The schema-level shape (64-hex, non-nullable) is already enforced by the
+   * `DustNullifierTransactionSchema` used by the streaming test above. This
+   * block adds the round-trip check: the streamed hash must resolve a
+   * transaction via `transactions(offset: { hash: ... })`.
+   *
+   * Match presence is environment-dependent (prefix `'00'` over the full
+   * chain). If no transactions match within the timeout, the round-trip is
+   * vacuous and we skip rather than asserting against an empty stream.
+   */
+  describe('transactionHash on dust nullifier events (#1114)', () => {
+    /**
+     * @given a wide prefix scan of the full chain
+     * @when we subscribe to `dustNullifierTransactions` and look up the first
+     *       streamed event's `transactionHash` via `transactions(offset)`
+     * @then the lookup resolves a single transaction whose `hash` equals the
+     *       streamed `transactionHash` — proving the field is the on-chain
+     *       identifier.
+     */
+    test('first event transactionHash resolves via transactions(offset)', async (ctx: TestContext) => {
+      const blockResponse = await indexerHttpClient.getLatestBlock();
+      expect(blockResponse).toBeSuccess();
+      const latestHeight = blockResponse.data!.block.height;
+
+      const received: DustNullifierTransaction[] = [];
+
+      await new Promise<void>((resolve) => {
+        const timeout = setTimeout(() => {
+          subscription.unsubscribe();
+          resolve();
+        }, 15_000);
+
+        const subscription = indexerWsClient.subscribeToDustNullifierTransactions(
+          {
+            next: (payload) => {
+              const tx = payload.data?.dustNullifierTransactions;
+              if (tx) {
+                received.push(tx);
+                clearTimeout(timeout);
+                subscription.unsubscribe();
+                resolve();
+              }
+            },
+            error: () => {
+              clearTimeout(timeout);
+              subscription.unsubscribe();
+              resolve();
+            },
+            complete: () => {
+              clearTimeout(timeout);
+              resolve();
+            },
+          },
+          ['00'],
+          0,
+          latestHeight,
+        );
+      });
+
+      if (received.length === 0) {
+        log.warn(
+          'no dustNullifierTransactions matched prefix "00" within the timeout; ' +
+            'round-trip skipped (environment has no dust nullifier transactions in range)',
+        );
+        ctx.skip?.(
+          true,
+          'no dust nullifier transactions matched within timeout — round-trip vacuous',
+        );
+        return;
+      }
+
+      const first = received[0];
+      log.debug(
+        `Round-tripping DustNullifierTransaction.transactionHash=${first.transactionHash} ` +
+          `(transactionId=${first.transactionId})`,
+      );
+
+      const txResponse = await indexerHttpClient.getTransactionByOffset({
+        hash: first.transactionHash,
+      });
+      expect(txResponse).toBeSuccess();
+      const transactions = txResponse.data!.transactions;
+      expect(transactions.length).toBeGreaterThanOrEqual(1);
+      expect(transactions[0].hash).toBe(first.transactionHash);
+    }, 30_000);
   });
 });

--- a/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
@@ -278,10 +278,10 @@ describe('dust nullifier transactions subscription', () => {
                 resolve();
               }
             },
-            error: () => {
+            error: (err) => {
               clearTimeout(timeout);
               subscription.unsubscribe();
-              resolve();
+              reject(new Error(`Subscription error: ${JSON.stringify(err)}`));
             },
             complete: () => {
               clearTimeout(timeout);

--- a/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
@@ -261,7 +261,7 @@ describe('dust nullifier transactions subscription', () => {
 
       const received: DustNullifierTransaction[] = [];
 
-      await new Promise<void>((resolve) => {
+      await new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
           subscription.unsubscribe();
           resolve();
@@ -317,7 +317,7 @@ describe('dust nullifier transactions subscription', () => {
       });
       expect(txResponse).toBeSuccess();
       const transactions = txResponse.data!.transactions;
-      expect(transactions.length).toBeGreaterThanOrEqual(1);
+      expect(transactions).toHaveLength(1);
       expect(transactions[0].hash).toBe(first.transactionHash);
     }, 30_000);
   });

--- a/qa/tests/tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts
@@ -320,10 +320,10 @@ describe('shielded nullifier transactions subscription', () => {
                 resolve();
               }
             },
-            error: () => {
+            error: (err) => {
               clearTimeout(timeout);
               subscription.unsubscribe();
-              resolve();
+              reject(new Error(`Subscription error: ${JSON.stringify(err)}`));
             },
             complete: () => {
               clearTimeout(timeout);

--- a/qa/tests/tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts
@@ -303,7 +303,7 @@ describe('shielded nullifier transactions subscription', () => {
 
       const received: ShieldedNullifierTransaction[] = [];
 
-      await new Promise<void>((resolve) => {
+      await new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
           subscription.unsubscribe();
           resolve();
@@ -359,7 +359,7 @@ describe('shielded nullifier transactions subscription', () => {
       });
       expect(txResponse).toBeSuccess();
       const transactions = txResponse.data!.transactions;
-      expect(transactions.length).toBeGreaterThanOrEqual(1);
+      expect(transactions).toHaveLength(1);
       expect(transactions[0].hash).toBe(first.transactionHash);
     }, 30_000);
   });

--- a/qa/tests/tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts
@@ -15,12 +15,14 @@
 
 import log from '@utils/logging/logger';
 import '@utils/logging/test-logging-hooks';
+import type { TestContext } from 'vitest';
 import {
   IndexerWsClient,
   ShieldedNullifierTransactionSubscriptionResponse,
 } from '@utils/indexer/websocket-client';
 import { ShieldedNullifierTransactionSchema } from '@utils/indexer/graphql/schema';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
+import { ShieldedNullifierTransaction } from '@utils/indexer/indexer-types';
 
 const indexerHttpClient = new IndexerHttpClient();
 
@@ -269,5 +271,96 @@ describe('shielded nullifier transactions subscription', () => {
       expect(settled.eventCount).toBe(0);
       expect(settled.completed).toBe(true);
     });
+  });
+
+  /**
+   * Coverage for midnight-indexer#1114 / PR #1116
+   * (`feat(indexer-api): add transactionHash to event subscription response types`).
+   *
+   * `transactionHash: HexEncoded!` was added to `ShieldedNullifierTransaction`.
+   * The schema-level shape (64-hex, non-nullable) is already enforced by the
+   * `ShieldedNullifierTransactionSchema` used by the streaming test above.
+   * This block adds the round-trip check: the streamed hash must resolve a
+   * transaction via `transactions(offset: { hash: ... })`.
+   *
+   * Match presence is environment-dependent. If no transactions match within
+   * the timeout, the round-trip is vacuous and we skip rather than asserting
+   * against an empty stream.
+   */
+  describe('transactionHash on shielded nullifier events (#1114)', () => {
+    /**
+     * @given a wide prefix scan of the full chain
+     * @when we subscribe to `shieldedNullifierTransactions` and look up the
+     *       first streamed event's `transactionHash` via `transactions(offset)`
+     * @then the lookup resolves a single transaction whose `hash` equals the
+     *       streamed `transactionHash` — proving the field is the on-chain
+     *       identifier.
+     */
+    test('first event transactionHash resolves via transactions(offset)', async (ctx: TestContext) => {
+      const blockResponse = await indexerHttpClient.getLatestBlock();
+      expect(blockResponse).toBeSuccess();
+      const latestHeight = blockResponse.data!.block.height;
+
+      const received: ShieldedNullifierTransaction[] = [];
+
+      await new Promise<void>((resolve) => {
+        const timeout = setTimeout(() => {
+          subscription.unsubscribe();
+          resolve();
+        }, 15_000);
+
+        const subscription = indexerWsClient.subscribeToShieldedNullifierTransactions(
+          {
+            next: (payload) => {
+              const tx = payload.data?.shieldedNullifierTransactions;
+              if (tx) {
+                received.push(tx);
+                clearTimeout(timeout);
+                subscription.unsubscribe();
+                resolve();
+              }
+            },
+            error: () => {
+              clearTimeout(timeout);
+              subscription.unsubscribe();
+              resolve();
+            },
+            complete: () => {
+              clearTimeout(timeout);
+              resolve();
+            },
+          },
+          ['00'],
+          0,
+          latestHeight,
+        );
+      });
+
+      if (received.length === 0) {
+        log.warn(
+          'no shieldedNullifierTransactions matched prefix "00" within the timeout; ' +
+            'round-trip skipped (environment has no shielded nullifier transactions in range)',
+        );
+        ctx.skip?.(
+          true,
+          'no shielded nullifier transactions matched within timeout — round-trip vacuous',
+        );
+        return;
+      }
+
+      const first = received[0];
+      log.debug(
+        `Round-tripping ShieldedNullifierTransaction.transactionHash=${first.transactionHash} ` +
+          `(transactionId=${first.transactionId})`,
+      );
+
+      const txResponse = await indexerHttpClient.getTransactionByOffset({
+        hash: first.transactionHash,
+      });
+      expect(txResponse).toBeSuccess();
+      const transactions = txResponse.data!.transactions;
+      expect(transactions.length).toBeGreaterThanOrEqual(1);
+      expect(transactions[0].hash).toBe(first.transactionHash);
+    }, 30_000);
   });
 });

--- a/qa/tests/utils/indexer/graphql/schema.ts
+++ b/qa/tests/utils/indexer/graphql/schema.ts
@@ -379,6 +379,7 @@ export const DustGenerationsItemSchema = z.object({
   backingNight: VarLenghtHex,
   ctime: z.number(),
   transactionId: z.number(),
+  transactionHash: Hash64,
   collapsedMerkleTree: CollapsedMerkleTreeSchema.nullable(),
 });
 
@@ -395,6 +396,7 @@ export const DustGenerationDtimeUpdateItemSchema = z.object({
   nightUtxoHash: VarLenghtHex,
   newDtime: z.number(),
   transactionId: z.number(),
+  transactionHash: Hash64,
   treeInsertionPath: VarLenghtHex,
 });
 
@@ -408,12 +410,14 @@ export const DustNullifierTransactionSchema = z.object({
   nullifier: VarLenghtHex,
   commitment: VarLenghtHex,
   transactionId: z.number(),
+  transactionHash: Hash64,
   blockHeight: z.number(),
   blockHash: Hash64,
 });
 
 export const ShieldedNullifierTransactionSchema = z.object({
   transactionId: z.number(),
+  transactionHash: Hash64,
   blockHash: Hash64,
   blockHeight: z.number(),
   nullifier: VarLenghtHex,

--- a/qa/tests/utils/indexer/graphql/subscriptions.ts
+++ b/qa/tests/utils/indexer/graphql/subscriptions.ts
@@ -354,6 +354,7 @@ export const DUST_GENERATIONS_SUBSCRIPTION = `
         backingNight
         ctime
         transactionId
+        transactionHash
         collapsedMerkleTree {
           startIndex
           endIndex
@@ -378,6 +379,7 @@ export const DUST_GENERATIONS_SUBSCRIPTION = `
         nightUtxoHash
         newDtime
         transactionId
+        transactionHash
         treeInsertionPath
       }
     }
@@ -390,6 +392,7 @@ export const DUST_NULLIFIER_TRANSACTIONS_SUBSCRIPTION = `
       nullifier
       commitment
       transactionId
+      transactionHash
       blockHeight
       blockHash
     }
@@ -400,6 +403,7 @@ export const SHIELDED_NULLIFIER_TRANSACTIONS_SUBSCRIPTION = `
   subscription ShieldedNullifierTransactions($nullifierPrefixes: [HexEncoded!]!, $fromBlock: Int, $toBlock: Int) {
     shieldedNullifierTransactions(nullifierPrefixes: $nullifierPrefixes, fromBlock: $fromBlock, toBlock: $toBlock) {
       transactionId
+      transactionHash
       blockHash
       blockHeight
       nullifier

--- a/qa/tests/utils/indexer/indexer-types.ts
+++ b/qa/tests/utils/indexer/indexer-types.ts
@@ -348,6 +348,7 @@ export interface DustGenerationsItem {
   backingNight: string;
   ctime: number;
   transactionId: number;
+  transactionHash: string;
   collapsedMerkleTree: CollapsedMerkleTree | null;
 }
 
@@ -364,6 +365,7 @@ export interface DustGenerationDtimeUpdateItem {
   nightUtxoHash: string;
   newDtime: number;
   transactionId: number;
+  transactionHash: string;
   treeInsertionPath: string;
 }
 
@@ -376,12 +378,14 @@ export interface DustNullifierTransaction {
   nullifier: string;
   commitment: string;
   transactionId: number;
+  transactionHash: string;
   blockHeight: number;
   blockHash: string;
 }
 
 export interface ShieldedNullifierTransaction {
   transactionId: number;
+  transactionHash: string;
   blockHash: string;
   blockHeight: number;
   nullifier: string;


### PR DESCRIPTION
## Summary

Adds QA integration coverage for [midnight-indexer#1114](https://github.com/midnightntwrk/midnight-indexer/issues/1114) / PR #1116 (`feat(indexer-api): add transactionHash to event subscription response types`). The new field gives wallets and downstream consumers a chain-stable 32-byte identifier on every streamed event, so they can resolve the full transaction via `transactions(offset: { hash: ... })` instead of relying on the indexer-internal BIGSERIAL `transactionId`.

Pre-change, the four affected types (`DustGenerationsItem`, `DustGenerationDtimeUpdateItem`, `DustNullifierTransaction`, `ShieldedNullifierTransaction`) had zero QA coverage for `transactionHash`: it wasn't selected in any GraphQL fragment, asserted in any zod schema, or typed in any TS interface.

## What changed

Two logical commits:

1. **`test: add transactionHash to subscription types`** — plumbing-only, additive (+12 lines):
   - `qa/tests/utils/indexer/graphql/subscriptions.ts` — add `transactionHash` to the 4 fragments
   - `qa/tests/utils/indexer/graphql/schema.ts` — add `transactionHash: Hash64` (64-hex, non-nullable) to the 4 zod schemas
   - `qa/tests/utils/indexer/indexer-types.ts` — add `transactionHash: string` to the 4 TS interfaces

   With the new field required by the zod schemas, the existing streaming tests already enforce shape-level coverage (any event missing or malforming `transactionHash` would fail validation).

2. **`test: cover transactionHash round-trip (#1114)`** — explicit per-surface round-trip (+305 lines):
   - `dust-generations-subscriptions.test.ts` — subscribe, take the first `DustGenerationsItem` (or `DustGenerationDtimeUpdateItem`), look up via `transactions(offset: { hash })`, assert the returned transaction's `hash` matches.
   - `dust-nullifier-subscriptions.test.ts` — same shape, scanning the full chain with prefix `'00'`.
   - `shielded-nullifier-subscriptions.test.ts` — same shape, mirroring the dust pattern.

   This is the wallet round-trip #1114 motivates: receive an event, resolve the full on-chain transaction by hash.

## Drift / env-resilience

Event presence is environment-dependent (prefix matches for the two nullifier surfaces; `registered-with-dust` wallet state for dust generations). When the streaming surface yields no events within the timeout, the round-trip assertion is vacuous, so the test `ctx.skip()`s with a clear message rather than false-failing.

## Test plan

`TARGET_ENV=qanet` against the 3 changed test files (13 tests):

- [x] **10 passed**, including the new `dust-nullifier-subscriptions > transactionHash on dust nullifier events (#1114) > first event transactionHash resolves via transactions(offset)` — real match, real round-trip resolved.
- [x] **2 skipped** gracefully — new `shielded-nullifier` round-trip (no prefix match in window) and new `dust-generations` round-trip (streaming surface yielded no items).
- [x] **1 failed** — `should stream dust generation events for a valid dust address in bech32m format`. **Pre-existing flake** confirmed by re-running on baseline `main` with my changes stashed (same failure, same timing). Tracked in `known-flaky-tests.md`; **not introduced by this PR**.
- [x] `yarn format` / `yarn lint` clean.
- [x] Smoke clean — 18 passed / 1 skipped.

## References

- #1114 — `feat(indexer-api): add transactionHash to event subscription response types`
- PR #1116 — implementation that closed #1114