### PR TITLE
feat(indexer-api): add transaction reference to nullifier transactions

### DIFF
--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -532,6 +532,10 @@ type DustNullifierTransaction {
 	The hex-encoded block hash (use to query block with ledger parameters).
 	"""
 	blockHash: HexEncoded!
+	"""
+	The transaction containing this nullifier match.
+	"""
+	transaction: Transaction! @beta
 }
 
 """
@@ -1015,6 +1019,10 @@ type ShieldedNullifierTransaction {
 	The hex-encoded matched nullifier.
 	"""
 	nullifier: HexEncoded!
+	"""
+	The transaction containing this nullifier match.
+	"""
+	transaction: Transaction! @beta
 }
 
 """

--- a/indexer-api/src/infra/api/v4/subscription/dust_nullifier_transactions.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_nullifier_transactions.rs
@@ -15,10 +15,10 @@ use crate::{
     domain::storage::Storage,
     infra::api::{
         ApiResult, ContextExt, OptionExt, ResultExt,
-        v4::{HexEncodable, HexEncoded, directives::beta},
+        v4::{HexEncodable, HexEncoded, directives::beta, transaction::Transaction},
     },
 };
-use async_graphql::{Context, SimpleObject, Subscription};
+use async_graphql::{ComplexObject, Context, SimpleObject, Subscription};
 use async_stream::try_stream;
 use futures::{Stream, TryStreamExt};
 use indexer_common::domain::{BlockIndexed, Subscriber};
@@ -41,7 +41,11 @@ impl<S, B> Default for DustNullifierTransactionsSubscription<S, B> {
 
 /// A transaction containing a dust nullifier match with block context.
 #[derive(Debug, Clone, SimpleObject)]
-pub struct DustNullifierTransaction {
+#[graphql(complex)]
+pub struct DustNullifierTransaction<S>
+where
+    S: Storage,
+{
     /// The hex-encoded matched nullifier.
     #[graphql(directive = beta::apply())]
     pub nullifier: HexEncoded,
@@ -56,6 +60,29 @@ pub struct DustNullifierTransaction {
     pub block_height: u32,
     /// The hex-encoded block hash (use to query block with ledger parameters).
     pub block_hash: HexEncoded,
+
+    #[graphql(skip)]
+    _s: PhantomData<S>,
+}
+
+#[ComplexObject]
+impl<S> DustNullifierTransaction<S>
+where
+    S: Storage,
+{
+    /// The transaction containing this nullifier match.
+    #[graphql(directive = beta::apply())]
+    async fn transaction(&self, cx: &Context<'_>) -> ApiResult<Transaction<S>> {
+        let id = self.transaction_id;
+        let transaction = cx
+            .get_transaction_by_id_loader::<S>()
+            .load_one(id)
+            .await
+            .map_err_into_server_error(|| format!("get transaction by id {id}"))?
+            .some_or_server_error(|| format!("transaction with id {id} not found"))?;
+
+        Ok(transaction.into())
+    }
 }
 
 #[Subscription]
@@ -73,7 +100,7 @@ where
         nullifier_prefixes: Vec<HexEncoded>,
         from_block: Option<u64>,
         to_block: Option<u64>,
-    ) -> impl Stream<Item = ApiResult<DustNullifierTransaction>> {
+    ) -> impl Stream<Item = ApiResult<DustNullifierTransaction<S>>> {
         let storage = cx.get_storage::<S>();
         let subscriber = cx.get_subscriber::<B>();
         let batch_size = cx
@@ -129,6 +156,7 @@ where
                     transaction_hash: entry.transaction_hash.hex_encode(),
                     block_height: entry.block_height,
                     block_hash: entry.block_hash.hex_encode(),
+                    _s: PhantomData,
                 };
             }
 
@@ -169,6 +197,7 @@ where
                         transaction_hash: entry.transaction_hash.hex_encode(),
                         block_height: entry.block_height,
                         block_hash: entry.block_hash.hex_encode(),
+                        _s: PhantomData,
                     };
                 }
 

--- a/indexer-api/src/infra/api/v4/subscription/shielded_nullifier_transactions.rs
+++ b/indexer-api/src/infra/api/v4/subscription/shielded_nullifier_transactions.rs
@@ -15,10 +15,10 @@ use crate::{
     domain::storage::Storage,
     infra::api::{
         ApiResult, ContextExt, OptionExt, ResultExt,
-        v4::{HexEncodable, HexEncoded},
+        v4::{HexEncodable, HexEncoded, directives::beta, transaction::Transaction},
     },
 };
-use async_graphql::{Context, SimpleObject, Subscription};
+use async_graphql::{ComplexObject, Context, SimpleObject, Subscription};
 use async_stream::try_stream;
 use futures::{Stream, TryStreamExt};
 use indexer_common::domain::{BlockIndexed, Subscriber};
@@ -41,7 +41,11 @@ impl<S, B> Default for ShieldedNullifierTransactionsSubscription<S, B> {
 
 /// A transaction containing a shielded (zswap) nullifier match with block context.
 #[derive(Debug, Clone, SimpleObject)]
-pub struct ShieldedNullifierTransaction {
+#[graphql(complex)]
+pub struct ShieldedNullifierTransaction<S>
+where
+    S: Storage,
+{
     /// The transaction ID (indexer-internal BIGSERIAL, use as resumption cursor).
     pub transaction_id: u64,
     /// The hex-encoded transaction hash (32-byte chain identifier).
@@ -52,9 +56,15 @@ pub struct ShieldedNullifierTransaction {
     pub block_height: u32,
     /// The hex-encoded matched nullifier.
     pub nullifier: HexEncoded,
+
+    #[graphql(skip)]
+    _s: PhantomData<S>,
 }
 
-impl From<crate::domain::ShieldedNullifierTransaction> for ShieldedNullifierTransaction {
+impl<S> From<crate::domain::ShieldedNullifierTransaction> for ShieldedNullifierTransaction<S>
+where
+    S: Storage,
+{
     fn from(t: crate::domain::ShieldedNullifierTransaction) -> Self {
         Self {
             transaction_id: t.transaction_id,
@@ -62,7 +72,28 @@ impl From<crate::domain::ShieldedNullifierTransaction> for ShieldedNullifierTran
             block_hash: t.block_hash.hex_encode(),
             block_height: t.block_height,
             nullifier: t.nullifier.hex_encode(),
+            _s: PhantomData,
         }
+    }
+}
+
+#[ComplexObject]
+impl<S> ShieldedNullifierTransaction<S>
+where
+    S: Storage,
+{
+    /// The transaction containing this nullifier match.
+    #[graphql(directive = beta::apply())]
+    async fn transaction(&self, cx: &Context<'_>) -> ApiResult<Transaction<S>> {
+        let id = self.transaction_id;
+        let transaction = cx
+            .get_transaction_by_id_loader::<S>()
+            .load_one(id)
+            .await
+            .map_err_into_server_error(|| format!("get transaction by id {id}"))?
+            .some_or_server_error(|| format!("transaction with id {id} not found"))?;
+
+        Ok(transaction.into())
     }
 }
 
@@ -81,7 +112,7 @@ where
         nullifier_prefixes: Vec<HexEncoded>,
         from_block: Option<u64>,
         to_block: Option<u64>,
-    ) -> impl Stream<Item = ApiResult<ShieldedNullifierTransaction>> {
+    ) -> impl Stream<Item = ApiResult<ShieldedNullifierTransaction<S>>> {
         let storage = cx.get_storage::<S>();
         let subscriber = cx.get_subscriber::<B>();
         let batch_size = cx


### PR DESCRIPTION
## Summary

Adds a `transaction: Transaction!` field to `DustNullifierTransaction` and `ShieldedNullifierTransaction` so consumers can navigate from a nullifier match to the full transaction without a separate lookup query.

Closes #1115.

## What changed

- `transaction: Transaction!` on both `DustNullifierTransaction` and `ShieldedNullifierTransaction`, resolved lazily via a `ComplexObject` resolver backed by the existing `TransactionByIdLoader` (the `UnshieldedUtxo.createdAtTransaction` precedent). The transaction is fetched only when the field is selected, so subscriptions that don't select it pay nothing.
- Marked `@beta`, staying beta while the wallet sync design keeps iterating (per Andrzej).
- Regenerated `schema-v4.graphql`.

## Scope

Narrowed from the four event types originally proposed on #1115 to just the two `*NullifierTransaction` types, per wallet-team input: the wallet consumes tx data only on the nullifier subscriptions, and a lazy resolver avoids inflating the stream for the prefix-matched results a consumer discards. `transactionId` and `transactionHash` are retained (resumption cursor + transaction sequencing). Full scope discussion on #1115.

## Backward compatibility

Additive only — `transaction` is a new field, existing queries are unaffected. Both source tables (`dust_nullifiers`, `zswap_nullifiers`) have `transaction_id NOT NULL`, so the non-null `Transaction!` is correct.

## Testing
- Local end-to-end against a running stack (node + chain-indexer + indexer-api + postgres/nats): both `dustNullifierTransactions` and `shieldedNullifierTransactions` resolve `transaction { __typename hash block { height } }`, and `transaction.hash` matches the existing `transactionHash` scalar in each, confirming the loader returns the correct transaction.