### PR TITLE
test: optimize ci with path-based filtering for qa/ folder

### DIFF
--- a/.github/workflows/ci-cloud.yaml
+++ b/.github/workflows/ci-cloud.yaml
@@ -16,8 +16,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Detects whether the PR touches anything outside `qa/**`. Subsequent jobs
+  # only run when non-qa files changed, so qa-only PRs skip Rust CI while
+  # this workflow still reports success (keeping branch protection happy).
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      non_qa: ${{steps.filter.outputs.non_qa}}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect non-qa changes
+        id: filter
+        env:
+          EVENT_NAME: ${{github.event_name}}
+          BASE_SHA: ${{github.event.pull_request.base.sha}}
+          HEAD_SHA: ${{github.event.pull_request.head.sha}}
+        run: |
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "Non-PR event; running full pipeline."
+            echo "non_qa=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Diffing $BASE_SHA..$HEAD_SHA"
+          changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          echo "Changed files:"
+          echo "$changed"
+          if echo "$changed" | grep -vE '^qa/' | grep -q .; then
+            echo "non_qa=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "non_qa=false" >> "$GITHUB_OUTPUT"
+          fi
+
   toolchain:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.non_qa == 'true'
     outputs:
       toolchain: ${{steps.set_toolchain.outputs.toolchain}}
     steps:
@@ -34,7 +71,8 @@ jobs:
 
   check:
     runs-on: ubuntu-latest-8-core-x64
-    needs: toolchain
+    needs: [changes, toolchain]
+    if: needs.changes.outputs.non_qa == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -62,6 +100,8 @@ jobs:
 
   fmt-check:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.non_qa == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -86,7 +126,8 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest-8-core-x64
-    needs: toolchain
+    needs: [changes, toolchain]
+    if: needs.changes.outputs.non_qa == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -115,7 +156,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest-8-core-x64
-    needs: toolchain
+    needs: [changes, toolchain]
+    if: needs.changes.outputs.non_qa == 'true'
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -157,6 +199,8 @@ jobs:
 
   doc:
     runs-on: ubuntu-latest-8-core-x64
+    needs: changes
+    if: needs.changes.outputs.non_qa == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci-qa.yaml
+++ b/.github/workflows/ci-qa.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js v22.x
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
           node-version: 22.x
 

--- a/.github/workflows/ci-qa.yaml
+++ b/.github/workflows/ci-qa.yaml
@@ -35,7 +35,7 @@ jobs:
           node-version: 22.x
 
       - name: Restore Yarn cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.3.0
         with:
           path: |
             qa/tests/.yarn/cache

--- a/.github/workflows/ci-qa.yaml
+++ b/.github/workflows/ci-qa.yaml
@@ -1,0 +1,96 @@
+name: ci-qa
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+      - feat/*
+      - release/*
+    paths:
+      - qa/**
+      - .github/workflows/ci-qa.yaml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{github.workflow}}-${{github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
+jobs:
+  qa-tests:
+    name: qa/tests — lint, format, audit
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: qa/tests
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js v22.x
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 22.x
+
+      - name: Restore Yarn cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: |
+            qa/tests/.yarn/cache
+            qa/tests/.yarn/install-state.gz
+          key: ${{runner.os}}-yarn-${{hashFiles('qa/tests/yarn.lock')}}
+          restore-keys: |
+            ${{runner.os}}-yarn-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Format check
+        run: yarn format:check
+
+      - name: Audit
+        run: yarn audit
+
+  block-scanner:
+    name: qa/tools/block-scanner — format, audit
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: qa/tools/block-scanner
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Format check
+        run: bun run format:check
+
+      - name: Audit
+        run: bun run audit
+
+  scripts:
+    name: qa/scripts — shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
+        with:
+          scandir: ./qa/scripts
+          # Pre-existing scripts carry style/warning findings. Start with
+          # `error` to gate real bugs; tighten in a follow-up cleanup.
+          severity: error

--- a/.github/workflows/ci-qa.yaml
+++ b/.github/workflows/ci-qa.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   qa-tests:
-    name: qa/tests — lint, format, audit
+    name: tests — lint, format, audit
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -57,7 +57,7 @@ jobs:
         run: yarn audit
 
   block-scanner:
-    name: qa/tools/block-scanner — format, audit
+    name: tools/block-scanner — lint, format, audit
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -74,6 +74,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Lint (typecheck)
+        run: bun run lint
+
       - name: Format check
         run: bun run format:check
 
@@ -81,7 +84,7 @@ jobs:
         run: bun run audit
 
   scripts:
-    name: qa/scripts — shellcheck
+    name: scripts — shellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci-standalone.yaml
+++ b/.github/workflows/ci-standalone.yaml
@@ -16,8 +16,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Detects whether the PR touches anything outside `qa/**`. Subsequent jobs
+  # only run when non-qa files changed, so qa-only PRs skip Rust CI while
+  # this workflow still reports success (keeping branch protection happy).
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      non_qa: ${{steps.filter.outputs.non_qa}}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect non-qa changes
+        id: filter
+        env:
+          EVENT_NAME: ${{github.event_name}}
+          BASE_SHA: ${{github.event.pull_request.base.sha}}
+          HEAD_SHA: ${{github.event.pull_request.head.sha}}
+        run: |
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "Non-PR event; running full pipeline."
+            echo "non_qa=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Diffing $BASE_SHA..$HEAD_SHA"
+          changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          echo "Changed files:"
+          echo "$changed"
+          if echo "$changed" | grep -vE '^qa/' | grep -q .; then
+            echo "non_qa=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "non_qa=false" >> "$GITHUB_OUTPUT"
+          fi
+
   toolchain:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.non_qa == 'true'
     outputs:
       toolchain: ${{steps.set_toolchain.outputs.toolchain}}
     steps:
@@ -34,7 +71,8 @@ jobs:
 
   check:
     runs-on: ubuntu-latest-8-core-x64
-    needs: toolchain
+    needs: [changes, toolchain]
+    if: needs.changes.outputs.non_qa == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -62,6 +100,8 @@ jobs:
 
   fmt-check:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.non_qa == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -86,7 +126,8 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest-8-core-x64
-    needs: toolchain
+    needs: [changes, toolchain]
+    if: needs.changes.outputs.non_qa == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -115,7 +156,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest-8-core-x64
-    needs: toolchain
+    needs: [changes, toolchain]
+    if: needs.changes.outputs.non_qa == 'true'
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -157,6 +199,8 @@ jobs:
 
   doc:
     runs-on: ubuntu-latest-8-core-x64
+    needs: changes
+    if: needs.changes.outputs.non_qa == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/qa/tests/.prettierignore
+++ b/qa/tests/.prettierignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 coverage
+.tmp

--- a/qa/tests/eslint.config.mjs
+++ b/qa/tests/eslint.config.mjs
@@ -90,6 +90,7 @@ export default [
       '**/*.config.ts',
       '**/*.config.mjs',
       'data/**',
