### PR TITLE
[showcase] Validate pr1094 against tests

### DIFF
--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -1092,11 +1092,9 @@ mod tests {
                 .display()
                 .to_string();
 
-            let pool = SqlitePool::new(pool::sqlite::Config {
-                cnn_url: sqlite_file,
-            })
-            .await
-            .context("create pool")?;
+            let pool = SqlitePool::new(pool::sqlite::Config::with_url(sqlite_file))
+                .await
+                .context("create pool")?;
             migrations::sqlite::run(&pool)
                 .await
                 .context("run migrations")?;

--- a/indexer-common/src/domain/ledger/transaction.rs
+++ b/indexer-common/src/domain/ledger/transaction.rs
@@ -309,11 +309,9 @@ mod tests {
                 .display()
                 .to_string();
 
-            let pool = SqlitePool::new(pool::sqlite::Config {
-                cnn_url: sqlite_file,
-            })
-            .await
-            .context("create pool")?;
+            let pool = SqlitePool::new(pool::sqlite::Config::with_url(sqlite_file))
+                .await
+                .context("create pool")?;
             migrations::sqlite::run(&pool)
                 .await
                 .context("run migrations")?;

--- a/indexer-common/src/infra/ledger_db.rs
+++ b/indexer-common/src/infra/ledger_db.rs
@@ -36,7 +36,7 @@ pub async fn init(config: Config) -> Result<(), Error> {
         cnn_url,
     } = config;
 
-    let pool = sqlite::SqlitePool::new(sqlite::Config { cnn_url }).await?;
+    let pool = sqlite::SqlitePool::new(sqlite::Config::with_url(cnn_url)).await?;
     migrations::sqlite::run_for_ledger_db(&pool).await?;
 
     let db = v1_1::LedgerDb::new(pool);

--- a/indexer-common/src/infra/ledger_db.rs
+++ b/indexer-common/src/infra/ledger_db.rs
@@ -36,7 +36,16 @@ pub async fn init(config: Config) -> Result<(), Error> {
         cnn_url,
     } = config;
 
-    let pool = sqlite::SqlitePool::new(sqlite::Config::with_url(cnn_url)).await?;
+    // storage-core assumes a single writer: `flush_*` reads root counts and
+    // then writes new ones, and that read-then-write must observe its own
+    // in-progress state. With max_connections > 1, sqlx can route the read to
+    // a different connection whose WAL snapshot predates the writer, breaking
+    // the invariant and producing "roots counts can't be negative" panics.
+    let pool = sqlite::SqlitePool::new(sqlite::Config {
+        cnn_url,
+        max_connections: 1,
+    })
+    .await?;
     migrations::sqlite::run_for_ledger_db(&pool).await?;
 
     let db = v1_1::LedgerDb::new(pool);

--- a/indexer-common/src/infra/pool/sqlite.rs
+++ b/indexer-common/src/infra/pool/sqlite.rs
@@ -14,8 +14,11 @@
 use derive_more::Into;
 use log::debug;
 use serde::Deserialize;
-use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
-use std::ops::Deref;
+use sqlx::{
+    Sqlite, Transaction,
+    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous},
+};
+use std::{ops::Deref, time::Duration};
 use thiserror::Error;
 
 /// New type for `sqlx::SqlitePool`, allowing for some custom extensions as well as security.
@@ -28,16 +31,33 @@ pub struct SqlitePool(sqlx::SqlitePool);
 impl SqlitePool {
     /// Try to create a new [SqlitePool] with the given config.
     pub async fn new(config: Config) -> Result<Self, Error> {
+        let max_connections = config.max_connections;
         let connect_options =
             SqliteConnectOptions::try_from(config).map_err(Error::ConvertConfig)?;
         let inner = SqlitePoolOptions::new()
-            .max_connections(1)
+            .max_connections(max_connections)
             .connect_with(connect_options)
             .await?;
         let pool = SqlitePool(inner);
         debug!(pool:?; "created pool");
 
         Ok(pool)
+    }
+
+    /// Begin a transaction with `BEGIN IMMEDIATE` semantics, claiming the
+    /// writer lock up front.
+    ///
+    /// SQLite's default `BEGIN DEFERRED` transaction stays a reader until its
+    /// first write statement. When multiple connections run in WAL mode, a
+    /// deferred reader that later tries to upgrade to a writer (while another
+    /// connection has committed in between) gets `SQLITE_BUSY_SNAPSHOT` (517),
+    /// which is not retryable via `busy_timeout`. Every caller in this
+    /// codebase that starts a transaction does so to write, so taking the
+    /// write lock immediately is both correct and avoids the race. Shadowing
+    /// `sqlx::Pool::begin` via inherent method makes the existing
+    /// `self.pool.begin()` call sites pick up the new behavior transparently.
+    pub async fn begin(&self) -> Result<Transaction<'static, Sqlite>, sqlx::Error> {
+        self.0.begin_with("BEGIN IMMEDIATE").await
     }
 }
 
