### PR TITLE
feat(indexer-api): rename DustNullifier byte fields with LeBytes suffix

### DIFF
--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -497,13 +497,13 @@ A transaction containing a dust nullifier match with block context.
 """
 type DustNullifierTransaction {
 	"""
-	The hex-encoded matched nullifier.
+	The hex-encoded matched nullifier, in 32-byte little-endian form.
 	"""
-	nullifier: HexEncoded! @beta
+	nullifierLeBytes: HexEncoded! @beta
 	"""
-	The hex-encoded commitment.
+	The hex-encoded commitment, in 32-byte little-endian form.
 	"""
-	commitment: HexEncoded! @beta
+	commitmentLeBytes: HexEncoded! @beta
 	"""
 	The transaction ID (indexer-internal BIGSERIAL, use as resumption cursor).
 	"""
@@ -1168,11 +1168,12 @@ type Subscription {
 	"""
 	dustLedgerEvents(id: Int): DustLedgerEvent!
 	"""
-	Subscribe to transactions containing dust nullifiers matching the provided prefixes.
-	Returns transaction and block references for wallet to fetch full data.
-	If `toBlock` is specified, the subscription finishes after reaching that block.
+	Subscribe to transactions containing dust nullifiers whose 32-byte little-endian form
+	starts with one of the provided prefixes. Returns transaction and block references for
+	the wallet to fetch full data. If `toBlock` is specified, the subscription finishes
+	after reaching that block.
 	"""
