### PR TITLE
feat(indexer-api): introduce @beta GraphQL directive for in-flight API fields

### DIFF
--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -305,7 +305,7 @@ type DustGenerationDtimeUpdate implements DustLedgerEvent {
 A dust generation dtime update emitted when the backing Night UTXO is
 spent and the entry's decay time is set.
 """
-type DustGenerationDtimeUpdateItem {
+type DustGenerationDtimeUpdateItem @beta {
 	"""
 	Generation-tree index of the entry whose dtime changed.
 	"""
@@ -402,7 +402,7 @@ union DustGenerationsEvent = DustGenerationsItem | DustGenerationsProgress | Dus
 """
 A dust generations item with optional collapsed Merkle tree update.
 """
-type DustGenerationsItem {
+type DustGenerationsItem @beta {
 	"""
 	Index of this output in the dust commitment Merkle tree.
 	"""
@@ -725,11 +725,11 @@ type Query {
 	"""
 	Get a collapsed Merkle tree update for the dust commitment tree.
 	"""
-	dustCommitmentMerkleTreeUpdate(startIndex: Int!, endIndex: Int!): MerkleTreeCollapsedUpdate!
+	dustCommitmentMerkleTreeUpdate(startIndex: Int!, endIndex: Int!): MerkleTreeCollapsedUpdate! @beta
 	"""
 	Get a collapsed Merkle tree update for the dust generation tree.
 	"""
-	dustGenerationMerkleTreeUpdate(startIndex: Int!, endIndex: Int!): MerkleTreeCollapsedUpdate!
+	dustGenerationMerkleTreeUpdate(startIndex: Int!, endIndex: Int!): MerkleTreeCollapsedUpdate! @beta
 	"""
 	Get the full history of D-parameter changes for governance auditability.
 	"""
@@ -896,19 +896,19 @@ type RegularTransaction implements Transaction {
 	"""
 	The dust commitment tree start index.
 	"""
-	dustCommitmentStartIndex: Int!
+	dustCommitmentStartIndex: Int! @beta
 	"""
 	The dust commitment tree end index.
 	"""
-	dustCommitmentEndIndex: Int!
+	dustCommitmentEndIndex: Int! @beta
 	"""
 	The dust generation tree start index.
 	"""
-	dustGenerationStartIndex: Int!
+	dustGenerationStartIndex: Int! @beta
 	"""
 	The dust generation tree end index.
 	"""
-	dustGenerationEndIndex: Int!
+	dustGenerationEndIndex: Int! @beta
 	"""
 	The fee for this transaction in SPECK (atomic unit of DUST).
 	"""
@@ -1163,7 +1163,7 @@ type Subscription {
 	`DustGenerationDtimeUpdateItem` events for entries the subscriber owns.
 	The subscription finishes after reaching the end index with a final collapsed update.
 	"""
-	dustGenerations(dustAddress: DustAddress!, startIndex: Int!, endIndex: Int!): DustGenerationsEvent!
+	dustGenerations(dustAddress: DustAddress!, startIndex: Int!, endIndex: Int!): DustGenerationsEvent! @beta
 	"""
 	Subscribe to dust ledger events starting at the given ID or at the very start if omitted.
 	"""
@@ -1465,6 +1465,15 @@ type ZswapLedgerEvent {
 	protocolVersion: Int!
 }
 
+"""
+Marks a schema field or type as in-flight / unstable. Consumers should
+expect the marked surface to change without notice; stability is signalled
+by removal of the directive.
+
+Currently used for the dust-generation API surface that's in mid-redesign
+pending #1181. See #1173.
+"""
+directive @beta on FIELD_DEFINITION | OBJECT
 """
 Marks an element of a GraphQL schema as no longer supported.
 """

--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -448,7 +448,7 @@ type DustGenerationsItem @beta {
 """
 Progress indicator for dust generations subscription (includes final collapsed update).
 """
-type DustGenerationsProgress {
+type DustGenerationsProgress @beta {
 	"""
 	The highest index processed so far.
 	"""
@@ -499,11 +499,11 @@ type DustNullifierTransaction {
 	"""
 	The hex-encoded matched nullifier.
 	"""
-	nullifier: HexEncoded!
+	nullifier: HexEncoded! @beta
 	"""
 	The hex-encoded commitment.
 	"""
-	commitment: HexEncoded!
+	commitment: HexEncoded! @beta
 	"""
 	The transaction ID (indexer-internal BIGSERIAL, use as resumption cursor).
 	"""

--- a/indexer-api/src/infra/api/v4.rs
+++ b/indexer-api/src/infra/api/v4.rs
@@ -14,6 +14,7 @@
 pub mod block;
 pub mod contract_action;
 pub mod dataloader;
+pub mod directives;
 pub mod dust;
 pub mod dust_generations;
 pub mod ledger_events;

--- a/indexer-api/src/infra/api/v4/directives.rs
+++ b/indexer-api/src/infra/api/v4/directives.rs
@@ -1,0 +1,25 @@
+// This file is part of midnight-indexer.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Schema-level GraphQL directives for indexer-api.
+
+use async_graphql::TypeDirective;
+
+/// Marks a schema field or type as in-flight / unstable. Consumers should
+/// expect the marked surface to change without notice; stability is signalled
+/// by removal of the directive.
+///
+/// Currently used for the dust-generation API surface that's in mid-redesign
+/// pending #1181. See #1173.
+#[TypeDirective(name = "beta", location = "FieldDefinition", location = "Object")]
+pub fn beta() {}

--- a/indexer-api/src/infra/api/v4/query.rs
+++ b/indexer-api/src/infra/api/v4/query.rs
@@ -19,6 +19,7 @@ use crate::{
             CardanoNetworkId, CardanoRewardAddress, HexEncoded,
             block::{Block, BlockOffset},
             contract_action::{ContractAction, ContractActionOffset},
+            directives::beta,
             dust::DustGenerationStatus,
             dust_generations::DustGenerations,
             merkle_tree_collapsed_update::MerkleTreeCollapsedUpdate,
@@ -311,6 +312,7 @@ where
 
     /// Get a collapsed Merkle tree update for the dust commitment tree.
     #[trace(properties = { "start_index": "{start_index}", "end_index": "{end_index}" })]
+    #[graphql(directive = beta::apply())]
     async fn dust_commitment_merkle_tree_update(
         &self,
         cx: &Context<'_>,
@@ -340,6 +342,7 @@ where
 
     /// Get a collapsed Merkle tree update for the dust generation tree.
     #[trace(properties = { "start_index": "{start_index}", "end_index": "{end_index}" })]
+    #[graphql(directive = beta::apply())]
     async fn dust_generation_merkle_tree_update(
         &self,
         cx: &Context<'_>,

--- a/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
@@ -16,7 +16,7 @@ use crate::{
     infra::api::{
         ApiResult, ContextExt, ResultExt,
         v4::{
-            HexEncodable, HexEncoded, dust::DustAddress,
+            HexEncodable, HexEncoded, directives::beta, dust::DustAddress,
             merkle_tree_collapsed_update::MerkleTreeCollapsedUpdate,
         },
     },
@@ -55,6 +55,7 @@ impl<S, B> Default for DustGenerationsSubscription<S, B> {
 
 /// A dust generations item with optional collapsed Merkle tree update.
 #[derive(Debug, Clone, SimpleObject)]
+#[graphql(directive = beta::apply())]
 pub struct DustGenerationsItem {
     /// Index of this output in the dust commitment Merkle tree.
     pub commitment_mt_index: u64,
@@ -90,6 +91,7 @@ pub struct DustGenerationsProgress {
 /// A dust generation dtime update emitted when the backing Night UTXO is
 /// spent and the entry's decay time is set.
 #[derive(Debug, Clone, SimpleObject)]
+#[graphql(directive = beta::apply())]
 pub struct DustGenerationDtimeUpdateItem {
     /// Generation-tree index of the entry whose dtime changed.
     pub generation_mt_index: u64,
@@ -119,6 +121,7 @@ where
     /// Entries are interleaved with collapsed Merkle tree updates and
     /// `DustGenerationDtimeUpdateItem` events for entries the subscriber owns.
     /// The subscription finishes after reaching the end index with a final collapsed update.
+    #[graphql(directive = beta::apply())]
     async fn dust_generations<'a>(
         &self,
         cx: &'a Context<'a>,

--- a/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
@@ -81,6 +81,7 @@ pub struct DustGenerationsItem {
 
 /// Progress indicator for dust generations subscription (includes final collapsed update).
 #[derive(Debug, Clone, SimpleObject)]
+#[graphql(directive = beta::apply())]
 pub struct DustGenerationsProgress {
     /// The highest index processed so far.
     pub highest_index: u64,

--- a/indexer-api/src/infra/api/v4/subscription/dust_nullifier_transactions.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_nullifier_transactions.rs
@@ -15,7 +15,7 @@ use crate::{
     domain::storage::Storage,
     infra::api::{
         ApiResult, ContextExt, OptionExt, ResultExt,
-        v4::{HexEncodable, HexEncoded},
+        v4::{HexEncodable, HexEncoded, directives::beta},
     },
 };
 use async_graphql::{Context, SimpleObject, Subscription};
@@ -43,8 +43,10 @@ impl<S, B> Default for DustNullifierTransactionsSubscription<S, B> {
 #[derive(Debug, Clone, SimpleObject)]
 pub struct DustNullifierTransaction {
     /// The hex-encoded matched nullifier.
+    #[graphql(directive = beta::apply())]
     pub nullifier: HexEncoded,
     /// The hex-encoded commitment.
+    #[graphql(directive = beta::apply())]
     pub commitment: HexEncoded,
     /// The transaction ID (indexer-internal BIGSERIAL, use as resumption cursor).
     pub transaction_id: u64,

--- a/indexer-api/src/infra/api/v4/transaction.rs
+++ b/indexer-api/src/infra/api/v4/transaction.rs
@@ -19,6 +19,7 @@ use crate::{
             HexEncodable, HexEncoded,
             block::Block,
             contract_action::ContractAction,
+            directives::beta,
             ledger_events::{DustLedgerEvent, ZswapLedgerEvent},
             unshielded::UnshieldedUtxo,
         },
@@ -124,15 +125,19 @@ where
     end_index: u64,
 
     /// The dust commitment tree start index.
+    #[graphql(directive = beta::apply())]
     dust_commitment_start_index: u64,
 
     /// The dust commitment tree end index.
+    #[graphql(directive = beta::apply())]
     dust_commitment_end_index: u64,
 
     /// The dust generation tree start index.
+    #[graphql(directive = beta::apply())]
     dust_generation_start_index: u64,
 
     /// The dust generation tree end index.
+    #[graphql(directive = beta::apply())]
     dust_generation_end_index: u64,
 
     /// The fee for this transaction in SPECK (atomic unit of DUST).


### PR DESCRIPTION
Adds a schema-level @beta directive (FIELD_DEFINITION | OBJECT) signalling contract maturity on the in-flight dust-generation API surface. Mirrors the standard @deprecated directive shape. No runtime enforcement, just honest documentation of contract maturity.

Defined via async-graphql's #[derive(TypeDirective)] in a new module indexer-api/src/infra/api/v4/directives.rs.

Schema regenerated: 10 @beta occurrences plus the directive declaration.

Closes #1173.