### PR TITLE
test: path-filter probe — qa-only

### DIFF
--- a/qa/tests/README.md
+++ b/qa/tests/README.md
@@ -336,3 +336,5 @@ TARGET_ENV=preprod INDEXER_API_VERSION=v3 yarn test:integration
 - **Dynamic Data Fetching**: Use the block scraper to fetch recent block data to execute the test against (potentially) different test data every run
 
 - **Log file per test**: Right now the test execution is per test file, having log files per test will allow concurrent test execution.
+
+<!-- ci-path-filter-test: qa-only -->


### PR DESCRIPTION
Synthetic probe for PR #1129 — exercises **qa-only** row of the matrix.

**Expected**:
- `ci-qa`: full run, all green.
- `ci-cloud`: only the `changes` job runs; all other jobs skipped → workflow ✅.
- `ci-standalone`: same as ci-cloud.

Base is `feat/ci-path-filter-test-base` (matches the `feat/*` trigger) so the diff GitHub sees is only this one synthetic commit, not the workflow files themselves.

Throwaway draft — do not merge. Will be closed once the matrix is verified.