-	dustNullifierTransactions(nullifierPrefixes: [HexEncoded!]!, fromBlock: Int, toBlock: Int): DustNullifierTransaction!
+	dustNullifierTransactions(nullifierLeBytesPrefixes: [HexEncoded!]!, fromBlock: Int, toBlock: Int): DustNullifierTransaction!
 	"""
 	Subscribe to transactions containing shielded (zswap) nullifiers matching the provided
 	prefixes. Returns transaction and block references for wallet to fetch full data.

--- a/indexer-api/src/domain/dust.rs
+++ b/indexer-api/src/domain/dust.rs
@@ -142,8 +142,8 @@ pub struct DustGenerationDtimeUpdateEntry {
 /// A dust nullifier transaction for the subscription stream.
 #[derive(Debug, Clone)]
 pub struct DustNullifierTransaction {
-    pub nullifier: ByteVec,
-    pub commitment: ByteVec,
+    pub nullifier_le_bytes: ByteVec,
+    pub commitment_le_bytes: ByteVec,
     pub transaction_id: u64,
     pub transaction_hash: TransactionHash,
     pub block_height: u32,

--- a/indexer-api/src/infra/api/v4/subscription/dust_nullifier_transactions.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_nullifier_transactions.rs
@@ -42,12 +42,12 @@ impl<S, B> Default for DustNullifierTransactionsSubscription<S, B> {
 /// A transaction containing a dust nullifier match with block context.
 #[derive(Debug, Clone, SimpleObject)]
 pub struct DustNullifierTransaction {
-    /// The hex-encoded matched nullifier.
+    /// The hex-encoded matched nullifier, in 32-byte little-endian form.
     #[graphql(directive = beta::apply())]
-    pub nullifier: HexEncoded,
-    /// The hex-encoded commitment.
+    pub nullifier_le_bytes: HexEncoded,
+    /// The hex-encoded commitment, in 32-byte little-endian form.
     #[graphql(directive = beta::apply())]
-    pub commitment: HexEncoded,
+    pub commitment_le_bytes: HexEncoded,
     /// The transaction ID (indexer-internal BIGSERIAL, use as resumption cursor).
     pub transaction_id: u64,
     /// The hex-encoded transaction hash (32-byte chain identifier).
@@ -64,13 +64,14 @@ where
     S: Storage,
     B: Subscriber,
 {
-    /// Subscribe to transactions containing dust nullifiers matching the provided prefixes.
-    /// Returns transaction and block references for wallet to fetch full data.
-    /// If `toBlock` is specified, the subscription finishes after reaching that block.
+    /// Subscribe to transactions containing dust nullifiers whose 32-byte little-endian form
+    /// starts with one of the provided prefixes. Returns transaction and block references for
+    /// the wallet to fetch full data. If `toBlock` is specified, the subscription finishes
+    /// after reaching that block.
     async fn dust_nullifier_transactions<'a>(
         &self,
         cx: &'a Context<'a>,
-        nullifier_prefixes: Vec<HexEncoded>,
+        nullifier_le_bytes_prefixes: Vec<HexEncoded>,
         from_block: Option<u64>,
         to_block: Option<u64>,
     ) -> impl Stream<Item = ApiResult<DustNullifierTransaction>> {
@@ -90,11 +91,11 @@ where
                 .try_acquire(per_connection_counter, None)
                 .map_err_into_client_error(|| "subscription limit exceeded")?;
 
-            (!nullifier_prefixes.is_empty())
+            (!nullifier_le_bytes_prefixes.is_empty())
                 .then_some(())
-                .some_or_client_error(|| "nullifierPrefixes must not be empty")?;
+                .some_or_client_error(|| "nullifierLeBytesPrefixes must not be empty")?;
 
-            let prefix_bytes = nullifier_prefixes
+            let prefix_bytes = nullifier_le_bytes_prefixes
                 .iter()
                 .map(|p| const_hex::decode(p.as_ref()))
                 .collect::<Result<Vec<_>, _>>()
@@ -104,7 +105,7 @@ where
                 .iter()
                 .all(|b| !b.is_empty())
                 .then_some(())
-                .some_or_client_error(|| "nullifierPrefixes elements must not be empty")?;
+                .some_or_client_error(|| "nullifierLeBytesPrefixes elements must not be empty")?;
 
             let from = from_block.unwrap_or(0);
             let to = to_block.unwrap_or(u64::MAX);
@@ -123,8 +124,8 @@ where
                 .map_err_into_server_error(|| "get next dust nullifier transaction")?
             {
                 yield DustNullifierTransaction {
-                    nullifier: entry.nullifier.hex_encode(),
-                    commitment: entry.commitment.hex_encode(),
+                    nullifier_le_bytes: entry.nullifier_le_bytes.hex_encode(),
+                    commitment_le_bytes: entry.commitment_le_bytes.hex_encode(),
                     transaction_id: entry.transaction_id,
                     transaction_hash: entry.transaction_hash.hex_encode(),
                     block_height: entry.block_height,
@@ -163,8 +164,8 @@ where
                     .map_err_into_server_error(|| "get next dust nullifier transaction")?
                 {
                     yield DustNullifierTransaction {
-                        nullifier: entry.nullifier.hex_encode(),
-                        commitment: entry.commitment.hex_encode(),
+                        nullifier_le_bytes: entry.nullifier_le_bytes.hex_encode(),
+                        commitment_le_bytes: entry.commitment_le_bytes.hex_encode(),
                         transaction_id: entry.transaction_id,
                         transaction_hash: entry.transaction_hash.hex_encode(),
                         block_height: entry.block_height,

--- a/indexer-api/src/infra/storage/dust_generations.rs
+++ b/indexer-api/src/infra/storage/dust_generations.rs
@@ -420,10 +420,10 @@ impl DustGenerationsStorage for Storage {
                         None => break,
                     }
 
-                    for (_, nullifier, commitment, transaction_id, transaction_hash, block_height, block_hash) in rows {
+                    for (_, nullifier_le_bytes, commitment_le_bytes, transaction_id, transaction_hash, block_height, block_hash) in rows {
                         yield DustNullifierTransaction {
-                            nullifier,
-                            commitment,
+                            nullifier_le_bytes,
+                            commitment_le_bytes,
                             transaction_id: transaction_id as u64,
                             transaction_hash,
                             block_height: block_height as u32,

--- a/indexer-tests/e2e.graphql
+++ b/indexer-tests/e2e.graphql
@@ -794,17 +794,17 @@ subscription ShieldedNullifierTransactionsSubscription(
 }
 
 subscription DustNullifierTransactionsSubscription(
-    $nullifierPrefixes: [HexEncoded!]!
+    $nullifierLeBytesPrefixes: [HexEncoded!]!
     $fromBlock: Int
     $toBlock: Int
 ) {
     dustNullifierTransactions(
-        nullifierPrefixes: $nullifierPrefixes
+        nullifierLeBytesPrefixes: $nullifierLeBytesPrefixes
         fromBlock: $fromBlock
         toBlock: $toBlock
     ) {
-        nullifier
-        commitment
+        nullifierLeBytes
+        commitmentLeBytes
         transactionId
         blockHeight
         blockHash

--- a/indexer-tests/src/e2e.rs
+++ b/indexer-tests/src/e2e.rs
@@ -1207,9 +1207,9 @@ async fn test_shielded_nullifier_transactions_subscription(ws_api_url: &str) -> 
 /// range completes empty. Each case is wrapped in a defensive timeout so the test
 /// fails fast rather than hanging if the server doesn't behave as expected.
 async fn test_dust_nullifier_transactions_subscription(ws_api_url: &str) -> anyhow::Result<()> {
-    // Empty nullifierPrefixes array → client error per #1089.
+    // Empty nullifierLeBytesPrefixes array → client error per #1089.
     let variables = dust_nullifier_transactions_subscription::Variables {
-        nullifier_prefixes: vec![],
+        nullifier_le_bytes_prefixes: vec![],
         from_block: Some(0),
         to_block: Some(0),
     };
@@ -1217,18 +1217,18 @@ async fn test_dust_nullifier_transactions_subscription(ws_api_url: &str) -> anyh
         ws_api_url, variables,
     )
     .await
-    .context("subscribe with empty nullifierPrefixes")?;
+    .context("subscribe with empty nullifierLeBytesPrefixes")?;
     let result = tokio::time::timeout(Duration::from_secs(3), stream.try_collect::<Vec<_>>())
         .await
-        .context("expected client error within 3s for empty nullifierPrefixes")?;
+        .context("expected client error within 3s for empty nullifierLeBytesPrefixes")?;
     assert!(
         result.is_err(),
-        "expected client error for empty nullifierPrefixes, got: {result:?}"
+        "expected client error for empty nullifierLeBytesPrefixes, got: {result:?}"
     );
 
     // Empty-string prefix element → also client error per #1089.
     let variables = dust_nullifier_transactions_subscription::Variables {
-        nullifier_prefixes: vec!["".to_string().try_into().unwrap()],
+        nullifier_le_bytes_prefixes: vec!["".to_string().try_into().unwrap()],
         from_block: Some(0),
         to_block: Some(0),
     };
@@ -1248,7 +1248,7 @@ async fn test_dust_nullifier_transactions_subscription(ws_api_url: &str) -> anyh
     // Valid non-matching prefix with bounded range → completes empty. Per-event
     // timeout pattern matches `test_shielded_nullifier_transactions_subscription`.
     let variables = dust_nullifier_transactions_subscription::Variables {
-        nullifier_prefixes: vec!["00".to_string().try_into().unwrap()],
+        nullifier_le_bytes_prefixes: vec!["00".to_string().try_into().unwrap()],
         from_block: Some(0),
         to_block: Some(0),
     };
@@ -1267,7 +1267,7 @@ async fn test_dust_nullifier_transactions_subscription(ws_api_url: &str) -> anyh
 
     // fromBlock > toBlock → client error per #1095.
     let variables = dust_nullifier_transactions_subscription::Variables {
-        nullifier_prefixes: vec!["00".to_string().try_into().unwrap()],
+        nullifier_le_bytes_prefixes: vec!["00".to_string().try_into().unwrap()],
         from_block: Some(10),
         to_block: Some(5),
     };

--- a/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
@@ -56,10 +56,10 @@ describe('dust nullifier transactions subscription', () => {
 
       // Use a broad prefix to increase chance of matches, bounded to first 10 blocks
       const toBlock = Math.min(latestHeight, 10);
-      const nullifierPrefixes = ['00'];
+      const nullifierLeBytesPrefixes = ['00'];
 
       log.debug(
-        `Subscribing to dust nullifier transactions with prefixes=${nullifierPrefixes}, fromBlock=0, toBlock=${toBlock}`,
+        `Subscribing to dust nullifier transactions with prefixes=${nullifierLeBytesPrefixes}, fromBlock=0, toBlock=${toBlock}`,
       );
 
       const received: DustNullifierTransactionSubscriptionResponse[] = [];
@@ -89,7 +89,7 @@ describe('dust nullifier transactions subscription', () => {
               resolve();
             },
           },
-          nullifierPrefixes,
+          nullifierLeBytesPrefixes,
           0,
           toBlock,
         );
@@ -167,7 +167,7 @@ describe('dust nullifier transactions subscription', () => {
         );
       });
 
-      expect(settled.error).toContain('nullifierPrefixes must not be empty');
+      expect(settled.error).toContain('nullifierLeBytesPrefixes must not be empty');
       expect(settled.completed).toBe(false);
       expect(settled.eventCount).toBeGreaterThanOrEqual(0);
     });

--- a/qa/tests/utils/indexer/graphql/schema.ts
+++ b/qa/tests/utils/indexer/graphql/schema.ts
@@ -407,8 +407,8 @@ export const DustGenerationsEventSchema = z.discriminatedUnion('__typename', [
 ]);
 
 export const DustNullifierTransactionSchema = z.object({
-  nullifier: VarLenghtHex,
-  commitment: VarLenghtHex,
+  nullifierLeBytes: VarLenghtHex,
+  commitmentLeBytes: VarLenghtHex,
   transactionId: z.number(),
   transactionHash: Hash64,
   blockHeight: z.number(),

--- a/qa/tests/utils/indexer/graphql/subscriptions.ts
+++ b/qa/tests/utils/indexer/graphql/subscriptions.ts
@@ -387,10 +387,10 @@ export const DUST_GENERATIONS_SUBSCRIPTION = `
 `;
 
 export const DUST_NULLIFIER_TRANSACTIONS_SUBSCRIPTION = `
-  subscription DustNullifierTransactions($nullifierPrefixes: [HexEncoded!]!, $fromBlock: Int, $toBlock: Int) {
-    dustNullifierTransactions(nullifierPrefixes: $nullifierPrefixes, fromBlock: $fromBlock, toBlock: $toBlock) {
-      nullifier
-      commitment
+  subscription DustNullifierTransactions($nullifierLeBytesPrefixes: [HexEncoded!]!, $fromBlock: Int, $toBlock: Int) {
+    dustNullifierTransactions(nullifierLeBytesPrefixes: $nullifierLeBytesPrefixes, fromBlock: $fromBlock, toBlock: $toBlock) {
+      nullifierLeBytes
+      commitmentLeBytes
       transactionId
       transactionHash
       blockHeight

--- a/qa/tests/utils/indexer/indexer-types.ts
+++ b/qa/tests/utils/indexer/indexer-types.ts
@@ -375,8 +375,8 @@ export type DustGenerationsEvent =
   | DustGenerationDtimeUpdateItem;
 
 export interface DustNullifierTransaction {
-  nullifier: string;
-  commitment: string;
+  nullifierLeBytes: string;
+  commitmentLeBytes: string;
   transactionId: number;
   transactionHash: string;
   blockHeight: number;

--- a/qa/tests/utils/indexer/websocket-client.ts
+++ b/qa/tests/utils/indexer/websocket-client.ts
@@ -1058,7 +1058,7 @@ export class IndexerWsClient {
    * If `toBlock` is specified, the subscription finishes after reaching that block.
    *
    * @param handlers - Callback functions for handling incoming nullifier transaction events
-   * @param nullifierPrefixes - Array of hex-encoded nullifier prefixes to match
+   * @param nullifierLeBytesPrefixes - Array of hex-encoded 32-byte little-endian nullifier prefixes to match
    * @param fromBlock - Optional starting block height
    * @param toBlock - Optional ending block height (subscription finishes after this)
    * @param queryOverride - Optional custom GraphQL subscription query
@@ -1067,13 +1067,13 @@ export class IndexerWsClient {
    */
   subscribeToDustNullifierTransactions(
     handlers: SubscriptionHandlers<DustNullifierTransactionSubscriptionResponse>,
-    nullifierPrefixes: string[],
+    nullifierLeBytesPrefixes: string[],
     fromBlock?: number,
     toBlock?: number,
     queryOverride?: string,
   ): { unsubscribe: () => void; id: string } {
     const query = queryOverride || DUST_NULLIFIER_TRANSACTIONS_SUBSCRIPTION;
-    const variables = { nullifierPrefixes, fromBlock, toBlock };
+    const variables = { nullifierLeBytesPrefixes, fromBlock, toBlock };
 
     const subscriptionId = this.getNextId();
 


### PR DESCRIPTION
Rename the byte-format fields on DustNullifierTransaction and the input prefix argument on the dustNullifierTransactions subscription so the constant-length little-endian byte encoding is explicit in the name. Wallets deriving nullifiers via SCALE no longer need to discover the encoding contract through trial and error; the name telegraphs it.

GraphQL surface changes:
- DustNullifierTransaction.nullifier  -> nullifierLeBytes  (@beta)
- DustNullifierTransaction.commitment -> commitmentLeBytes (@beta)
- dustNullifierTransactions(nullifierPrefixes:) -> nullifierLeBytesPrefixes

LeBytes names the encoding (raw little-endian bytes of the underlying Fr field element), not a fixed length. The value is stored as variable-length bytes (ByteVec / BYTEA) and matched by byte-range, so no length is hardcoded: the dust nullifier and commitment are 32 bytes today (Fr field size), and a future field-size change is absorbed without code changes. This raw LE form is deliberately kept over the ledger-native SCALE encoding (variable-length 32/33-byte compact form) because fixed-length is more practical for indexed prefix-matching.

Shielded nullifier surface left as-is (SHA-256 bytes, no LE/BE ambiguity).

Closes #1174.