### PR TITLE
chore(ci): disable Docker Hub publish, GHCR-only

### DIFF
--- a/.github/workflows/build-indexer-images.yaml
+++ b/.github/workflows/build-indexer-images.yaml
@@ -53,11 +53,15 @@ jobs:
           version=$(grep '^version.*=' Cargo.toml | sed -E 's/version.*=.*"(.*)"/\1/')
           echo "VERSION=$version" | tee -a "$GITHUB_ENV"
 
-      - name: Login to DockerHub
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          username: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_USER }}
-          password: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_TOKEN }}
+      # Docker Hub publish disabled 2026-05-19: org access token is dead and
+      # the account may be tied to a decommissioned IOHK email. Mirrors Giles's
+      # removal in midnight-node PR #1538. Restore once SRE resolves the
+      # org-account/token situation.
+      # - name: Login to DockerHub
+      #   uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_USER }}
+      #     password: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_TOKEN }}
 
       - name: Login to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -74,7 +78,9 @@ jobs:
         with:
           images: |
             ghcr.io/midnight-ntwrk/${{ matrix.name }}
-            ${{ github.ref_type == 'tag' && format('midnightntwrk/{0}', matrix.name) || '' }}
+            # Docker Hub publish disabled 2026-05-19, restore line below once
+            # SRE resolves the org account/token situation:
+            # ${{ github.ref_type == 'tag' && format('midnightntwrk/{0}', matrix.name) || '' }}
           tags: |
             type=semver,pattern={{version}}
             ${{ github.ref_type != 'tag' && format('type=sha,prefix={0}-,format=short', env.VERSION) || '' }}


### PR DESCRIPTION
Mirrors Giles's midnight-node PR https://github.com/midnightntwrk/midnight-node/pull/1538. Docker Hub org access token is dead; commented out (not removed) the DockerHub login step and the metadata-action Docker Hub image line in `build-indexer-images.yaml`, so restore is one revert when SRE resolves.

GHCR publish unchanged at `ghcr.io/midnight-ntwrk/{chain-indexer,indexer-api,wallet-indexer,indexer-standalone,spo-indexer}`. README swap (`hub.docker.com/r/midnightntwrk/...` → `ghcr.io/midnight-ntwrk/...`) deferred until SRE confirms direction.
