### PR TITLE
test: shielded tx subscription relevance + toolkit fetch-cache fixes

### DIFF
--- a/qa/tests/README.md
+++ b/qa/tests/README.md
@@ -103,8 +103,27 @@ E2E and integration tests that use the Node Toolkit fetch a Postgres-backed
 cache (`MN_FETCH_CACHE`). The test harness brings the `toolkit-postgres`
 container up automatically on a dynamically chosen host port — no manual
 step is required. Cache data persists between runs under
-`qa/tests/.tmp/toolkit-postgres-data/`. To start fresh, stop and remove the
-container: `docker rm -f toolkit-postgres`.
+`qa/tests/.tmp/toolkit-postgres-data/`.
+
+The cache is **shared across every target environment**: each chain lives in
+the same Postgres keyed by its `chain_id`, so a single volume can hold the
+multi-million-block `qanet` and `preview` chains alongside ephemeral
+`undeployed` chains. Because `undeployed` provisions a fresh genesis (a new
+`chain_id`) on every run, the warmup reporter auto-prunes superseded
+`undeployed` chains per-`chain_id` — it never deletes another env's data.
+
+> **Do not** `docker rm -f toolkit-postgres` / delete `.tmp/toolkit-postgres-data`
+> to clear "stale" chains: that wipes **all** environments' caches, forcing a
+> multi-hour re-sync of `qanet`/`preview`. To reclaim a single chain, prune just
+> its rows (the reporter prints the exact command when it flags an unexpected
+> chain):
+>
+> ```bash
+> docker exec toolkit-postgres psql -U toolkit -d toolkit \
+>   -c "DELETE FROM raw_block_data_v2 WHERE chain_id = decode('<chain_id_hex>','hex'); \
+>       DELETE FROM highest_verified  WHERE chain_id = decode('<chain_id_hex>','hex'); \
+>       DELETE FROM chain_names       WHERE chain_id = decode('<chain_id_hex>','hex');"
+> ```
 
 #### Undeployed / local environment
 
@@ -118,6 +137,7 @@ export NODE_TOOLKIT_TAG=latest-main
 ```
 
 Note: if you need to match a particular toolkit version:
+
 ```bash
 export NODE_TOOLKIT_TAG=0.18.0-rc.7
 ```
@@ -133,6 +153,7 @@ export NODE_TOOLKIT_TAG=latest-main
 ```
 
 Note: if you need to match a particular toolkit version:
+
 ```bash
 export NODE_TOOLKIT_TAG=0.17.0-rc.4
 ```
@@ -177,11 +198,11 @@ suite finishes. **No manual script invocation is required.**
 
 Stack flavour by suite:
 
-| Suite | Provisioning script invoked | Chain state |
-|-------|----------------------------|-------------|
-| `smoke` | `qa/scripts/startup-localenv-with-data.sh` | pre-seeded from `.node/<NODE_TAG>/` |
-| `integration` | `qa/scripts/startup-localenv-with-data.sh` | pre-seeded from `.node/<NODE_TAG>/` |
-| `e2e` | `qa/scripts/startup-localenv-from-genesis.sh` | fresh (toolkit generates data dynamically) |
+| Suite         | Provisioning script invoked                   | Chain state                                |
+| ------------- | --------------------------------------------- | ------------------------------------------ |
+| `smoke`       | `qa/scripts/startup-localenv-with-data.sh`    | pre-seeded from `.node/<NODE_TAG>/`        |
+| `integration` | `qa/scripts/startup-localenv-with-data.sh`    | pre-seeded from `.node/<NODE_TAG>/`        |
+| `e2e`         | `qa/scripts/startup-localenv-from-genesis.sh` | fresh (toolkit generates data dynamically) |
 
 > ℹ️ **`.node/<NODE_TAG>/` must exist** for the with-data flavour. Generate it
 > via `./generate_node_data.sh <NODE_TAG>` from the repo root if it isn't there.
