### PR TITLE
fix(indexer-api): skip unexpected ledger events in graphql resolvers

### DIFF
--- a/indexer-api/src/infra/api/v4/ledger_events.rs
+++ b/indexer-api/src/infra/api/v4/ledger_events.rs
@@ -54,6 +54,19 @@ impl TryFrom<LedgerEvent> for ZswapLedgerEvent {
     }
 }
 
+impl ZswapLedgerEvent {
+    pub fn from_ledger_event(ledger_event: LedgerEvent) -> Option<Self> {
+        let id = ledger_event.id;
+        match ledger_event.try_into() {
+            Ok(event) => Some(event),
+            Err(error) => {
+                log::warn!("skipping unexpected zswap ledger event with ID {id}: {error}");
+                None
+            }
+        }
+    }
+}
+
 /// A dust related ledger event.
 #[derive(Debug, Interface)]
 #[allow(clippy::duplicated_attributes)]
@@ -121,6 +134,19 @@ impl TryFrom<LedgerEvent> for DustLedgerEvent {
             }
 
             other => Err(UnexpectedLedgerEvent(other)),
+        }
+    }
+}
+
+impl DustLedgerEvent {
+    pub fn from_ledger_event(ledger_event: LedgerEvent) -> Option<Self> {
+        let id = ledger_event.id;
+        match ledger_event.try_into() {
+            Ok(event) => Some(event),
+            Err(error) => {
+                log::warn!("skipping unexpected dust ledger event with ID {id}: {error}");
+                None
+            }
         }
     }
 }
@@ -209,5 +235,35 @@ impl From<indexer_common::domain::DustOutput> for DustOutput {
         Self {
             nonce: dust_output.nonce.hex_encode(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexer_common::domain::{ByteVec, ProtocolVersion};
+
+    fn ledger_event(attributes: LedgerEventAttributes) -> LedgerEvent {
+        LedgerEvent {
+            id: 1,
+            raw: ByteVec::from(vec![0]),
+            attributes,
+            max_id: 1,
+            protocol_version: ProtocolVersion::V0_22(22_000),
+        }
+    }
+
+    #[test]
+    fn dust_event_conversion_skips_unexpected_zswap_event() {
+        let event = ledger_event(LedgerEventAttributes::ZswapOutput);
+
+        assert!(DustLedgerEvent::from_ledger_event(event).is_none());
+    }
+
+    #[test]
+    fn zswap_event_conversion_skips_unexpected_dust_event() {
+        let event = ledger_event(LedgerEventAttributes::ParamChange);
+
+        assert!(ZswapLedgerEvent::from_ledger_event(event).is_none());
     }
 }

--- a/indexer-api/src/infra/api/v4/subscription/dust_ledger_events.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_ledger_events.rs
@@ -75,9 +75,9 @@ where
             {
                 let ledger_event_id = ledger_event.id;
                 id = ledger_event_id + 1;
-                yield ledger_event.try_into().map_err_into_server_error(|| {
-                    format!("unexpected dust ledger event with ID {ledger_event_id}")
-                })?;
+                if let Some(ledger_event) = DustLedgerEvent::from_ledger_event(ledger_event) {
+                    yield ledger_event;
+                }
             }
 
             debug!(id; "streaming live events");
@@ -100,9 +100,9 @@ where
                 {
                     let ledger_event_id = ledger_event.id;
                     id = ledger_event_id + 1;
-                    yield ledger_event.try_into().map_err_into_server_error(|| {
-                        format!("unexpected dust ledger event with ID {ledger_event_id}")
-                    })?;
+                    if let Some(ledger_event) = DustLedgerEvent::from_ledger_event(ledger_event) {
+                        yield ledger_event;
+                    }
                 }
             }
 

--- a/indexer-api/src/infra/api/v4/subscription/zswap_ledger_events.rs
+++ b/indexer-api/src/infra/api/v4/subscription/zswap_ledger_events.rs
@@ -75,9 +75,9 @@ where
             {
                 let ledger_event_id = ledger_event.id;
                 id = ledger_event_id + 1;
-                yield ledger_event.try_into().map_err_into_server_error(|| {
-                    format!("unexpected zswap ledger event with ID {ledger_event_id}")
-                })?
+                if let Some(ledger_event) = ZswapLedgerEvent::from_ledger_event(ledger_event) {
+                    yield ledger_event;
+                }
             }
 
             debug!(id; "streaming live events");
@@ -100,9 +100,9 @@ where
                 {
                     let ledger_event_id = ledger_event.id;
                     id = ledger_event_id + 1;
-                    yield ledger_event.try_into().map_err_into_server_error(|| {
-                        format!("unexpected zswap ledger event with ID {ledger_event_id}")
-                    })?
+                    if let Some(ledger_event) = ZswapLedgerEvent::from_ledger_event(ledger_event) {
+                        yield ledger_event;
+                    }
                 }
             }
 

--- a/indexer-api/src/infra/api/v4/transaction.rs
+++ b/indexer-api/src/infra/api/v4/transaction.rs
@@ -523,12 +523,8 @@ where
             format!("cannot get zswap ledger events for transaction with ID {id}")
         })?
         .into_iter()
-        .map(|event| {
-            event
-                .try_into()
-                .map_err_into_server_error(|| "unexpected zswap ledger event")
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+        .filter_map(ZswapLedgerEvent::from_ledger_event)
+        .collect();
 
     Ok(zswap_ledger_events)
 }
@@ -545,12 +541,8 @@ where
             format!("cannot get dust ledger events for transaction with ID {id}")
         })?
         .into_iter()
-        .map(|event| {
-            event
-                .try_into()
-                .map_err_into_server_error(|| "unexpected dust ledger event")
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+        .filter_map(DustLedgerEvent::from_ledger_event)
+        .collect();
 
     Ok(dust_ledger_events)
 }


### PR DESCRIPTION
Our internal Blockfrost test suite caught this recently, we just skip them so it's not an urgent issue:

Example on preview
Transaction ID: 26
Transaction hash: f35e751d24821e38f3a0249f754f19fd461a6d0b04bfbcae11438e19747e623b
Querying dustLedgerEvents for that system transaction returned a GraphQL Internal Server Error.

We see same on other networks:
preprod, tx ID 11803, hash d2c36ef2ddf07db984405dbd6528b9c457f990924f94c6aee99621e0aa6bd28e
mainnet, tx ID 73355, hash d72c3aa1e0f2cb5db6f8731252c1114e096a8c1d48cac4882e14b34286688347

The resolver was assuming every returned DUST/zswap ledger-event row always converts cleanly to that GraphQL event type.

```diff
- Expected
+ Received

@@ -8,17 +8,32 @@
            "height": 1,
            "protocolVersion": 22000,
            "timestamp": 1774400742000,
          },
          "contractActions": [],
-         "dustLedgerEvents": Any<Array>,
          "hash": "f35e751d24821e38f3a0249f754f19fd461a6d0b04bfbcae11438e19747e623b",
          "id": 26,
          "protocolVersion": 22000,
          "raw": Any<String>,
          "unshieldedCreatedOutputs": [],
          "unshieldedSpentOutputs": [],
          "zswapLedgerEvents": [],
        },
      ],
+   },
+   "errors": [
+     {
+       "locations": [
+         {
+           "column": 452,
+           "line": 1,
          },
+       ],
+       "message": "Internal Server Error",
+       "path": [
+         "transactions",
+         0,
+         "dustLedgerEvents",
+       ],
+     },
+   ],
  }
  ```