### PR TITLE
test: add transaction reference coverage for nullifier subscriptions (#1115)

### DIFF
--- a/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts
@@ -304,4 +304,81 @@ describe('dust nullifier transactions subscription', () => {
       expect(transactions[0].hash).toBe(first.transactionHash);
     }, 30_000);
   });
+
+  /**
+   * Coverage for midnight-indexer#1115
+   * (`feat: add transaction reference field for event subscription navigation`).
+   *
+   * `transaction: Transaction! @beta` was added to `DustNullifierTransaction`
+   * so consumers can navigate to all Transaction fields directly from the
+   * streamed event without a separate lookup. The Zod schema enforces the
+   * field shape; this block adds the consistency check: `transaction.hash`
+   * must equal `transactionHash` on the same event.
+   */
+  describe('transaction reference on dust nullifier events (#1115)', () => {
+    /**
+     * @given a wide prefix scan of the full chain
+     * @when we subscribe to dustNullifierTransactions and receive the first event
+     * @then event.transaction.hash equals event.transactionHash, confirming the
+     *       reference field is wired to the same on-chain transaction
+     */
+    test('first event transaction.hash matches transactionHash', async (ctx: TestContext) => {
+      const blockResponse = await indexerHttpClient.getLatestBlock();
+      expect(blockResponse).toBeSuccess();
+      const latestHeight = blockResponse.data!.block.height;
+
+      const received: DustNullifierTransaction[] = [];
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          subscription.unsubscribe();
+          resolve();
+        }, 15_000);
+
+        const subscription = indexerWsClient.subscribeToDustNullifierTransactions(
+          {
+            next: (payload) => {
+              const tx = payload.data?.dustNullifierTransactions;
+              if (tx) {
+                received.push(tx);
+                clearTimeout(timeout);
+                subscription.unsubscribe();
+                resolve();
+              }
+            },
+            error: (err) => {
+              clearTimeout(timeout);
+              subscription.unsubscribe();
+              reject(new Error(`Subscription error: ${JSON.stringify(err)}`));
+            },
+            complete: () => {
+              clearTimeout(timeout);
+              resolve();
+            },
+          },
+          ['00'],
+          0,
+          latestHeight,
+        );
+      });
+
+      if (received.length === 0) {
+        log.warn(
+          'no dustNullifierTransactions matched prefix "00" within the timeout; ' +
+            'transaction reference check skipped',
+        );
+        ctx.skip?.(true, 'no dust nullifier transactions matched — check vacuous');
+        return;
+      }
+
+      const first = received[0];
+      log.debug(
+        `Checking DustNullifierTransaction.transaction.hash=${first.transaction.hash} ` +
+          `against transactionHash=${first.transactionHash}`,
+      );
+
+      expect(first.transaction.hash).toBeDefined();
+      expect(first.transaction.hash).toBe(first.transactionHash);
+    }, 30_000);
+  });
 });

--- a/qa/tests/tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts
@@ -359,4 +359,81 @@ describe('shielded nullifier transactions subscription', () => {
       expect(transactions[0].hash).toBe(first.transactionHash);
     }, 30_000);
   });
+
+  /**
+   * Coverage for midnight-indexer#1115
+   * (`feat: add transaction reference field for event subscription navigation`).
+   *
+   * `transaction: Transaction! @beta` was added to `ShieldedNullifierTransaction`
+   * so consumers can navigate to all Transaction fields directly from the
+   * streamed event without a separate lookup. The Zod schema enforces the
+   * field shape; this block adds the consistency check: `transaction.hash`
+   * must equal `transactionHash` on the same event.
+   */
+  describe('transaction reference on shielded nullifier events (#1115)', () => {
+    /**
+     * @given a wide prefix scan of the full chain
+     * @when we subscribe to shieldedNullifierTransactions and receive the first event
+     * @then event.transaction.hash equals event.transactionHash, confirming the
+     *       reference field is wired to the same on-chain transaction
+     */
+    test('first event transaction.hash matches transactionHash', async (ctx: TestContext) => {
+      const blockResponse = await indexerHttpClient.getLatestBlock();
+      expect(blockResponse).toBeSuccess();
+      const latestHeight = blockResponse.data!.block.height;
+
+      const received: ShieldedNullifierTransaction[] = [];
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          subscription.unsubscribe();
+          resolve();
+        }, 15_000);
+
+        const subscription = indexerWsClient.subscribeToShieldedNullifierTransactions(
+          {
+            next: (payload) => {
+              const tx = payload.data?.shieldedNullifierTransactions;
+              if (tx) {
+                received.push(tx);
+                clearTimeout(timeout);
+                subscription.unsubscribe();
+                resolve();
+              }
+            },
+            error: (err) => {
+              clearTimeout(timeout);
+              subscription.unsubscribe();
+              reject(new Error(`Subscription error: ${JSON.stringify(err)}`));
+            },
+            complete: () => {
+              clearTimeout(timeout);
+              resolve();
+            },
+          },
+          ['00'],
+          0,
+          latestHeight,
+        );
+      });
+
+      if (received.length === 0) {
+        log.warn(
+          'no shieldedNullifierTransactions matched prefix "00" within the timeout; ' +
+            'transaction reference check skipped',
+        );
+        ctx.skip?.(true, 'no shielded nullifier transactions matched — check vacuous');
+        return;
+      }
+
+      const first = received[0];
+      log.debug(
+        `Checking ShieldedNullifierTransaction.transaction.hash=${first.transaction.hash} ` +
+          `against transactionHash=${first.transactionHash}`,
+      );
+
+      expect(first.transaction.hash).toBeDefined();
+      expect(first.transaction.hash).toBe(first.transactionHash);
+    }, 30_000);
+  });
 });

