### PR TITLE
feat(indexer-api): add per-tree end indexes to Block

### DIFF
--- a/chain-indexer/src/application.rs
+++ b/chain-indexer/src/application.rs
@@ -385,6 +385,9 @@ where
 
     *parent_block_timestamp = block.timestamp;
     block.ledger_parameters = ledger_parameters.serialize()?;
+    block.zswap_end_index = ledger_state.zswap_first_free();
+    block.dust_commitment_end_index = ledger_state.dust_commitments_first_free();
+    block.dust_generation_end_index = ledger_state.dust_generations_first_free();
 
     // Validate ledger state.
     // TODO: Only use ledger state root comparison once support for Node < 0.22 is dropped!

--- a/chain-indexer/src/domain/block.rs
+++ b/chain-indexer/src/domain/block.rs
@@ -34,6 +34,9 @@ pub struct Block {
 
     // These fields are set after applying all transactions of this block to the ledger state.
     pub ledger_parameters: SerializedLedgerParameters,
+    pub zswap_end_index: u64,
+    pub dust_commitment_end_index: u64,
+    pub dust_generation_end_index: u64,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/chain-indexer/src/domain/node.rs
+++ b/chain-indexer/src/domain/node.rs
@@ -90,6 +90,9 @@ impl TryFrom<Block> for (domain::Block, Vec<Transaction>) {
             ledger_state_root: block.ledger_state_root,
             dust_registration_events: block.dust_registration_events,
             ledger_parameters: Default::default(),
+            zswap_end_index: 0,
+            dust_commitment_end_index: 0,
+            dust_generation_end_index: 0,
         };
 
         Ok((block, transactions))

--- a/chain-indexer/src/infra/storage.rs
+++ b/chain-indexer/src/infra/storage.rs
@@ -264,7 +264,10 @@ async fn save_block(
             timestamp,
             zswap_merkle_tree_root,
             ledger_parameters,
-            ledger_state_key
+            ledger_state_key,
+            zswap_end_index,
+            dust_commitment_end_index,
+            dust_generation_end_index
         )
     "};
 
@@ -279,6 +282,9 @@ async fn save_block(
                 timestamp,
                 zswap_merkle_tree_root,
                 ledger_parameters,
+                zswap_end_index,
+                dust_commitment_end_index,
+                dust_generation_end_index,
                 ..
             } = block;
 
@@ -290,7 +296,10 @@ async fn save_block(
                 .push_bind(*timestamp as i64)
                 .push_bind(zswap_merkle_tree_root.as_ref())
                 .push_bind(ledger_parameters.as_ref())
-                .push_bind(ledger_state_key);
+                .push_bind(ledger_state_key)
+                .push_bind(*zswap_end_index as i64)
+                .push_bind(*dust_commitment_end_index as i64)
+                .push_bind(*dust_generation_end_index as i64);
         })
         .push(" RETURNING id")
         .build_query_as::<(i64,)>()

