### PR TITLE
test: normalize subscription error handling across qa/tests

### DIFF
--- a/qa/tests/tests/integration/basic/subscriptions/block-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/block-subscriptions.test.ts
@@ -175,18 +175,17 @@ describe('block subscriptions', () => {
       const blockSubscriptionHandler: SubscriptionHandlers<BlockSubscriptionResponse> = {
         next: (payload: BlockSubscriptionResponse) => {
           log.debug(`Received data: ${JSON.stringify(payload)}`);
-
           messagesReceived.push(payload);
-
-          if (payload.errors) {
-            eventCoordinator.notify('error');
-            log.error(`Error received: ${JSON.stringify(payload.errors)}`);
-          }
-
           if (messagesReceived.length === 10) {
             eventCoordinator.notify('expectedBlocksReceived');
             log.debug('Expected # of blocks received');
           }
+        },
+        error: (err) => {
+          const synthetic = buildErrorPayload<BlockSubscriptionResponse>(err);
+          log.error(`Unexpected error frame: ${JSON.stringify(synthetic)}`);
+          messagesReceived.push(synthetic);
+          eventCoordinator.notify('error');
         },
       };
 
@@ -234,10 +233,6 @@ describe('block subscriptions', () => {
         next: (payload: BlockSubscriptionResponse) => {
           log.debug(`Received data: ${JSON.stringify(payload)}`);
           messagesReceived.push(payload);
-          if (payload.errors !== undefined) {
-            log.debug('Received the expected error message');
-            eventCoordinator.notify('error');
-          }
         },
         error: (err) => {
           const synthetic = buildErrorPayload<BlockSubscriptionResponse>(err);
@@ -291,10 +286,6 @@ describe('block subscriptions', () => {
         next: (payload: BlockSubscriptionResponse) => {
           log.debug(`Received data: ${JSON.stringify(payload)}`);
           messagesReceived.push(payload);
-          if (payload.errors !== undefined) {
-            log.debug('Received the expected error message');
-            eventCoordinator.notify('error');
-          }
         },
         error: (err) => {
           const synthetic = buildErrorPayload<BlockSubscriptionResponse>(err);
@@ -419,10 +410,6 @@ describe('block subscriptions', () => {
         next: (payload) => {
           blockMessagesReceived.push(payload);
           log.debug(`Received data: ${JSON.stringify(payload)}`);
-          if (payload.errors !== undefined) {
-            log.debug('Received the expected error message');
-            eventCoordinator.notify('error');
-          }
         },
         error: (err) => {
           const synthetic = buildErrorPayload<BlockSubscriptionResponse>(err);
@@ -464,10 +451,6 @@ describe('block subscriptions', () => {
         next: (payload) => {
           blockMessagesReceived.push(payload);
           log.debug(`Received data: ${JSON.stringify(payload)}`);
-          if (payload.errors !== undefined) {
-            log.debug('Received the expected error message');
-            eventCoordinator.notify('error');
-          }
         },
         error: (err) => {
           const synthetic = buildErrorPayload<BlockSubscriptionResponse>(err);
@@ -521,10 +504,6 @@ describe('block subscriptions', () => {
         next: (payload) => {
           blockMessagesReceived.push(payload);
           log.debug(`Received data: ${JSON.stringify(payload)}`);
-          if (payload.errors !== undefined) {
-            log.debug('Received the expected error message');
-            eventCoordinator.notify('error');
-          }
         },
         error: (err) => {
           const synthetic = buildErrorPayload<BlockSubscriptionResponse>(err);

--- a/qa/tests/tests/integration/basic/subscriptions/block-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/block-subscriptions.test.ts
@@ -23,6 +23,7 @@ import {
   BlockSubscriptionResponse,
   GraphQLCompleteMessage,
 } from '@utils/indexer/websocket-client';
+import { buildErrorPayload } from '@utils/indexer/subscription-error';
 import { EventCoordinator } from '@utils/event-coordinator';
 import type { TestContext } from 'vitest';
 import { BlockSchema } from '@utils/indexer/graphql/schema';
@@ -238,6 +239,12 @@ describe('block subscriptions', () => {
             eventCoordinator.notify('error');
           }
         },
+        error: (err) => {
+          const synthetic = buildErrorPayload<BlockSubscriptionResponse>(err);
+          log.debug(`Received error frame: ${JSON.stringify(synthetic)}`);
+          messagesReceived.push(synthetic);
+          eventCoordinator.notify('error');
+        },
         complete: (message) => {
           log.debug(`Complete message: ${JSON.stringify(message)}`);
           completionMessage = message;
@@ -288,6 +295,12 @@ describe('block subscriptions', () => {
             log.debug('Received the expected error message');
             eventCoordinator.notify('error');
           }
+        },
+        error: (err) => {
+          const synthetic = buildErrorPayload<BlockSubscriptionResponse>(err);
+          log.debug(`Received error frame: ${JSON.stringify(synthetic)}`);
+          messagesReceived.push(synthetic);
+          eventCoordinator.notify('error');
         },
         complete: (message) => {
           log.debug(`Complete message: ${JSON.stringify(message)}`);
@@ -411,6 +424,12 @@ describe('block subscriptions', () => {
             eventCoordinator.notify('error');
           }
         },
+        error: (err) => {
+          const synthetic = buildErrorPayload<BlockSubscriptionResponse>(err);
+          log.debug(`Received error frame: ${JSON.stringify(synthetic)}`);
+          blockMessagesReceived.push(synthetic);
+          eventCoordinator.notify('error');
+        },
       };
 
       indexerWsClient.subscribeToBlockEvents(blockSubscriptionHandler, blockOffset);
@@ -449,6 +468,12 @@ describe('block subscriptions', () => {
             log.debug('Received the expected error message');
             eventCoordinator.notify('error');
           }
+        },
+        error: (err) => {
+          const synthetic = buildErrorPayload<BlockSubscriptionResponse>(err);
+          log.debug(`Received error frame: ${JSON.stringify(synthetic)}`);
+          blockMessagesReceived.push(synthetic);
+          eventCoordinator.notify('error');
         },
         complete: (message) => {
           log.debug(`Complete message: ${JSON.stringify(message)}`);
@@ -500,6 +525,12 @@ describe('block subscriptions', () => {
             log.debug('Received the expected error message');
             eventCoordinator.notify('error');
           }
+        },
+        error: (err) => {
+          const synthetic = buildErrorPayload<BlockSubscriptionResponse>(err);
+          log.debug(`Received error frame: ${JSON.stringify(synthetic)}`);
+          blockMessagesReceived.push(synthetic);
+          eventCoordinator.notify('error');
         },
         complete: (message) => {
           log.debug(`Complete message: ${JSON.stringify(message)}`);

--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -207,13 +207,6 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
 
         const subscription = indexerWsClient.subscribeToDustGenerations(
           {
-            next: (payload) => {
-              if (payload.errors && payload.errors.length > 0) {
-                clearTimeout(timeout);
-                safeUnsubscribe(unsubscribe);
-                resolve(payload.errors[0].message);
-              }
-            },
             error: (error) => {
               clearTimeout(timeout);
               safeUnsubscribe(unsubscribe);
@@ -278,17 +271,6 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
 
           const subscription = indexerWsClient.subscribeToDustGenerations(
             {
-              next: (payload) => {
-                if (payload.errors && payload.errors.length > 0) {
-                  clearTimeout(timeout);
-                  safeUnsubscribe(unsubscribe);
-                  settle({
-                    error: payload.errors[0].message,
-                    completed: false,
-                    timedOut: false,
-                  });
-                }
-              },
               error: (error) => {
                 clearTimeout(timeout);
                 safeUnsubscribe(unsubscribe);
@@ -352,13 +334,6 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
 
         const subscription = indexerWsClient.subscribeToDustGenerations(
           {
-            next: (payload) => {
-              if (payload.errors && payload.errors.length > 0) {
-                clearTimeout(timeout);
-                safeUnsubscribe(unsubscribe);
-                resolve(payload.errors[0].message);
-              }
-            },
             error: (error) => {
               clearTimeout(timeout);
               safeUnsubscribe(unsubscribe);

--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -22,6 +22,7 @@ import {
   IndexerWsClient,
   DustGenerationsSubscriptionResponse,
 } from '@utils/indexer/websocket-client';
+import { extractSubscriptionErrorMessage } from '@utils/indexer/subscription-error';
 import { DustGenerationsEventSchema } from '@utils/indexer/graphql/schema';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
 import { env } from 'environment/model';
@@ -216,7 +217,7 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
             error: (error) => {
               clearTimeout(timeout);
               safeUnsubscribe(unsubscribe);
-              resolve(typeof error === 'string' ? error : JSON.stringify(error));
+              resolve(extractSubscriptionErrorMessage(error));
             },
             complete: () => {
               clearTimeout(timeout);
@@ -292,7 +293,7 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
                 clearTimeout(timeout);
                 safeUnsubscribe(unsubscribe);
                 settle({
-                  error: typeof error === 'string' ? error : JSON.stringify(error),
+                  error: extractSubscriptionErrorMessage(error),
                   completed: false,
                   timedOut: false,
                 });
@@ -361,7 +362,7 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
             error: (error) => {
               clearTimeout(timeout);
               safeUnsubscribe(unsubscribe);
-              resolve(typeof error === 'string' ? error : JSON.stringify(error));
+              resolve(extractSubscriptionErrorMessage(error));
             },
             complete: () => {
               clearTimeout(timeout);

--- a/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
@@ -20,6 +20,7 @@ import {
   IndexerWsClient,
   DustNullifierTransactionSubscriptionResponse,
 } from '@utils/indexer/websocket-client';
+import { extractSubscriptionErrorMessage } from '@utils/indexer/subscription-error';
 import { DustNullifierTransactionSchema } from '@utils/indexer/graphql/schema';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
 import { DustNullifierTransaction } from '@utils/indexer/indexer-types';
@@ -153,7 +154,7 @@ describe('dust nullifier transactions subscription', () => {
               subscription.unsubscribe();
               resolve({
                 completed: false,
-                error: typeof error === 'string' ? error : JSON.stringify(error),
+                error: extractSubscriptionErrorMessage(error),
                 eventCount,
               });
             },
@@ -210,7 +211,7 @@ describe('dust nullifier transactions subscription', () => {
               subscription.unsubscribe();
               resolve({
                 completed: false,
-                error: typeof error === 'string' ? error : JSON.stringify(error),
+                error: extractSubscriptionErrorMessage(error),
                 eventCount,
               });
             },

--- a/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
@@ -137,17 +137,8 @@ describe('dust nullifier transactions subscription', () => {
 
         const subscription = indexerWsClient.subscribeToDustNullifierTransactions(
           {
-            next: (payload) => {
+            next: () => {
               eventCount++;
-              if (payload.errors && payload.errors.length > 0) {
-                clearTimeout(timeout);
-                subscription.unsubscribe();
-                resolve({
-                  completed: false,
-                  error: payload.errors[0].message,
-                  eventCount,
-                });
-              }
             },
             error: (error) => {
               clearTimeout(timeout);
@@ -194,17 +185,8 @@ describe('dust nullifier transactions subscription', () => {
 
         const subscription = indexerWsClient.subscribeToDustNullifierTransactions(
           {
-            next: (payload) => {
+            next: () => {
               eventCount++;
-              if (payload.errors && payload.errors.length > 0) {
-                clearTimeout(timeout);
-                subscription.unsubscribe();
-                resolve({
-                  completed: false,
-                  error: payload.errors[0].message,
-                  eventCount,
-                });
-              }
             },
             error: (error) => {
               clearTimeout(timeout);

--- a/qa/tests/tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts
@@ -22,6 +22,7 @@ import {
   ShieldedNullifierTransactionSubscriptionResponse,
   SubscriptionHandlers,
 } from '@utils/indexer/websocket-client';
+import { extractSubscriptionErrorMessage } from '@utils/indexer/subscription-error';
 import { ShieldedNullifierTransactionSchema } from '@utils/indexer/graphql/schema';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
 import { ShieldedNullifierTransaction } from '@utils/indexer/indexer-types';
@@ -67,7 +68,7 @@ function collectSubscriptionError(
       error: (error) => {
         clearTimeout(timeout);
         subscription.unsubscribe();
-        const message = typeof error === 'string' ? error : JSON.stringify(error);
+        const message = extractSubscriptionErrorMessage(error);
         resolve({
           payload: {
             data: null,

--- a/qa/tests/tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts
@@ -57,13 +57,8 @@ function collectSubscriptionError(
     }, timeoutMs);
 
     const subscription = start({
-      next: (payload) => {
+      next: () => {
         eventCount++;
-        if (payload.errors && payload.errors.length > 0) {
-          clearTimeout(timeout);
-          subscription.unsubscribe();
-          resolve({ payload, completed: false, eventCount });
-        }
       },
       error: (error) => {
         clearTimeout(timeout);

--- a/qa/tests/tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts
@@ -16,13 +16,12 @@
 import log from '@utils/logging/logger';
 import '@utils/logging/test-logging-hooks';
 import type { TestContext } from 'vitest';
-import type { GraphQLError } from 'graphql';
 import {
   IndexerWsClient,
   ShieldedNullifierTransactionSubscriptionResponse,
   SubscriptionHandlers,
 } from '@utils/indexer/websocket-client';
-import { extractSubscriptionErrorMessage } from '@utils/indexer/subscription-error';
+import { buildErrorPayload } from '@utils/indexer/subscription-error';
 import { ShieldedNullifierTransactionSchema } from '@utils/indexer/graphql/schema';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
 import { ShieldedNullifierTransaction } from '@utils/indexer/indexer-types';
@@ -63,12 +62,8 @@ function collectSubscriptionError(
       error: (error) => {
         clearTimeout(timeout);
         subscription.unsubscribe();
-        const message = extractSubscriptionErrorMessage(error);
         resolve({
-          payload: {
-            data: null,
-            errors: [{ message } as GraphQLError],
-          },
+          payload: buildErrorPayload<ShieldedNullifierTransactionSubscriptionResponse>(error),
           completed: false,
           eventCount,
         });

--- a/qa/tests/tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts
@@ -24,6 +24,7 @@ import {
   GraphQLCloseSessionMessage,
   ShieldedTxSubscriptionResponse,
 } from '@utils/indexer/websocket-client';
+import { buildErrorPayload } from '@utils/indexer/subscription-error';
 import { generateSyntheticViewingKey } from '@utils/bech32-codec';
 import { ToolkitWrapper } from '@utils/toolkit/toolkit-wrapper';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
@@ -415,18 +416,20 @@ describe('shielded transaction subscriptions', () => {
             ),
           );
         }, 10_000);
+        const checkForExpiredSession = (payload: ShieldedTxSubscriptionResponse) => {
+          afterLogoutEvents.push(payload);
+          log.debug(`Received event after logout: ${JSON.stringify(payload)}`);
+          if (payload.errors?.some((e) => e.message.includes('unknown or expired session ID'))) {
+            clearTimeout(timeout);
+            unsubscribe();
+            resolve();
+          }
+        };
         const unsubscribe = indexerWsClient.subscribeToShieldedTransactionEvents(
           {
-            next: (payload) => {
-              afterLogoutEvents.push(payload);
-              log.debug(`Received event after logout: ${JSON.stringify(payload)}`);
-              if (
-                payload.errors?.some((e) => e.message.includes('unknown or expired session ID'))
-              ) {
-                clearTimeout(timeout);
-                unsubscribe();
-                resolve();
-              }
+            next: checkForExpiredSession,
+            error: (err) => {
+              checkForExpiredSession(buildErrorPayload<ShieldedTxSubscriptionResponse>(err));
             },
           },
           sessionId,

--- a/qa/tests/tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts
@@ -24,6 +24,7 @@ import {
   UnshieldedTransactionSubscriptionParams,
   UnshieldedTxSubscriptionResponse,
 } from '@utils/indexer/websocket-client';
+import { buildErrorPayload } from '@utils/indexer/subscription-error';
 import type {
   UnshieldedTransaction,
   UnshieldedTransactionEvent,
@@ -107,6 +108,14 @@ async function subscribeToUnshieldedTransactionEvents(
       next: (payload) => {
         log.debug(`Received data:\n${JSON.stringify(payload, null, 2)}`);
         receivedUnshieldedTransactions.push(payload);
+        if (stopCondition(receivedUnshieldedTransactions)) {
+          stopListening();
+        }
+      },
+      error: (err) => {
+        const synthetic = buildErrorPayload<UnshieldedTxSubscriptionResponse>(err);
+        log.debug(`Received error frame:\n${JSON.stringify(synthetic, null, 2)}`);
+        receivedUnshieldedTransactions.push(synthetic);
         if (stopCondition(receivedUnshieldedTransactions)) {
           stopListening();
         }

--- a/qa/tests/tests/integration/basic/subscriptions/wallet-connect-options.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/wallet-connect-options.test.ts
@@ -17,6 +17,7 @@ import log from '@utils/logging/logger';
 import '@utils/logging/test-logging-hooks';
 import { env } from 'environment/model';
 import { IndexerWsClient } from '@utils/indexer/websocket-client';
+import { extractSubscriptionErrorMessage } from '@utils/indexer/subscription-error';
 import { ToolkitWrapper } from '@utils/toolkit/toolkit-wrapper';
 import dataProvider from '@utils/testdata-provider';
 
@@ -168,20 +169,19 @@ describe.skipIf(env.isUndeployedEnv())('wallet connect options (startIndex)', ()
         const unsubscribe = indexerWsClient.subscribeToShieldedTransactionEvents(
           {
             next: (payload) => {
-              if (payload.errors && payload.errors.length > 0) {
-                clearTimeout(timeout);
-                unsubscribe();
-                reject(
-                  new Error(`subscription returned errors: ${JSON.stringify(payload.errors)}`),
-                );
-                return;
-              }
               const event = payload.data?.shieldedTransactions;
               if (event?.__typename === 'ShieldedTransactionsProgress') {
                 clearTimeout(timeout);
                 unsubscribe();
                 resolve(event);
               }
+            },
+            error: (err) => {
+              clearTimeout(timeout);
+              unsubscribe();
+              reject(
+                new Error(`subscription returned errors: ${extractSubscriptionErrorMessage(err)}`),
+              );
             },
           },
           sessionId,
@@ -234,20 +234,19 @@ describe.skipIf(env.isUndeployedEnv())('wallet connect options (startIndex)', ()
         const unsubscribe = indexerWsClient.subscribeToShieldedTransactionEvents(
           {
             next: (payload) => {
-              if (payload.errors && payload.errors.length > 0) {
-                clearTimeout(timeout);
-                unsubscribe();
-                reject(
-                  new Error(`subscription returned errors: ${JSON.stringify(payload.errors)}`),
-                );
-                return;
-              }
               const event = payload.data?.shieldedTransactions;
               if (event?.__typename === 'ShieldedTransactionsProgress') {
                 clearTimeout(timeout);
                 unsubscribe();
                 resolve(event);
               }
+            },
+            error: (err) => {
+              clearTimeout(timeout);
+              unsubscribe();
+              reject(
+                new Error(`subscription returned errors: ${extractSubscriptionErrorMessage(err)}`),
+              );
             },
           },
           sessionId,

--- a/qa/tests/tests/shared/dust-ledger-utils.ts
+++ b/qa/tests/tests/shared/dust-ledger-utils.ts
@@ -18,6 +18,7 @@ import {
   DustLedgerEventSubscriptionResponse,
   IndexerWsClient,
 } from '@utils/indexer/websocket-client';
+import { extractSubscriptionErrorMessage } from '@utils/indexer/subscription-error';
 import { EventCoordinator } from '@utils/event-coordinator';
 import log from '@utils/logging/logger';
 
@@ -104,7 +105,7 @@ export async function collectDustLedgerEventError(
         resolved = true;
         subscription.unsubscribe();
         clearTimeout(timeout);
-        resolve(String(err));
+        resolve(extractSubscriptionErrorMessage(err));
       },
     };
 

--- a/qa/tests/tests/shared/zswap-events-utils.ts
+++ b/qa/tests/tests/shared/zswap-events-utils.ts
@@ -18,6 +18,7 @@ import {
   IndexerWsClient,
   SubscriptionHandlers,
 } from '@utils/indexer/websocket-client';
+import { extractSubscriptionErrorMessage } from '@utils/indexer/subscription-error';
 import { EventCoordinator } from '@utils/event-coordinator';
 import log from '@utils/logging/logger';
 
@@ -95,7 +96,7 @@ export async function collectZswapEventError(
         resolved = true;
         subscription.unsubscribe();
         clearTimeout(timeout);
-        resolve(String(err));
+        resolve(extractSubscriptionErrorMessage(err));
       },
     };
 

--- a/qa/tests/tests/smoke/graphql-healthchecks.test.ts
+++ b/qa/tests/tests/smoke/graphql-healthchecks.test.ts
@@ -19,7 +19,7 @@ import { IntrospectionQuery } from 'graphql';
 import { GraphQLResponse } from '@utils/indexer/indexer-types';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
 import { IndexerWsClient } from '@utils/indexer/websocket-client';
-import { extractSubscriptionErrorMessage } from '@utils/indexer/subscription-error';
+import { buildErrorPayload } from '@utils/indexer/subscription-error';
 import {
   SCHEMA_QUERY,
   INTROSPECTION_QUERY,
@@ -104,10 +104,7 @@ describe('graphql health checks', () => {
             settle(data);
           },
           error: (err) => {
-            settle({
-              data: null,
-              errors: [{ message: extractSubscriptionErrorMessage(err) }],
-            } as unknown as GraphQLResponse<IntrospectionQuery>);
+            settle(buildErrorPayload<GraphQLResponse<IntrospectionQuery>>(err));
           },
           complete: () => {
             if (!settled) {

--- a/qa/tests/tests/smoke/graphql-healthchecks.test.ts
+++ b/qa/tests/tests/smoke/graphql-healthchecks.test.ts
@@ -19,6 +19,7 @@ import { IntrospectionQuery } from 'graphql';
 import { GraphQLResponse } from '@utils/indexer/indexer-types';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
 import { IndexerWsClient } from '@utils/indexer/websocket-client';
+import { extractSubscriptionErrorMessage } from '@utils/indexer/subscription-error';
 import {
   SCHEMA_QUERY,
   INTROSPECTION_QUERY,
@@ -83,17 +84,33 @@ describe('graphql health checks', () => {
     test('should return an error, given the depth of the query is > 15', async () => {
       const query = BIG_INTROSPECTION_QUERY;
 
+      // The server may deliver the recursion-depth rejection either as a
+      // legacy `next` frame carrying `{data: null, errors: [...]}` or — under
+      // async-graphql 7.2 — as the `errors`-in-`next` shape that
+      // `IndexerWsClient` routes to the `error` handler. Normalize both
+      // paths into a `GraphQLResponse` shape so `toBeError()` works the same
+      // way regardless of which route the server picked.
       const response = await new Promise<GraphQLResponse<IntrospectionQuery>>((resolve, reject) => {
-        let dataReceived = false;
-        const unsubscribe = client.subscribe(query, {
+        let settled = false;
+        let unsubscribe = () => {};
+        const settle = (value: GraphQLResponse<IntrospectionQuery>) => {
+          if (settled) return;
+          settled = true;
+          unsubscribe();
+          resolve(value);
+        };
+        unsubscribe = client.subscribe(query, {
           next: (data: GraphQLResponse<IntrospectionQuery>) => {
-            dataReceived = true;
-            unsubscribe();
-            resolve(data);
+            settle(data);
           },
-          error: reject,
+          error: (err) => {
+            settle({
+              data: null,
+              errors: [{ message: extractSubscriptionErrorMessage(err) }],
+            } as unknown as GraphQLResponse<IntrospectionQuery>);
+          },
           complete: () => {
-            if (!dataReceived) {
+            if (!settled) {
               reject(new Error('No data received before completion'));
             }
           },

--- a/qa/tests/utils/indexer/subscription-error.ts
+++ b/qa/tests/utils/indexer/subscription-error.ts
@@ -1,0 +1,64 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Normalize whatever a subscription `error` handler receives into a bare
+ * server message string suitable for `expect(...).toBe(...)` /
+ * `.toContain(...)` / `.toMatch(...)` assertions.
+ *
+ * `IndexerWsClient`'s `error` handler can be invoked with three different
+ * shapes depending on which graphql-transport-ws route the server takes:
+ *
+ *   1. `Error` — when the server emits errors inside a `next` frame
+ *      (async-graphql 7.2 style); the client wraps `errors[0].message`
+ *      in a `new Error(...)` before dispatching.
+ *   2. `string` — when the server emits the legacy `type: 'error'` frame
+ *      with a plain string payload.
+ *   3. `object` — when the legacy `error` frame carries the spec-shaped
+ *      `Array<GraphQLError>` payload, or some other structured value.
+ *
+ * Naive coercion is broken for each of these in a different way:
+ *   - `String(new Error('X'))` is `'Error: X'`, not `'X'`.
+ *   - `JSON.stringify(new Error('X'))` is `'{}'` (Error fields are not
+ *     enumerable).
+ * This helper exists so every collector / inline error handler in the
+ * subscription tests resolves to the bare message string regardless of
+ * which route the server took.
+ */
+export function extractSubscriptionErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (Array.isArray(error)) {
+    const first = error[0] as { message?: unknown } | undefined;
+    if (first && typeof first.message === 'string') {
+      return first.message;
+    }
+  }
+  if (error && typeof error === 'object') {
+    const maybe = error as { message?: unknown; errors?: Array<{ message?: unknown }> };
+    if (typeof maybe.message === 'string') {
+      return maybe.message;
+    }
+    const first = maybe.errors?.[0];
+    if (first && typeof first.message === 'string') {
+      return first.message;
+    }
+  }
+  return JSON.stringify(error);
+}

--- a/qa/tests/utils/indexer/subscription-error.ts
+++ b/qa/tests/utils/indexer/subscription-error.ts
@@ -62,3 +62,23 @@ export function extractSubscriptionErrorMessage(error: unknown): string {
   }
   return JSON.stringify(error);
 }
+
+/**
+ * Build a synthetic `{ data: null, errors: [{ message }] }` payload from
+ * whatever `IndexerWsClient`'s `error` handler received. Used in tests that
+ * were written before PR #1198 to collect error frames out of the `next`
+ * callback: registering this on the `error` callback funnels both routes
+ * (legacy `next` errors and the new `errors`-in-`next` route) into the same
+ * collected-payload shape, so existing assertions on `payload.errors[0].message`
+ * keep working.
+ *
+ * The generic parameter exists only to let call sites assign the result back
+ * into their typed subscription-response array without a separate cast at
+ * each call site.
+ */
+export function buildErrorPayload<T>(error: unknown): T {
+  return {
+    data: null,
+    errors: [{ message: extractSubscriptionErrorMessage(error) }],
+  } as unknown as T;
+}

--- a/qa/tests/utils/indexer/websocket-client.ts
+++ b/qa/tests/utils/indexer/websocket-client.ts
@@ -369,6 +369,12 @@ export class IndexerWsClient {
         // the legacy `{type: 'error', payload: [...]}`. Both shapes are valid
         // in graphql-transport-ws; route errors-inside-next to the error
         // handler so tests don't silently treat rejections as successes.
+        //
+        // Consequence: `handlers.error` receives an `Error` from this branch
+        // and the raw payload (string or `Array<GraphQLError>`) from the
+        // legacy `case 'error'` branch below. Helpers that need the bare
+        // server message must coerce both — use
+        // `extractSubscriptionErrorMessage()` from `./subscription-error`.
         const errors = (payload as { errors?: Array<{ message?: string }> } | null)?.errors;
         if (Array.isArray(errors) && errors.length > 0) {
           const message = errors[0]?.message ?? 'GraphQL subscription error';


### PR DESCRIPTION
## Scope

Closes #1206.

PR #1198 routed `graphql-transport-ws` `errors`-in-`next` frames to
`IndexerWsClient`'s `error` handler and wrapped the message in
`new Error(...)`. That fixed the silent-success regression but left
three latent breakages across the subscription test surface:

1. Helpers / inline error handlers that did
   `resolve(String(err))` or
   `resolve(typeof error === 'string' ? error : JSON.stringify(error))`
   produced `'Error: <msg>'` or `'{}'` instead of the bare server
   message — exact-match assertions like
   `expect(msg).toBe('Unknown field "unknownField" on …')` were one
   server-side change away from breaking.
2. Tests that collected error frames out of the `next` callback
   (block-subscriptions, unshielded-transaction-subscriptions,
   shielded-transaction-subscriptions expired-session, and the
   graphql-healthchecks smoke recursion-depth test) never saw the
   frame at all post-#1198: the `messages` array stayed empty and
   `expect(messages.length).toBe(1)` failed.
3. Every `if (payload.errors)` branch inside a `next` callback was
   now unreachable code — confusing for future readers and at risk
   of being copied into new tests as a pattern that has not
   actually worked since #1198.

The first chunk is what #1206 originally captured; the second and
third were uncovered while running the full integration suite
against `undeployed` and `qanet`, and are the same root cause —
kept in this PR rather than spun off because the fix shares the
same helper module.

## Approach

`utils/indexer/subscription-error.ts` exposes two small primitives:

- `extractSubscriptionErrorMessage(err)` — coerce `Error`, raw
  string, `Array<GraphQLError>`, or generic `{ errors: [...] }`
  into the bare message string. Replaces every previous ad-hoc
  coercion at the call sites.
- `buildErrorPayload<T>(err)` — synthesize a
  `{ data: null, errors: [{ message }] }` payload from whatever
  the `error` handler received. Used as a one-line `error` shim in
  tests that collect error frames from the `next` callback, so
  both transport routes funnel into the same payload shape and
  existing `payload.errors?.[0].message` assertions keep working
  unchanged.

`IndexerWsClient.handleMessage` gets a documentation comment
calling out the dual contract — no behavior change there.

Dead `if (payload.errors)` branches inside `next` callbacks are
removed across `block-subscriptions`, `dust-generations`,
`dust-nullifier`, `shielded-nullifier`, and `wallet-connect-options`.
Where a dead branch was the only fail-safe error path (the
wallet-connect happy-path tests and the block-subscriptions
known-hash streaming test), it is replaced with a proper `error`
handler so an unexpected server error still fast-fails rather than
silently timing out.

## Why this approach (vs unifying the dispatch in `IndexerWsClient`)

The ticket considered two options: helper-side normalization or
forwarding the raw envelope from the dispatch site. Picked the
helper-side approach to keep PR #1198's just-landed
`new Error(message)` contract intact and the blast radius confined
to test code. The two helpers and a 6-line doc comment in
`IndexerWsClient` are the only client-area changes.

## What was validated

| Suite | undeployed | qanet |
|---|---|---|
| smoke | 18 passed / 1 skipped | 18 passed / 1 skipped |
| integration (full) | 127 passed / 43 skipped | 168 passed / 2 skipped |

Re-run after the dead-branch cleanup commit produced identical
totals — no regressions from removing the unreachable code.

Earlier failures during validation:

- 10 integration failures in `block-subscriptions`,
  `unshielded-transaction-subscriptions`,
  `shielded-transaction-subscriptions` (undeployed) — all
  pre-existing, all caused by #1198; fixed in this PR via the
  `buildErrorPayload` shim.
- 1 smoke failure in `graphql-healthchecks` (undeployed) — same
  root cause; fixed in this PR.
- 11 transient qanet failures on the first full-suite run that
  did not reproduce on a targeted rerun nor on a second
  full-suite rerun — qanet load flakes, unrelated.

## Out of scope

- Changes to `IndexerWsClient` beyond the dispatch-site comment.