--- a/qa/tests/utils/indexer/graphql/schema.ts
+++ b/qa/tests/utils/indexer/graphql/schema.ts
@@ -413,6 +413,7 @@ export const DustNullifierTransactionSchema = z.object({
   transactionHash: Hash64,
   blockHeight: z.number(),
   blockHash: Hash64,
+  transaction: z.object({ hash: Hash64 }),
 });
 
 export const ShieldedNullifierTransactionSchema = z.object({
@@ -421,4 +422,5 @@ export const ShieldedNullifierTransactionSchema = z.object({
   blockHash: Hash64,
   blockHeight: z.number(),
   nullifier: VarLenghtHex,
+  transaction: z.object({ hash: Hash64 }),
 });

--- a/qa/tests/utils/indexer/graphql/subscriptions.ts
+++ b/qa/tests/utils/indexer/graphql/subscriptions.ts
@@ -395,6 +395,9 @@ export const DUST_NULLIFIER_TRANSACTIONS_SUBSCRIPTION = `
       transactionHash
       blockHeight
       blockHash
+      transaction {
+        hash
+      }
     }
   }
 `;
@@ -407,6 +410,9 @@ export const SHIELDED_NULLIFIER_TRANSACTIONS_SUBSCRIPTION = `
       blockHash
       blockHeight
       nullifier
+      transaction {
+        hash
+      }
     }
   }
 `;

--- a/qa/tests/utils/indexer/indexer-types.ts
+++ b/qa/tests/utils/indexer/indexer-types.ts
@@ -381,6 +381,7 @@ export interface DustNullifierTransaction {
   transactionHash: string;
   blockHeight: number;
   blockHash: string;
+  transaction: { hash: string };
 }
 
 export interface ShieldedNullifierTransaction {
@@ -389,6 +390,7 @@ export interface ShieldedNullifierTransaction {
   blockHash: string;
   blockHeight: number;
   nullifier: string;
+  transaction: { hash: string };
 }
 
 export type ViewingKey = string & { __brand: 'ViewingKey' };


### PR DESCRIPTION
## Summary

Coverage for midnight-indexer#1115 (`feat: add transaction reference field for event subscription navigation`).

`transaction: Transaction! @beta` was added to `DustNullifierTransaction` and `ShieldedNullifierTransaction` in #1115, but the field was absent from the subscription query strings and the test utilities, so no existing test was fetching or validating it.

**Utility changes (commit 1):**
- Add `transaction { hash }` to `DUST_NULLIFIER_TRANSACTIONS_SUBSCRIPTION` and `SHIELDED_NULLIFIER_TRANSACTIONS_SUBSCRIPTION`
- Add `transaction: z.object({ hash: Hash64 })` to `DustNullifierTransactionSchema` and `ShieldedNullifierTransactionSchema` (Zod) — makes all existing schema-validation tests cover the new field automatically
- Add `transaction: { hash: string }` to both TypeScript interfaces

**New tests (commit 2):**
- `describe('transaction reference on dust nullifier events (#1115)')` — subscribes with prefix `'00'` over the full chain, receives the first event, and asserts `event.transaction.hash === event.transactionHash`, proving the reference field is wired to the correct on-chain entity
- `describe('transaction reference on shielded nullifier events (#1115)')` — same pattern for the shielded surface; skips gracefully if no matching events exist (same behaviour as the adjacent #1114 tests)

## Test plan

- [x] Integration suite on qanet with indexer `4.3.3-rc.4`: **169 passed, 3 skipped, 0 failed**
- [x] Dust nullifier `transaction.hash` consistency test: ✓ passes (626 ms)
- [x] Shielded nullifier test: ↓ graceful skip (no shielded nullifier events on current qanet chain — schema validation still covers the field)
- [x] `yarn format` and `yarn lint` clean
- [x] Commits GPG-signed as Giuseppe Salvatore

Provides test coverage for midnightntwrk/midnight-indexer#1115