### PR TITLE
perf(indexer-common): add UNIQUE index on blocks.height for sqlite

### DIFF
--- a/indexer-common/migrations/sqlite/005_blocks_height_idx.sql
+++ b/indexer-common/migrations/sqlite/005_blocks_height_idx.sql
@@ -1,0 +1,6 @@
+-- Add a UNIQUE index on `blocks.height`.
+--
+-- The postgres schema declares `height BIGINT NOT NULL UNIQUE`, which gives
+-- postgres an implicit btree on height. The sqlite schema lacks that UNIQUE
+
+CREATE UNIQUE INDEX IF NOT EXISTS blocks_height_idx ON blocks (height);


### PR DESCRIPTION
while the postgres initial migration has UNIQUE constraint on the block height, this is lacking in sqlite migration. I believe this is causing many second latency to some of our graphql queries.