### PR TITLE
fix(indexer-api): dustGenerations subscription terminates on chain progress, not per-wallet cursor

### DIFF
--- a/indexer-api/src/domain/storage/dust_generations.rs
+++ b/indexer-api/src/domain/storage/dust_generations.rs
@@ -78,6 +78,10 @@ where
         to_block: u64,
         batch_size: NonZeroU32,
     ) -> impl Stream<Item = Result<DustNullifierTransaction, sqlx::Error>> + Send;
+
+    /// Returns the chain's current dust-generation first-free index
+    /// (`MAX(generation_index) + 1`, or `0` for an empty table).
+    async fn get_dust_generations_chain_first_free(&self) -> Result<u64, sqlx::Error>;
 }
 
 #[allow(unused_variables)]
@@ -126,5 +130,9 @@ impl DustGenerationsStorage for NoopStorage {
         batch_size: NonZeroU32,
     ) -> impl Stream<Item = Result<DustNullifierTransaction, sqlx::Error>> + Send {
         stream::empty()
+    }
+
+    async fn get_dust_generations_chain_first_free(&self) -> Result<u64, sqlx::Error> {
+        Ok(0)
     }
 }

--- a/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
@@ -210,7 +210,14 @@ where
                 });
             }
 
-            if cursor > end_index {
+            // Terminate on chain progress, not the subscriber's `cursor`,
+            // which only crosses `end_index` when the wallet owns an
+            // entry there.
+            let chain_first_free = storage
+                .get_dust_generations_chain_first_free()
+                .await
+                .map_err_into_server_error(|| "get dust generations chain first free")?;
+            if chain_first_free > end_index {
                 let final_update = make_final_collapsed_update(
                     cursor, end_index, storage, ledger_state_cache,
                 ).await?;
@@ -288,8 +295,11 @@ where
                     }
                 }
 
-                // Check if we've now reached end_index.
-                if cursor > end_index {
+                let chain_first_free = storage
+                    .get_dust_generations_chain_first_free()
+                    .await
+                    .map_err_into_server_error(|| "get dust generations chain first free")?;
+                if chain_first_free > end_index {
                     let final_update = make_final_collapsed_update(
                         cursor, end_index, storage, ledger_state_cache,
                     ).await?;

--- a/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
@@ -218,6 +218,40 @@ where
                 .await
                 .map_err_into_server_error(|| "get dust generations chain first free")?;
             if chain_first_free > end_index {
+                // Re-drain to catch entries committed in the window between
+                // the backfill drain ending and the chain-progress read.
+                let entries = storage
+                    .get_dust_generation_entries(&dust_address_bytes, cursor, end_index, batch_size)
+                    .await;
+                let mut entries = pin!(entries);
+                while let Some(entry) = entries
+                    .try_next()
+                    .await
+                    .map_err_into_server_error(|| "get next dust generation entry")?
+                {
+                    let collapsed_merkle_tree = make_collapsed_update(
+                        cursor,
+                        entry.generation_mt_index,
+                        storage,
+                        ledger_state_cache,
+                    ).await?;
+
+                    cursor = entry.generation_mt_index + 1;
+
+                    yield DustGenerationsEvent::DustGenerationsItem(DustGenerationsItem {
+                        commitment_mt_index: entry.commitment_mt_index,
+                        generation_mt_index: entry.generation_mt_index,
+                        owner: entry.owner.hex_encode(),
+                        value: entry.value.to_string(),
+                        initial_value: entry.initial_value.to_string(),
+                        backing_night: entry.backing_night.hex_encode(),
+                        ctime: entry.ctime,
+                        transaction_id: entry.transaction_id,
+                        transaction_hash: entry.transaction_hash.hex_encode(),
+                        collapsed_merkle_tree,
+                    });
+                }
+
                 let final_update = make_final_collapsed_update(
                     cursor, end_index, storage, ledger_state_cache,
                 ).await?;
@@ -300,6 +334,40 @@ where
                     .await
                     .map_err_into_server_error(|| "get dust generations chain first free")?;
                 if chain_first_free > end_index {
+                    // Re-drain to catch entries committed in the window between
+                    // the live-tail drain ending and the chain-progress read.
+                    let entries = storage
+                        .get_dust_generation_entries(&dust_address_bytes, cursor, end_index, batch_size)
+                        .await;
+                    let mut entries = pin!(entries);
+                    while let Some(entry) = entries
+                        .try_next()
+                        .await
+                        .map_err_into_server_error(|| "get next dust generation entry")?
+                    {
+                        let collapsed_merkle_tree = make_collapsed_update(
+                            cursor,
+                            entry.generation_mt_index,
+                            storage,
+                            ledger_state_cache,
+                        ).await?;
+
+                        cursor = entry.generation_mt_index + 1;
+
+                        yield DustGenerationsEvent::DustGenerationsItem(DustGenerationsItem {
+                            commitment_mt_index: entry.commitment_mt_index,
+                            generation_mt_index: entry.generation_mt_index,
+                            owner: entry.owner.hex_encode(),
+                            value: entry.value.to_string(),
+                            initial_value: entry.initial_value.to_string(),
+                            backing_night: entry.backing_night.hex_encode(),
+                            ctime: entry.ctime,
+                            transaction_id: entry.transaction_id,
+                            transaction_hash: entry.transaction_hash.hex_encode(),
+                            collapsed_merkle_tree,
+                        });
+                    }
+
                     let final_update = make_final_collapsed_update(
                         cursor, end_index, storage, ledger_state_cache,
                     ).await?;

--- a/indexer-api/src/infra/storage/dust_generations.rs
+++ b/indexer-api/src/infra/storage/dust_generations.rs
@@ -434,6 +434,18 @@ impl DustGenerationsStorage for Storage {
             }
         }
     }
+
+    #[trace]
+    async fn get_dust_generations_chain_first_free(&self) -> Result<u64, sqlx::Error> {
+        // `IS NOT NULL` skips legacy rows pre-dating the generation/commitment split.
+        let (max_index,) = sqlx::query_as::<_, (Option<i64>,)>(
+            "SELECT MAX(generation_index) FROM dust_generation_info WHERE generation_index IS NOT NULL",
+        )
+        .fetch_one(&*self.pool)
+        .await?;
+
+        Ok(max_index.map(|i| i as u64 + 1).unwrap_or(0))
+    }
 }
 
 /// Row shape returned by the dtime-updates query. The `attributes` JSONB


### PR DESCRIPTION
# Overview

The `dustGenerations` subscription used to gate termination on `cursor > end_index`, where `cursor = last_owned_entry.generation_mt_index + 1`. That meant `DustGenerationsProgress` only ever fired when the subscriber's wallet happened to own an entry at index `>= end_index`. For any other `endIndex` (above the wallet's max owned index, or below all owned entries), the subscription hung in live-tail forever waiting for entries that, given the bounded range, would never arrive.

