### PR TITLE
feat(indexer-api): add /live HTTP endpoint for kubernetes liveness probe

### DIFF
--- a/.github/workflows/build-indexer-images.yaml
+++ b/.github/workflows/build-indexer-images.yaml
@@ -15,15 +15,6 @@ on:
         description: "Node tag to use for testing (e.g., 0.13.2-rc.1)"
         required: false
         type: string
-      profile:
-        description: "Cargo profile. `auto` keeps the default (release for v* tags, dev otherwise)."
-        required: false
-        type: choice
-        options:
-          - auto
-          - dev
-          - release
-        default: auto
 
 concurrency:
   group: build-indexer-images
@@ -103,7 +94,7 @@ jobs:
       - name: Build and push Docker Image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         env:
-          PROFILE: ${{ (inputs.profile != null && inputs.profile != 'auto') && inputs.profile || (startsWith(github.ref, 'refs/tags/v') && 'release' || 'dev') }}
+          PROFILE: ${{ startsWith(github.ref, 'refs/tags/v') && 'release' || 'dev' }}
         with:
           context: .
           file: ./${{ matrix.name }}/Dockerfile

--- a/.github/workflows/build-indexer-images.yaml
+++ b/.github/workflows/build-indexer-images.yaml
@@ -15,6 +15,15 @@ on:
         description: "Node tag to use for testing (e.g., 0.13.2-rc.1)"
         required: false
         type: string
+      profile:
+        description: "Cargo profile. `auto` keeps the default (release for v* tags, dev otherwise)."
+        required: false
+        type: choice
+        options:
+          - auto
+          - dev
+          - release
+        default: auto
 
 concurrency:
   group: build-indexer-images
@@ -94,7 +103,7 @@ jobs:
       - name: Build and push Docker Image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         env:
-          PROFILE: ${{ startsWith(github.ref, 'refs/tags/v') && 'release' || 'dev' }}
+          PROFILE: ${{ (inputs.profile != null && inputs.profile != 'auto') && inputs.profile || (startsWith(github.ref, 'refs/tags/v') && 'release' || 'dev') }}
         with:
           context: .
           file: ./${{ matrix.name }}/Dockerfile

--- a/indexer-api/src/infra/api.rs
+++ b/indexer-api/src/infra/api.rs
@@ -264,9 +264,6 @@ where
     Router::new()
         .route("/live", get(live))
         .route("/ready", get(ready))
-        // TEMPORARY: end-to-end probe-loop validation only. Revert with the trigger commit after
-        // qanet validation.
-        .route("/trigger-live-failure", get(trigger_live_failure))
         .nest("/api/v3", v4_app.clone()) // v3 is an alias to v4 for backwards compatibility.
         .nest("/api/v4", v4_app)
         .route("/api/{*rest}", any(redirect_api_to_latest))
@@ -280,28 +277,11 @@ where
         .layer(CorsLayer::permissive())
 }
 
-// TEMPORARY (revert after qanet probe-loop validation): backing flag and trigger
-// handler for `/trigger-live-failure`. Not feature-gated, so any caller who knows
-// the URL can hang a pod's `/live` handler and force a restart.
-static LIVE_FAILURE_TRIGGERED: AtomicBool = AtomicBool::new(false);
-
 // Returns 200 when reachable. If the runtime is parked (e.g. storage-core deadlock during
 // `creating dust generations collapsed update`), this handler does not run; kubelet's
 // liveness probe times out and the pod is terminated and recreated.
 async fn live() -> impl IntoResponse {
-    // TEMPORARY: remove together with the trigger handler below.
-    // Hang indefinitely instead of returning 503 so kubelet sees a probe timeout,
-    // mimicking the real parked-runtime case rather than a clean status response.
-    if LIVE_FAILURE_TRIGGERED.load(Ordering::Acquire) {
-        std::future::pending::<()>().await;
-    }
     StatusCode::OK.into_response()
-}
-
-// TEMPORARY: see note on LIVE_FAILURE_TRIGGERED above.
-async fn trigger_live_failure() -> impl IntoResponse {
-    LIVE_FAILURE_TRIGGERED.store(true, Ordering::Release);
-    StatusCode::OK
 }
 
 async fn ready(State(caught_up): State<Arc<AtomicBool>>) -> impl IntoResponse {

--- a/indexer-api/src/infra/api.rs
+++ b/indexer-api/src/infra/api.rs
@@ -264,6 +264,8 @@ where
     Router::new()
         .route("/live", get(live))
         .route("/ready", get(ready))
+        // TEMPORARY: end-to-end probe-loop validation only. Revert with the trigger commit after qanet validation.
+        .route("/trigger-live-failure", get(trigger_live_failure))
         .nest("/api/v3", v4_app.clone()) // v3 is an alias to v4 for backwards compatibility.
         .nest("/api/v4", v4_app)
         .route("/api/{*rest}", any(redirect_api_to_latest))
@@ -277,11 +279,28 @@ where
         .layer(CorsLayer::permissive())
 }
 
