### PR TITLE
fix(indexer-api): deliver DustGenerationDtimeUpdate items on fresh dustGenerations subscriptions

### DIFF
--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -1158,10 +1158,9 @@ type Subscription {
 	"""
 	contractActions(address: HexEncoded!, offset: BlockOffset): ContractAction!
 	"""
-	Subscribe to dust generation entries for a dust address within an index range.
-	Entries are interleaved with collapsed Merkle tree updates and
-	`DustGenerationDtimeUpdateItem` events for entries the subscriber owns.
-	The subscription finishes after reaching the end index with a final collapsed update.
+	Subscribe to dust generation entries for a dust address in `[start_index, end_index]`
+	inclusive. `dustGenerationEndIndex` is exclusive, pass `dustGenerationEndIndex - 1`.
+	Entries interleaved with collapsed Merkle tree updates and owned-entry dtime updates.
 	"""
 	dustGenerations(dustAddress: DustAddress!, startIndex: Int!, endIndex: Int!): DustGenerationsEvent! @beta
 	"""

--- a/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
@@ -118,10 +118,9 @@ where
     S: Storage,
     B: Subscriber,
 {
-    /// Subscribe to dust generation entries for a dust address within an index range.
-    /// Entries are interleaved with collapsed Merkle tree updates and
-    /// `DustGenerationDtimeUpdateItem` events for entries the subscriber owns.
-    /// The subscription finishes after reaching the end index with a final collapsed update.
+    /// Subscribe to dust generation entries for a dust address in `[start_index, end_index]`
+    /// inclusive. `dustGenerationEndIndex` is exclusive, pass `dustGenerationEndIndex - 1`.
+    /// Entries interleaved with collapsed Merkle tree updates and owned-entry dtime updates.
     #[graphql(directive = beta::apply())]
     async fn dust_generations<'a>(
         &self,
@@ -150,40 +149,39 @@ where
                 .map_err_into_client_error(|| "invalid bech32m dust address")?;
             let mut cursor = start_index;
 
-            // Derive the dtime cutoff from the wallet's most recent owned
-            // entry below `start_index`. `None` for fresh subscriptions; we
-            // skip historical dtime backfill in that case.
+            // Fall back to 0 (= replay all dtime updates for this address) when
+            // the wallet has no entry below `start_index`. The dtime SQL filters
+            // by owner and per-stream event-id cursor, so cutoff = 0 is safe.
             let dtime_cutoff_block_id = storage
                 .get_dust_generation_dtime_cutoff_block_id(&dust_address_bytes, start_index)
                 .await
-                .map_err_into_server_error(|| "get dtime cutoff block id")?;
+                .map_err_into_server_error(|| "get dtime cutoff block id")?
+                .unwrap_or(0);
 
             // Single dtime cursor across initial backfill and live tail. It
             // advances past every emitted DustGenerationDtimeUpdateItem so
             // subsequent block-driven polls don't re-emit.
             let mut dtime_after_event_id = 0u64;
 
-            if let Some(cutoff) = dtime_cutoff_block_id {
-                debug!(cutoff; "replaying dtime updates after cutoff");
-                let updates = storage
-                    .get_dust_generation_dtime_updates(
-                        &dust_address_bytes,
-                        cutoff,
-                        dtime_after_event_id,
-                        batch_size,
-                    )
-                    .await;
-                let mut updates = pin!(updates);
-                while let Some(update) = updates
-                    .try_next()
-                    .await
-                    .map_err_into_server_error(|| "get next dtime update")?
-                {
-                    dtime_after_event_id = update.ledger_event_id;
-                    yield DustGenerationsEvent::DustGenerationDtimeUpdateItem(
-                        dtime_update_item(update),
-                    );
-                }
+            debug!(cutoff = dtime_cutoff_block_id; "replaying dtime updates after cutoff");
+            let updates = storage
+                .get_dust_generation_dtime_updates(
+                    &dust_address_bytes,
+                    dtime_cutoff_block_id,
+                    dtime_after_event_id,
+                    batch_size,
+                )
+                .await;
+            let mut updates = pin!(updates);
+            while let Some(update) = updates
+                .try_next()
+                .await
+                .map_err_into_server_error(|| "get next dtime update")?
+            {
+                dtime_after_event_id = update.ledger_event_id;
+                yield DustGenerationsEvent::DustGenerationDtimeUpdateItem(
+                    dtime_update_item(update),
+                );
             }
 
             debug!(start_index, end_index; "streaming existing dust generation entries");
@@ -317,26 +315,24 @@ where
                 // Drain any new dtime updates for entries the subscriber
                 // owns. Reuses the same cutoff (initial entry-block anchor)
                 // and the running event cursor so we don't re-emit.
-                if let Some(cutoff) = dtime_cutoff_block_id {
-                    let updates = storage
-                        .get_dust_generation_dtime_updates(
-                            &dust_address_bytes,
-                            cutoff,
-                            dtime_after_event_id,
-                            batch_size,
-                        )
-                        .await;
-                    let mut updates = pin!(updates);
-                    while let Some(update) = updates
-                        .try_next()
-                        .await
-                        .map_err_into_server_error(|| "get next dtime update")?
-                    {
-                        dtime_after_event_id = update.ledger_event_id;
-                        yield DustGenerationsEvent::DustGenerationDtimeUpdateItem(
-                            dtime_update_item(update),
-                        );
-                    }
+                let updates = storage
+                    .get_dust_generation_dtime_updates(
+                        &dust_address_bytes,
+                        dtime_cutoff_block_id,
+                        dtime_after_event_id,
+                        batch_size,
+                    )
+                    .await;
+                let mut updates = pin!(updates);
+                while let Some(update) = updates
+                    .try_next()
+                    .await
+                    .map_err_into_server_error(|| "get next dtime update")?
+                {
+                    dtime_after_event_id = update.ledger_event_id;
+                    yield DustGenerationsEvent::DustGenerationDtimeUpdateItem(
+                        dtime_update_item(update),
+                    );
                 }
 
                 let chain_first_free = storage


### PR DESCRIPTION
## Summary

The dtime drain at both call sites in `indexer-api/src/infra/api/v4/subscription/dust_generations.rs` (post-backfill and live-tail) was gated on `dtime_cutoff_block_id.is_some()`. The cutoff returns `None` for fresh subscriptions (`start_index <= min(owned generation_index)`, most commonly `start_index = 0`), so wallets that begin syncing after their NIGHT has been spent never saw the dtime updates that mark generation as stopped.

The cutoff-based design from #1078 assumed fresh subscriptions don't need historical dtime replay, which holds for wallets that sync from genesis forward but not for the projection-based wallet sync flow being integrated (NIGHT received at block 0, spent at block 5, wallet's first `dustGenerations` subscription at block N > 5).

## Fix

`unwrap_or(0)` the cutoff and run the dtime drain unconditionally at both call sites. The dtime SQL already filters by owner and a per-stream event-id cursor (`le.id > $after_event_id`), so `cutoff = 0` returns all the wallet's dtime updates safely with no re-emit risk. The block-based cutoff still applies for resumption flows where the wallet has prior entries below `start_index`.

## What changes

- `indexer-api/src/infra/api/v4/subscription/dust_generations.rs`: drop the `if let Some(cutoff)` guards at both call sites; `unwrap_or(0)` at the cutoff query result.
- Docstring clarifies `[start_index, end_index]` is inclusive and that `RegularTransaction.dustGenerationEndIndex` is exclusive (wallets pass `dustGenerationEndIndex - 1`).
- `indexer-api/graphql/schema-v4.graphql` regenerated.

## Verification

- `cargo check / clippy -D warnings / fmt-check / nextest` all green across cloud + standalone.
- Manual end-to-end against local stack, wallet with owned indices `[0,1,2,3,4,85,86]`, `startIndex=0, endIndex=86`:
  - Before: 7 items, **0** dtime updates, Progress.
  - After: 7 items, **2** dtime updates (indices 3 and 85, matching the NIGHT spend events in `ledger_events`), Progress.

## Backwards compatibility

Additive, no schema or migration change. Wallets that previously got 0 dtime items for fresh subscriptions now receive the dtime updates the indexer already has.

## Related

- Reported by @JegorSidorenko in `#topic-indexer` (18 May) during projection-based wallet sync integration.
- Closes #1167.
- Design context: #1078 / PR #1080 added `DustGenerationDtimeUpdateItem` to the union with the cutoff-based replay design.