### PR TITLE
test: add INDEXER_INSTANCE blue/green selector

### DIFF
--- a/qa/tests/README.md
+++ b/qa/tests/README.md
@@ -170,7 +170,7 @@ This controls the version segment in the API endpoint paths (e.g. `/api/v3/graph
 
 #### Indexer Blue/Green Instance
 
-Each deployed environment runs two indexer instances behind the public `indexer.<env>.midnight.network` URL (blue/green). In normal conditions that URL points at whichever instance is currently primary; a new indexer version is rolled out to the secondary instance first, so QA can validate it before it is promoted. To target a specific instance, set the `INDEXER_INSTANCE` environment variable:
+The blue/green environments run two indexer instances behind the public `indexer.<env>.midnight.network` URL. In normal conditions that URL points at whichever instance is currently primary; a new indexer version is rolled out to the secondary instance first, so QA can validate it before it is promoted. To target a specific instance, set the `INDEXER_INSTANCE` environment variable:
 
 ```bash
 # Target the blue instance
@@ -180,7 +180,9 @@ INDEXER_INSTANCE=blue TARGET_ENV=qanet yarn test:smoke
 INDEXER_INSTANCE=green TARGET_ENV=qanet yarn test:smoke
 ```
 
-This rewrites the indexer host to `indexer-blue.<env>.midnight.network` / `indexer-green.<env>.midnight.network` for both the HTTP and WebSocket clients. If not set, the clients use the primary `indexer.<env>.midnight.network` URL. The value is case-insensitive and accepts only `blue` or `green`; any other value fails fast. It has no effect on `TARGET_ENV=undeployed` (localhost has no blue/green split).
+This rewrites the indexer host to `indexer-blue.<env>.midnight.network` / `indexer-green.<env>.midnight.network` for both the HTTP and WebSocket clients. If not set, the clients use the primary `indexer.<env>.midnight.network` URL. The value is case-insensitive and accepts only `blue` or `green`; any other value fails fast.
+
+**Supported environments:** `INDEXER_INSTANCE` is only meaningful on the blue/green environments — `qanet`, `preview`, and `preprod`. It is ignored on `undeployed` (localhost has no blue/green split) and has no usable target on `devnet` (single instance) — see the preflight behaviour below.
 
 When `INDEXER_INSTANCE` is set, a preflight check hits the resolved host's `/ready` endpoint before any tests run and fails fast with a clear message if the target isn't usable:
 

--- a/qa/tests/README.md
+++ b/qa/tests/README.md
@@ -182,6 +182,12 @@ INDEXER_INSTANCE=green TARGET_ENV=qanet yarn test:smoke
 
 This rewrites the indexer host to `indexer-blue.<env>.midnight.network` / `indexer-green.<env>.midnight.network` for both the HTTP and WebSocket clients. If not set, the clients use the primary `indexer.<env>.midnight.network` URL. The value is case-insensitive and accepts only `blue` or `green`; any other value fails fast. It has no effect on `TARGET_ENV=undeployed` (localhost has no blue/green split).
 
+When `INDEXER_INSTANCE` is set, a preflight check hits the resolved host's `/ready` endpoint before any tests run and fails fast with a clear message if the target isn't usable:
+
+- **HTTP 200** — routed and ready; tests proceed.
+- **HTTP 503** — routed but the instance hasn't caught up yet; wait for it to finish syncing.
+- **HTTP 404 / anything else** — no ingress for that colour. Only the *secondary* instance gets a colour-suffixed host; the *primary* is served at the bare `indexer.<env>` URL and flips colour on promotion. A 404 therefore means the chosen colour is currently the primary — target the other colour, or unset `INDEXER_INSTANCE`. (This also covers single-instance environments like `devnet`.)
+
 #### Vitest Worker Pool Cap
 
 By default Vitest sizes its worker pool to all available parallelism (≈ `os.cpus().length`), so on a typical CI runner each test run drives 4–8 forked workers concurrently against the indexer. To cap that — for example when characterising load-induced flakiness against a shared environment — set the `VITEST_MAX_WORKERS` environment variable:

--- a/qa/tests/README.md
+++ b/qa/tests/README.md
@@ -168,6 +168,20 @@ export INDEXER_API_VERSION=v3
 
 This controls the version segment in the API endpoint paths (e.g. `/api/v3/graphql` and `/api/v3/graphql/ws`). If not set, the clients will use `/api/v4/graphql` and `/api/v4/graphql/ws`.
 
+#### Indexer Blue/Green Instance
+
+Each deployed environment runs two indexer instances behind the public `indexer.<env>.midnight.network` URL (blue/green). In normal conditions that URL points at whichever instance is currently primary; a new indexer version is rolled out to the secondary instance first, so QA can validate it before it is promoted. To target a specific instance, set the `INDEXER_INSTANCE` environment variable:
+
+```bash
+# Target the blue instance
+INDEXER_INSTANCE=blue TARGET_ENV=qanet yarn test:smoke
+
+# Target the green instance
+INDEXER_INSTANCE=green TARGET_ENV=qanet yarn test:smoke
+```
+
+This rewrites the indexer host to `indexer-blue.<env>.midnight.network` / `indexer-green.<env>.midnight.network` for both the HTTP and WebSocket clients. If not set, the clients use the primary `indexer.<env>.midnight.network` URL. The value is case-insensitive and accepts only `blue` or `green`; any other value fails fast. It has no effect on `TARGET_ENV=undeployed` (localhost has no blue/green split).
+
 #### Vitest Worker Pool Cap
 
 By default Vitest sizes its worker pool to all available parallelism (≈ `os.cpus().length`), so on a typical CI runner each test run drives 4–8 forked workers concurrently against the indexer. To cap that — for example when characterising load-induced flakiness against a shared environment — set the `VITEST_MAX_WORKERS` environment variable:

--- a/qa/tests/environment/model.ts
+++ b/qa/tests/environment/model.ts
@@ -304,6 +304,54 @@ export class Environment {
   getNodeToolkitVersion(): string {
     return this.nodeToolkitTag;
   }
+
+  /**
+   * When INDEXER_INSTANCE targets a blue/green colour, verify the resolved host
+   * is actually routed and ready before any tests run.
+   *
+   * An unrouted colour host does NOT fail at the transport layer: deployed
+   * environments use wildcard DNS plus a default ingress backend, so a colour
+   * with no ingress rule answers `/ready` with HTTP 404 rather than refusing
+   * the connection. We therefore discriminate on the HTTP status:
+   *   - 200 → routed and ready, proceed.
+   *   - 503 → routed but not caught up yet (instance still syncing).
+   *   - 404 / any other status / transport error → no ingress for this colour,
+   *     so it is almost certainly the primary (served at the bare host).
+   *
+   * No-op when INDEXER_INSTANCE is unset or the env has no blue/green split.
+   */
+  async preflightInstanceSelection(): Promise<void> {
+    const instance = process.env.INDEXER_INSTANCE?.trim();
+    if (!instance || this.isUndeployed) return;
+
+    const url = `${this.getIndexerHttpBaseURL()}/ready`;
+    let status: number;
+    try {
+      status = (await fetch(url, { signal: AbortSignal.timeout(10_000) })).status;
+    } catch (err) {
+      throw new Error(
+        `INDEXER_INSTANCE="${instance}": could not reach ${this.indexerHost} ` +
+          `(${(err as Error).message}). Unset INDEXER_INSTANCE to target the primary instance.`,
+      );
+    }
+
+    if (status === 200) {
+      log.info(`INDEXER_INSTANCE="${instance}" → ${this.indexerHost} is routed and ready.`);
+      return;
+    }
+    if (status === 503) {
+      throw new Error(
+        `INDEXER_INSTANCE="${instance}" (${this.indexerHost}) is routed but NOT caught up yet ` +
+          `(HTTP 503). Wait for it to finish syncing before testing against it.`,
+      );
+    }
+    throw new Error(
+      `INDEXER_INSTANCE="${instance}" (${this.indexerHost}) returned HTTP ${status} on /ready — ` +
+        `no ingress for this colour, so it is almost certainly the PRIMARY (served at the bare ` +
+        `indexer.${this.envName}.midnight.network). Target the other colour, or unset ` +
+        `INDEXER_INSTANCE to use the primary.`,
+    );
+  }
 }
 
 export const env = new Environment();

--- a/qa/tests/environment/model.ts
+++ b/qa/tests/environment/model.ts
@@ -36,6 +36,60 @@ export enum CardanoNetworkType {
   TESTNET = 'testnet',
 }
 
+/**
+ * Selectable indexer deployment instance.
+ *
+ * Each deployed environment runs two indexer instances behind the public
+ * `indexer.<env>.midnight.network` URL (blue/green). A new indexer version is
+ * rolled out to the secondary instance first, so QA can target it explicitly
+ * before it is promoted to primary.
+ */
+export enum IndexerInstance {
+  BLUE = 'blue',
+  GREEN = 'green',
+}
+
+/**
+ * Resolves the indexer host for an optional blue/green instance override.
+ *
+ * - When `rawInstance` is unset/empty, the host is returned unchanged so the
+ *   public URL keeps pointing at whichever instance is currently primary.
+ * - `blue`/`green` (case-insensitive) rewrite the leading `indexer` label to
+ *   `indexer-blue`/`indexer-green` (e.g. `indexer-green.qanet.midnight.network`).
+ * - Any other value fails fast, mirroring the `TARGET_ENV` validation style.
+ * - The undeployed/localhost environment has no blue/green split, so the
+ *   override is ignored there (with a warning) rather than corrupting the host.
+ */
+export function resolveIndexerHost(
+  baseHost: string,
+  rawInstance: string | undefined,
+  isUndeployed: boolean,
+): string {
+  const instance = rawInstance?.trim();
+  if (!instance) {
+    return baseHost;
+  }
+
+  if (isUndeployed) {
+    log.warn(
+      `Ignoring INDEXER_INSTANCE="${instance}": the undeployed environment has no blue/green instances.`,
+    );
+    return baseHost;
+  }
+
+  const normalized = instance.toLowerCase();
+  const validInstances = Object.values(IndexerInstance);
+  if (!validInstances.includes(normalized as IndexerInstance)) {
+    throw new Error(
+      `Invalid INDEXER_INSTANCE: "${rawInstance}". ` +
+        `Expected one of: ${validInstances.map((name) => `"${name}"`).join(', ')} ` +
+        `(or unset to target the primary indexer instance).`,
+    );
+  }
+
+  return baseHost.replace(/^indexer\./, `indexer-${normalized}.`);
+}
+
 type HostConfig = {
   indexerHost: string;
   nodeHost: string;
@@ -154,8 +208,13 @@ export class Environment {
     // These should be now safe to assign as we already
     // checked envName
     this.networkId = this.envName;
-    this.indexerHost = hostConfigByEnvName[this.envName].indexerHost;
+    this.indexerHost = resolveIndexerHost(
+      hostConfigByEnvName[this.envName].indexerHost,
+      process.env.INDEXER_INSTANCE,
+      this.isUndeployed,
+    );
     this.nodeHost = hostConfigByEnvName[this.envName].nodeHost;
+    log.debug(`Using indexer host: ${this.indexerHost}`);
 
     // What we are actually doing here is the following:
     // 1. If the NODE_TAG is specified as an environment variable, use it. otherwise

--- a/qa/tests/utils/logging/setup.ts
+++ b/qa/tests/utils/logging/setup.ts
@@ -15,8 +15,13 @@
 
 import { join } from 'path';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { env } from '../../environment/model';
 
-export default () => {
+export default async () => {
+  // Fail fast (with a clear message) if INDEXER_INSTANCE points at an
+  // unrouted/not-yet-synced blue/green host. No-op when unset or undeployed.
+  await env.preflightInstanceSelection();
+
   const BASE = 'logs';
   if (!existsSync(BASE)) {
     mkdirSync(BASE);


### PR DESCRIPTION
## Scope

Adds an optional `INDEXER_INSTANCE` environment variable to the QA test framework that selects which indexer deployment instance (blue/green) the HTTP and WebSocket clients target.

- unset (default) → `indexer.<env>.midnight.network` (current behavior, unchanged)
- `INDEXER_INSTANCE=blue` → `indexer-blue.<env>.midnight.network`
- `INDEXER_INSTANCE=green` → `indexer-green.<env>.midnight.network`

Resolution happens once in the `Environment` constructor via a pure, exported `resolveIndexerHost` helper, so both `getIndexerHttpBaseURL()` and `getIndexerWebsocketBaseURL()` inherit the suffix with no client changes.

## Why

Each deployed environment runs two indexer instances behind the public URL, with new versions rolled out to the secondary instance first so QA can validate before promotion. Targeting that instance previously required hand-editing the indexer URL. This makes pre-promotion validation a one-line config change.

## Behavior

- Value is case-insensitive and trimmed; only `blue`/`green` are accepted.
- Invalid values fail fast, mirroring the existing `TARGET_ENV` validation.
- Ignored (with a warning) for `TARGET_ENV=undeployed`, which has no blue/green split.
- Documented in `qa/tests/README.md`.

## Validation

Resolution logic exercised across unset / empty / blue / green / case / trim / undeployed / invalid cases, plus the full `Environment` path confirming both HTTP (`https://indexer-green.<env>.midnight.network`) and WebSocket (`wss://...`) base URLs pick up the suffix and that the unset path preserves the primary host. `yarn format` and `yarn lint` pass.

Closes #1209