@@ -287,13 +308,13 @@ TARGET_ENV=undeployed yarn test:integration
 
 #### Environment variables
 
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `FROM_NODE_TAG` | Yes | — | Old node version (e.g. `0.21.0`) |
-| `TO_NODE_TAG` | Yes | — | New node version (e.g. `0.22.2`) |
-| `INDEXER_TAG` | Yes | — | Indexer image tag to test |
-| `NODE_TOOLKIT_TAG` | No | `latest-main` | Node toolkit version for the governance upgrade |
-| `IMAGE_REGISTRY` | No | `midnightntwrk` | Docker image registry (use `ghcr.io/midnight-ntwrk` for GHCR images) |
+| Variable           | Required | Default         | Description                                                          |
+| ------------------ | -------- | --------------- | -------------------------------------------------------------------- |
+| `FROM_NODE_TAG`    | Yes      | —               | Old node version (e.g. `0.21.0`)                                     |
+| `TO_NODE_TAG`      | Yes      | —               | New node version (e.g. `0.22.2`)                                     |
+| `INDEXER_TAG`      | Yes      | —               | Indexer image tag to test                                            |
+| `NODE_TOOLKIT_TAG` | No       | `latest-main`   | Node toolkit version for the governance upgrade                      |
+| `IMAGE_REGISTRY`   | No       | `midnightntwrk` | Docker image registry (use `ghcr.io/midnight-ntwrk` for GHCR images) |
 
 #### Notes
 

--- a/qa/tests/tests/e2e/shielded-transactions.test.ts
+++ b/qa/tests/tests/e2e/shielded-transactions.test.ts
@@ -27,10 +27,55 @@ import {
 } from './test-utils';
 import { TestContext } from 'vitest';
 import { collectValidZswapEvents } from 'tests/shared/zswap-events-utils';
-import { RegularTransactionSchema, ZswapLedgerEventSchema } from '@utils/indexer/graphql/schema';
+import {
+  RegularTransactionSchema,
+  RelevantTransactionSchema,
+  ZswapLedgerEventSchema,
+} from '@utils/indexer/graphql/schema';
 import { IndexerWsClient } from '@utils/indexer/websocket-client';
 import { EventCoordinator } from '@utils/event-coordinator';
 import { collectValidDustLedgerEvents } from 'tests/shared/dust-ledger-utils';
