### PR TITLE
fix(indexer-api): serialise LedgerStateCache merkle-tree operations to prevent storage-core arena deadlock

### DIFF
--- a/.github/workflows/build-indexer-images.yaml
+++ b/.github/workflows/build-indexer-images.yaml
@@ -15,6 +15,15 @@ on:
         description: "Node tag to use for testing (e.g., 0.13.2-rc.1)"
         required: false
         type: string
+      profile:
+        description: "Cargo profile. `auto` keeps the default (release for v* tags, dev otherwise)."
+        required: false
+        type: choice
+        options:
+          - auto
+          - dev
+          - release
+        default: auto
 
 concurrency:
   group: build-indexer-images
@@ -94,7 +103,7 @@ jobs:
       - name: Build and push Docker Image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         env:
-          PROFILE: ${{ startsWith(github.ref, 'refs/tags/v') && 'release' || 'dev' }}
+          PROFILE: ${{ (inputs.profile != null && inputs.profile != 'auto') && inputs.profile || (startsWith(github.ref, 'refs/tags/v') && 'release' || 'dev') }}
         with:
           context: .
           file: ./${{ matrix.name }}/Dockerfile

--- a/indexer-api/src/domain/ledger_state.rs
+++ b/indexer-api/src/domain/ledger_state.rs
@@ -18,10 +18,15 @@ use indexer_common::domain::{
 };
 use log::debug;
 use thiserror::Error;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
+/// `merkle_op_lock` serialises the synchronous merkle-tree walks so
+/// concurrent walks don't deadlock on the storage-core arena locks.
 #[derive(Debug, Default)]