@@ -63,14 +83,45 @@ pub enum Error {
 #[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     pub cnn_url: String,
+
+    #[serde(default = "default_max_connections")]
+    pub max_connections: u32,
+}
+
+impl Config {
+    /// Build a [Config] for the given connection URL using defaults for the
+    /// remaining fields.
+    pub fn with_url(cnn_url: impl Into<String>) -> Self {
+        Self {
+            cnn_url: cnn_url.into(),
+            ..Default::default()
+        }
+    }
+}
+
+fn default_max_connections() -> u32 {
+    8
 }
 
 impl TryFrom<Config> for SqliteConnectOptions {
     type Error = sqlx::Error;
 
     fn try_from(config: Config) -> Result<Self, Self::Error> {
-        let mut options = config.cnn_url.parse::<SqliteConnectOptions>()?;
-        options = options.create_if_missing(true);
+        // WAL lets readers run concurrent with a single writer; without it the
+        // default `DELETE` journal mode serializes all access on a single file.
+        // `busy_timeout` lets SQLite itself retry on lock contention instead of
+        // immediately returning `SQLITE_BUSY`. It needs to cover the worst-case
+        // writer hold time: on mainnet, chain-indexer's per-block write
+        // transaction (many inserts across several tables) can exceed a few
+        // seconds, so a short timeout causes concurrent writes (e.g. an API
+        // `disconnect_wallet` UPDATE) to spuriously fail.
+        let options = config
+            .cnn_url
+            .parse::<SqliteConnectOptions>()?
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .synchronous(SqliteSynchronous::Normal)
+            .busy_timeout(Duration::from_secs(30));
         Ok(options)
     }
 }
@@ -79,6 +130,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             cnn_url: "sqlite::memory:".to_string(),
+            max_connections: default_max_connections(),
         }
     }
 }
@@ -100,10 +152,7 @@ mod tests {
         }
         assert!(!Path::new(db_path).exists());
 
-        let pool = SqlitePool::new(Config {
-            cnn_url: format!("sqlite://{db_path}"),
-        })
-        .await;
+        let pool = SqlitePool::new(Config::with_url(format!("sqlite://{db_path}"))).await;
 
         assert!(pool.is_ok());
         assert!(Path::new(db_path).exists());

--- a/indexer-common/src/infra/pool/sqlite.rs
+++ b/indexer-common/src/infra/pool/sqlite.rs
@@ -136,6 +136,186 @@ impl Default for Config {
 }
 
 #[cfg(test)]
