### PR TITLE
chore(release): prepare for 4.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.2] - 2026-05-15
+
+### 🚀 Features
+
+- *(indexer-api)* Add /live HTTP endpoint for kubernetes liveness probe (#1145)
+
+### 🐛 Bug Fixes
+
+- *(indexer-api)* DustGenerations subscription terminates on chain progress, not per-wallet cursor (#1137)
+
+### 📚 Documentation
+
+- *(indexer-standalone)* Document mandatory APP__INFRA__SPO_NODE__BLOCKFROST_ID (#1149)
+
 ## [4.3.1] - 2026-05-11
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "chain-indexer"
-version = "4.3.1"
+version = "4.3.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-api"
-version = "4.3.1"
+version = "4.3.2"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-standalone"
-version = "4.3.1"
+version = "4.3.2"
 dependencies = [
  "anyhow",
  "byte-unit-serde",
@@ -3276,7 +3276,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-tests"
-version = "4.3.1"
+version = "4.3.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -6784,7 +6784,7 @@ dependencies = [
 
 [[package]]
 name = "spo-indexer"
-version = "4.3.1"
+version = "4.3.2"
 dependencies = [
  "anyhow",
  "blake2",
@@ -8279,7 +8279,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-indexer"
-version = "4.3.1"
+version = "4.3.2"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version       = "4.3.1"
+version       = "4.3.2"
 edition       = "2024"
 license       = "Apache-2.0"
 readme        = "README.md"


### PR DESCRIPTION
## Summary
Prepare 4.3.2 release. Workspace version bump 4.3.1 → 4.3.2, CHANGELOG entry, Cargo.lock refresh.