-pub struct LedgerStateCache(RwLock<Option<LedgerState>>);
+pub struct LedgerStateCache {
+    state: RwLock<Option<LedgerState>>,
+    merkle_op_lock: Mutex<()>,
+}
 
 impl LedgerStateCache {
     /// Create a zswap state Merkle tree collapsed update. Only load the ledger state if it is
@@ -34,7 +39,7 @@ impl LedgerStateCache {
         protocol_version: ProtocolVersion,
     ) -> Result<MerkleTreeCollapsedUpdate, LedgerStateCacheError> {
         // Acquire a read lock.
-        let mut ledger_state_read = self.0.read().await;
+        let mut ledger_state_read = self.state.read().await;
 
         // Check if the current ledger state is stale and needs to be updated.
         let first_free = ledger_state_read
@@ -44,7 +49,7 @@ impl LedgerStateCache {
         if end_index >= first_free {
             // Release the read lock and acquire a write lock.
             drop(ledger_state_read);
-            let mut ledger_state_write = self.0.write().await;
+            let mut ledger_state_write = self.state.write().await;
 
             // Check if the ledger state has been updated in the meantime.
             let first_free = ledger_state_write
@@ -70,6 +75,7 @@ impl LedgerStateCache {
 
         debug!(start_index, end_index; "creating collapsed update");
 
+        let _merkle_op_guard = self.merkle_op_lock.lock().await;
         let update = ledger_state_read
             .as_ref()
             .expect("ledger state should exist after loading")
@@ -86,7 +92,7 @@ impl LedgerStateCache {
         storage: &impl Storage,
         protocol_version: ProtocolVersion,
     ) -> Result<MerkleTreeCollapsedUpdate, LedgerStateCacheError> {
-        let mut ledger_state_read = self.0.read().await;
+        let mut ledger_state_read = self.state.read().await;
 
         let first_free = ledger_state_read
             .as_ref()
@@ -94,7 +100,7 @@ impl LedgerStateCache {
             .unwrap_or_default();
         if end_index >= first_free {
             drop(ledger_state_read);
-            let mut ledger_state_write = self.0.write().await;
+            let mut ledger_state_write = self.state.write().await;
 
             let first_free = ledger_state_write
                 .as_ref()
@@ -119,6 +125,7 @@ impl LedgerStateCache {
 
         debug!(start_index, end_index; "creating dust generations collapsed update");
 
+        let _merkle_op_guard = self.merkle_op_lock.lock().await;
         let collapsed_update = ledger_state_read
             .as_ref()
             .expect("ledger state should exist after loading")
@@ -135,7 +142,7 @@ impl LedgerStateCache {
         storage: &impl Storage,
         protocol_version: ProtocolVersion,
     ) -> Result<MerkleTreeCollapsedUpdate, LedgerStateCacheError> {
-        let mut ledger_state_read = self.0.read().await;
+        let mut ledger_state_read = self.state.read().await;
 
         let first_free = ledger_state_read
             .as_ref()
@@ -143,7 +150,7 @@ impl LedgerStateCache {
             .unwrap_or_default();
         if end_index >= first_free {
             drop(ledger_state_read);
-            let mut ledger_state_write = self.0.write().await;
+            let mut ledger_state_write = self.state.write().await;
 
             let first_free = ledger_state_write
                 .as_ref()
@@ -168,6 +175,7 @@ impl LedgerStateCache {
 
         debug!(start_index, end_index; "creating dust commitments collapsed update");
 
+        let _merkle_op_guard = self.merkle_op_lock.lock().await;
         let collapsed_update = ledger_state_read
             .as_ref()
             .expect("ledger state should exist after loading")
@@ -181,11 +189,11 @@ impl LedgerStateCache {
         &self,
         storage: &impl Storage,
     ) -> Result<DustMerkleTreeRoots, LedgerStateCacheError> {
-        let mut ledger_state_read = self.0.read().await;
+        let mut ledger_state_read = self.state.read().await;
 
         if ledger_state_read.is_none() {
             drop(ledger_state_read);
-            let mut ledger_state_write = self.0.write().await;
+            let mut ledger_state_write = self.state.write().await;
 
             if ledger_state_write.is_none() {
                 let Some((protocol_version, ledger_state_key)) =
@@ -205,6 +213,8 @@ impl LedgerStateCache {
         let ledger_state = ledger_state_read
             .as_ref()
             .expect("ledger state should exist after loading");
+
+        let _merkle_op_guard = self.merkle_op_lock.lock().await;
         let commitment_root = ledger_state.dust_commitment_merkle_tree_root()?;
         let generation_root = ledger_state.dust_generation_merkle_tree_root()?;
 


### PR DESCRIPTION
# Overview
Adds a `tokio::sync::Mutex` to `LedgerStateCache` to serialise the synchronous merkle-tree operations (`make_zswap_collapsed_update`, `dust_generations_collapsed_update`, `dust_commitments_collapsed_update`, `dust_merkle_tree_roots`). Concurrent calls into these from the same cache can deadlock the tokio runtime by triggering a `parking_lot::ReentrantMutex` cycle inside `storage-core::arena::Sp::force_as_arc`.

Observed on qanet-green twice (13 + 14 May 2026): both indexer-api pods went `0/1 NotReady` within minutes of each other, pool fully saturated and frozen idle for hours, last log was `creating dust generations / dust commitments collapsed update start_index=0` followed by silence. Yesterday's manual restart bought ~17h of runway before the same bug fired again today.

## Root cause

`LedgerStateCache` holds the `LedgerState` under a `tokio::sync::RwLock`. The synchronous merkle walks run under the read lock, so multiple readers can be inside them concurrently. The walks descend via `Sp::deref` (`storage-core`), which acquires global `parking_lot::ReentrantMutex` locks (`metadata` / `sp_cache` / `backend`) for cold or lazy-loaded nodes. Concurrent readers form a lock cycle that parks all tokio worker threads.

The existing storage-core regression test (`force_as_arc_lock_ordering_regression`) covers one ABBA but not the one we're hitting (likely reachable through `BackendLoader::get`).

## Fix

Per-instance `Mutex<()>` acquired before each synchronous merkle call:

```rust
let _merkle_op_guard = self.merkle_op_lock.lock().await;
let update = ledger_state_read.as_ref().expect(…).make_zswap_collapsed_update(…)?;
```

Held only for the synchronous computation, not for the cache-staleness check or reload path. Per-pod serialisation removes the trigger condition. Applied to all four merkle call sites. Throughput cost is negligible (calls are CPU-cheap once the cache is warm).

## Notes

Indexer-side mitigation. A ledger-side audit of `storage-core::Sp::force_as_arc` for the sibling ABBA pattern is recommended as a parallel workstream (Thomas / Andrzej / Alex).