--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -31,6 +31,18 @@ type Block {
 	"""
 	ledgerParameters: HexEncoded!
 	"""
+	The zswap commitment tree end index at this block; exclusive, i.e. the next free index.
+	"""
+	zswapEndIndex: Int!
+	"""
+	The dust commitment tree end index at this block; exclusive, i.e. the next free index.
+	"""
+	dustCommitmentEndIndex: Int! @beta
+	"""
+	The dust generation tree end index at this block; exclusive, i.e. the next free index.
+	"""
+	dustGenerationEndIndex: Int! @beta
+	"""
 	The parent of this block.
 	"""
 	parent: Block

--- a/indexer-api/src/domain/block.rs
+++ b/indexer-api/src/domain/block.rs
@@ -45,4 +45,13 @@ pub struct Block {
     pub zswap_merkle_tree_root: SerializedZswapMerkleTreeRoot,
 
     pub ledger_parameters: SerializedLedgerParameters,
+
+    #[sqlx(try_from = "i64")]
+    pub zswap_end_index: u64,
+
+    #[sqlx(try_from = "i64")]
+    pub dust_commitment_end_index: u64,
+
+    #[sqlx(try_from = "i64")]
+    pub dust_generation_end_index: u64,
 }

--- a/indexer-api/src/infra/api/v4/block.rs
+++ b/indexer-api/src/infra/api/v4/block.rs
@@ -17,6 +17,7 @@ use crate::{
         ApiResult, ContextExt, ResultExt,
         v4::{
             HexEncodable, HexEncoded,
+            directives::beta,
             system_parameters::{DParameter, SystemParameters, TermsAndConditions},
             transaction::Transaction,
         },
@@ -55,6 +56,17 @@ where
 
     /// The hex-encoded ledger parameters for this block.
     ledger_parameters: HexEncoded,
+
+    /// The zswap commitment tree end index at this block; exclusive, i.e. the next free index.
+    zswap_end_index: u64,
+
+    /// The dust commitment tree end index at this block; exclusive, i.e. the next free index.
+    #[graphql(directive = beta::apply())]
+    dust_commitment_end_index: u64,
+
+    /// The dust generation tree end index at this block; exclusive, i.e. the next free index.
+    #[graphql(directive = beta::apply())]
+    dust_generation_end_index: u64,
 
     #[graphql(skip)]
     id: u64,
@@ -166,6 +178,9 @@ where
             parent_hash,
             zswap_merkle_tree_root,
             ledger_parameters,
+            zswap_end_index,
+            dust_commitment_end_index,
+            dust_generation_end_index,
         } = value;
 
         Block {
@@ -176,6 +191,9 @@ where
             zswap_merkle_tree_root: zswap_merkle_tree_root.hex_encode(),
             ledger_parameters: ledger_parameters.hex_encode(),
             timestamp,
+            zswap_end_index,
+            dust_commitment_end_index,
+            dust_generation_end_index,
             id,
             parent_hash,
             _s: PhantomData,

--- a/indexer-api/src/infra/storage/block.rs
+++ b/indexer-api/src/infra/storage/block.rs
@@ -35,7 +35,10 @@ impl BlockStorage for Storage {
                 author,
                 timestamp,
                 zswap_merkle_tree_root,
-                ledger_parameters
+                ledger_parameters,
+                zswap_end_index,
+                dust_commitment_end_index,
+                dust_generation_end_index
             FROM blocks
             ORDER BY height DESC
             LIMIT 1
@@ -63,7 +66,10 @@ impl BlockStorage for Storage {
                 author,
                 timestamp,
                 zswap_merkle_tree_root,
-                ledger_parameters
+                ledger_parameters,
+                zswap_end_index,
+                dust_commitment_end_index,
+                dust_generation_end_index
             FROM blocks
             WHERE height = $1
             LIMIT 1
@@ -112,7 +118,10 @@ impl Storage {
                 author,
                 timestamp,
                 zswap_merkle_tree_root,
-                ledger_parameters
+                ledger_parameters,
+                zswap_end_index,
+                dust_commitment_end_index,
+                dust_generation_end_index
             FROM blocks
             WHERE hash = ANY($1)
         "};
@@ -137,7 +146,10 @@ impl Storage {
                 author,
                 timestamp,
                 zswap_merkle_tree_root,
-                ledger_parameters
+                ledger_parameters,
+                zswap_end_index,
+                dust_commitment_end_index,
+                dust_generation_end_index
             FROM blocks
             WHERE hash IN (
         "};
@@ -168,7 +180,10 @@ impl Storage {
                 author,
                 timestamp,
                 zswap_merkle_tree_root,
-                ledger_parameters
+                ledger_parameters,
+                zswap_end_index,
+                dust_commitment_end_index,
+                dust_generation_end_index
             FROM blocks
             WHERE height >= $1
             ORDER BY height

--- a/indexer-common/migrations/postgres/003_block_tree_end_indexes.sql
+++ b/indexer-common/migrations/postgres/003_block_tree_end_indexes.sql
@@ -1,0 +1,50 @@
+-- Per-block tree end indexes (chain's `*_first_free` as of this block).
+-- Lets clients read a chain-aligned upper bound for `dustGenerations` and
+-- the zswap / dust-commitment merkle update queries directly from `Block`,
+-- without walking back through transactions to find one of variant
+-- `RegularTransaction` (the only variant that carries these on the
+-- transaction level today).
+--
+-- Columns are added with `NOT NULL DEFAULT 0` so the ALTER runs cleanly on a
+-- populated database. The backfill below derives historic values from the
+-- highest `RegularTransaction.*_end_index` seen up to and including each
+-- block (running max ordered by `height`). New blocks get the accurate
+-- ledger-state value via the chain-indexer's `save_block` write path.
+--
+-- Approximation note: for blocks whose `SystemTransaction`s also modify
+-- these trees (notably the genesis block 0 with initial dust generation
+-- seeding), the backfilled value lags the true chain state since the
+-- `*_end_index` columns only live on `regular_transactions`. New blocks
+-- always carry the exact ledger-state value.
+
+ALTER TABLE blocks ADD COLUMN zswap_end_index BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE blocks ADD COLUMN dust_commitment_end_index BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE blocks ADD COLUMN dust_generation_end_index BIGINT NOT NULL DEFAULT 0;
+
+WITH per_block_max AS (
+    SELECT
+        b.id AS block_id,
+        b.height AS block_height,
+        MAX(rt.zswap_end_index) AS zswap_max,
+        MAX(rt.dust_commitment_end_index) AS dust_commitment_max,
+        MAX(rt.dust_generation_end_index) AS dust_generation_max
+    FROM blocks b
+    LEFT JOIN transactions t ON t.block_id = b.id
+    LEFT JOIN regular_transactions rt ON rt.id = t.id
+    GROUP BY b.id, b.height
+),
+running_max AS (
+    SELECT
+        block_id,
+        COALESCE(MAX(zswap_max) OVER w, 0) AS zswap_end_index,
+        COALESCE(MAX(dust_commitment_max) OVER w, 0) AS dust_commitment_end_index,
+        COALESCE(MAX(dust_generation_max) OVER w, 0) AS dust_generation_end_index
+    FROM per_block_max
+    WINDOW w AS (ORDER BY block_height ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+)
+UPDATE blocks
+SET zswap_end_index = running_max.zswap_end_index,
+    dust_commitment_end_index = running_max.dust_commitment_end_index,
+    dust_generation_end_index = running_max.dust_generation_end_index
+FROM running_max
+WHERE blocks.id = running_max.block_id;

--- a/indexer-common/migrations/sqlite/004_block_tree_end_indexes.sql
+++ b/indexer-common/migrations/sqlite/004_block_tree_end_indexes.sql
@@ -1,0 +1,49 @@
+-- Per-block tree end indexes (chain's `*_first_free` as of this block).
+-- Lets clients read a chain-aligned upper bound for `dustGenerations` and
+-- the zswap / dust-commitment merkle update queries directly from `Block`,
+-- without walking back through transactions to find one of variant
+-- `RegularTransaction` (the only variant that carries these on the
+-- transaction level today).
+--
+-- Columns are added with `NOT NULL DEFAULT 0` so the ALTER runs cleanly on a
+-- populated database. The backfill below derives historic values from the
+-- highest `RegularTransaction.*_end_index` seen up to and including each
+-- block (running max ordered by `height`). New blocks get the accurate
+-- ledger-state value via the chain-indexer's `save_block` write path.
+--
+-- Approximation note: for blocks whose `SystemTransaction`s also modify
+-- these trees (notably the genesis block 0 with initial dust generation
+-- seeding), the backfilled value lags the true chain state since the
+-- `*_end_index` columns only live on `regular_transactions`. New blocks
+-- always carry the exact ledger-state value.
+
+ALTER TABLE blocks ADD COLUMN zswap_end_index INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE blocks ADD COLUMN dust_commitment_end_index INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE blocks ADD COLUMN dust_generation_end_index INTEGER NOT NULL DEFAULT 0;
+
+WITH per_block_max AS (
+    SELECT
+        b.id AS block_id,
+        b.height AS block_height,
+        MAX(rt.zswap_end_index) AS zswap_max,
+        MAX(rt.dust_commitment_end_index) AS dust_commitment_max,
+        MAX(rt.dust_generation_end_index) AS dust_generation_max
+    FROM blocks b
+    LEFT JOIN transactions t ON t.block_id = b.id
+    LEFT JOIN regular_transactions rt ON rt.id = t.id
+    GROUP BY b.id, b.height
+),
+running_max AS (
+    SELECT
+        block_id,
+        COALESCE(MAX(zswap_max) OVER (ORDER BY block_height ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), 0) AS zswap_end_index,
+        COALESCE(MAX(dust_commitment_max) OVER (ORDER BY block_height ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), 0) AS dust_commitment_end_index,
+        COALESCE(MAX(dust_generation_max) OVER (ORDER BY block_height ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), 0) AS dust_generation_end_index
+    FROM per_block_max
+)
+UPDATE blocks
+SET zswap_end_index = running_max.zswap_end_index,
+    dust_commitment_end_index = running_max.dust_commitment_end_index,
+    dust_generation_end_index = running_max.dust_generation_end_index
+FROM running_max
+WHERE blocks.id = running_max.block_id;


### PR DESCRIPTION
Adds zswapEndIndex, dustCommitmentEndIndex (@beta), and dustGenerationEndIndex (@beta) to the Block GraphQL type, giving clients a chain-aligned upper bound for dustGenerations and the zswap / dust-commitment merkle update queries directly from Block, without walking back through transactions to find one of variant RegularTransaction (the only variant that carries these on the transaction level today).

Denormalises ledger_state's *_first_free values onto the blocks table via chain-indexer's save_block write path. New columns are added with NOT NULL DEFAULT 0 plus a running-max backfill from regular_transactions for historic rows; the backfill is approximate for blocks where SystemTransactions also modified these trees (notably genesis with initial dust generation seeding), but new blocks always carry the exact ledger-state value.

Closes #1139.