This contradicts the schema docstring:

> "The subscription finishes after reaching the end index with a final collapsed update."

Reported by Jegor (wallet team) and reproduced on qanet-green 4.3.1 and a local `just run-*` stack.

## Fix

Mirror the termination pattern used by the two other bounded subscriptions in `indexer-api/src/infra/api/v4/subscription/` (`dust_nullifier_transactions`, `shielded_nullifier_transactions`): use the **chain's** progress as the termination signal, not the subscriber's per-address cursor.

For dust generations specifically: the chain's `dust_generations_first_free` (i.e. `MAX(generation_index) + 1` across `dust_generation_info`) tells us whether the chain has assigned an index past `end_index`. Once it has, no new entries can ever land at indices `<= end_index`, so the bounded range is exhausted for every address.

## Verification

- `cargo check -p indexer-api --features cloud` ✓
- `cargo check -p indexer-api --features standalone` ✓
- `cargo clippy -p indexer-api --features cloud -- -D warnings` ✓
- Local stack (`just run-node` / `run-chain-indexer` / `run-wallet-indexer` / `run-indexer-api`), against an owner with 5 dust generation entries at indices `5..9`:

  | scenario | `endIndex` | items | `DustGenerationsProgress`? | outcome |
  |---|---|---|---|---|
  | A: `endIndex` = wallet's max | 9 | 5 | yes | clean termination (unchanged) |
  | B: `endIndex` = max + 1 (Jegor's bug case) | 10 | 5 | **yes** | clean termination (fixed) |
  | C: `endIndex` < all owned entries | 4 | 0 | **yes** | clean termination (fixed) |

  Pre-fix, scenarios B and C hung in live-tail with no `Progress`.

- Reproduced on qanet-green 4.3.1 against an owner with 1 entry at index 20 (`endIndex=21` and `endIndex=19` both hung pre-fix).

## Notes

- The `cursor` variable is still computed and threaded through the resolver because `make_collapsed_update(cursor, entry_index, …)` and `make_final_collapsed_update(cursor, end_index, …)` need it for the merkle-tree update payload. Only the termination check moved off it.
- No GraphQL schema change. No migration. Drop-in fix.
- `dustGenerations` was the only bounded subscription in `infra/api/v4/subscription/` using per-wallet termination; the two sibling bounded subscriptions (`dust_nullifier_transactions`, `shielded_nullifier_transactions`) already use the chain-progress pattern.
