### PR TITLE
test: route graphql-transport-ws errors-in-next to error handler in IndexerWsClient

### DIFF
--- a/qa/tests/utils/indexer/websocket-client.ts
+++ b/qa/tests/utils/indexer/websocket-client.ts
@@ -364,7 +364,18 @@ export class IndexerWsClient {
 
     switch (type) {
       case 'next':
-        handlers.next?.(payload);
+        // async-graphql 7.2 emits subscription errors (e.g. quota rejections)
+        // as `{type: 'next', payload: {data: null, errors: [...]}}` rather than
+        // the legacy `{type: 'error', payload: [...]}`. Both shapes are valid
+        // in graphql-transport-ws; route errors-inside-next to the error
+        // handler so tests don't silently treat rejections as successes.
+        const errors = (payload as { errors?: Array<{ message?: string }> } | null)?.errors;
+        if (Array.isArray(errors) && errors.length > 0) {
+          const message = errors[0]?.message ?? 'GraphQL subscription error';
+          handlers.error?.(new Error(message));
+        } else {
+          handlers.next?.(payload);
+        }
         break;
       case 'error':
         handlers.error?.(payload);


### PR DESCRIPTION
## Summary

`IndexerWsClient.handleMessage` only routed `type: 'error'` messages to `handlers.error`, treating every `type: 'next'` as successful data delivery. async-graphql 7.2 emits subscription rejections (e.g. the per-connection quota cap from PR #1104) as

```
{ type: 'next', payload: { data: null, errors: [{ message: '...' }] } }
```

Both shapes are valid in graphql-transport-ws; the modern shape keeps the GraphQL response envelope on subscription items so partial errors can be co-emitted with data. Without this fix the test client silently treats those rejections as successful `next` calls.

This is why issue #1196 (subscription-quotas integration test on rc.3 / qanet) reported the 21st subscription as "accepted and streaming data". The server was correctly rejecting it via the modern shape; the client just mis-routed the error payload.

## Implementation notes

- Single-method change in `handleMessage`. When `type === 'next'`, check for a non-empty `payload.errors` array and route to `handlers.error` with a synthesised `Error(message)`; otherwise pass to `handlers.next` as before.
- Other `subscribeToXxx` helpers (block, unshielded, contract action, etc.) all funnel through `handleMessage`, so they all benefit without further edits.

## Verification

Reproduced on a local indexer-api built from `main` with a Python `websockets` client:

- 25 back-to-back `blocks` subscriptions on one WS connection
- 20 accepted, 5 rejected with `subscription limit exceeded: per-connection limit exceeded (20)`
- Each rejection arrived as `{type: 'next', payload: {data: null, errors: [{message: '...'}]}}`

Pre-fix: TS test client would have called `handlers.next(payload)` for each rejection, the test sees the 21st as accepted, assertion fails.

Post-fix: rejections route to `handlers.error?.(new Error('subscription limit exceeded: per-connection limit exceeded (20)'))`, the integration test's `error` handler fires, `expect(rejected).not.toBeNull()` passes.

## Test plan

- [ ] Re-run `qa subscription-quotas` test against rc.3 docker stack
- [ ] Re-run against qanet
- [x] Surgical diff (12 added, 1 removed) scoped to `handleMessage`

## Closes

#1196