+// TEMPORARY (revert after qanet probe-loop validation): backing flag and trigger
+// handler for `/trigger-live-failure`. Not feature-gated, so any caller who knows
+// the URL can hang a pod's `/live` handler and force a restart.
+static LIVE_FAILURE_TRIGGERED: AtomicBool = AtomicBool::new(false);
+
 // Returns 200 when reachable. If the runtime is parked (e.g. storage-core deadlock during
 // `creating dust generations collapsed update`), this handler does not run; kubelet's
 // liveness probe times out and the pod is terminated and recreated.
 async fn live() -> impl IntoResponse {
+    // TEMPORARY: remove together with the trigger handler below.
+    // Hang indefinitely instead of returning 503 so kubelet sees a probe timeout,
+    // mimicking the real parked-runtime case rather than a clean status response.
+    if LIVE_FAILURE_TRIGGERED.load(Ordering::Acquire) {
+        std::future::pending::<()>().await;
+    }
     StatusCode::OK.into_response()
+}
+
+// TEMPORARY: see note on LIVE_FAILURE_TRIGGERED above.
+async fn trigger_live_failure() -> impl IntoResponse {
+    LIVE_FAILURE_TRIGGERED.store(true, Ordering::Release);
+    StatusCode::OK
 }
 
 async fn ready(State(caught_up): State<Arc<AtomicBool>>) -> impl IntoResponse {

--- a/indexer-api/src/infra/api.rs
+++ b/indexer-api/src/infra/api.rs
@@ -262,6 +262,7 @@ where
     // For some reason the FastraceLayer and RequestBodyLimitLayer cannot be put into a
     // ServiceBuilder together, so we use `Router::layer` with the inverted (bottom to top) order.
     Router::new()
+        .route("/live", get(live))
         .route("/ready", get(ready))
         .nest("/api/v3", v4_app.clone()) // v3 is an alias to v4 for backwards compatibility.
         .nest("/api/v4", v4_app)
@@ -274,6 +275,13 @@ where
                 .and_then(transform_lentgh_limit_exceeded),
         )
         .layer(CorsLayer::permissive())
