### PR TITLE
feat(indexer-api): tighten shielded nullifier transactions input validation

### DIFF
--- a/indexer-api/src/infra/api/v4/subscription/shielded_nullifier_transactions.rs
+++ b/indexer-api/src/infra/api/v4/subscription/shielded_nullifier_transactions.rs
@@ -98,6 +98,10 @@ where
                 .try_acquire(per_connection_counter, None)
                 .map_err_into_client_error(|| "subscription limit exceeded")?;
 
+            (!nullifier_prefixes.is_empty())
+                .then_some(())
+                .some_or_client_error(|| "nullifierPrefixes must not be empty")?;
+
             (nullifier_prefixes.len() <= 10)
                 .then_some(())
                 .some_or_client_error(|| "maximum of ten nullifier prefixes allowed")?;
@@ -108,8 +112,16 @@ where
                 .collect::<Result<Vec<_>, _>>()
                 .map_err_into_client_error(|| "invalid hex-encoded nullifier prefix")?;
 
+            prefix_bytes
+                .iter()
+                .all(|b| !b.is_empty())
+                .then_some(())
+                .some_or_client_error(|| "nullifierPrefixes elements must not be empty")?;
+
             let from = from_block.unwrap_or(0);
             let to = to_block.unwrap_or(u64::MAX);
+
+            validate_block_range(from, to)?;
 
             debug!("streaming existing shielded nullifier transactions");
 
@@ -174,5 +186,33 @@ where
 
             warn!("stream of BlockIndexed events completed unexpectedly");
         }
+    }
+}
+
+/// Reject `fromBlock > toBlock` with a client error so callers get a clear
+/// signal that they likely have a bug in their request rather than thinking
+/// their query just happens to match nothing (#1095).
+fn validate_block_range(from: u64, to: u64) -> ApiResult<()> {
+    (from <= to)
+        .then_some(())
+        .some_or_client_error(|| "fromBlock must not exceed toBlock")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_block_range;
+
+    #[test]
+    fn test_validate_block_range_accepts_valid_ranges() {
+        assert!(validate_block_range(0, 0).is_ok());
+        assert!(validate_block_range(5, 10).is_ok());
+        assert!(validate_block_range(0, u64::MAX).is_ok());
+    }
+
+    #[test]
+    fn test_validate_block_range_rejects_from_greater_than_to() {
+        assert!(validate_block_range(1, 0).is_err());
+        assert!(validate_block_range(10, 5).is_err());
+        assert!(validate_block_range(u64::MAX, 0).is_err());
     }
 }

--- a/indexer-tests/src/e2e.rs
+++ b/indexer-tests/src/e2e.rs
@@ -1114,8 +1114,51 @@ async fn test_dust_generations_subscription(ws_api_url: &str) -> anyhow::Result<
     Ok(())
 }
 