+mod pool_concurrency {
+    use crate::infra::pool::sqlite::{Config, SqlitePool};
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicU64, Ordering},
+        },
+        time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+    };
+    use tokio::sync::Notify;
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    async fn fresh_pool() -> SqlitePool {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "indexer_pool_test_{}_{}_{}.sqlite",
+            std::process::id(),
+            nanos,
+            seq
+        ));
+        let url = format!("sqlite://{}", path.display());
+        SqlitePool::new(Config { cnn_url: url })
+            .await
+            .expect("create pool")
+    }
+
+    async fn create_t(pool: &SqlitePool) {
+        sqlx::query("CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, v INTEGER NOT NULL)")
+            .execute(&**pool)
+            .await
+            .expect("create table");
+    }
+
+    /// A SELECT issued while a writer holds an in-progress transaction returns
+    /// promptly rather than queueing behind the writer's commit.
+    #[tokio::test]
+    async fn reader_runs_concurrent_with_in_progress_writer() {
+        let pool = fresh_pool().await;
+        create_t(&pool).await;
+
+        let writer_acquired = Arc::new(Notify::new());
+        let writer_acquired_inner = writer_acquired.clone();
+        let pool_writer = pool.clone();
+
+        let writer = tokio::spawn(async move {
+            let mut tx = pool_writer.begin().await.expect("begin");
+            sqlx::query("INSERT INTO t (v) VALUES (1)")
+                .execute(&mut *tx)
+                .await
+                .expect("insert");
+            writer_acquired_inner.notify_one();
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            tx.commit().await.expect("commit");
+        });
+
+        writer_acquired.notified().await;
+
+        let start = Instant::now();
+        let result = tokio::time::timeout(
+            Duration::from_millis(200),
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM t").fetch_one(&*pool),
+        )
+        .await;
+        let elapsed = start.elapsed();
+
+        writer.await.expect("writer task");
+
+        assert!(
+            result.is_ok(),
+            "SELECT did not return within 200ms while writer held a 500ms tx; elapsed = {:?}",
+            elapsed
+        );
+    }
+
+    /// Eight concurrent SELECTs against the pool while a writer holds a
+    /// transaction complete in roughly the time of one SELECT.
+    #[tokio::test]
+    async fn many_readers_run_in_parallel_with_writer() {
+        let pool = fresh_pool().await;
+        create_t(&pool).await;
+        sqlx::query("INSERT INTO t (v) VALUES (0)")
+            .execute(&*pool)
+            .await
+            .expect("seed");
+
+        let writer_acquired = Arc::new(Notify::new());
+        let writer_acquired_inner = writer_acquired.clone();
+        let pool_writer = pool.clone();
+
+        let writer = tokio::spawn(async move {
+            let mut tx = pool_writer.begin().await.expect("begin");
+            sqlx::query("INSERT INTO t (v) VALUES (1)")
+                .execute(&mut *tx)
+                .await
+                .expect("insert");
+            writer_acquired_inner.notify_one();
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            tx.commit().await.expect("commit");
+        });
+
+        writer_acquired.notified().await;
+
+        let start = Instant::now();
+        let readers = (0..8).map(|_| {
+            let p = pool.clone();
+            tokio::spawn(async move {
+                sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM t")
+                    .fetch_one(&*p)
+                    .await
+            })
+        });
+        let results = futures::future::join_all(readers).await;
+        let elapsed = start.elapsed();
+
+        writer.await.expect("writer task");
+        for r in results {
+            r.expect("reader task").expect("reader query");
+        }
+
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "8 concurrent SELECTs took {:?} while writer held a 500ms tx",
+            elapsed
+        );
+    }
+
+    /// A second writer issued while a first writer holds a long-running
+    /// transaction succeeds (the pool retries via busy_timeout) rather than
+    /// failing with SQLITE_BUSY / "database is locked".
+    #[tokio::test]
+    async fn concurrent_writer_does_not_fail_with_database_is_locked() {
+        let pool = fresh_pool().await;
+        create_t(&pool).await;
+
+        let long_writer_started = Arc::new(Notify::new());
+        let long_writer_started_inner = long_writer_started.clone();
+        let pool_long = pool.clone();
+
+        let long_writer = tokio::spawn(async move {
+            let mut tx = pool_long.begin().await.expect("begin");
+            sqlx::query("INSERT INTO t (v) VALUES (1)")
+                .execute(&mut *tx)
+                .await
+                .expect("insert");
+            long_writer_started_inner.notify_one();
+            for _ in 0..10 {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                sqlx::query("INSERT INTO t (v) VALUES (1)")
+                    .execute(&mut *tx)
+                    .await
+                    .expect("insert in loop");
+            }
+            tx.commit().await.expect("commit");
+        });
+
+        long_writer_started.notified().await;
+
+        let start = Instant::now();
+        let result = sqlx::query("INSERT INTO t (v) VALUES (2)")
+            .execute(&*pool)
+            .await;
+        let elapsed = start.elapsed();
+
+        long_writer.await.expect("long writer task");
+
+        assert!(
+            result.is_ok(),
+            "concurrent INSERT failed after {:?}: {:?}",
+            elapsed,
+            result.err()
+        );
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use crate::infra::pool::sqlite::{Config, SqlitePool};
     use std::{ops::Deref, path::Path};

--- a/indexer-common/src/infra/pool/sqlite.rs
+++ b/indexer-common/src/infra/pool/sqlite.rs
@@ -162,7 +162,7 @@ mod pool_concurrency {
             seq
         ));
         let url = format!("sqlite://{}", path.display());
