### PR TITLE
test: add regression guard for #1167 dtime fresh sub fix

### DIFF
--- a/qa/tests/data/static/qanet/cardano-stake-addresses.jsonc
+++ b/qa/tests/data/static/qanet/cardano-stake-addresses.jsonc
@@ -13,6 +13,12 @@
   // Expected status: registered=false, dustAddress=null, nightBalance="0", generationRate="0", currentCapacity="0"
   // Note: This differs from non-registered in the execution path (deregistration vs never registered), but the status is the same
   "deregistered": "stake_test1uqu5f7ctsrrfqys5rqf9843nwmrf2w0ea8hae0xe3f9fdcqucy6a8",
+  // A cardano address that is registered for dust production and has had backing NIGHT UTXOs spent
+  // on the Midnight chain, so a fresh dustGenerations(startIndex=0) subscription returns at least
+  // one DustGenerationDtimeUpdateItem. Used as the regression fixture for #1167.
+  // Observed on 2026-06-03: 19 DustGenerationsItem + 9 DustGenerationDtimeUpdateItem events.
+  // Also present in the multi-utxo array (first entry); duplicated here for named access.
+  "registered-with-dust-and-spent": "stake_test1uqg6d2c4nmmf8088j8cejsxdcanms5x6et5x87rg6v5x03shyhyd8",
 
   // ---------------------------------------------------------------------------
   // Multi-UTXO candidates for the #926 aggregation test (best-effort fixture).

--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -189,6 +189,270 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
     }, 90_000);
   });
 
