### PR TITLE
test: resolve block hash after contract call and update

### DIFF
--- a/qa/tests/utils/toolkit/toolkit-cache.ts
+++ b/qa/tests/utils/toolkit/toolkit-cache.ts
@@ -112,7 +112,6 @@ async function ensureContainer(): Promise<number> {
     if (!port) {
       throw new Error(`Could not determine host port for existing ${CONTAINER_NAME} container`);
     }
-    console.log(`[CACHE] Reusing ${CONTAINER_NAME} on host port ${port}`);
     return port;
   }
 

--- a/qa/tests/utils/toolkit/toolkit-wrapper.ts
+++ b/qa/tests/utils/toolkit/toolkit-wrapper.ts
@@ -19,7 +19,7 @@ import { retry } from '../retry-helper';
 import log from '@utils/logging/logger';
 import { env } from '../../environment/model';
 import { GenericContainer, StartedTestContainer } from 'testcontainers';
-import { getContractDeploymentHashes } from '../../tests/e2e/test-utils';
+import { getContractDeploymentHashes, resolveBlockHash } from '../../tests/e2e/test-utils';
 import { ensureToolkitCachePostgres } from './toolkit-cache';
 import { z } from 'zod';
 import {
@@ -834,7 +834,9 @@ class ToolkitWrapper {
 
     log.info('Submitting transaction to network...');
     const rawOutput = await this.sendGeneratedTx(txFileName);
-    return this.parseTransactionOutput(rawOutput);
+    const result = this.parseTransactionOutput(rawOutput);
+    await resolveBlockHash(result);
+    return result;
   }
 
   /**
@@ -884,8 +886,10 @@ class ToolkitWrapper {
     }
 
     log.info('Running contract maintenance (update)...');
-    const result = await this.execToolkit(maintenanceArgs, 'contract maintenance failed');
-    return this.parseTransactionOutput(result.output.trim());
+    const execResult = await this.execToolkit(maintenanceArgs, 'contract maintenance failed');
+    const result = this.parseTransactionOutput(execResult.output.trim());
+    await resolveBlockHash(result);
+    return result;
   }
 
   /**


### PR DESCRIPTION
## Summary

Two `contract-actions-sequential` e2e tests (block-by-hash for contract call and contract update) were timing out at 10s. Root cause: the newer toolkit's `send` and `maintenance` commands no longer emit `block_hash` in their structured output — only `midnight_tx_hash` plus a `FINALIZED` marker. As a result `callContract` and `updateContract` in the toolkit wrapper were returning an empty `blockHash`, and the tests then retried `getBlockByOffset` against an empty string until the test timeout fired. Not an indexer bug.

`deployContract` already side-steps this by independently resolving its hashes via `getContractDeploymentHashes`. The wrapper has had a purpose-built helper `resolveBlockHash()` in `tests/e2e/test-utils.ts` for exactly this scenario; it just wasn't wired into call/update.

## Changes

- `utils/toolkit/toolkit-wrapper.ts` — wire `resolveBlockHash()` into `callContract` and `updateContract` so they finalise their result by looking up the block hash via the indexer when the toolkit omits it.
- `utils/toolkit/toolkit-cache.ts` — drop the `[CACHE] Reusing toolkit-postgres on host port …` `console.log` line that was bypassing the structured logger and adding noise to test output.

## Test plan

- [x] `NODE_TOOLKIT_TAG=1.0.0 NODE_IMAGE=1.0.0 INDEXER_TAG=local TARGET_ENV=undeployed yarn test:e2e --no-file-parallelism tests/e2e/contract-actions-sequential.test.ts` — all 9 tests pass; the two previously timing-out block-by-hash tests now complete in ~6–8ms.
- [x] `yarn format` — clean
- [x] `yarn lint` — clean