-        SqlitePool::new(Config { cnn_url: url })
+        SqlitePool::new(Config::with_url(url))
             .await
             .expect("create pool")
     }

--- a/indexer-standalone/config.yaml
+++ b/indexer-standalone/config.yaml
@@ -42,6 +42,12 @@ infra:
     # APP__INFRA__SPO_NODE__BLOCKFROST_ID env var. If you are not exercising
     # SPO features locally, any non-empty placeholder is accepted at startup,
     # e.g. APP__INFRA__SPO_NODE__BLOCKFROST_ID=dummy-not-using-spo
+    #
+    # Optional Blockfrost HTTP pool tuning (defaults: 4 / 30s / 60s).
+    # http_pool:
+    #   max_idle_per_host: 4
+    #   idle_timeout: "30s"
+    #   tcp_keepalive: "60s"
 
   api:
     address: "0.0.0.0"

--- a/indexer-standalone/src/config.rs
+++ b/indexer-standalone/src/config.rs
@@ -17,7 +17,7 @@ use indexer_common::{domain::NetworkId, infra::pool, telemetry};
 use serde::Deserialize;
 use spo_indexer::{
     application::{self as spo_app, StakeRefreshConfig},
-    infra::spo_client,
+    infra::spo_client::{self, HttpPoolConfig},
 };
 use std::{num::NonZeroUsize, time::Duration};
 use wallet_indexer::application as wallet_app;
@@ -157,6 +157,8 @@ pub struct SpoNodeConfig {
     #[serde(with = "humantime_serde")]
     pub reconnect_max_delay: Duration,
     pub reconnect_max_attempts: usize,
+    #[serde(default)]
+    pub http_pool: HttpPoolConfig,
 }
 
 impl From<SpoNodeConfig> for spo_client::Config {
@@ -166,6 +168,7 @@ impl From<SpoNodeConfig> for spo_client::Config {
             blockfrost_id: secrecy::SecretString::from(config.blockfrost_id),
             reconnect_max_delay: config.reconnect_max_delay,
             reconnect_max_attempts: config.reconnect_max_attempts,
+            http_pool: config.http_pool,
         }
     }
 }

--- a/spo-indexer/src/application.rs
+++ b/spo-indexer/src/application.rs
@@ -20,13 +20,18 @@ use crate::{
     infra::spo_client::{SLOT_DURATION, SPOClient},
     utils::{hex_to_bytes, remove_hex_prefix},
 };
+use anyhow::Context;
 use blake2::{
     Blake2bVar,
     digest::{Update, VariableOutput},
 };
 use log::{debug, error, info, warn};
 use serde::Deserialize;