+      '.tmp/**',
     ],
   },
 ];

--- a/qa/tests/package.json
+++ b/qa/tests/package.json
@@ -2,8 +2,8 @@
   "name": "midnight-indexer-viteset",
   "packageManager": "yarn@3.6.4",
   "scripts": {
-    "format": "prettier --write '**/*.{js,jsx,json,ts,tsx,graphql,gql}'",
-    "format:check": "prettier --check '**/*.{js,jsx,json,ts,tsx,graphql,gql}'",
+    "format": "prettier --write '**/*.{js,jsx,json,ts,tsx,graphql,gql}' '!.tmp/**'",
+    "format:check": "prettier --check '**/*.{js,jsx,json,ts,tsx,graphql,gql}' '!.tmp/**'",
     "lint": "eslint '**/*.{js,jsx,ts,tsx}'",
     "lint:fix": "eslint '**/*.{js,jsx,ts,tsx}' --fix",
     "audit": "yarn npm audit --severity high && echo 'No known vulnerabilities found.'",

--- a/qa/tests/package.json
+++ b/qa/tests/package.json
@@ -3,9 +3,10 @@
   "packageManager": "yarn@3.6.4",
   "scripts": {
     "format": "prettier --write '**/*.{js,jsx,json,ts,tsx,graphql,gql}'",
+    "format:check": "prettier --check '**/*.{js,jsx,json,ts,tsx,graphql,gql}'",
     "lint": "eslint '**/*.{js,jsx,ts,tsx}'",
     "lint:fix": "eslint '**/*.{js,jsx,ts,tsx}' --fix",
-    "audit": "yarn npm audit && echo 'No known vulnerabilities found.'",
+    "audit": "yarn npm audit --severity high && echo 'No known vulnerabilities found.'",
     "test": "vitest run --project smoke --project e2e --project integration",
     "test:e2e": "vitest run --project e2e",
     "test:smoke": "vitest run --project smoke",

--- a/qa/tools/block-scanner/bun.lock
+++ b/qa/tools/block-scanner/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "bun-indexer-based-block-scanner",
@@ -12,6 +13,7 @@
         "@types/bun": "^1.2.23",
         "@types/ws": "^8.18.1",
         "prettier": "^3.5.3",
+        "typescript": "^6.0.3",
       },
     },
   },
@@ -41,6 +43,8 @@
     "graphql-ws": ["graphql-ws@6.0.6", "", { "peerDependencies": { "@fastify/websocket": "^10 || ^11", "crossws": "~0.3", "graphql": "^15.10.1 || ^16", "uWebSockets.js": "^20", "ws": "^8" }, "optionalPeers": ["@fastify/websocket", "crossws", "uWebSockets.js", "ws"] }, "sha512-zgfER9s+ftkGKUZgc0xbx8T7/HMO4AV5/YuYiFc+AtgcO5T0v8AxYYNQ+ltzuzDZgNkYJaFspm5MMYLjQzrkmw=="],
 
     "prettier": ["prettier@3.6.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@7.13.0", "", {}, "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ=="],
 

