### PR TITLE
chore(deps): bump Rust toolchain to 1.96.0

### DIFF
--- a/chain-indexer/src/infra/subxt_node.rs
+++ b/chain-indexer/src/infra/subxt_node.rs
@@ -336,7 +336,7 @@ impl Node for SubxtNode {
                 // is verified against it too.
                 let mut last_forward_hash = after_height.map(|_| H256(after_hash.0));
                 for height in start_height..safe_height {
-                    if height % CATCH_UP_LOG_INTERVAL == 0 {
+                    if height.is_multiple_of(CATCH_UP_LOG_INTERVAL) {
                         info!(
                             highest_stored_height:? = after_height,
                             current_height = height,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"


### PR DESCRIPTION
## Summary

Bumps the pinned Rust toolchain from 1.95.0 to 1.96.0 (released 2026-05-28).

Two files:
- `rust-toolchain.toml`: `1.95.0` -> `1.96.0`
- `chain-indexer/src/infra/subxt_node.rs`: adopt the stabilized unsigned `is_multiple_of` in the catch-up logging check (`height` is `u64`), replacing `height % CATCH_UP_LOG_INTERVAL == 0`. Pure readability, identical logic.

No other code changes are required for 1.96.0. The release's stabilized APIs (`assert_matches!`, `core::range::*`, `From for LazyCell`/`LazyLock`, `NonZero` range iteration) don't intersect this codebase, and the existing code already passes `clippy -D warnings`.

A workspace-wide sweep for other modern-idiom opportunities (`div_ceil`, `next_multiple_of`, `abs_diff`, `midpoint`, `map().unwrap_or(bool)`, `rev().next()`) found none. The only other `% n == 0` site (`wallet-indexer/src/infra/storage.rs`, a test) uses a signed `i64`, for which `is_multiple_of` is not available, so it is intentionally left as-is.

## Testing

- `just lint` (clippy `-D warnings`, includes `--tests`) passes clean on both `cloud` and `standalone` features (7/7 crates, 0 warnings).
- No functional change; the `is_multiple_of` rewrite is semantically identical to the modulo check.

## Links

- Rust 1.96.0 release: https://blog.rust-lang.org/2026/05/28/Rust-1.96.0/