-/// Test the shieldedNullifierTransactions subscription with a non-matching prefix.
+/// Test the shieldedNullifierTransactions subscription. Verifies the input-validation
+/// guards added in #1119 to mirror dust (empty array, empty-string element, and
+/// fromBlock > toBlock all error), plus a valid non-matching prefix with a bounded
+/// range completes empty. Each error case is wrapped in a defensive timeout so the
+/// test fails fast rather than hanging if the server doesn't behave as expected.
 async fn test_shielded_nullifier_transactions_subscription(ws_api_url: &str) -> anyhow::Result<()> {
+    // Empty nullifierPrefixes array → client error per #1119.
+    let variables = shielded_nullifier_transactions_subscription::Variables {
+        nullifier_prefixes: vec![],
+        from_block: Some(0),
+        to_block: Some(0),
+    };
+    let stream = graphql_ws_client::subscribe::<ShieldedNullifierTransactionsSubscription>(
+        ws_api_url, variables,
+    )
+    .await
+    .context("subscribe with empty nullifierPrefixes")?;
+    let result = tokio::time::timeout(Duration::from_secs(3), stream.try_collect::<Vec<_>>())
+        .await
+        .context("expected client error within 3s for empty nullifierPrefixes")?;
+    assert!(
+        result.is_err(),
+        "expected client error for empty nullifierPrefixes, got: {result:?}"
+    );
+
+    // Empty-string prefix element → also client error per #1119.
+    let variables = shielded_nullifier_transactions_subscription::Variables {
+        nullifier_prefixes: vec!["".to_string().try_into().unwrap()],
+        from_block: Some(0),
+        to_block: Some(0),
+    };
+    let stream = graphql_ws_client::subscribe::<ShieldedNullifierTransactionsSubscription>(
+        ws_api_url, variables,
+    )
+    .await
+    .context("subscribe with empty-string prefix")?;
+    let result = tokio::time::timeout(Duration::from_secs(3), stream.try_collect::<Vec<_>>())
+        .await
+        .context("expected client error within 3s for empty-string prefix")?;
+    assert!(
+        result.is_err(),
+        "expected client error for empty-string prefix, got: {result:?}"
+    );
+
+    // Valid non-matching prefix with bounded range → completes empty.
     let variables = shielded_nullifier_transactions_subscription::Variables {
         nullifier_prefixes: vec!["00".to_string().try_into().unwrap()],
         from_block: Some(0),
@@ -1135,6 +1178,25 @@ async fn test_shielded_nullifier_transactions_subscription(ws_api_url: &str) -> 
 
     // No matching nullifiers expected in test data.
     assert!(events.is_empty());
+
+    // fromBlock > toBlock → client error per #1119.
+    let variables = shielded_nullifier_transactions_subscription::Variables {
+        nullifier_prefixes: vec!["00".to_string().try_into().unwrap()],
+        from_block: Some(10),
+        to_block: Some(5),
+    };
+    let stream = graphql_ws_client::subscribe::<ShieldedNullifierTransactionsSubscription>(
+        ws_api_url, variables,
+    )
+    .await
+    .context("subscribe with fromBlock > toBlock")?;
+    let result = tokio::time::timeout(Duration::from_secs(3), stream.try_collect::<Vec<_>>())
+        .await
+        .context("expected client error within 3s for fromBlock > toBlock")?;
+    assert!(
+        result.is_err(),
+        "expected client error for fromBlock > toBlock, got: {result:?}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
# Overview

Closes #1119.

Brings `shieldedNullifierTransactions` input validation in line with `dustNullifierTransactions` (hardened in #1090 to close #1089 + #1095). Three new client errors,

- `nullifierPrefixes: []` → `"nullifierPrefixes must not be empty"`
- `nullifierPrefixes: [""]` (empty-string element after hex decode) → `"nullifierPrefixes elements must not be empty"`
- `fromBlock > toBlock` → `"fromBlock must not exceed toBlock"`

Parity goal confirmed by Andrzej on `#topic-indexer` (9 May 2026, 10:17 BST): "`shieldedNullifierTransactions` and `dustNullifierTransactions` should behave almost identically when it comes to restrictions and other semantics."

## Implementation

Mirrors PR #1090's pattern in `indexer-api/src/infra/api/v4/subscription/shielded_nullifier_transactions.rs`,

- Three validation blocks at the top of `try_stream!`, placed in the same order as dust (empty list → existing `<= 10` cap → hex decode → empty element → block-range validate).
- Local `fn validate_block_range` + 2 unit tests, copied from dust to keep this PR's scope minimal. Extracting to a shared helper across both files is a reasonable follow-up if preferred.

E2e test `test_shielded_nullifier_transactions_subscription` extended in `indexer-tests/src/e2e.rs` to mirror dust's 4-case shape: empty array, empty-string element, fromBlock > toBlock all error; valid non-matching prefix still completes empty. Defensive timeouts on each error case to fail fast.

## Out of scope

Two items deliberately deferred (per ticket),

1. The `<= 10` cap asymmetry: `shieldedNullifierTransactions` rejects more than 10 prefixes, `dustNullifierTransactions` doesn't. Worth a separate design discussion on whether to add the cap to dust or drop it from shielded; either path is independent of this validation-parity work.
2. Extracting `validate_block_range` to a shared helper across both subscription files. Trivial to do, but kept local here to match dust's pattern; happy to extract in a follow-up if reviewers prefer.

## Links

Closes #1119
Mirrors #1090 (the equivalent dust-side hardening that closed #1089 + #1095)