+
+/**
+ * Subscribe to shielded transaction events for an open wallet session and resolve `true` as soon
+ * as a `RelevantTransaction` whose transaction hash equals `expectedTxHash` is delivered, or
+ * `false` if no such event arrives within `timeoutMs`.
+ *
+ * The shielded subscription replays relevant history from the beginning, so a transaction
+ * confirmed before the subscription opened is still delivered. The indexer never exposes
+ * decrypted shielded amounts, so identity (the transaction hash) is the correctness handle:
+ * matching it proves the indexer streamed *the* transaction, not merely *a* transaction. The
+ * helper is used both to assert delivery to the involved viewing keys (expect `true`) and to
+ * assert non-delivery to an unrelated viewing key (expect `false`).
+ */
+async function awaitRelevantTransaction(
+  ws: IndexerWsClient,
+  sessionId: string,
+  expectedTxHash: string,
+  timeoutMs: number,
+): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    let unsubscribe = () => {};
+    const timeout = setTimeout(() => {
+      unsubscribe();
+      resolve(false);
+    }, timeoutMs);
+
+    unsubscribe = ws.subscribeToShieldedTransactionEvents(
+      {
+        next: (payload) => {
+          const parsed = RelevantTransactionSchema.safeParse(payload.data?.shieldedTransactions);
+          if (parsed.success && parsed.data.transaction.hash === expectedTxHash) {
+            clearTimeout(timeout);
+            unsubscribe();
+            resolve(true);
+          }
+        },
+      },
+      sessionId,
+    );
+  });
+}
 
 describe('shielded transactions', () => {
   let indexerWsClient: IndexerWsClient;
@@ -319,50 +364,129 @@ describe('shielded transactions', () => {
         `dustCommitmentEndIndex before tx: ${dustCommitmentEndIndexBeforeTx}, after tx: ${regularTx.dustCommitmentEndIndex}`,
       );
     });
+  });
+
+  describe('a confirmed shielded transfer streamed to wallet sessions by viewing key', () => {
+    // A third seed that is NOT party to the source->destination transfer, used as a negative
+    // control for the indexer's relevance filtering / shielded privacy guarantee.
+    const unrelatedSeed = '0'.repeat(56) + 'deadbeef';
 
     /**
-     * Once a shielded transaction has been submitted to node and confirmed, the indexer should report
-     * that transaction through an shielded transaction event for the source viewing key.
+     * The indexer streams a confirmed shielded transaction to the wallet session of the source
+     * viewing key. The indexer never exposes decrypted shielded value, so identity is the
+     * assertion: the streamed RelevantTransaction must carry the same hash the toolkit submitted.
      *
-     * @given we subscribe to shielded transaction events for the source viewing key
-     * @when we submit an shielded transaction to node
-     * @then we should receive a transaction event that includes transaction details for the source viewing key
+     * @given a confirmed shielded transaction and a session opened with the source viewing key
+     * @when we subscribe to shielded transaction events for that session
+     * @then a RelevantTransaction whose hash matches the submitted transaction is delivered
      */
-    test.todo(
-      'should be reported by the indexer through an shielded transaction event for the source address',
-      async () => {
-        // Implement me
+    test(
+      'should stream the transaction to the source viewing key with a matching hash',
+      { timeout: 60_000 },
+      async (ctx: TestContext) => {
+        ctx.task!.meta.custom = {
+          labels: ['Subscription', 'ShieldedTransaction', 'ViewingKey', 'Source'],
+        };
+
+        ctx.skip?.(
+          transactionResult.status !== 'confirmed',
+          "Toolkit transaction hasn't been confirmed",
+        );
+
+        // Reconnect WS client - the connection may have gone stale during the long toolkit transaction
+        await indexerWsClient.connectionClose();
+        await indexerWsClient.connectionInit();
+
+        const viewingKey = await toolkit.showViewingKey(sourceSeed);
+        const sessionId = await indexerWsClient.openWalletSession(viewingKey);
+
+        const delivered = await awaitRelevantTransaction(
+          indexerWsClient,
+          sessionId,
+          transactionResult.txHash!,
+          30_000,
+        );
+        expect(delivered).toBe(true);
       },
     );
 
     /**
-     * Once a shielded transaction has been submitted to node and confirmed, the indexer should report
-     * that transaction through an shielded transaction event for the destination viewing key.
+     * The same confirmed transaction is also relevant to the destination wallet (via the output
+     * addressed to it), so the indexer must stream it to the destination viewing key too.
      *
-     * @given we subscribe to shielded transaction events for the destination viewing key
-     * @when we submit an shielded transaction to node
-     * @then we should receive a transaction event that includes transaction details for the destination viewing key
+     * @given a confirmed shielded transaction and a session opened with the destination viewing key
+     * @when we subscribe to shielded transaction events for that session
+     * @then a RelevantTransaction whose hash matches the submitted transaction is delivered
      */
-    test.todo(
-      'should be reported by the indexer through an shielded transaction event for the destination address',
-      async () => {
-        // Implement me
+    test(
+      'should stream the transaction to the destination viewing key with a matching hash',
+      { timeout: 60_000 },
+      async (ctx: TestContext) => {
+        ctx.task!.meta.custom = {
+          labels: ['Subscription', 'ShieldedTransaction', 'ViewingKey', 'Destination'],
+        };
+
+        ctx.skip?.(
+          transactionResult.status !== 'confirmed',
+          "Toolkit transaction hasn't been confirmed",
+        );
+
+        // Reconnect WS client - the connection may have gone stale during the long toolkit transaction
+        await indexerWsClient.connectionClose();
+        await indexerWsClient.connectionInit();
+
+        const viewingKey = await toolkit.showViewingKey(destinationSeed);
+        const sessionId = await indexerWsClient.openWalletSession(viewingKey);
+
+        const delivered = await awaitRelevantTransaction(
+          indexerWsClient,
+          sessionId,
+          transactionResult.txHash!,
+          30_000,
+        );
+        expect(delivered).toBe(true);
       },
     );
 
     /**
-     * Once an shielded transaction has been submitted to node and confirmed, we should see the transaction
-     * giving 1 shielded token to the destination address.
+     * The indexer must publish the transaction only to the viewing keys it concerns. A viewing
+     * key not party to the transfer must not receive it. This is the negative control that, paired
+     * with the two delivery cases above, proves the indexer routes the right transaction to the
+     * right parties and only them. Asserting decrypted amounts is intentionally out of scope: the
+     * indexer is privacy-preserving and never exposes plaintext shielded value (a 1-token balance
+     * change is a wallet-side concern, not the indexer's).
      *
-     * @given a confirmed shielded transaction between two wallets
-     * @when we inspect the containing block for shielded transaction details
-     * @then there should be a balance change that reflects the transfer of 1 shielded token
+     * @given a confirmed shielded transaction and a session opened with an unrelated viewing key
+     * @when we subscribe to shielded transaction events for that session
+     * @then no RelevantTransaction matching the submitted transaction is delivered
      */
-    test.todo(
-      'should have transferred 1 token from the source to the destination address',
-      async () => {
-        // Implement me but... can we really implement this test? We need to be able to view the transaction details in
-        // the block and use the viewing key for that. Does the toolkit offer that level of support?
+    test(
+      'should not stream the transaction to an unrelated viewing key',
+      { timeout: 40_000 },
+      async (ctx: TestContext) => {
+        ctx.task!.meta.custom = {
+          labels: ['Subscription', 'ShieldedTransaction', 'ViewingKey', 'Privacy'],
+        };
+
+        ctx.skip?.(
+          transactionResult.status !== 'confirmed',
+          "Toolkit transaction hasn't been confirmed",
+        );
+
+        // Reconnect WS client - the connection may have gone stale during the long toolkit transaction
+        await indexerWsClient.connectionClose();
+        await indexerWsClient.connectionInit();
+
+        const viewingKey = await toolkit.showViewingKey(unrelatedSeed);
+        const sessionId = await indexerWsClient.openWalletSession(viewingKey);
+
+        const delivered = await awaitRelevantTransaction(
+          indexerWsClient,
+          sessionId,
+          transactionResult.txHash!,
+          20_000,
+        );
+        expect(delivered).toBe(false);
       },
     );
   });

--- a/qa/tests/utils/toolkit/toolkit-cache.ts
+++ b/qa/tests/utils/toolkit/toolkit-cache.ts
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { execFile } from 'child_process';
+import { execFile, spawn } from 'child_process';
 import { createServer } from 'net';
 import fs from 'fs';
 import path from 'path';
@@ -274,83 +274,181 @@ export function startCacheProgressReporter(
   nodeRpcUrl?: string,
 ): CacheProgressReporter {
   const prev = new Map<string, number>();
-  let chainTip: number | undefined;
+  // Chains already pruned in this process, so we don't re-issue DELETEs every tick.
+  const pruned = new Set<string>();
+  // `undeployed` provisions a fresh genesis (new chain_id) on every run, so superseded
+  // undeployed chains in the shared cache are garbage and safe to reclaim. Persistent
+  // networks (qanet, preview, …) have a single stable chain_id, so a second chain under
+  // their label means mis-attribution, not a reset — never auto-prune those; surface
+  // them for a targeted manual prune instead.
+  const autoPrune = label === 'undeployed';
 
-  const fetchChainTip = async (): Promise<void> => {
-    if (!nodeRpcUrl) return;
+  let chainTip: number | undefined;
+  // Hash of block height 1 on the live node. In the toolkit fetch cache the chain_id *is*
+  // the block-1 hash (verified against the qanet/preview indexers), NOT the genesis hash:
+  // block 1 incorporates its own content (timestamp/author) on top of genesis, so a chain
+  // reset from the SAME genesis still yields a different block-1 hash → a new chain_id.
+  // Genesis hash would collide across resets and mis-match a freshly-synced chain to an old
+  // one. This is the authoritative identity of the chain THIS run is fetching — far more
+  // reliable than guessing from block counts or growth, which let a larger leftover chain
+  // win the "active" race (e.g. 601 cached blocks vs a tip of 7 → 8585%).
+  let currentChainIdHex: string | undefined;
+  let registeredCurrent = false;
+
+  const rpc = async <T>(method: string, params: unknown[]): Promise<T | undefined> => {
+    if (!nodeRpcUrl) return undefined;
     try {
       const res = await fetch(nodeRpcUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id: 1, jsonrpc: '2.0', method: 'chain_getHeader', params: [] }),
+        body: JSON.stringify({ id: 1, jsonrpc: '2.0', method, params }),
       });
-      const json = (await res.json()) as { result?: { number?: string } };
-      const hex = json?.result?.number;
-      if (hex) chainTip = parseInt(hex, 16);
+      const json = (await res.json()) as { result?: T };
+      return json?.result;
     } catch {
-      // Non-fatal
+      return undefined; // Non-fatal — the reporter is best-effort.
     }
+  };
+
+  const fetchChainTip = async (): Promise<void> => {
+    const header = await rpc<{ number?: string }>('chain_getHeader', []);
+    if (header?.number) chainTip = parseInt(header.number, 16);
+  };
+
+  const fetchCurrentChainId = async (): Promise<void> => {
+    if (currentChainIdHex) return; // block-1 hash is stable for the life of the run
+    // Block height 1 (not 0): see the currentChainIdHex comment. Returns null until the
+    // node has authored block 1 — harmless, we just retry on the next tick. The 30s
+    // genesis settle in the undeployed provisioner ensures block 1 exists well before.
+    const hash = await rpc<string>('chain_getBlockHash', [1]);
+    const hex = hash?.replace(/^0x/, '').toLowerCase();
+    if (hex && /^[0-9a-f]+$/.test(hex)) currentChainIdHex = hex;
   };
 
   const tick = async () => {
     try {
-      await fetchChainTip();
+      await Promise.all([fetchChainTip(), fetchCurrentChainId()]);
       const chains = await queryChainProgress();
       if (chains.length === 0) {
         console.log(`[CACHE:${label}] Waiting for first blocks…`);
         return;
       }
 
-      // Capture deltas against the previous snapshot before mutating `prev`,
-      // otherwise every later `c.blockCount - prev.get(c.chainId)` is 0.
+      // Per-interval deltas, used only for the Δ display and the active-chain fallback.
       const deltas = new Map<string, number>();
       for (const c of chains) {
-        deltas.set(c.chainId, c.blockCount - (prev.get(c.chainId) ?? 0));
+        const seen = prev.has(c.chainId);
+        deltas.set(c.chainId, seen ? c.blockCount - (prev.get(c.chainId) ?? 0) : 0);
         prev.set(c.chainId, c.blockCount);
       }
 
-      // Unregistered chains (no envName) are treated as belonging to the current env
-      // until we know otherwise — they'll get registered below once they start growing.
-      const currentChains = chains.filter((c) => !c.envName || c.envName === label);
+      // The chain THIS run is fetching, identified by its block-1 hash when available.
+      const current = currentChainIdHex
+        ? chains.find((c) => c.chainIdHex === currentChainIdHex)
+        : undefined;
 
-      // Register unregistered growing chains with the current env label.
-      for (const c of currentChains) {
-        if (!c.envName && (deltas.get(c.chainId) ?? 0) > 0) {
-          await registerChainName(c.chainIdHex, label).catch(() => undefined);
-        }
+      // Register the current chain to this env deterministically — no need to watch it
+      // grow, which a fast (few-second) undeployed warmup never gives us time to observe.
+      if (current && !registeredCurrent && current.envName !== label) {
+        await registerChainName(current.chainIdHex, label).catch(() => undefined);
+        registeredCurrent = true;
+        current.envName = label;
       }
 
-      if (currentChains.length === 0) {
+      // Chains relevant to this env: the current chain plus same-label / untagged ones.
+      const candidates = chains.filter((c) => !c.envName || c.envName === label);
+      if (!current && candidates.length === 0) {
         console.log(`[CACHE:${label}] Waiting for first blocks…`);
-      } else {
-        // Active chain within the current env = one currently growing; fall back to highest count.
-        const growingIds = new Set(
-          currentChains.filter((c) => (deltas.get(c.chainId) ?? 0) > 0).map((c) => c.chainId),
-        );
-        const activeChainId =
-          growingIds.size > 0
-            ? [...growingIds][0]
-            : currentChains.reduce((a, b) => (a.blockCount >= b.blockCount ? a : b)).chainId;
+        return;
+      }
 
-        for (const c of currentChains) {
-          const delta = deltas.get(c.chainId) ?? 0;
-          const isActive = c.chainId === activeChainId;
-          const tag = isActive ? '' : ' ⚠ stale';
+      // Active chain: the block-1-hash-matched current chain when known; otherwise fall
+      // back to a currently-growing chain, then the highest block count (display guess).
+      const growing = candidates.filter((c) => (deltas.get(c.chainId) ?? 0) > 0);
+      const activeChainId =
+        current?.chainId ??
+        (growing.length > 0
+          ? growing[0].chainId
+          : candidates.reduce((a, b) => (a.blockCount >= b.blockCount ? a : b)).chainId);
 
-          const progress =
-            chainTip !== undefined && chainTip > 0
-              ? `fetch progress: ${c.blockCount.toLocaleString()}/${chainTip.toLocaleString()} (${((c.blockCount / chainTip) * 100).toFixed(1)}%) blocks complete`
-              : `${c.blockCount.toLocaleString()} blocks fetched (Δ +${delta.toLocaleString()} in ${PROGRESS_INTERVAL_MS / 1000}s)`;
+      // ---- display ----
+      const denom = chainTip !== undefined ? chainTip + 1 : undefined; // heights are 0-indexed
+      for (const c of chains) {
+        // Skip foreign-env chains (a different label) — noise during this run.
+        if (c.envName && c.envName !== label && c.chainId !== activeChainId) continue;
+        const delta = deltas.get(c.chainId) ?? 0;
+        const isActive = c.chainId === activeChainId;
+        const tag = isActive
+          ? ''
+          : c.envName === label
+            ? ' ⚠ stale'
+            : ' ↪ unattributed (another env?)';
+        // A percentage against the live tip is only meaningful for the current chain;
+        // showing it for an unrelated leftover yields nonsense like 8585%.
+        const progress =
+          isActive && denom !== undefined && denom > 0
+            ? `fetch progress: ${c.blockCount.toLocaleString()}/${denom.toLocaleString()} (${Math.min(100, (c.blockCount / denom) * 100).toFixed(1)}%) blocks complete`
+            : `${c.blockCount.toLocaleString()} blocks fetched (Δ +${delta.toLocaleString()} in ${PROGRESS_INTERVAL_MS / 1000}s)`;
+        console.log(`[CACHE:${label}] chain ${c.chainId}${tag} — ${progress}`);
+      }
 
-          console.log(`[CACHE:${label}] chain ${c.chainId}${tag} — ${progress}`);
+      // ---- reclaim / warn ----
+      if (autoPrune) {
+        // Deterministic identity is REQUIRED before deleting anything: if the genesis
+        // hash could not be read, skip pruning rather than risk the wrong chain.
+        if (current) {
+          // Only reclaim chains explicitly tagged with THIS env. We deliberately do NOT
+          // touch untagged chains: a `withData` undeployed run (integration/smoke) loads
+          // pre-seeded node data, so its block-1 hash — and thus chain_id — is STABLE across
+          // runs, but those suites never run this reporter, so that chain sits UNTAGGED in
+          // the shared cache. Pruning untagged chains here would evict that reusable
+          // pre-seeded cache on every from-genesis e2e run. From-genesis chains are tagged
+          // deterministically (above), so tag-scoped pruning still clears superseded runs.
+          const reclaim = chains.filter(
+            (c) => c.chainIdHex !== current.chainIdHex && c.envName === label,
+          );
+          for (const c of reclaim) {
+            if (pruned.has(c.chainIdHex)) continue;
+            pruned.add(c.chainIdHex);
+            const ok = await pruneChain(c.chainIdHex)
+              .then(() => true)
+              .catch((err) => {
+                console.warn(`[CACHE:${label}] failed to prune ${c.chainId}: ${err}`);
+                return false;
+              });
+            if (ok) {
+              console.log(
+                `[CACHE:${label}] reclaimed superseded chain ${c.chainId}` +
+                  ` (${c.blockCount.toLocaleString()} blocks) — kept current chain ${current.chainId}.`,
+              );
+            }
+          }
         }
-
-        const staleCurrentCount = currentChains.length - 1;
-        if (staleCurrentCount > 0) {
+      } else {
+        // Persistent network: a second chain tagged with this env is mis-attribution,
+        // not a reset. Never touch the shared data dir (that wipes every env's cache);
+        // surface the exact chains with a scoped prune command instead.
+        const mislabeled = chains.filter(
+          (c) =>
+            c.envName === label &&
+            c.chainIdHex !== currentChainIdHex &&
+            c.chainId !== activeChainId,
+        );
+        if (mislabeled.length > 0) {
+          const ids = mislabeled.map((c) => `${c.chainId} (${c.chainIdHex})`).join(', ');
           console.warn(
-            `[CACHE:${label}] ⚠  ${staleCurrentCount} stale ${label} chain(s) detected from past env resets.` +
-              ` Run \`docker rm -f ${CONTAINER_NAME}\` and delete \`.tmp/toolkit-postgres-data\`` +
-              ` to reclaim space.`,
+            `[CACHE:${label}] ⚠  ${mislabeled.length} unexpected chain(s) tagged \`${label}\`: ${ids}. ` +
+              `These look mis-attributed, not ${label} data. ` +
+              `Prune only those chains (do NOT delete .tmp/toolkit-postgres-data — that wipes every env's cache):\n` +
+              mislabeled
+                .map(
+                  (c) =>
+                    `    docker exec ${CONTAINER_NAME} psql -U ${POSTGRES_USER} -d ${POSTGRES_DB} ` +
+                    `-c "DELETE FROM raw_block_data_v2 WHERE chain_id = decode('${c.chainIdHex}','hex'); ` +
+                    `DELETE FROM highest_verified WHERE chain_id = decode('${c.chainIdHex}','hex'); ` +
+                    `DELETE FROM chain_names WHERE chain_id = decode('${c.chainIdHex}','hex');"`,
+                )
+                .join('\n'),
           );
         }
       }
@@ -414,24 +512,76 @@ async function queryChainProgress(): Promise<ChainProgress[]> {
     });
 }
 
+/**
+ * Remove a single chain's blocks from the shared fetch cache.
+ *
+ * Deletes only the rows keyed by this `chain_id` across `raw_block_data_v2`,
+ * `highest_verified`, and `chain_names`. The shared Postgres container and its
+ * `.tmp/toolkit-postgres-data` volume (which holds every env's cache, including
+ * the multi-million-block qanet/preview chains) are left fully intact — this is
+ * the surgical alternative to wiping the whole data dir.
+ *
+ * Exported so it can be driven from a one-off cleanup script or test if needed.
+ */
+export async function pruneChain(chainIdHex: string): Promise<void> {
+  await runPsqlScript(
+    `DELETE FROM raw_block_data_v2 WHERE chain_id = decode(:'chain_id_hex', 'hex');
+     DELETE FROM highest_verified WHERE chain_id = decode(:'chain_id_hex', 'hex');
+     DELETE FROM chain_names      WHERE chain_id = decode(:'chain_id_hex', 'hex');`,
+    { chain_id_hex: chainIdHex },
+  );
+}
+
 async function registerChainName(chainIdHex: string, envName: string): Promise<void> {
-  await execFileAsync('docker', [
-    'exec',
-    CONTAINER_NAME,
-    'psql',
-    '-U',
-    POSTGRES_USER,
-    '-d',
-    POSTGRES_DB,
-    // Pass values as psql variables rather than interpolating into the SQL text,
-    // so chain_id_hex/env can never be parsed as SQL regardless of their content.
-    '-v',
-    `chain_id_hex=${chainIdHex}`,
-    '-v',
-    `env=${envName}`,
-    '-c',
+  await runPsqlScript(
     `INSERT INTO chain_names (chain_id, env_name)
      VALUES (decode(:'chain_id_hex', 'hex'), :'env')
      ON CONFLICT (chain_id) DO NOTHING;`,
-  ]);
+    { chain_id_hex: chainIdHex, env: envName },
+  );
+}
+
+/**
+ * Run a psql script inside the cache container, with values passed as psql
+ * variables (interpolated via `:'name'`) so they can never be parsed as SQL.
+ *
+ * The script is fed on stdin (`-f -`) rather than via `-c`: psql performs
+ * `:'var'` interpolation only for scripts read from a file/stdin, NOT for `-c`
+ * command strings. Using `-c` here silently produced a `syntax error at or
+ * near ":"`, which — because callers swallowed the error — meant chain
+ * registration and pruning never actually ran. `ON_ERROR_STOP=1` makes any
+ * failure surface as a non-zero exit instead of a partial, ignored result.
+ */
+async function runPsqlScript(sql: string, vars: Record<string, string> = {}): Promise<void> {
+  const varArgs = Object.entries(vars).flatMap(([k, v]) => ['-v', `${k}=${v}`]);
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(
+      'docker',
+      [
+        'exec',
+        '-i',
+        CONTAINER_NAME,
+        'psql',
+        '-U',
+        POSTGRES_USER,
+        '-d',
+        POSTGRES_DB,
+        '-v',
+        'ON_ERROR_STOP=1',
+        ...varArgs,
+        '-f',
+        '-',
+      ],
+      { stdio: ['pipe', 'ignore', 'pipe'] },
+    );
+    let stderr = '';
+    child.stderr.on('data', (d) => (stderr += String(d)));
+    child.on('error', reject);
+    child.on('close', (code) =>
+      code === 0
+        ? resolve()
+        : reject(new Error(`psql exited with code ${code}${stderr ? `: ${stderr.trim()}` : ''}`)),
+    );
+    child.stdin.end(sql);
+  });
 }

--- a/qa/tests/utils/undeployed/environment-manager.ts
+++ b/qa/tests/utils/undeployed/environment-manager.ts
@@ -36,6 +36,12 @@ const READY_URL = 'http://localhost:8088/ready';
 const HEALTH_CHECK_ATTEMPTS = 10;
 const HEALTH_CHECK_INTERVAL_MS = 2000;
 
+// A from-genesis stack starts with an empty chain: the indexer reports ready as
+// soon as it has indexed the genesis block, but tests that read recent blocks
+// need a few real blocks on chain first. Give the node time to author a handful
+// (~5 at the default ~6s block time) before the suite starts querying.
+const GENESIS_BLOCK_PRODUCTION_WAIT_MS = 30_000;
+
 /**
  * Provisions the local `undeployed` docker stack from within the test framework.
  *
@@ -118,6 +124,18 @@ export class UndeployedEnvironmentManager {
 
     await this.waitForIndexerReady();
     console.log('[undeployed] Stack is up and reachable.');
+
+    // Only a from-genesis stack (withData: false) starts with an empty chain and
+    // needs to author blocks before tests run. A with-data stack is pre-seeded, and
+    // a manually-managed stack (detected above, returns early) has been running for
+    // a while — neither needs the wait.
+    if (!this.withData) {
+      console.log(
+        `[undeployed] Genesis stack — waiting ${GENESIS_BLOCK_PRODUCTION_WAIT_MS / 1000}s ` +
+          'for the node to produce a few blocks before tests start...',
+      );
+      await new Promise((resolve) => setTimeout(resolve, GENESIS_BLOCK_PRODUCTION_WAIT_MS));
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #1006.

## Scope

Two related pieces of work on the QA suite, in separate commits:

1. **Shielded tx subscription relevance coverage** (`c869b77`) — expands the shielded-transaction e2e tests to assert subscription relevance.
2. **Toolkit fetch-cache chain attribution & pruning fixes** (`ff72e03`) — correctness fixes to the shared `toolkit-postgres` fetch cache surfaced while running the shielded e2e suite.

## Why

The shared toolkit fetch cache mis-identified chains and recommended a cleanup (`docker rm -f` + delete the data dir) that would wipe **every** environment's cache, including the multi-million-block qanet/preview chains.

Root causes fixed:

- **`chain_id` is the block-1 hash** (verified against the qanet/preview indexers), not genesis. The current run's chain is now identified via `chain_getBlockHash([1])` instead of guessing by block count — which had mislabeled a 601-block leftover as "active" (601/7 = 8585%). Using block 1 also correctly distinguishes a chain reset that reuses the same genesis.
- `registerChainName` / prune passed values as psql `:'var'` variables via `-c`, which psql never interpolates (silent no-op, error swallowed). SQL is now fed via stdin so chain tagging actually works.
- Added a scoped `pruneChain()` and tag-scoped auto-prune for `undeployed`, so superseded chains are reclaimed per `chain_id` — never the whole data dir. Untagged chains (including the stable with-data cache) are never auto-deleted; persistent envs print a scoped `DELETE` instead of the destructive advice.
- `undeployed` from-genesis waits 30s after readiness so the node produces a few blocks before tests query.

## Validated

- `chain_id == block-1 hash` confirmed against the live qanet & preview indexers.
- Scoped `pruneChain` and `registerChainName` verified end-to-end against a real Postgres: only the targeted chain's rows are removed; other chains' blocks and tags are untouched.
- `yarn lint`, type-check, and `prettier` pass on the changed files.