-use std::{cmp, collections::HashMap, time::Duration};
+use std::{
+    cmp,
+    collections::{HashMap, hash_map::Entry},
+    time::{Duration, Instant},
+};
 use subxt::utils::to_hex;
 use tokio::{
     select,
@@ -99,31 +104,62 @@ async fn process_next_epoch(
     };
     info!(epoch_no = epoch.epoch_no; "processing epoch");
 
-    let mut tx = storage.create_tx().await?;
+    // Fetch everything from the network before opening a transaction. Holding
+    // the SQLite writer across HTTP calls starves concurrent writers (e.g. the
+    // chain-indexer or the stake-refresh task) beyond `busy_timeout` and trips
+    // `database is locked` errors.
+    let prefetch_started = Instant::now();
     let committee = client.get_committee(epoch.epoch_no).await?;
     let raw_spos = client.get_spo_registrations(epoch.epoch_no).await?;
     let membership = committee_to_membership(client, &committee);
 
-    storage.save_epoch(&epoch, &mut tx).await?;
-    storage.save_membership(&membership, &mut tx).await?;
+    let entries = raw_spos
+        .candidate_registrations
+        .values()
+        .flatten()
+        .map(|reg| (get_cardano_id(&reg.mainchain_pub_key), reg.clone()))
+        .collect::<Vec<_>>();
 
     let mut blocks_produced: HashMap<String, u32> = HashMap::new();
     let mut val_to_registration: HashMap<String, CandidateRegistration> = HashMap::new();
+    let mut pool_metadata: HashMap<String, PoolMetadata> = HashMap::new();
 
-    for (_, registrations) in raw_spos.candidate_registrations {
-        for raw_spo in &registrations {
-            let cardano_id = get_cardano_id(&raw_spo.mainchain_pub_key);
-            // Normalize all keys by stripping optional 0x prefix for consistency with DB values.
-            let spo_sk = remove_hex_prefix(&raw_spo.sidechain_pub_key).to_owned();
+    for (cardano_id, raw_spo) in &entries {
+        // Normalize all keys by stripping optional 0x prefix for consistency with DB values.
+        let spo_sk = remove_hex_prefix(&raw_spo.sidechain_pub_key).to_owned();
+        val_to_registration.insert(spo_sk.clone(), raw_spo.clone());
+        *blocks_produced.entry(spo_sk).or_insert(0) += 1;
 
-            val_to_registration.insert(spo_sk.clone(), raw_spo.clone());
-            save_pool_metadata(client, storage, &mut tx, cardano_id.clone()).await?;
-            save_spo_identity(storage, raw_spo, cardano_id, &mut tx).await?;
-            save_spo_history(storage, raw_spo, epoch.epoch_no.into(), &mut tx).await?;
-
-            let count_mk = blocks_produced.entry(spo_sk).or_insert(0);
-            *count_mk += 1;
+        if let Entry::Vacant(slot) = pool_metadata.entry(cardano_id.clone()) {
+            let meta = client
+                .get_pool_metadata(cardano_id.clone())
+                .await
+                .unwrap_or_else(|_| PoolMetadata::placeholder(cardano_id.clone()));
+            slot.insert(meta);
         }
+    }
+
+    debug!(
+        epoch_no = epoch.epoch_no,
+        registrations = val_to_registration.len(),
+        unique_pools = pool_metadata.len(),
+        prefetch_ms = elapsed_ms(prefetch_started);
+        "spo: network pre-fetch complete"
+    );
+
+    // All network work is done; now persist in a single short transaction.
+    let tx_started = Instant::now();
+    let mut tx = storage.create_tx().await?;
+    storage.save_epoch(&epoch, &mut tx).await?;
+    storage.save_membership(&membership, &mut tx).await?;
+
+    for (cardano_id, raw_spo) in &entries {
+        let meta = pool_metadata
+            .get(cardano_id)
+            .expect("metadata inserted for every entry above");
+        storage.save_pool_meta(meta, &mut tx).await?;
+        save_spo_identity(storage, raw_spo, cardano_id.clone(), &mut tx).await?;
+        save_spo_history(storage, raw_spo, epoch.epoch_no.into(), &mut tx).await?;
     }
 
     debug!(committee_size = committee.len(); "committee");
@@ -161,7 +197,11 @@ async fn process_next_epoch(
     }
 
     tx.commit().await?;
-    info!(epoch_no = epoch.epoch_no; "processed epoch");
+    info!(
+        epoch_no = epoch.epoch_no,
+        tx_ms = elapsed_ms(tx_started);
+        "processed epoch"
+    );
     Ok(())
 }
 
@@ -205,10 +245,17 @@ async fn refresh_stake_snapshots(
         (1000 / cfg.max_rps.max(1)) as u64
     };
 
-    let mut tx = storage.create_tx().await?;
+    // Use one transaction per pool so the shared SQLite writer is not held
+    // across Blockfrost HTTP calls and rate-limit sleeps, which would otherwise
+    // starve the connection pool for concurrent readers/writers.
     for pid in pool_ids.iter() {
         match client.get_pool_data(pid).await {
             Ok(pd) => {
+                let tx_started = Instant::now();
+                let mut tx = storage
+                    .create_tx()
+                    .await
+                    .with_context(|| format!("begin tx for pool {pid}"))?;
                 storage
                     .save_stake_snapshot(
                         pid,
@@ -220,7 +267,8 @@ async fn refresh_stake_snapshots(
                         pd.live_pledge,
                         &mut tx,
                     )
-                    .await?;
+                    .await
+                    .with_context(|| format!("save_stake_snapshot for pool {pid}"))?;
                 storage
                     .insert_stake_history(
                         pid,
@@ -233,7 +281,15 @@ async fn refresh_stake_snapshots(
                         pd.live_pledge,
                         &mut tx,
                     )
-                    .await?;
+                    .await
+                    .with_context(|| format!("insert_stake_history for pool {pid}"))?;
+                tx.commit()
+                    .await
+                    .with_context(|| format!("commit tx for pool {pid}"))?;
+                let tx_ms = elapsed_ms(tx_started);
+                if tx_ms > 1_000 {
+                    warn!(pid, tx_ms; "spo: stake snapshot tx held > 1s");
+                }
                 total_updated += 1;
             }
             Err(error) => {
@@ -244,7 +300,6 @@ async fn refresh_stake_snapshots(
             sleep(Duration::from_millis(sleep_per_req_ms)).await;
         }
     }
-    tx.commit().await?;
 
     // Persist cursor at the last processed id
     let last_id = pool_ids.last().map(|s| s.as_str());
@@ -299,28 +354,6 @@ async fn save_spo_identity(
     };
 
     storage.save_spo(&spo, tx).await?;
-    Ok(())
-}
-
-async fn save_pool_metadata(
-    client: &SPOClient,
-    storage: &impl Storage,
-    tx: &mut SqlxTransaction,
-    cardano_id: String,
-) -> anyhow::Result<()> {
-    let saved_meta = client
-        .get_pool_metadata(cardano_id.clone())
-        .await
-        .unwrap_or_else(|_| PoolMetadata {
-            pool_id: cardano_id.clone(),
-            hex_id: cardano_id,
-            name: String::new(),
-            ticker: String::new(),
-            homepage_url: String::new(),
-            url: String::new(),
-        });
-
-    storage.save_pool_meta(&saved_meta, tx).await?;
     Ok(())
 }
 
@@ -387,6 +420,10 @@ async fn get_epoch_to_process(
             ends_at: current_epoch.ends_at - time_offset,
         }))
     }
+}
+
+fn elapsed_ms(t: Instant) -> u64 {
+    u64::try_from(t.elapsed().as_millis()).unwrap_or(u64::MAX)
 }
 
 fn get_cardano_id(mainchain_pk: &str) -> String {

--- a/spo-indexer/src/domain/pool.rs
+++ b/spo-indexer/src/domain/pool.rs
@@ -20,3 +20,18 @@ pub struct PoolMetadata {
     pub homepage_url: String,
     pub url: String,
 }
+
+impl PoolMetadata {
+    /// Placeholder used when the upstream metadata fetch fails so we still
+    /// persist a row keyed by `cardano_id`.
+    pub fn placeholder(cardano_id: String) -> Self {
+        Self {
+            pool_id: cardano_id.clone(),
+            hex_id: cardano_id,
+            name: String::new(),
+            ticker: String::new(),
+            homepage_url: String::new(),
+            url: String::new(),
+        }
+    }
+}

--- a/spo-indexer/src/infra/spo_client.rs
+++ b/spo-indexer/src/infra/spo_client.rs
@@ -24,10 +24,10 @@ use http::{
     header::{InvalidHeaderValue, USER_AGENT},
 };
 use indexer_common::error::BoxError;
-use reqwest::Client as HttpClient;
+use reqwest::{Client as HttpClient, ClientBuilder};
 use secrecy::{ExposeSecret, SecretString};
 use serde_json::value::RawValue;
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 use subxt::{
     OnlineClient, PolkadotConfig,
     config::RpcConfigFor,
@@ -51,9 +51,36 @@ pub struct Config {
     pub blockfrost_id: SecretString,
 
     #[serde(with = "humantime_serde")]
-    pub reconnect_max_delay: std::time::Duration,
+    pub reconnect_max_delay: Duration,
 
     pub reconnect_max_attempts: usize,
+
+    #[serde(default)]
+    pub http_pool: HttpPoolConfig,
+}
+
+/// Pool tuning applied to every `reqwest::Client` SPOClient owns (its own direct
+/// Blockfrost client and the one wrapped by `BlockfrostAPI`). Both clients use the
+/// same values so the total idle socket count is bounded.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct HttpPoolConfig {
+    pub max_idle_per_host: usize,
+
+    #[serde(with = "humantime_serde")]
+    pub idle_timeout: Duration,
+
+    #[serde(with = "humantime_serde")]
+    pub tcp_keepalive: Duration,
+}
+
+impl Default for HttpPoolConfig {
+    fn default() -> Self {
+        Self {
+            max_idle_per_host: 4,
+            idle_timeout: Duration::from_secs(30),
+            tcp_keepalive: Duration::from_secs(60),
+        }
+    }
 }
 
 /// A [Node] implementation based on subxt.
@@ -77,6 +104,7 @@ impl SPOClient {
             blockfrost_id,
             reconnect_max_delay,
             reconnect_max_attempts,
+            http_pool,
         } = config;
 
         if blockfrost_id.expose_secret().is_empty() {
@@ -94,14 +122,19 @@ impl SPOClient {
             .build(&url)
             .await
             .map_err(|error| SPOClientError::Subtx(error.into()))?;
+
         let online_client = OnlineClient::<PolkadotConfig>::from_rpc_client(rpc_client.clone())
             .await
             .map_err(|error| SPOClientError::UnexpectedResponse(error.to_string()))?;
 
-        let blockfrost = BlockfrostAPI::new(blockfrost_id.expose_secret(), Default::default());
+        let blockfrost = BlockfrostAPI::new_with_client(
+            blockfrost_id.expose_secret(),
+            Default::default(),
+            tuned_client_builder(&http_pool),
+        )
+        .map_err(|error| SPOClientError::UnexpectedResponse(error.to_string()))?;
 
-        let http = HttpClient::builder()
-            .user_agent("midnight-spo-indexer/1.0")
+        let http = tuned_client_builder(&http_pool)
             .build()
             .map_err(|error| SPOClientError::UnexpectedResponse(error.to_string()))?;
 
@@ -400,6 +433,15 @@ fn parse_lovelace(v: &serde_json::Value, field: &str) -> Option<i64> {
             None
         }
     }
+}
+
+fn tuned_client_builder(http_pool: &HttpPoolConfig) -> ClientBuilder {
+    let user_agent = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
+    ClientBuilder::new()
+        .user_agent(user_agent)
+        .pool_max_idle_per_host(http_pool.max_idle_per_host)
+        .pool_idle_timeout(http_pool.idle_timeout)
+        .tcp_keepalive(http_pool.tcp_keepalive)
 }
 
 async fn get_epoch_duration(


### PR DESCRIPTION
This PR combines the PR #1094 against the proposed unit tests of #1178

Test | main | PR (sockets-2)
-- | -- | --
reader_runs_concurrent_with_in_progress_writer | FAIL — 202.6 ms (timed out at 200 ms) | PASS — 0.06 ms
many_readers_run_in_parallel_with_writer | FAIL — 502.8 ms (serialized through 1 conn) | PASS — 1.08 ms
concurrent_writer_does_not_fail_with_database_is_locked | PASS — 1028.9 ms (queued at pool layer) | PASS — 1097.4 ms (busy_timeout retry)