+  /**
+   * Regression guard for midnight-indexer#1167.
+   *
+   * Before the fix, both dtime drain sites in dust_generations.rs were gated on
+   * `dtime_cutoff_block_id.is_some()`, which returns None when startIndex=0 and
+   * the wallet has no prior owned entries below that index — silently dropping all
+   * DustGenerationDtimeUpdateItem records for wallets that begin syncing after
+   * their NIGHT has already been spent.
+   *
+   * The fix: unwrap_or(0) the cutoff and run the drain unconditionally. The dtime
+   * SQL still filters by owner and event-id cursor, so cutoff=0 is safe.
+   */
+  describe('fresh subscription dtime delivery (#1167)', () => {
+    /**
+     * @given a wallet known to have spent NIGHT UTXOs (registered-with-dust-and-spent)
+     * @when we open a fresh dustGenerations subscription with startIndex=0
+     * @then at least one DustGenerationDtimeUpdateItem is received before the progress
+     *       event, and each event matches the expected schema
+     */
+    test('fresh startIndex=0 subscription delivers DustGenerationDtimeUpdateItem for a wallet with spent NIGHT', async (ctx: TestContext) => {
+      let rewardAddress: string;
+      try {
+        rewardAddress = dataProvider.getCardanoRewardAddress('registered-with-dust-and-spent');
+      } catch (error) {
+        log.warn(error);
+        ctx.skip?.(true, (error as Error).message);
+        return;
+      }
+
+      const generationsResponse = await indexerHttpClient.getDustGenerations([rewardAddress]);
+      expect(generationsResponse).toBeSuccess();
+      const generations = generationsResponse.data!.dustGenerations;
+      expect(generations.length).toBeGreaterThanOrEqual(1);
+      expect(generations[0].registrations.length).toBeGreaterThanOrEqual(1);
+      const dustAddress = generations[0].registrations[0].dustAddress;
+      log.debug(`Using dust address (bech32m): ${dustAddress}`);
+
+      const received: DustGenerationsSubscriptionResponse[] = [];
+
+      // DustGenerationsProgress is only emitted when the chain's generation-tree head
+      // has advanced past endIndex, which for this wallet's historical data doesn't
+      // happen within the test window. Instead we terminate on an idle signal: if no
+      // new event arrives within IDLE_MS after the last one, all historical data has
+      // been delivered and we can assert.
+      const IDLE_MS = 5_000;
+      const HARD_TIMEOUT_MS = 60_000;
+
+      await new Promise<void>((resolve, reject) => {
+        let settled = false;
+        let idleTimer: ReturnType<typeof setTimeout> | undefined;
+        let unsubscribe = () => {};
+        const settle = (handler: () => void) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(idleTimer);
+          handler();
+        };
+
+        const hardTimeout = setTimeout(() => {
+          safeUnsubscribe(unsubscribe);
+          // Hard timeout: fail only if we received no events at all.
+          if (received.length > 0) {
+            settle(resolve);
+          } else {
+            settle(() => reject(new Error('Hard timeout: no dust generations events received')));
+          }
+        }, HARD_TIMEOUT_MS);
+
+        const resetIdle = () => {
+          clearTimeout(idleTimer);
+          idleTimer = setTimeout(() => {
+            clearTimeout(hardTimeout);
+            safeUnsubscribe(unsubscribe);
+            settle(resolve);
+          }, IDLE_MS);
+        };
+
+        const subscription = indexerWsClient.subscribeToDustGenerations(
+          {
+            next: (payload) => {
+              received.push(payload);
+              resetIdle();
+            },
+            error: (error) => {
+              clearTimeout(hardTimeout);
+              clearTimeout(idleTimer);
+              safeUnsubscribe(unsubscribe);
+              settle(() => reject(new Error(`Subscription error: ${JSON.stringify(error)}`)));
+            },
+            complete: () => {
+              clearTimeout(hardTimeout);
+              settle(resolve);
+            },
+          },
+          dustAddress,
+          0,
+          2_147_483_647,
+        );
+        unsubscribe = subscription.unsubscribe;
+      });
+
+      for (const msg of received) {
+        expect(msg).toBeSuccess();
+        const event = msg.data!.dustGenerations;
+        const parsed = DustGenerationsEventSchema.safeParse(event);
+        expect(
+          parsed.success,
+          `Dust generations event schema validation failed: ${JSON.stringify(parsed.error, null, 2)}`,
+        ).toBe(true);
+      }
+
+      const dtimeItems = received.filter(
+        (msg) => msg.data?.dustGenerations?.__typename === 'DustGenerationDtimeUpdateItem',
+      );
+      log.debug(
+        `Received ${dtimeItems.length} DustGenerationDtimeUpdateItem event(s) (expected ≥1)`,
+      );
+      expect(
+        dtimeItems.length,
+        'Expected ≥1 DustGenerationDtimeUpdateItem on a fresh startIndex=0 subscription ' +
+          'for a wallet with spent NIGHT UTXOs — regression guard for #1167',
+      ).toBeGreaterThanOrEqual(1);
+    }, 90_000);
+
+    /**
+     * Resumption flow: a subscription with startIndex > 0, where entries below that
+     * index already exist, must still work correctly — items returned must be scoped
+     * to [startIndex, endIndex), and the subscription must complete.
+     *
+     * This is the complementary case to the startIndex=0 test above. The #1167 fix
+     * (unwrap_or(0) on the dtime cutoff) must not disturb the pre-existing cutoff-based
+     * logic used when startIndex > 0.
+     *
+     * Fixture: registered-with-dust-and-spent has gen entries at mtIndex
+     * [283, 559, 560, 561, 169290-169304]. startIndex=559 places exactly one entry
+     * (mtIndex 283) below the subscription window, exercising the non-None cutoff path.
+     *
+     * @given a wallet with entries below startIndex (registered-with-dust-and-spent,
+     *        startIndex=559 leaves one entry at mtIndex 283 below the window)
+     * @when we subscribe to dustGenerations with startIndex=559
+     * @then all DustGenerationsItem events have generationMtIndex >= 559
+     * @and the subscription completes with a DustGenerationsProgress event
+     * @and every event passes schema validation
+     */
+    test('resumption startIndex>0 delivers only in-range items and completes correctly', async (ctx: TestContext) => {
+      let rewardAddress: string;
+      try {
+        rewardAddress = dataProvider.getCardanoRewardAddress('registered-with-dust-and-spent');
+      } catch (error) {
+        log.warn(error);
+        ctx.skip?.(true, (error as Error).message);
+        return;
+      }
+
+      const generationsResponse = await indexerHttpClient.getDustGenerations([rewardAddress]);
+      expect(generationsResponse).toBeSuccess();
+      const generations = generationsResponse.data!.dustGenerations;
+      expect(generations.length).toBeGreaterThanOrEqual(1);
+      expect(generations[0].registrations.length).toBeGreaterThanOrEqual(1);
+      const dustAddress = generations[0].registrations[0].dustAddress;
+      log.debug(`Using dust address (bech32m): ${dustAddress}`);
+
+      // startIndex=559 is the second-lowest gen entry for this wallet (283 sits below it),
+      // exercising the non-None cutoff path in get_dust_generation_dtime_cutoff_block_id.
+      const RESUMPTION_START_INDEX = 559;
+
+      const received: DustGenerationsSubscriptionResponse[] = [];
+
+      // Same idle-based termination as the fresh-sub test above: DustGenerationsProgress
+      // does not fire for historical data ranges on this environment.
+      const IDLE_MS = 5_000;
+      const HARD_TIMEOUT_MS = 60_000;
+
+      await new Promise<void>((resolve, reject) => {
+        let settled = false;
+        let idleTimer: ReturnType<typeof setTimeout> | undefined;
+        let unsubscribe = () => {};
+        const settle = (handler: () => void) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(idleTimer);
+          handler();
+        };
+
+        const hardTimeout = setTimeout(() => {
+          safeUnsubscribe(unsubscribe);
+          if (received.length > 0) {
+            settle(resolve);
+          } else {
+            settle(() => reject(new Error('Hard timeout: no dust generations events received')));
+          }
+        }, HARD_TIMEOUT_MS);
+
+        const resetIdle = () => {
+          clearTimeout(idleTimer);
+          idleTimer = setTimeout(() => {
+            clearTimeout(hardTimeout);
+            safeUnsubscribe(unsubscribe);
+            settle(resolve);
+          }, IDLE_MS);
+        };
+
+        const subscription = indexerWsClient.subscribeToDustGenerations(
+          {
+            next: (payload) => {
+              received.push(payload);
+              resetIdle();
+            },
+            error: (error) => {
+              clearTimeout(hardTimeout);
+              clearTimeout(idleTimer);
+              safeUnsubscribe(unsubscribe);
+              settle(() => reject(new Error(`Subscription error: ${JSON.stringify(error)}`)));
+            },
+            complete: () => {
+              clearTimeout(hardTimeout);
+              settle(resolve);
+            },
+          },
+          dustAddress,
+          RESUMPTION_START_INDEX,
+          2_147_483_647,
+        );
+        unsubscribe = subscription.unsubscribe;
+      });
+
+      for (const msg of received) {
+        expect(msg).toBeSuccess();
+        const event = msg.data!.dustGenerations;
+        const parsed = DustGenerationsEventSchema.safeParse(event);
+        expect(
+          parsed.success,
+          `Dust generations event schema validation failed: ${JSON.stringify(parsed.error, null, 2)}`,
+        ).toBe(true);
+      }
+
+      // All generation items must be within the requested window
+      const genItems = received.filter(
+        (msg) => msg.data?.dustGenerations?.__typename === 'DustGenerationsItem',
+      );
+      for (const msg of genItems) {
+        const event = msg.data!.dustGenerations as { generationMtIndex: number };
+        expect(
+          event.generationMtIndex,
+          `DustGenerationsItem at mtIndex ${event.generationMtIndex} is below startIndex ${RESUMPTION_START_INDEX}`,
+        ).toBeGreaterThanOrEqual(RESUMPTION_START_INDEX);
+      }
+
+      // At least some items must be delivered (proves the subscription works)
+      expect(
+        received.length,
+        'Expected at least one event from the resumption subscription',
+      ).toBeGreaterThan(0);
+
+      const dtimeItems = received.filter(
+        (msg) => msg.data?.dustGenerations?.__typename === 'DustGenerationDtimeUpdateItem',
+      );
+      log.debug(
+        `Resumption (startIndex=${RESUMPTION_START_INDEX}): ` +
+          `${genItems.length} gen items, ${dtimeItems.length} dtime items`,
+      );
+    }, 90_000);
+  });
+
   describe('subscription error handling', () => {
     /**
      * A dust generations subscription with an invalid dust address should return an error

--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -330,7 +330,6 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
      *        startIndex=559 leaves one entry at mtIndex 283 below the window)
      * @when we subscribe to dustGenerations with startIndex=559
      * @then all DustGenerationsItem events have generationMtIndex >= 559
-     * @and the subscription completes with a DustGenerationsProgress event
      * @and every event passes schema validation
      */
     test('resumption startIndex>0 delivers only in-range items and completes correctly', async (ctx: TestContext) => {


### PR DESCRIPTION
## Summary

- Add `registered-with-dust-and-spent` fixture to `qanet/cardano-stake-addresses.jsonc` — a wallet whose backing NIGHT UTXOs have been spent, producing observable `DustGenerationDtimeUpdateItem` events (verified: 9 dtime events, 19 gen events on qanet)
- Add two regression tests inside a new `describe('fresh subscription dtime delivery (#1167)')` block in `dust-generations-subscriptions.test.ts`:
  1. **Fresh sub (startIndex=0)** — hard-asserts ≥1 `DustGenerationDtimeUpdateItem` is received; catches a regression of the fix where dtime drain was gated on a cutoff that returned `None` at startIndex=0
  2. **Resumption (startIndex=559)** — verifies the pre-existing cutoff-based path still delivers correctly-scoped `DustGenerationsItem` events (all with `generationMtIndex ≥ startIndex`)

Both tests use idle-based termination (5 s without new events) because `DustGenerationsProgress` is not emitted for historical-range subscriptions on qanet — the subscription stays open as a live-tail until the chain's generation tree advances past `endIndex`.

## Test plan

- [x] Integration suite run on qanet with indexer `4.3.3-rc.4`: **168 passed, 0 failed**
- [x] Both new tests pass (~6 s each)
- [x] `yarn format` and `yarn lint` clean
- [x] Commits GPG-signed as Giuseppe Salvatore

Closes / provides test coverage for midnightntwrk/midnight-indexer#1167