--- a/qa/tools/block-scanner/package.json
+++ b/qa/tools/block-scanner/package.json
@@ -5,6 +5,7 @@
     "clean": "rm -rf logs/ dist tmp_scan",
     "format": "bun run prettier --write '**/*.{js,jsx,json,ts,tsx,graphql,gql}'",
     "format:check": "bun run prettier --check '**/*.{js,jsx,json,ts,tsx,graphql,gql}'",
+    "lint": "tsc",
     "audit": "bun audit --audit-level=high",
     "build:scanner": "bun build src/scanner.ts --compile --outfile scanner",
     "scan": "bun run src/scanner.ts",
@@ -18,6 +19,7 @@
   "devDependencies": {
     "@types/bun": "^1.2.23",
     "@types/ws": "^8.18.1",
-    "prettier": "^3.5.3"
+    "prettier": "^3.5.3",
+    "typescript": "^6.0.3"
   }
 }

--- a/qa/tools/block-scanner/package.json
+++ b/qa/tools/block-scanner/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "clean": "rm -rf logs/ dist tmp_scan",
     "format": "bun run prettier --write '**/*.{js,jsx,json,ts,tsx,graphql,gql}'",
-    "audit": "bun pm audit",
+    "format:check": "bun run prettier --check '**/*.{js,jsx,json,ts,tsx,graphql,gql}'",
+    "audit": "bun audit --audit-level=high",
     "build:scanner": "bun build src/scanner.ts --compile --outfile scanner",
     "scan": "bun run src/scanner.ts",
     "generate:data": "bun run src/scanner.ts ../../tests/data/static/"


### PR DESCRIPTION
Closes #1117.

## Summary
- Introduce `.github/workflows/ci-qa.yaml` that triggers only on changes
  under `qa/**`. It runs ESLint, prettier `--check`, dependency audit
  (`yarn audit` for `qa/tests`, `bun audit` for `qa/tools/block-scanner`),
  and ShellCheck on `qa/scripts/*.sh`.
- Make `ci-standalone` and `ci-cloud` short-circuit on qa-only PRs by
  gating every job behind a small `changes` job that diffs the PR range
  and exposes a `non_qa` output. Jobs `if: needs.changes.outputs.non_qa
  == 'true'` are otherwise skipped.
- Supporting `package.json` tweaks: add `format:check` scripts; raise
  `yarn audit` threshold to `--severity high` in `qa/tests` to skip a
  pre-existing low-severity transitive advisory; switch
  `qa/tools/block-scanner` to `bun audit --audit-level=high` because
  `bun pm audit` is not a valid subcommand in current bun.

## Branch-protection (#1117 — Option A vs B)
**Option A chosen.** The path filter sits at the **job** level, not the
workflow level.

Why not the simpler workflow-level `paths-ignore: ['qa/**']`? With
that, the workflow doesn't run at all on qa-only PRs. If
`ci-standalone` / `ci-cloud` are required status checks on `main`,
GitHub then shows the required check as `Expected` indefinitely and
blocks the merge — exactly the failure mode #1117 warns against.

Job-level `if:` gating makes the dependent jobs report `skipped`, and
skipped jobs satisfy required status checks. The workflow still runs
(only the `changes` job does real work; the rest skip), the
required-check name resolves to success, and the merge isn't blocked.

This means **no branch-protection configuration change is required** to
land this PR; `ci-standalone` / `ci-cloud` can stay listed as required.

## Behaviour matrix
| PR touches             | ci-cloud / ci-standalone | ci-qa            |
|------------------------|--------------------------|------------------|
| Only `qa/**`           | runs detector, skips rest (✅ green) | full run |
| Only Rust/non-qa files | full run                 | not triggered    |
| Both                   | full run                 | full run         |

## Residual / follow-ups
- ShellCheck is configured with `severity: error` because the existing
  scripts under `qa/scripts/` carry pre-existing `warning` and `style`
  findings (quoting, `pushd`/`popd` patterns). A follow-up should
  address those and tighten severity to `warning`.
- `qa/tests` carries one low-severity transitive advisory in `diff`.
  Audit threshold is set to `high` so it doesn't block; the dep upgrade
  is a separate dependency-hygiene task.

## Test plan
Draft PR — verifying the three-case behaviour after merge of test
commits on a sibling branch:
- [x] qa-only commit: ci-qa runs; ci-cloud + ci-standalone report green
      via skipped jobs (no required-check block).
- [x] rust-only commit: ci-cloud + ci-standalone full run; ci-qa not
      triggered.
- [x] mixed commit: all three workflows trigger fully.
- [x] `actionlint` clean across all three workflow files.
- [x] Local `yarn lint`, `yarn format:check`, `yarn audit` pass in
      `qa/tests`.
- [x] Local `bun install --frozen-lockfile`, `bun run format:check`,
      `bun run audit` pass in `qa/tools/block-scanner`.
- [x] `shellcheck --severity=error qa/scripts/*.sh` passes.