+}
+
+// Returns 200 when reachable. If the runtime is parked (e.g. storage-core deadlock during
+// `creating dust generations collapsed update`), this handler does not run; kubelet's
+// liveness probe times out and the pod is terminated and recreated.
+async fn live() -> impl IntoResponse {
+    StatusCode::OK.into_response()
 }
 
 async fn ready(State(caught_up): State<Arc<AtomicBool>>) -> impl IntoResponse {

--- a/indexer-api/src/infra/api.rs
+++ b/indexer-api/src/infra/api.rs
@@ -264,7 +264,8 @@ where
     Router::new()
         .route("/live", get(live))
         .route("/ready", get(ready))
-        // TEMPORARY: end-to-end probe-loop validation only. Revert with the trigger commit after qanet validation.
+        // TEMPORARY: end-to-end probe-loop validation only. Revert with the trigger commit after
+        // qanet validation.
         .route("/trigger-live-failure", get(trigger_live_failure))
         .nest("/api/v3", v4_app.clone()) // v3 is an alias to v4 for backwards compatibility.
         .nest("/api/v4", v4_app)


### PR DESCRIPTION
## Overview

Adds `/live` to indexer-api, returning `200 OK` when the tokio runtime can schedule the handler. Companion shielded-charts PR will switch the indexer-api liveness probe from `cat /var/run/indexer-api/running` (file existence) to `httpGet /live`. When the runtime parks (e.g. the `storage-core::Sp::force_as_arc` deadlock reproduced on qanet-green 13/14 May), the handler does not run, kubelet's probe times out, and the pod is restarted within ~30s. Multi-replica absorbs traffic during the recovery.

## Why a separate `/live`, not reusing `/ready`

`/ready` already times out under a parked runtime, so it could in principle detect the deadlock too. We don't reuse it because `/ready` *also* returns 503 in legitimate catchup states (cold start, NATS blip, chain-indexer restart, brief network partition), where the runtime is healthy and self-recoverable. K8s deliberately separates readiness and liveness:

- **Readiness fail** → pod removed from Service Endpoints, traffic routed away, pod keeps running.
- **Liveness fail** → container killed and restarted by kubelet.

Conflating the two reintroduces the worst failure mode: a cluster-wide cold-start (e.g., after a NATS outage) would have all indexer-api pods returning `/ready` 503 simultaneously, kubelet would kill all of them, restart loop ensues, catchup never completes, service fully down.

`/live` answers a different question (does the runtime schedule a handler?) and only fails when the pod is structurally broken, which is exactly the signal kubelet's liveness probe is meant for.

| state | `/ready` | `/live` |
|---|---|---|
| Healthy, caught up | 200 | 200 |
| Healthy, not caught up (cold start, NATS blip, chain-indexer restart) | **503** | 200 |
| Runtime parked (deadlock) | timeout | timeout |

## Detection mechanism

The detection signal is **probe timeout, not a 503 status**. A parked runtime cannot schedule the `/live` handler, so kubelet sees no response within `timeoutSeconds`, which counts as a failure.

~~Commit `af930510` (temporary) adds `GET /trigger-live-failure`, which flips a process-local `AtomicBool` so subsequent `/live` calls hang via `std::future::pending().await`. This lets us validate the kubelet → restart loop end-to-end without inducing a real deadlock; the hang mimics the parked-runtime case faithfully (probe timeout from kubelet's view) rather than returning a clean 503.~~

~~**The trigger commit must be reverted before propagating the chart change beyond qanet** (`git revert ffe44b24 af930510 --no-edit`, or squash `ffe44b24` into `af930510` first and revert the single commit); the endpoint is not feature-gated and any caller who knows the URL can hang a pod's `/live` and force a restart.~~

The trigger handler used for qanet validation has been reverted in `b3f4e7c0`. The test image `4.3.1-ffe44b24` (built before the revert) still contains `/trigger-live-failure` and is what's deployed to qanet-green for end-to-end probe-loop validation; once validation completes, the merged result on main is the clean `/live`-only diff with no trigger code.

## Also includes (in `ad31ec56`)

A `profile` workflow_dispatch input on the `build-indexer-images` CI workflow, so branch builds can request the `release` profile to avoid the recursion stack limit `dev` builds hit.

## Verification
- Will deploy the `4.3.1-ffe44b24` `release`-profile image to qanet-green, exercise `/trigger-live-failure` (present in the deployed image only), and confirm the pod is restarted within ~30s.

## Notes

This is mitigation, not root-cause closure. Storage-core lock-ordering audit on `Sp::force_as_arc` (reachable via `BackendLoader::get`) is owed by ledger team. The existing `force_as_arc_lock_ordering_regression` test catches one ABBA pattern but not the one being hit on qanet.

## Links

- Companion shielded-charts probe-config change: https://github.com/shieldedtech/shielded-charts/pull/169
- Closed PR #1144 (mutex approach, falsified on qanet-green): https://github.com/midnightntwrk/midnight-indexer/pull/1144