### PR TITLE
investigate(ledger-db): read count column in get_root_count

### DIFF
--- a/indexer-common/src/infra/ledger_db/v1_1.rs
+++ b/indexer-common/src/infra/ledger_db/v1_1.rs
@@ -280,19 +280,21 @@ impl DB for LedgerDb {
     fn get_root_count(&self, key: &ArenaHash<Self::Hasher>) -> u32 {
         block_in_place(|| {
             Handle::current().block_on(async {
+                // Read the stored `count` column, not `count(1)`: the row-count aggregate
+                // is 0/1 (key is the primary key) and under-reports true counts >= 2, which
+                // storage-core's flush then drives negative. A missing row means count 0.
                 let query = indoc! {"
-                    SELECT count(1)
+                    SELECT count
                     FROM ledger_db_roots
                     WHERE key = $1
                 "};
 
-                let (count,) = sqlx::query_as::<_, (i64,)>(query)
+                sqlx::query_as::<_, (i64,)>(query)
                     .bind(key.0.as_slice())
-                    .fetch_one(&*self.pool)
+                    .fetch_optional(&*self.pool)
                     .await
-                    .unwrap_or_panic("cannot get root count");
-
-                count as u32
+                    .unwrap_or_panic("cannot get root count")
+                    .map_or(0, |(count,)| count as u32)
             })
         })
     }


### PR DESCRIPTION
Speculative. get_root_count uses SELECT count(1), the row-count aggregate, which returns 0 or 1 since key is the primary key, so it under-reports any true root count >= 2. storage-core's flush reads this value and asserts it stays non-negative, so a decrement of an under-read root could drive it negative and panic. This change reads the stored count column instead, matching storage-core's own SqlDB reference; a missing row means count 0.

Whether this is the actual cause of the observed negative-root-count panics is unconfirmed. This branch exists to test that hypothesis.