### PR TITLE
test: add bridge query test skeletons for #941

### DIFF
--- a/qa/tests/tests/integration/basic/queries/bridge-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/bridge-queries.test.ts
@@ -1,0 +1,394 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Integration tests for c2m-bridge GraphQL queries.
+//
+// Covers: bridgeEvents, bridgeClaims, bridgeBalance, bridgeDeposits (#941).
+//
+// ── Status of tests ──────────────────────────────────────────────────────────
+//
+//   it.todo   → Requires bridge event data to be present in the test
+//               environment. Current status: UNKNOWN — see Q1 in the test
+//               plan. Investigation needed: does the with-data chain contain
+//               any C2M bridge pallet events? If not, these tests must stay
+//               as todo until (a) node branch `c-to-m-subminimal-transfers-
+//               accumulation` merges, (b) the toolkit gains bridge tx support,
+//               and (c) the with-data chain is refreshed.
+//               Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/941
+//
+//   it.skip   → Blocked on a specific in-flight feature (noted inline).
+//               These are intentionally skipped; do not remove the skip
+//               without confirming the upstream blocker has landed.
+//
+// ── Types ─────────────────────────────────────────────────────────────────────
+//
+// Bridge GraphQL types are defined inline below as stubs. Move them to
+// utils/indexer/indexer-types.ts once #941 is merged and the exact field
+// names are confirmed against the live schema.
+
+import log from '@utils/logging/logger';
+import '@utils/logging/test-logging-hooks';
+import type { TestContext } from 'vitest';
+import { IndexerHttpClient } from '@utils/indexer/http-client';
+import type { GraphQLResponse } from '@utils/indexer/indexer-types';
+
+// ── Stub types (move to indexer-types.ts once #941 lands) ──────────────────
+
+export type BridgePalletEventVariant =
+  | 'USER_TRANSFER'
+  | 'RESERVE_TRANSFER'
+  | 'INVALID_TRANSFER'
+  | 'UNAPPROVED_TRANSFER'
+  | 'SUBMINIMAL_FLUSH_TRANSFER';
+
+export interface BlockReference {
+  blockHeight: number;
+  blockHash: string;
+}
+
+export interface BridgeEventBase {
+  id: number;
+  midnightTxHash: string;
+  indexedAt: BlockReference;
+}
+
+export interface BridgeUserTransfer extends BridgeEventBase {
+  __typename: 'BridgeUserTransfer';
+  cardanoTxHash: string;
+  amount: string;
+  recipient: string;
+}
+
+export interface BridgeReserveTransfer extends BridgeEventBase {
+  __typename: 'BridgeReserveTransfer';
+  cardanoTxHash: string;
+  amount: string;
+}
+
+export interface BridgeInvalidTransfer extends BridgeEventBase {
+  __typename: 'BridgeInvalidTransfer';
+  cardanoTxHash: string;
+  amount: string;
+}
+
+export interface BridgeUnapprovedTransfer extends BridgeEventBase {
+  __typename: 'BridgeUnapprovedTransfer';
+  cardanoTxHash: string;
+  amount: string;
+  recipient: string;
+}
+
+export interface BridgeSubminimalFlushTransfer extends BridgeEventBase {
+  __typename: 'BridgeSubminimalFlushTransfer';
+  amount: string;
+  count: number;
+}
+
+export type BridgeEvent =
+  | BridgeUserTransfer
+  | BridgeReserveTransfer
+  | BridgeInvalidTransfer
+  | BridgeUnapprovedTransfer
+  | BridgeSubminimalFlushTransfer;
+
+export interface BridgeClaim {
+  id: number;
+  transactionHash: string;
+  recipient: string;
+  amount: string;
+  indexedAt: BlockReference;
+}
+
+export interface BridgeBalance {
+  address: string;
+  deposited: string;
+  claimed: string;
+  balance: string;
+}
+
+// ── GraphQL query strings ───────────────────────────────────────────────────
+
+const BRIDGE_EVENT_FRAGMENT = `
+  fragment BridgeEventFields on BridgeEvent {
+    id
+    midnightTxHash
+    indexedAt { blockHeight blockHash }
+    ... on BridgeUserTransfer {
+      __typename cardanoTxHash amount recipient
+    }
+    ... on BridgeReserveTransfer {
+      __typename cardanoTxHash amount
+    }
+    ... on BridgeInvalidTransfer {
+      __typename cardanoTxHash amount
+    }
+    ... on BridgeUnapprovedTransfer {
+      __typename cardanoTxHash amount recipient
+    }
+    ... on BridgeSubminimalFlushTransfer {
+      __typename amount count
+    }
+  }
+`;
+
+const BRIDGE_EVENTS_QUERY = `
+  ${BRIDGE_EVENT_FRAGMENT}
+  query BridgeEvents(
+    $blockHeight: Int
+    $transactionId: Int
+    $recipient: HexEncoded
+    $variant: BridgePalletEventVariant
+    $offset: Int
+    $limit: Int
+  ) {
+    bridgeEvents(
+      blockHeight: $blockHeight
+      transactionId: $transactionId
+      recipient: $recipient
+      variant: $variant
+      offset: $offset
+      limit: $limit
+    ) {
+      ...BridgeEventFields
+    }
+  }
+`;
+
+const BRIDGE_CLAIMS_QUERY = `
+  query BridgeClaims($recipient: HexEncoded, $offset: Int, $limit: Int) {
+    bridgeClaims(recipient: $recipient, offset: $offset, limit: $limit) {
+      id
+      transactionHash
+      recipient
+      amount
+      indexedAt { blockHeight blockHash }
+    }
+  }
+`;
+
+const BRIDGE_BALANCE_QUERY = `
+  query BridgeBalance($address: HexEncoded!) {
+    bridgeBalance(address: $address) {
+      address
+      deposited
+      claimed
+      balance
+    }
+  }
+`;
+
+const BRIDGE_DEPOSITS_QUERY = `
+  ${BRIDGE_EVENT_FRAGMENT}
+  query BridgeDeposits($recipient: HexEncoded!, $includeUnapproved: Boolean) {
+    bridgeDeposits(recipient: $recipient, includeUnapproved: $includeUnapproved) {
+      ...BridgeEventFields
+    }
+  }
+`;
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const httpClient = new IndexerHttpClient();
+
+function rawRequest<T>(
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<GraphQLResponse<T>> {
+  return (
+    httpClient as unknown as {
+      client: {
+        rawRequest: (q: string, vars?: Record<string, unknown>) => Promise<GraphQLResponse<T>>;
+      };
+    }
+  ).client.rawRequest(query, variables);
+}
+
+// A 32-byte all-zeros hex string: deterministically has no bridge activity.
+const UNKNOWN_RECIPIENT = '0'.repeat(64);
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('bridge queries — bridgeEvents', () => {
+  /**
+   * bridgeEvents for an unknown recipient returns an empty list (not an error).
+   * This test is deterministic and does not require bridge event data.
+   *
+   * @given a 32-byte all-zeros hex address that has no bridge activity
+   * @when we query bridgeEvents with recipient=<zeros>
+   * @then the response is successful and bridgeEvents is an empty array
+   */
+  it.todo('should return an empty list for a recipient address with no bridge activity');
+
+  /**
+   * bridgeEvents with a valid variant filter for USER_TRANSFER returns only UserTransfer events.
+   *
+   * @given the with-data chain contains indexed UserTransfer events
+   * @when we query bridgeEvents(variant: USER_TRANSFER)
+   * @then every event in the response has __typename BridgeUserTransfer
+   */
+  it.todo('should return only UserTransfer events when filtered by variant USER_TRANSFER');
+
+  /**
+   * bridgeEvents with a recipient filter returns only events matching that recipient.
+   *
+   * @given the with-data chain contains UserTransfer events for a known recipient address
+   * @when we query bridgeEvents(recipient: <knownAddress>)
+   * @then every returned event has recipient equal to <knownAddress>
+   */
+  it.todo('should return only events for the specified recipient address');
+
+  /**
+   * bridgeEvents without filters returns all 5 variant types if they are present.
+   *
+   * @given the with-data chain contains all 5 bridge pallet event variants
+   * @when we query bridgeEvents with no filters
+   * @then the response contains events of each __typename
+   */
+  it.todo('should return events of all 5 variant types when present');
+
+  /**
+   * bridgeEvents respects offset and limit pagination.
+   *
+   * @given the with-data chain contains at least 3 indexed bridge events
+   * @when we query bridgeEvents(limit: 2, offset: 0) and bridgeEvents(limit: 2, offset: 1)
+   * @then the two pages share exactly 1 event (offset overlap) and ids are in ascending order
+   */
+  it.todo('should paginate results with offset and limit');
+
+  /**
+   * bridgeEvents response shape matches the BridgeEvent interface and concrete type fields.
+   * Validates all required fields are present and non-null where expected.
+   *
+   * @given the with-data chain contains at least one UserTransfer event
+   * @when we query bridgeEvents(variant: USER_TRANSFER, limit: 1)
+   * @then the single event has id, midnightTxHash, indexedAt, cardanoTxHash, amount, recipient
+   * @and all hex-encoded fields are non-empty strings
+   * @and indexedAt.blockHeight is a positive integer
+   */
+  it.todo('should return events with the correct shape for BridgeUserTransfer');
+});
+
+describe('bridge queries — bridgeClaims', () => {
+  /**
+   * bridgeClaims for an unknown recipient returns an empty list.
+   *
+   * @given a 32-byte all-zeros hex address with no claims
+   * @when we query bridgeClaims(recipient: <zeros>)
+   * @then the response is successful and bridgeClaims is an empty array
+   */
+  it.todo('should return an empty list for an address with no claims');
+
+  /**
+   * bridgeClaims for a known claimer returns their claim records.
+   *
+   * @given the with-data chain contains a CardanoBridge claim for a known address
+   * @when we query bridgeClaims(recipient: <claimerAddress>)
+   * @then each claim has id, transactionHash, recipient, amount, indexedAt
+   * @and the recipient field matches the queried address
+   */
+  it.todo('should return claims for a known claimer address');
+
+  /**
+   * bridgeClaims respects offset and limit pagination.
+   *
+   * @given the with-data chain contains at least 3 bridge claims
+   * @when we paginate with limit 2 and offset 0, then offset 1
+   * @then results are consistent and ids are in ascending order
+   */
+  it.todo('should paginate claims with offset and limit');
+});
+
+describe('bridge queries — bridgeBalance', () => {
+  /**
+   * bridgeBalance for an address with no bridge activity returns a zero balance.
+   * The zero value is HexEncoded big-endian u128, which is "00" * 16.
+   *
+   * @given a 32-byte all-zeros hex address with no bridge activity
+   * @when we query bridgeBalance(address: <zeros>)
+   * @then the response is successful
+   * @and deposited, claimed, and balance are all zero-value hex strings
+   */
+  it.todo('should return zero balance for an address with no bridge activity');
+
+  /**
+   * bridgeBalance.deposited reflects the sum of UserTransfer amounts for the address.
+   *
+   * @given the with-data chain contains UserTransfer events for a known recipient
+   * @when we query bridgeBalance(address: <knownAddress>)
+   * @then deposited equals the sum of UserTransfer.amount values for that address
+   */
+  it.todo('should set deposited to the sum of UserTransfer amounts for the address');
+
+  /**
+   * bridgeBalance.balance = deposited - claimed, clamped to zero.
+   *
+   * @given the with-data chain has UserTransfer and a subsequent BridgeClaim for the same address
+   * @when we query bridgeBalance(address: <address>)
+   * @then balance = deposited - claimed
+   * @and balance is never negative (clamped to zero)
+   */
+  it.todo('should return balance equal to deposited minus claimed');
+
+  /**
+   * bridgeBalance supports partial claims (claimed < deposited).
+   *
+   * @given an address with a UserTransfer of amount A and a BridgeClaim of amount B (B < A)
+   * @when we query bridgeBalance
+   * @then balance = A - B (partial claim leaves remaining claimable balance)
+   */
+  it.todo('should reflect partial claims correctly in balance');
+});
+
+describe('bridge queries — bridgeDeposits', () => {
+  /**
+   * bridgeDeposits for an unknown address returns an empty list by default.
+   *
+   * @given a 32-byte all-zeros hex address with no deposits
+   * @when we query bridgeDeposits(recipient: <zeros>)
+   * @then the response is an empty array
+   */
+  it.todo('should return an empty list for an address with no deposits');
+
+  /**
+   * bridgeDeposits without includeUnapproved flag returns only UserTransfer events.
+   *
+   * @given the with-data chain has both UserTransfer and UnapprovedTransfer for the same address
+   * @when we query bridgeDeposits(recipient: <address>) without includeUnapproved
+   * @then only BridgeUserTransfer events are returned (no BridgeUnapprovedTransfer)
+   */
+  it.todo('should return only UserTransfer events by default (excludes UnapprovedTransfer)');
+
+  // Skipped: UnapprovedTransfer is emitted only after the approval governance logic lands
+  // on node branch `c-to-m-subminimal-transfers-accumulation`. The `UnapprovedTransfer`
+  // variant is defined but unreachable until `ApprovedTransactions` storage and the
+  // governance extrinsic land (see #940 notes, commit 03bda8f4, 29 Apr 2026).
+  // Re-enable this test once UnapprovedTransfer events appear in a test environment.
+  // Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/940
+  test.skip('should include UnapprovedTransfer events when includeUnapproved=true', async (_ctx: TestContext) => {
+    // TODO: implement once UnapprovedTransfer can be generated in test env
+    // Query bridgeDeposits(recipient: <address>, includeUnapproved: true)
+    // Expect response to contain both BridgeUserTransfer and BridgeUnapprovedTransfer
+  });
+});
+
+// Keep this at the bottom so unused imports are not flagged by the linter
+// until the test bodies are fleshed out.
+void BRIDGE_EVENTS_QUERY;
+void BRIDGE_CLAIMS_QUERY;
+void BRIDGE_BALANCE_QUERY;
+void BRIDGE_DEPOSITS_QUERY;
+void UNKNOWN_RECIPIENT;
+void rawRequest;
+void log;

--- a/qa/tests/tests/integration/basic/queries/bridge-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/bridge-queries.test.ts
@@ -13,349 +13,131 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Integration tests for c2m-bridge GraphQL queries.
+// Integration tests for c2m-bridge GraphQL queries: bridgeEvents, bridgeBalance,
+// bridgeDeposits, and claims surfaced as BridgeClaimTransaction (#941).
 //
-// Covers: bridgeEvents, bridgeBalance, bridgeDeposits (#941).
+// These are skeletons enumerating the intended cases:
+//   test.todo → needs bridge event/claim data in the test environment. When
+//               implemented, follow the framework conventions
+//               (how-to-write-a-qa-indexer-test): issue the query via an
+//               IndexerHttpClient method, define response types in
+//               utils/indexer/indexer-types.ts, gate on bridge availability,
+//               assert with toBeSuccess(), and set ctx.task labels.
+//   test.skip → blocked on a specific in-flight feature (noted inline).
 //
-// ── Status of tests ──────────────────────────────────────────────────────────
-//
-//   it.todo   → Requires bridge event data to be present in the test
-//               environment. Current status: UNKNOWN — see Q1 in the test
-//               plan. Investigation needed: does the with-data chain contain
-//               any C2M bridge pallet events? If not, these tests must stay
-//               as todo until (a) node branch `c-to-m-subminimal-transfers-
-//               accumulation` merges, (b) the toolkit gains bridge tx support,
-//               and (c) the with-data chain is refreshed.
-//               Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/941
-//
-//   it.skip   → Blocked on a specific in-flight feature (noted inline).
-//               These are intentionally skipped; do not remove the skip
-//               without confirming the upstream blocker has landed.
-//
-// ── Types ─────────────────────────────────────────────────────────────────────
-//
-// Bridge GraphQL types are defined inline below as stubs. Move them to
-// utils/indexer/indexer-types.ts once #941 is merged and the exact field
-// names are confirmed against the live schema.
+// Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/941
 
-import log from '@utils/logging/logger';
-import '@utils/logging/test-logging-hooks';
-import type { TestContext } from 'vitest';
-import { IndexerHttpClient } from '@utils/indexer/http-client';
-import type { GraphQLResponse } from '@utils/indexer/indexer-types';
+describe('bridge queries', () => {
+  describe('bridgeEvents', () => {
+    /**
+     * @given a 32-byte all-zeros recipient address with no bridge activity
+     * @when we query bridgeEvents with that recipient
+     * @then the response is successful and bridgeEvents is an empty array
+     */
+    test.todo('should return an empty list for a recipient address with no bridge activity');
 
-// ── Stub types (move to indexer-types.ts once #941 lands) ──────────────────
+    /**
+     * @given the with-data chain contains indexed UserTransfer events
+     * @when we query bridgeEvents(variant: USER_TRANSFER)
+     * @then every event in the response has __typename BridgeUserTransfer
+     */
+    test.todo('should return only UserTransfer events when filtered by variant USER_TRANSFER');
 
-export type BridgeEventVariant =
-  | 'USER_TRANSFER'
-  | 'RESERVE_TRANSFER'
-  | 'INVALID_TRANSFER'
-  | 'UNAPPROVED_TRANSFER'
-  | 'SUBMINIMAL_FLUSH_TRANSFER';
+    /**
+     * @given the with-data chain contains UserTransfer events for a known recipient
+     * @when we query bridgeEvents(recipient: <knownAddress>)
+     * @then every returned event has recipient equal to <knownAddress>
+     */
+    test.todo('should return only events for the specified recipient address');
 
-export interface BridgeEventBase {
-  id: number;
-  blockHeight: number;
-  midnightTxHash: string;
-}
+    /**
+     * @given the with-data chain contains all 5 bridge pallet event variants
+     * @when we query bridgeEvents with no filters
+     * @then the response contains events of each __typename
+     */
+    test.todo('should return events of all 5 variant types when present');
 
-export interface BridgeUserTransfer extends BridgeEventBase {
-  __typename: 'BridgeUserTransfer';
-  cardanoTxHash: string;
-  amount: string;
-  recipient: string;
-}
+    /**
+     * @given the with-data chain contains at least 3 indexed bridge events
+     * @when we query bridgeEvents(limit: 2, offset: 0) and (limit: 2, offset: 1)
+     * @then the two pages overlap by exactly 1 event and ids are ascending
+     */
+    test.todo('should paginate results with offset and limit');
 
-export interface BridgeReserveTransfer extends BridgeEventBase {
-  __typename: 'BridgeReserveTransfer';
-  cardanoTxHash: string;
-  amount: string;
-}
+    /**
+     * @given the with-data chain contains at least one UserTransfer event
+     * @when we query bridgeEvents(variant: USER_TRANSFER, limit: 1)
+     * @then the event exposes id, blockHeight, midnightTxHash, cardanoTxHash, amount, recipient
+     * @and all hex-encoded fields are non-empty and blockHeight is a positive integer
+     */
+    test.todo('should return events with the correct shape for BridgeUserTransfer');
+  });
 
-export interface BridgeInvalidTransfer extends BridgeEventBase {
-  __typename: 'BridgeInvalidTransfer';
-  cardanoTxHash: string;
-  amount: string;
-}
+  describe('claims via unshieldedTransactions', () => {
+    // A claim is surfaced as a BridgeClaimTransaction (a ClaimRewards transaction
+    // with ClaimKind CardanoBridge) via the existing unshieldedTransactions query,
+    // not a bridge-specific query — hence it is covered here rather than as a
+    // bridgeClaims query.
+    /**
+     * @given the with-data chain contains a CardanoBridge claim for a known recipient
+     * @when we subscribe to unshieldedTransactions for that recipient
+     * @then the matched transaction is a BridgeClaimTransaction with the bridged recipient and amount
+     */
+    test.todo(
+      'should surface a BridgeClaimTransaction (recipient, amount) via unshieldedTransactions for a claim recipient',
+    );
+  });
 
-export interface BridgeUnapprovedTransfer extends BridgeEventBase {
-  __typename: 'BridgeUnapprovedTransfer';
-  cardanoTxHash: string;
-  amount: string;
-  recipient: string;
-}
+  describe('bridgeBalance', () => {
+    /**
+     * @given a 32-byte all-zeros address with no bridge activity
+     * @when we query bridgeBalance(address: <zeros>)
+     * @then deposited, claimed and balance are all the zero-value hex string
+     */
+    test.todo('should return zero balance for an address with no bridge activity');
 
-export interface BridgeSubminimalFlushTransfer extends BridgeEventBase {
-  __typename: 'BridgeSubminimalFlushTransfer';
-  amount: string;
-  count: number;
-}
+    /**
+     * @given the with-data chain contains UserTransfer events for a known recipient
+     * @when we query bridgeBalance(address: <knownAddress>)
+     * @then deposited equals the sum of UserTransfer.amount values for that address
+     */
+    test.todo('should set deposited to the sum of UserTransfer amounts for the address');
 
-export type BridgeEvent =
-  | BridgeUserTransfer
-  | BridgeReserveTransfer
-  | BridgeInvalidTransfer
-  | BridgeUnapprovedTransfer
-  | BridgeSubminimalFlushTransfer;
+    /**
+     * @given an address with a UserTransfer and a subsequent fully-claimed claim
+     * @when we query bridgeBalance(address: <address>)
+     * @then balance is the zero-value hex string (read from the ledger's remaining-claimable map)
+     */
+    test.todo('should return zero balance once an address has fully claimed');
 
-export interface BridgeBalance {
-  deposited: string;
-  claimed: string;
-  balance: string;
-}
+    /**
+     * @given an address with a UserTransfer and a subsequent partial claim
+     * @when we query bridgeBalance(address: <address>)
+     * @then balance is a non-zero hex string reflecting the remaining-claimable amount
+     */
+    test.todo('should reflect a non-zero remaining-claimable balance after a partial claim');
+  });
 
-// ── GraphQL query strings ───────────────────────────────────────────────────
+  describe('bridgeDeposits', () => {
+    /**
+     * @given a 32-byte all-zeros address with no deposits
+     * @when we query bridgeDeposits(recipient: <zeros>)
+     * @then the response is an empty array
+     */
+    test.todo('should return an empty list for an address with no deposits');
 
-const BRIDGE_EVENT_FRAGMENT = `
-  fragment BridgeEventFields on BridgeEvent {
-    id
-    blockHeight
-    midnightTxHash
-    ... on BridgeUserTransfer {
-      __typename cardanoTxHash amount recipient
-    }
-    ... on BridgeReserveTransfer {
-      __typename cardanoTxHash amount
-    }
-    ... on BridgeInvalidTransfer {
-      __typename cardanoTxHash amount
-    }
-    ... on BridgeUnapprovedTransfer {
-      __typename cardanoTxHash amount recipient
-    }
-    ... on BridgeSubminimalFlushTransfer {
-      __typename amount count
-    }
-  }
-`;
+    /**
+     * @given the with-data chain has both UserTransfer and UnapprovedTransfer for the same address
+     * @when we query bridgeDeposits(recipient: <address>) without includeUnapproved
+     * @then only BridgeUserTransfer events are returned (no BridgeUnapprovedTransfer)
+     */
+    test.todo('should return only UserTransfer events by default (excludes UnapprovedTransfer)');
 
-const BRIDGE_EVENTS_QUERY = `
-  ${BRIDGE_EVENT_FRAGMENT}
-  query BridgeEvents(
-    $recipient: HexEncoded
-    $variant: BridgeEventVariant
-    $blockHeightFrom: Int
-    $blockHeightTo: Int
-    $offset: Int
-    $limit: Int
-  ) {
-    bridgeEvents(
-      recipient: $recipient
-      variant: $variant
-      blockHeightFrom: $blockHeightFrom
-      blockHeightTo: $blockHeightTo
-      offset: $offset
-      limit: $limit
-    ) {
-      ...BridgeEventFields
-    }
-  }
-`;
-
-const BRIDGE_BALANCE_QUERY = `
-  query BridgeBalance($address: HexEncoded!) {
-    bridgeBalance(address: $address) {
-      deposited
-      claimed
-      balance
-    }
-  }
-`;
-
-const BRIDGE_DEPOSITS_QUERY = `
-  ${BRIDGE_EVENT_FRAGMENT}
-  query BridgeDeposits(
-    $recipient: HexEncoded!
-    $includeUnapproved: Boolean
-    $offset: Int
-    $limit: Int
-  ) {
-    bridgeDeposits(
-      recipient: $recipient
-      includeUnapproved: $includeUnapproved
-      offset: $offset
-      limit: $limit
-    ) {
-      ...BridgeEventFields
-    }
-  }
-`;
-
-// ── Helpers ─────────────────────────────────────────────────────────────────
-
-const httpClient = new IndexerHttpClient();
-
-function rawRequest<T>(
-  query: string,
-  variables?: Record<string, unknown>,
-): Promise<GraphQLResponse<T>> {
-  return (
-    httpClient as unknown as {
-      client: {
-        rawRequest: (q: string, vars?: Record<string, unknown>) => Promise<GraphQLResponse<T>>;
-      };
-    }
-  ).client.rawRequest(query, variables);
-}
-
-// A 32-byte all-zeros hex string: deterministically has no bridge activity.
-const UNKNOWN_RECIPIENT = '0'.repeat(64);
-
-// ── Tests ───────────────────────────────────────────────────────────────────
-
-describe('bridge queries — bridgeEvents', () => {
-  /**
-   * bridgeEvents for an unknown recipient returns an empty list (not an error).
-   * This test is deterministic and does not require bridge event data.
-   *
-   * @given a 32-byte all-zeros hex address that has no bridge activity
-   * @when we query bridgeEvents with recipient=<zeros>
-   * @then the response is successful and bridgeEvents is an empty array
-   */
-  it.todo('should return an empty list for a recipient address with no bridge activity');
-
-  /**
-   * bridgeEvents with a valid variant filter for USER_TRANSFER returns only UserTransfer events.
-   *
-   * @given the with-data chain contains indexed UserTransfer events
-   * @when we query bridgeEvents(variant: USER_TRANSFER)
-   * @then every event in the response has __typename BridgeUserTransfer
-   */
-  it.todo('should return only UserTransfer events when filtered by variant USER_TRANSFER');
-
-  /**
-   * bridgeEvents with a recipient filter returns only events matching that recipient.
-   *
-   * @given the with-data chain contains UserTransfer events for a known recipient address
-   * @when we query bridgeEvents(recipient: <knownAddress>)
-   * @then every returned event has recipient equal to <knownAddress>
-   */
-  it.todo('should return only events for the specified recipient address');
-
-  /**
-   * bridgeEvents without filters returns all 5 variant types if they are present.
-   *
-   * @given the with-data chain contains all 5 bridge pallet event variants
-   * @when we query bridgeEvents with no filters
-   * @then the response contains events of each __typename
-   */
-  it.todo('should return events of all 5 variant types when present');
-
-  /**
-   * bridgeEvents respects offset and limit pagination.
-   *
-   * @given the with-data chain contains at least 3 indexed bridge events
-   * @when we query bridgeEvents(limit: 2, offset: 0) and bridgeEvents(limit: 2, offset: 1)
-   * @then the two pages share exactly 1 event (offset overlap) and ids are in ascending order
-   */
-  it.todo('should paginate results with offset and limit');
-
-  /**
-   * bridgeEvents response shape matches the BridgeEvent interface and concrete type fields.
-   * Validates all required fields are present and non-null where expected.
-   *
-   * @given the with-data chain contains at least one UserTransfer event
-   * @when we query bridgeEvents(variant: USER_TRANSFER, limit: 1)
-   * @then the single event has id, blockHeight, midnightTxHash, cardanoTxHash, amount, recipient
-   * @and all hex-encoded fields are non-empty strings
-   * @and blockHeight is a positive integer
-   */
-  it.todo('should return events with the correct shape for BridgeUserTransfer');
-});
-
-describe('bridge queries — claims (BridgeClaimTransaction)', () => {
-  // A claim is surfaced as a `BridgeClaimTransaction implements Transaction`
-  // via the existing `unshieldedTransactions` subscription, not a
-  // bridge-specific query. Covering it means subscribing for a known claim
-  // recipient address and asserting the __typename and bridged recipient /
-  // amount fields on the matched transaction.
-  it.todo(
-    'should surface a BridgeClaimTransaction (recipient, amount) via unshieldedTransactions for a claim recipient',
-  );
-});
-
-describe('bridge queries — bridgeBalance', () => {
-  /**
-   * bridgeBalance for an address with no bridge activity returns a zero balance.
-   * The zero value is HexEncoded big-endian u128, which is "00" * 16.
-   *
-   * @given a 32-byte all-zeros hex address with no bridge activity
-   * @when we query bridgeBalance(address: <zeros>)
-   * @then the response is successful
-   * @and deposited, claimed, and balance are all zero-value hex strings
-   */
-  it.todo('should return zero balance for an address with no bridge activity');
-
-  /**
-   * bridgeBalance.deposited reflects the sum of UserTransfer amounts for the address.
-   *
-   * @given the with-data chain contains UserTransfer events for a known recipient
-   * @when we query bridgeBalance(address: <knownAddress>)
-   * @then deposited equals the sum of UserTransfer.amount values for that address
-   */
-  it.todo('should set deposited to the sum of UserTransfer amounts for the address');
-
-  /**
-   * bridgeBalance.balance is read from the ledger's remaining-claimable map, not
-   * derived from deposited/claimed. Once an address has fully claimed, balance is
-   * the zero-value hex string.
-   *
-   * @given the with-data chain has a UserTransfer and a subsequent fully-claimed claim
-   * @given for the same address
-   * @when we query bridgeBalance(address: <address>)
-   * @then balance is the zero-value hex string (net remaining-claimable is zero)
-   */
-  it.todo('should return zero balance once an address has fully claimed');
-
-  /**
-   * bridgeBalance.balance reflects the ledger's net remaining-claimable after a
-   * partial claim; it is read from the ledger and is not asserted to equal
-   * deposited minus claimed.
-   *
-   * @given an address with a UserTransfer and a subsequent partial claim
-   * @when we query bridgeBalance(address: <address>)
-   * @then balance is a non-zero hex string reflecting the remaining-claimable amount
-   */
-  it.todo('should reflect a non-zero remaining-claimable balance after a partial claim');
-});
-
-describe('bridge queries — bridgeDeposits', () => {
-  /**
-   * bridgeDeposits for an unknown address returns an empty list by default.
-   *
-   * @given a 32-byte all-zeros hex address with no deposits
-   * @when we query bridgeDeposits(recipient: <zeros>)
-   * @then the response is an empty array
-   */
-  it.todo('should return an empty list for an address with no deposits');
-
-  /**
-   * bridgeDeposits without includeUnapproved flag returns only UserTransfer events.
-   *
-   * @given the with-data chain has both UserTransfer and UnapprovedTransfer for the same address
-   * @when we query bridgeDeposits(recipient: <address>) without includeUnapproved
-   * @then only BridgeUserTransfer events are returned (no BridgeUnapprovedTransfer)
-   */
-  it.todo('should return only UserTransfer events by default (excludes UnapprovedTransfer)');
-
-  // Skipped: UnapprovedTransfer is emitted only after the approval governance logic lands
-  // on node branch `c-to-m-subminimal-transfers-accumulation`. The `UnapprovedTransfer`
-  // variant is defined but unreachable until `ApprovedTransactions` storage and the
-  // governance extrinsic land (see #940 notes, commit 03bda8f4, 29 Apr 2026).
-  // Re-enable this test once UnapprovedTransfer events appear in a test environment.
-  // Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/940
-  test.skip('should include UnapprovedTransfer events when includeUnapproved=true', async (_ctx: TestContext) => {
-    // TODO: implement once UnapprovedTransfer can be generated in test env
-    // Query bridgeDeposits(recipient: <address>, includeUnapproved: true)
-    // Expect response to contain both BridgeUserTransfer and BridgeUnapprovedTransfer
+    // Blocked: UnapprovedTransfer is emitted only after the approval governance
+    // logic lands on the node. The variant is defined but unreachable until the
+    // ApprovedTransactions storage and governance extrinsic land.
+    // Re-enable once UnapprovedTransfer events can be produced in a test env.
+    // Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/940
+    test.skip('should include UnapprovedTransfer events when includeUnapproved=true', () => {});
   });
 });
-
-// Keep this at the bottom so unused imports are not flagged by the linter
-// until the test bodies are fleshed out.
-void BRIDGE_EVENTS_QUERY;
-void BRIDGE_BALANCE_QUERY;
-void BRIDGE_DEPOSITS_QUERY;
-void UNKNOWN_RECIPIENT;
-void rawRequest;
-void log;

--- a/qa/tests/tests/integration/basic/queries/bridge-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/bridge-queries.test.ts
@@ -16,71 +16,140 @@
 // Integration tests for c2m-bridge GraphQL queries: bridgeEvents, bridgeBalance,
 // bridgeDeposits, and claims surfaced as BridgeClaimTransaction (#941).
 //
-// These are skeletons enumerating the intended cases:
-//   test.todo → needs bridge event/claim data in the test environment. When
-//               implemented, follow the framework conventions
-//               (how-to-write-a-qa-indexer-test): issue the query via an
-//               IndexerHttpClient method, define response types in
-//               utils/indexer/indexer-types.ts, gate on bridge availability,
-//               assert with toBeSuccess(), and set ctx.task labels.
+// Test-data reality (2026-07): the bridge is a cross-chain feature — events
+// originate from Cardano locks, so they cannot be produced by the indexer's own
+// toolkit-driven node-data generation. Of the five BridgeEvent variants only
+// BridgeUserTransfer has any on-chain data, and only on devnet. Cases that need
+// only the surface (empty results, zero balances) run wherever the surface is
+// deployed; cases that need a real UserTransfer run where such data exists and
+// ctx.skip otherwise; cases that need the other four variants or non-trivial
+// pool state stay test.todo until a data source exists.
+//   test.todo → needs bridge data not yet producible in any test environment.
 //   test.skip → blocked on a specific in-flight feature (noted inline).
 //
 // Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/941
 
-describe('bridge queries', () => {
+import log from '@utils/logging/logger';
+import { env } from 'environment/model';
+import type { TestContext } from 'vitest';
+import '@utils/logging/test-logging-hooks';
+import { IndexerHttpClient } from '@utils/indexer/http-client';
+import type { BridgeUserTransfer } from '@utils/indexer/indexer-types';
+
+const httpClient = new IndexerHttpClient();
+
+// 32-byte all-zeros recipient (HexEncoded) — a valid address with no bridge activity.
+const EMPTY_RECIPIENT = '0'.repeat(64);
+// 16-byte u128 zero value, as returned by the bridge amount/balance fields.
+const ZERO_U128 = '0'.repeat(32);
+
+// Probed once against the target environment: whether the bridge surface exists,
+// a real UserTransfer to assert shape against, and a fully-claimed address (a
+// recipient whose deposited > 0 but remaining balance is zero).
+let surfacePresent = false;
+let sampleUserTransfer: BridgeUserTransfer | null = null;
+let fullyClaimedAddress: string | null = null;
+
+// Bridge events cannot be produced on the undeployed environment (no Cardano
+// side), so the whole surface is skipped there.
+describe.skipIf(env.isUndeployedEnv())('bridge queries', () => {
+  beforeAll(async () => {
+    const probe = await httpClient.getBridgeEvents({ variant: 'USER_TRANSFER', limit: 1 });
+    // A GraphQL error here means the deployed indexer predates the bridge surface
+    // (pre-4.4). Leave surfacePresent false so every case skips rather than fails.
+    if (probe.errors || !probe.data) {
+      log.warn(`Bridge surface not present on ${env.getCurrentEnvironmentName()}; skipping`);
+      return;
+    }
+    surfacePresent = true;
+
+    const first = probe.data.bridgeEvents.find(
+      (e): e is BridgeUserTransfer => e.__typename === 'BridgeUserTransfer',
+    );
+    sampleUserTransfer = first ?? null;
+
+    if (sampleUserTransfer) {
+      const balance = await httpClient.getBridgeBalance(sampleUserTransfer.recipient);
+      const b = balance.data?.bridgeBalance;
+      if (b && b.deposited !== ZERO_U128 && b.balance === ZERO_U128) {
+        fullyClaimedAddress = sampleUserTransfer.recipient;
+      }
+    }
+  }, 30_000);
+
   describe('bridgeEvents', () => {
     /**
      * @given a 32-byte all-zeros recipient address with no bridge activity
-     * @when we query bridgeEvents with that recipient
+     * @when bridgeEvents is queried for that recipient
      * @then the response is successful and bridgeEvents is an empty array
      */
-    test.todo('should return an empty list for a recipient address with no bridge activity');
+    test('should return an empty list for a recipient address with no bridge activity', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'Bridge', 'Negative'] };
+      if (!surfacePresent) return ctx.skip();
+
+      const response = await httpClient.getBridgeEvents({ recipient: EMPTY_RECIPIENT });
+
+      expect(response).toBeSuccess();
+      expect(response.data?.bridgeEvents).toEqual([]);
+    });
 
     /**
-     * @given the with-data chain contains indexed UserTransfer events
-     * @when we query bridgeEvents(variant: USER_TRANSFER)
-     * @then every event in the response has __typename BridgeUserTransfer
+     * @given an environment with at least one indexed BridgeUserTransfer
+     * @when bridgeEvents(variant: USER_TRANSFER, limit: 1) is queried
+     * @then the event exposes id, blockHeight, midnightTxHash, cardanoTxHash, amount, recipient
+     * @and the hex fields are non-empty and blockHeight is a positive integer
      */
-    test.todo('should return only UserTransfer events when filtered by variant USER_TRANSFER');
+    test('should return events with the correct shape for BridgeUserTransfer', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'Bridge', 'UserTransfer'] };
+      if (!surfacePresent) return ctx.skip();
+      if (!sampleUserTransfer) return ctx.skip(true, 'no BridgeUserTransfer data on this env');
+
+      const event = sampleUserTransfer;
+      expect(event.__typename).toBe('BridgeUserTransfer');
+      expect(Number.isInteger(event.id)).toBe(true);
+      expect(event.blockHeight).toBeGreaterThan(0);
+      expect(event.midnightTxHash).toMatch(/^[0-9a-f]+$/);
+      expect(event.cardanoTxHash).toMatch(/^[0-9a-f]+$/);
+      expect(event.amount).toMatch(/^[0-9a-f]+$/);
+      expect(event.recipient).toMatch(/^[0-9a-f]+$/);
+    });
 
     /**
-     * @given the with-data chain contains UserTransfer events for a known recipient
-     * @when we query bridgeEvents(recipient: <knownAddress>)
+     * @given an environment whose chain has UserTransfer events for a known recipient
+     * @when bridgeEvents(recipient: <knownAddress>) is queried
      * @then every returned event has recipient equal to <knownAddress>
      */
     test.todo('should return only events for the specified recipient address');
 
     /**
-     * @given the with-data chain contains all 5 bridge pallet event variants
-     * @when we query bridgeEvents with no filters
+     * @given a chain containing all 5 bridge pallet event variants
+     * @when bridgeEvents is queried with no filters
      * @then the response contains events of each __typename
      */
     test.todo('should return events of all 5 variant types when present');
 
     /**
-     * @given the with-data chain contains at least 3 indexed bridge events
-     * @when we query bridgeEvents(limit: 2, offset: 0) and (limit: 2, offset: 1)
+     * @given a chain with at least 3 indexed bridge events
+     * @when bridgeEvents(limit: 2, offset: 0) and (limit: 2, offset: 1) are queried
      * @then the two pages overlap by exactly 1 event and ids are ascending
      */
     test.todo('should paginate results with offset and limit');
 
     /**
-     * @given the with-data chain contains at least one UserTransfer event
-     * @when we query bridgeEvents(variant: USER_TRANSFER, limit: 1)
-     * @then the event exposes id, blockHeight, midnightTxHash, cardanoTxHash, amount, recipient
-     * @and all hex-encoded fields are non-empty and blockHeight is a positive integer
+     * @given a chain containing indexed UserTransfer events
+     * @when bridgeEvents(variant: USER_TRANSFER) is queried
+     * @then every event has __typename BridgeUserTransfer
      */
-    test.todo('should return events with the correct shape for BridgeUserTransfer');
+    test.todo('should return only UserTransfer events when filtered by variant USER_TRANSFER');
   });
 
   describe('claims via unshieldedTransactions', () => {
     // A claim is surfaced as a BridgeClaimTransaction (a ClaimRewards transaction
     // with ClaimKind CardanoBridge) via the existing unshieldedTransactions query,
-    // not a bridge-specific query — hence it is covered here rather than as a
-    // bridgeClaims query.
+    // not a bridge-specific query.
     /**
-     * @given the with-data chain contains a CardanoBridge claim for a known recipient
-     * @when we subscribe to unshieldedTransactions for that recipient
+     * @given a chain containing a CardanoBridge claim for a known recipient
+     * @when unshieldedTransactions is queried for that recipient
      * @then the matched transaction is a BridgeClaimTransaction with the bridged recipient and amount
      */
     test.todo(
@@ -91,28 +160,55 @@ describe('bridge queries', () => {
   describe('bridgeBalance', () => {
     /**
      * @given a 32-byte all-zeros address with no bridge activity
-     * @when we query bridgeBalance(address: <zeros>)
+     * @when bridgeBalance(address: <zeros>) is queried
      * @then deposited, claimed and balance are all the zero-value hex string
      */
-    test.todo('should return zero balance for an address with no bridge activity');
+    test('should return zero balance for an address with no bridge activity', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'Bridge', 'Balance', 'Negative'] };
+      if (!surfacePresent) return ctx.skip();
+
+      const response = await httpClient.getBridgeBalance(EMPTY_RECIPIENT);
+
+      expect(response).toBeSuccess();
+      expect(response.data?.bridgeBalance).toEqual({
+        deposited: ZERO_U128,
+        claimed: ZERO_U128,
+        balance: ZERO_U128,
+      });
+    });
 
     /**
-     * @given the with-data chain contains UserTransfer events for a known recipient
-     * @when we query bridgeBalance(address: <knownAddress>)
+     * @given an address with a UserTransfer deposit that has been fully claimed
+     * @when bridgeBalance(address: <address>) is queried
+     * @then deposited and claimed are non-zero and balance is the zero-value hex string
+     *
+     * The remaining-claimable balance is read from the ledger's bridge_receiving map.
+     */
+    test('should return zero balance once an address has fully claimed', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'Bridge', 'Balance'] };
+      if (!surfacePresent) return ctx.skip();
+      if (!fullyClaimedAddress)
+        return ctx.skip(true, 'no fully-claimed bridge address on this env');
+
+      const response = await httpClient.getBridgeBalance(fullyClaimedAddress);
+
+      expect(response).toBeSuccess();
+      const b = response.data!.bridgeBalance;
+      expect(b.deposited).not.toBe(ZERO_U128);
+      expect(b.claimed).not.toBe(ZERO_U128);
+      expect(b.balance).toBe(ZERO_U128);
+    });
+
+    /**
+     * @given an address with UserTransfer events
+     * @when bridgeBalance(address: <knownAddress>) is queried
      * @then deposited equals the sum of UserTransfer.amount values for that address
      */
     test.todo('should set deposited to the sum of UserTransfer amounts for the address');
 
     /**
-     * @given an address with a UserTransfer and a subsequent fully-claimed claim
-     * @when we query bridgeBalance(address: <address>)
-     * @then balance is the zero-value hex string (read from the ledger's remaining-claimable map)
-     */
-    test.todo('should return zero balance once an address has fully claimed');
-
-    /**
      * @given an address with a UserTransfer and a subsequent partial claim
-     * @when we query bridgeBalance(address: <address>)
+     * @when bridgeBalance(address: <address>) is queried
      * @then balance is a non-zero hex string reflecting the remaining-claimable amount
      */
     test.todo('should reflect a non-zero remaining-claimable balance after a partial claim');
@@ -121,14 +217,22 @@ describe('bridge queries', () => {
   describe('bridgeDeposits', () => {
     /**
      * @given a 32-byte all-zeros address with no deposits
-     * @when we query bridgeDeposits(recipient: <zeros>)
+     * @when bridgeDeposits(recipient: <zeros>) is queried
      * @then the response is an empty array
      */
-    test.todo('should return an empty list for an address with no deposits');
+    test('should return an empty list for an address with no deposits', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'Bridge', 'Deposits', 'Negative'] };
+      if (!surfacePresent) return ctx.skip();
+
+      const response = await httpClient.getBridgeDeposits(EMPTY_RECIPIENT);
+
+      expect(response).toBeSuccess();
+      expect(response.data?.bridgeDeposits).toEqual([]);
+    });
 
     /**
-     * @given the with-data chain has both UserTransfer and UnapprovedTransfer for the same address
-     * @when we query bridgeDeposits(recipient: <address>) without includeUnapproved
+     * @given a chain with both UserTransfer and UnapprovedTransfer for the same address
+     * @when bridgeDeposits(recipient: <address>) is queried without includeUnapproved
      * @then only BridgeUserTransfer events are returned (no BridgeUnapprovedTransfer)
      */
     test.todo('should return only UserTransfer events by default (excludes UnapprovedTransfer)');
@@ -136,7 +240,6 @@ describe('bridge queries', () => {
     // Blocked: UnapprovedTransfer is emitted only after the approval governance
     // logic lands on the node. The variant is defined but unreachable until the
     // ApprovedTransactions storage and governance extrinsic land.
-    // Re-enable once UnapprovedTransfer events can be produced in a test env.
     // Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/940
     test.skip('should include UnapprovedTransfer events when includeUnapproved=true', () => {});
   });

--- a/qa/tests/tests/integration/basic/queries/bridge-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/bridge-queries.test.ts
@@ -15,7 +15,7 @@
 
 // Integration tests for c2m-bridge GraphQL queries.
 //
-// Covers: bridgeEvents, bridgeClaims, bridgeBalance, bridgeDeposits (#941).
+// Covers: bridgeEvents, bridgeBalance, bridgeDeposits (#941).
 //
 // ── Status of tests ──────────────────────────────────────────────────────────
 //
@@ -46,22 +46,17 @@ import type { GraphQLResponse } from '@utils/indexer/indexer-types';
 
 // ── Stub types (move to indexer-types.ts once #941 lands) ──────────────────
 
-export type BridgePalletEventVariant =
+export type BridgeEventVariant =
   | 'USER_TRANSFER'
   | 'RESERVE_TRANSFER'
   | 'INVALID_TRANSFER'
   | 'UNAPPROVED_TRANSFER'
   | 'SUBMINIMAL_FLUSH_TRANSFER';
 
-export interface BlockReference {
-  blockHeight: number;
-  blockHash: string;
-}
-
 export interface BridgeEventBase {
   id: number;
+  blockHeight: number;
   midnightTxHash: string;
-  indexedAt: BlockReference;
 }
 
 export interface BridgeUserTransfer extends BridgeEventBase {
@@ -103,16 +98,7 @@ export type BridgeEvent =
   | BridgeUnapprovedTransfer
   | BridgeSubminimalFlushTransfer;
 
-export interface BridgeClaim {
-  id: number;
-  transactionHash: string;
-  recipient: string;
-  amount: string;
-  indexedAt: BlockReference;
-}
-
 export interface BridgeBalance {
-  address: string;
   deposited: string;
   claimed: string;
   balance: string;
@@ -123,8 +109,8 @@ export interface BridgeBalance {
 const BRIDGE_EVENT_FRAGMENT = `
   fragment BridgeEventFields on BridgeEvent {
     id
+    blockHeight
     midnightTxHash
-    indexedAt { blockHeight blockHash }
     ... on BridgeUserTransfer {
       __typename cardanoTxHash amount recipient
     }
@@ -146,18 +132,18 @@ const BRIDGE_EVENT_FRAGMENT = `
 const BRIDGE_EVENTS_QUERY = `
   ${BRIDGE_EVENT_FRAGMENT}
   query BridgeEvents(
-    $blockHeight: Int
-    $transactionId: Int
     $recipient: HexEncoded
-    $variant: BridgePalletEventVariant
+    $variant: BridgeEventVariant
+    $blockHeightFrom: Int
+    $blockHeightTo: Int
     $offset: Int
     $limit: Int
   ) {
     bridgeEvents(
-      blockHeight: $blockHeight
-      transactionId: $transactionId
       recipient: $recipient
       variant: $variant
+      blockHeightFrom: $blockHeightFrom
+      blockHeightTo: $blockHeightTo
       offset: $offset
       limit: $limit
     ) {
@@ -166,22 +152,9 @@ const BRIDGE_EVENTS_QUERY = `
   }
 `;
 
-const BRIDGE_CLAIMS_QUERY = `
-  query BridgeClaims($recipient: HexEncoded, $offset: Int, $limit: Int) {
-    bridgeClaims(recipient: $recipient, offset: $offset, limit: $limit) {
-      id
-      transactionHash
-      recipient
-      amount
-      indexedAt { blockHeight blockHash }
-    }
-  }
-`;
-
 const BRIDGE_BALANCE_QUERY = `
   query BridgeBalance($address: HexEncoded!) {
     bridgeBalance(address: $address) {
-      address
       deposited
       claimed
       balance
@@ -191,8 +164,18 @@ const BRIDGE_BALANCE_QUERY = `
 
 const BRIDGE_DEPOSITS_QUERY = `
   ${BRIDGE_EVENT_FRAGMENT}
-  query BridgeDeposits($recipient: HexEncoded!, $includeUnapproved: Boolean) {
-    bridgeDeposits(recipient: $recipient, includeUnapproved: $includeUnapproved) {
+  query BridgeDeposits(
+    $recipient: HexEncoded!
+    $includeUnapproved: Boolean
+    $offset: Int
+    $limit: Int
+  ) {
+    bridgeDeposits(
+      recipient: $recipient
+      includeUnapproved: $includeUnapproved
+      offset: $offset
+      limit: $limit
+    ) {
       ...BridgeEventFields
     }
   }
@@ -273,41 +256,22 @@ describe('bridge queries — bridgeEvents', () => {
    *
    * @given the with-data chain contains at least one UserTransfer event
    * @when we query bridgeEvents(variant: USER_TRANSFER, limit: 1)
-   * @then the single event has id, midnightTxHash, indexedAt, cardanoTxHash, amount, recipient
+   * @then the single event has id, blockHeight, midnightTxHash, cardanoTxHash, amount, recipient
    * @and all hex-encoded fields are non-empty strings
-   * @and indexedAt.blockHeight is a positive integer
+   * @and blockHeight is a positive integer
    */
   it.todo('should return events with the correct shape for BridgeUserTransfer');
 });
 
-describe('bridge queries — bridgeClaims', () => {
-  /**
-   * bridgeClaims for an unknown recipient returns an empty list.
-   *
-   * @given a 32-byte all-zeros hex address with no claims
-   * @when we query bridgeClaims(recipient: <zeros>)
-   * @then the response is successful and bridgeClaims is an empty array
-   */
-  it.todo('should return an empty list for an address with no claims');
-
-  /**
-   * bridgeClaims for a known claimer returns their claim records.
-   *
-   * @given the with-data chain contains a CardanoBridge claim for a known address
-   * @when we query bridgeClaims(recipient: <claimerAddress>)
-   * @then each claim has id, transactionHash, recipient, amount, indexedAt
-   * @and the recipient field matches the queried address
-   */
-  it.todo('should return claims for a known claimer address');
-
-  /**
-   * bridgeClaims respects offset and limit pagination.
-   *
-   * @given the with-data chain contains at least 3 bridge claims
-   * @when we paginate with limit 2 and offset 0, then offset 1
-   * @then results are consistent and ids are in ascending order
-   */
-  it.todo('should paginate claims with offset and limit');
+describe('bridge queries — claims (BridgeClaimTransaction)', () => {
+  // A claim is surfaced as a `BridgeClaimTransaction implements Transaction`
+  // via the existing `unshieldedTransactions` subscription, not a
+  // bridge-specific query. Covering it means subscribing for a known claim
+  // recipient address and asserting the __typename and bridged recipient /
+  // amount fields on the matched transaction.
+  it.todo(
+    'should surface a BridgeClaimTransaction (recipient, amount) via unshieldedTransactions for a claim recipient',
+  );
 });
 
 describe('bridge queries — bridgeBalance', () => {
@@ -332,23 +296,27 @@ describe('bridge queries — bridgeBalance', () => {
   it.todo('should set deposited to the sum of UserTransfer amounts for the address');
 
   /**
-   * bridgeBalance.balance = deposited - claimed, clamped to zero.
+   * bridgeBalance.balance is read from the ledger's remaining-claimable map, not
+   * derived from deposited/claimed. Once an address has fully claimed, balance is
+   * the zero-value hex string.
    *
-   * @given the with-data chain has UserTransfer and a subsequent BridgeClaim for the same address
+   * @given the with-data chain has a UserTransfer and a subsequent fully-claimed claim
+   * @given for the same address
    * @when we query bridgeBalance(address: <address>)
-   * @then balance = deposited - claimed
-   * @and balance is never negative (clamped to zero)
+   * @then balance is the zero-value hex string (net remaining-claimable is zero)
    */
-  it.todo('should return balance equal to deposited minus claimed');
+  it.todo('should return zero balance once an address has fully claimed');
 
   /**
-   * bridgeBalance supports partial claims (claimed < deposited).
+   * bridgeBalance.balance reflects the ledger's net remaining-claimable after a
+   * partial claim; it is read from the ledger and is not asserted to equal
+   * deposited minus claimed.
    *
-   * @given an address with a UserTransfer of amount A and a BridgeClaim of amount B (B < A)
-   * @when we query bridgeBalance
-   * @then balance = A - B (partial claim leaves remaining claimable balance)
+   * @given an address with a UserTransfer and a subsequent partial claim
+   * @when we query bridgeBalance(address: <address>)
+   * @then balance is a non-zero hex string reflecting the remaining-claimable amount
    */
-  it.todo('should reflect partial claims correctly in balance');
+  it.todo('should reflect a non-zero remaining-claimable balance after a partial claim');
 });
 
 describe('bridge queries — bridgeDeposits', () => {
@@ -386,7 +354,6 @@ describe('bridge queries — bridgeDeposits', () => {
 // Keep this at the bottom so unused imports are not flagged by the linter
 // until the test bodies are fleshed out.
 void BRIDGE_EVENTS_QUERY;
-void BRIDGE_CLAIMS_QUERY;
 void BRIDGE_BALANCE_QUERY;
 void BRIDGE_DEPOSITS_QUERY;
 void UNKNOWN_RECIPIENT;

--- a/qa/tests/tests/smoke/bridge-schema.test.ts
+++ b/qa/tests/tests/smoke/bridge-schema.test.ts
@@ -81,28 +81,30 @@ describe('bridge GraphQL schema — types (#941)', () => {
   it.todo('should expose BridgeUnapprovedTransfer type');
   it.todo('should expose BridgeSubminimalFlushTransfer type');
 
-  // BridgeClaim: ClaimRewardsTransaction with kind=CardanoBridge.
-  it.todo('should expose BridgeClaim type');
+  // BridgeClaimTransaction: a ClaimRewards transaction with kind=CardanoBridge,
+  // surfaced as its own Transaction type (no bridge-specific query).
+  it.todo('should expose BridgeClaimTransaction type implementing Transaction');
 
   // BridgeBalance: deposited / claimed / balance summary per address.
   it.todo('should expose BridgeBalance type with deposited, claimed, balance fields');
 
   // Discriminator enum used by bridgeEvents(variant: ...) filter.
-  it.todo('should expose BridgePalletEventVariant enum with 5 values');
+  it.todo('should expose BridgeEventVariant enum with 5 values');
 });
 
 describe('bridge GraphQL schema — queries (#941)', () => {
-  // bridgeEvents: filterable list of BridgeEvent (by block, recipient, variant).
+  // bridgeEvents: filterable list of BridgeEvent (by recipient, variant, block range).
   it.todo('should expose bridgeEvents query on Query type');
 
-  // bridgeClaims: list of BridgeClaim, filterable by recipient.
-  it.todo('should expose bridgeClaims query on Query type');
-
-  // bridgeBalance: aggregate summary (deposited - claimed) for a recipient address.
+  // bridgeBalance: deposited / claimed / balance summary for an address.
   it.todo('should expose bridgeBalance query on Query type');
 
   // bridgeDeposits: convenience filter combining UserTransfer + optional UnapprovedTransfer.
   it.todo('should expose bridgeDeposits query on Query type');
+
+  // Note: the bridge pool query surface (bridgeReserveInflows, bridgeTreasuryInflows,
+  // bridgePoolSummary) is owned by the pool-observability work (#944) and is asserted
+  // in that branch's tests, not here.
 });
 
 // #942 — GraphQL subscriptions for bridge events
@@ -110,11 +112,11 @@ describe('bridge GraphQL schema — subscriptions (#942)', () => {
   // Real-time push of new BridgeEvents; supports from-cursor reconnection.
   it.todo('should expose bridgeEvents subscription on Subscription type');
 
-  // Real-time push of new BridgeClaims; supports from-cursor reconnection.
-  it.todo('should expose bridgeClaims subscription on Subscription type');
-
   // Live BridgeBalance recomputed on every matching event for an address.
   it.todo('should expose bridgeBalance subscription on Subscription type');
+
+  // Note: the bridgePoolUpdates subscription is owned by the pool-observability
+  // work (#944) and is asserted in that branch's tests, not here.
 });
 
 // Reference implementation for when it.todo is removed:
@@ -127,7 +129,7 @@ describe('bridge GraphQL schema — subscriptions (#942)', () => {
 //   expect(response.data?.__type?.kind).toBe('INTERFACE');
 //   expect(response.data?.__type?.fields?.map((f) => f.name)).toContain('id');
 //   expect(response.data?.__type?.fields?.map((f) => f.name)).toContain('midnightTxHash');
-//   expect(response.data?.__type?.fields?.map((f) => f.name)).toContain('indexedAt');
+//   expect(response.data?.__type?.fields?.map((f) => f.name)).toContain('blockHeight');
 //   log.debug('BridgeEvent interface confirmed in schema');
 // });
 

--- a/qa/tests/tests/smoke/bridge-schema.test.ts
+++ b/qa/tests/tests/smoke/bridge-schema.test.ts
@@ -17,17 +17,20 @@
 //
 // These tests verify that every bridge type, query, and subscription declared
 // in #941 and #942 actually appears in the deployed schema. They run via
-// introspection so they cost only one HTTP round-trip each, and they fail fast
-// if a deployment is missing bridge support entirely.
+// introspection so they cost only one HTTP round-trip each.
 //
-// They require an environment whose indexer exposes the bridge surface (the
-// bridge feature is @beta and not yet on main). Run against an env that has it
-// deployed, e.g. TARGET_ENV=devnet.
+// The bridge feature is @beta and not present on every environment. A beforeAll
+// introspects whether the surface exists and the suite skips itself where it is
+// absent, so a normal smoke run on a non-bridge env (e.g. undeployed) is green
+// rather than red. Run against an env that has it deployed (e.g.
+// TARGET_ENV=devnet) to exercise the assertions.
 //
 // Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/941
 //           https://github.com/midnightntwrk/midnight-indexer/issues/942
 
+import log from '@utils/logging/logger';
 import '@utils/logging/test-logging-hooks';
+import type { TestContext } from 'vitest';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
 
 const INTROSPECT_TYPE = (name: string) => `
@@ -64,6 +67,7 @@ interface IntrospectionTypeResult {
 
 const httpClient = new IndexerHttpClient();
 
+// Raw introspection over HTTP, mirroring tests/smoke/graphql-healthchecks.test.ts.
 function rawRequest<T>(query: string): Promise<{ data: T | null }> {
   return (
     httpClient as unknown as {
@@ -82,142 +86,189 @@ async function rootFieldNames(rootType: 'Query' | 'Subscription') {
   return (response.data?.__type?.fields ?? []).map((f) => f.name);
 }
 
-// #941 — GraphQL types and queries for bridge events
-describe('bridge GraphQL schema — types (#941)', () => {
-  /**
-   * @given an indexer deployment with the bridge surface
-   * @when the BridgeEvent type is introspected
-   * @then it is an INTERFACE exposing the flat fields id, blockHeight and midnightTxHash
-   * @and it does not expose a nested indexedAt field
-   */
-  test('should expose BridgeEvent interface with flat blockHeight', async (ctx) => {
-    ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
-    const type = await introspectType('BridgeEvent');
-    expect(type).not.toBeNull();
-    expect(type?.kind).toBe('INTERFACE');
-    const fields = (type?.fields ?? []).map((f) => f.name);
-    expect(fields).toEqual(expect.arrayContaining(['id', 'blockHeight', 'midnightTxHash']));
-    expect(fields).not.toContain('indexedAt');
-  });
-
-  /**
-   * @given an indexer deployment with the bridge surface
-   * @when each concrete bridge event type is introspected
-   * @then every variant exists and declares BridgeEvent as an implemented interface
-   */
-  test('should expose the five concrete BridgeEvent variants', async (ctx) => {
-    ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
-    const variants = [
-      'BridgeUserTransfer',
-      'BridgeReserveTransfer',
-      'BridgeInvalidTransfer',
-      'BridgeUnapprovedTransfer',
-      'BridgeSubminimalFlushTransfer',
-    ];
-    for (const name of variants) {
-      const type = await introspectType(name);
-      expect(type, `${name} should exist`).not.toBeNull();
-      const interfaces = (type?.interfaces ?? []).map((i) => i.name);
-      expect(interfaces, `${name} should implement BridgeEvent`).toContain('BridgeEvent');
+describe('bridge GraphQL schema', () => {
+  // The bridge surface is feature-gated and absent on some environments. Probe
+  // once and skip every test below where it is not deployed.
+  let bridgeAvailable = false;
+  beforeAll(async () => {
+    bridgeAvailable = (await introspectType('BridgeEvent')) !== null;
+    if (!bridgeAvailable) {
+      log.warn(
+        'Bridge GraphQL surface not present on this environment — skipping bridge schema smoke checks.',
+      );
     }
   });
 
-  /**
-   * @given an indexer deployment with the bridge surface
-   * @when the BridgeSubminimalFlushTransfer type is introspected
-   * @then it exposes amount and count and carries no Cardano tx hash
-   */
-  test('should expose BridgeSubminimalFlushTransfer without a cardanoTxHash', async (ctx) => {
-    ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
-    const type = await introspectType('BridgeSubminimalFlushTransfer');
-    expect(type).not.toBeNull();
-    const fields = (type?.fields ?? []).map((f) => f.name);
-    expect(fields).toEqual(expect.arrayContaining(['amount', 'count']));
-    expect(fields).not.toContain('cardanoTxHash');
+  // #941 — GraphQL types for bridge events
+  describe('types', () => {
+    /**
+     * @given an indexer deployment with the bridge surface
+     * @when the BridgeEvent type is introspected
+     * @then it is an INTERFACE exposing the flat fields id, blockHeight and midnightTxHash
+     * @and it does not expose a nested indexedAt field
+     */
+    test('should expose BridgeEvent interface with flat blockHeight', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
+      if (!bridgeAvailable) {
+        ctx.skip();
+        return;
+      }
+      const type = await introspectType('BridgeEvent');
+      expect(type).not.toBeNull();
+      expect(type?.kind).toBe('INTERFACE');
+      const fields = (type?.fields ?? []).map((f) => f.name);
+      expect(fields).toEqual(expect.arrayContaining(['id', 'blockHeight', 'midnightTxHash']));
+      expect(fields).not.toContain('indexedAt');
+    });
+
+    /**
+     * @given an indexer deployment with the bridge surface
+     * @when each concrete bridge event type is introspected
+     * @then every variant exists and declares BridgeEvent as an implemented interface
+     */
+    test('should expose the five concrete BridgeEvent variants', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
+      if (!bridgeAvailable) {
+        ctx.skip();
+        return;
+      }
+      const variants = [
+        'BridgeUserTransfer',
+        'BridgeReserveTransfer',
+        'BridgeInvalidTransfer',
+        'BridgeUnapprovedTransfer',
+        'BridgeSubminimalFlushTransfer',
+      ];
+      for (const name of variants) {
+        const type = await introspectType(name);
+        expect(type, `${name} should exist`).not.toBeNull();
+        const interfaces = (type?.interfaces ?? []).map((i) => i.name);
+        expect(interfaces, `${name} should implement BridgeEvent`).toContain('BridgeEvent');
+      }
+    });
+
+    /**
+     * @given an indexer deployment with the bridge surface
+     * @when the BridgeSubminimalFlushTransfer type is introspected
+     * @then it exposes amount and count and carries no Cardano tx hash
+     */
+    test('should expose BridgeSubminimalFlushTransfer without a cardanoTxHash', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
+      if (!bridgeAvailable) {
+        ctx.skip();
+        return;
+      }
+      const type = await introspectType('BridgeSubminimalFlushTransfer');
+      expect(type).not.toBeNull();
+      const fields = (type?.fields ?? []).map((f) => f.name);
+      expect(fields).toEqual(expect.arrayContaining(['amount', 'count']));
+      expect(fields).not.toContain('cardanoTxHash');
+    });
+
+    /**
+     * @given an indexer deployment with the bridge surface
+     * @when the BridgeClaimTransaction type is introspected
+     * @then it exists and implements the Transaction interface
+     */
+    test('should expose BridgeClaimTransaction implementing Transaction', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
+      if (!bridgeAvailable) {
+        ctx.skip();
+        return;
+      }
+      const type = await introspectType('BridgeClaimTransaction');
+      expect(type).not.toBeNull();
+      const interfaces = (type?.interfaces ?? []).map((i) => i.name);
+      expect(interfaces).toContain('Transaction');
+    });
+
+    /**
+     * @given an indexer deployment with the bridge surface
+     * @when the BridgeBalance type is introspected
+     * @then it exposes deposited, claimed and balance and no per-type address field
+     */
+    test('should expose BridgeBalance with deposited, claimed, balance', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
+      if (!bridgeAvailable) {
+        ctx.skip();
+        return;
+      }
+      const type = await introspectType('BridgeBalance');
+      expect(type).not.toBeNull();
+      const fields = (type?.fields ?? []).map((f) => f.name);
+      expect(fields).toEqual(expect.arrayContaining(['deposited', 'claimed', 'balance']));
+      expect(fields).not.toContain('address');
+    });
+
+    /**
+     * @given an indexer deployment with the bridge surface
+     * @when the BridgeEventVariant enum is introspected
+     * @then it exposes exactly the five pallet event discriminators
+     */
+    test('should expose BridgeEventVariant enum with five values', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
+      if (!bridgeAvailable) {
+        ctx.skip();
+        return;
+      }
+      const type = await introspectType('BridgeEventVariant');
+      expect(type).not.toBeNull();
+      expect(type?.kind).toBe('ENUM');
+      const values = (type?.enumValues ?? []).map((v) => v.name).sort();
+      expect(values).toEqual(
+        [
+          'INVALID_TRANSFER',
+          'RESERVE_TRANSFER',
+          'SUBMINIMAL_FLUSH_TRANSFER',
+          'UNAPPROVED_TRANSFER',
+          'USER_TRANSFER',
+        ].sort(),
+      );
+    });
   });
 
-  /**
-   * @given an indexer deployment with the bridge surface
-   * @when the BridgeClaimTransaction type is introspected
-   * @then it exists and implements the Transaction interface
-   */
-  test('should expose BridgeClaimTransaction implementing Transaction', async (ctx) => {
-    ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
-    const type = await introspectType('BridgeClaimTransaction');
-    expect(type).not.toBeNull();
-    const interfaces = (type?.interfaces ?? []).map((i) => i.name);
-    expect(interfaces).toContain('Transaction');
+  // #941 — bridge query root fields
+  describe('queries', () => {
+    /**
+     * @given an indexer deployment with the bridge surface
+     * @when the Query root type is introspected
+     * @then the bridgeEvents, bridgeBalance and bridgeDeposits fields are present
+     */
+    test('should expose the bridge query fields on Query', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
+      if (!bridgeAvailable) {
+        ctx.skip();
+        return;
+      }
+      const fields = await rootFieldNames('Query');
+      expect(fields).toEqual(
+        expect.arrayContaining(['bridgeEvents', 'bridgeBalance', 'bridgeDeposits']),
+      );
+    });
+
+    // Note: the bridge pool query surface (bridgeReserveInflows, bridgeTreasuryInflows,
+    // bridgePoolSummary) is owned by the pool-observability work (#944) and is asserted
+    // in that branch's tests, not here.
   });
 
-  /**
-   * @given an indexer deployment with the bridge surface
-   * @when the BridgeBalance type is introspected
-   * @then it exposes deposited, claimed and balance and no per-type address field
-   */
-  test('should expose BridgeBalance with deposited, claimed, balance', async (ctx) => {
-    ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
-    const type = await introspectType('BridgeBalance');
-    expect(type).not.toBeNull();
-    const fields = (type?.fields ?? []).map((f) => f.name);
-    expect(fields).toEqual(expect.arrayContaining(['deposited', 'claimed', 'balance']));
-    expect(fields).not.toContain('address');
+  // #942 — bridge subscription root fields
+  describe('subscriptions', () => {
+    /**
+     * @given an indexer deployment with the bridge surface
+     * @when the Subscription root type is introspected
+     * @then the bridgeEvents and bridgeBalance subscription fields are present
+     */
+    test('should expose the bridge subscription fields on Subscription', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
+      if (!bridgeAvailable) {
+        ctx.skip();
+        return;
+      }
+      const fields = await rootFieldNames('Subscription');
+      expect(fields).toEqual(expect.arrayContaining(['bridgeEvents', 'bridgeBalance']));
+    });
+
+    // Note: the bridgePoolUpdates subscription is owned by the pool-observability
+    // work (#944) and is asserted in that branch's tests, not here.
   });
-
-  /**
-   * @given an indexer deployment with the bridge surface
-   * @when the BridgeEventVariant enum is introspected
-   * @then it exposes exactly the five pallet event discriminators
-   */
-  test('should expose BridgeEventVariant enum with five values', async (ctx) => {
-    ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
-    const type = await introspectType('BridgeEventVariant');
-    expect(type).not.toBeNull();
-    expect(type?.kind).toBe('ENUM');
-    const values = (type?.enumValues ?? []).map((v) => v.name).sort();
-    expect(values).toEqual(
-      [
-        'INVALID_TRANSFER',
-        'RESERVE_TRANSFER',
-        'SUBMINIMAL_FLUSH_TRANSFER',
-        'UNAPPROVED_TRANSFER',
-        'USER_TRANSFER',
-      ].sort(),
-    );
-  });
-});
-
-describe('bridge GraphQL schema — queries (#941)', () => {
-  /**
-   * @given an indexer deployment with the bridge surface
-   * @when the Query root type is introspected
-   * @then the bridgeEvents, bridgeBalance and bridgeDeposits fields are present
-   */
-  test('should expose the #941 bridge query fields on Query', async (ctx) => {
-    ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
-    const fields = await rootFieldNames('Query');
-    expect(fields).toEqual(
-      expect.arrayContaining(['bridgeEvents', 'bridgeBalance', 'bridgeDeposits']),
-    );
-  });
-
-  // Note: the bridge pool query surface (bridgeReserveInflows, bridgeTreasuryInflows,
-  // bridgePoolSummary) is owned by the pool-observability work (#944) and is asserted
-  // in that branch's tests, not here.
-});
-
-// #942 — GraphQL subscriptions for bridge events
-describe('bridge GraphQL schema — subscriptions (#942)', () => {
-  /**
-   * @given an indexer deployment with the bridge surface
-   * @when the Subscription root type is introspected
-   * @then the bridgeEvents and bridgeBalance subscription fields are present
-   */
-  test('should expose the #942 bridge subscription fields on Subscription', async (ctx) => {
-    ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
-    const fields = await rootFieldNames('Subscription');
-    expect(fields).toEqual(expect.arrayContaining(['bridgeEvents', 'bridgeBalance']));
-  });
-
-  // Note: the bridgePoolUpdates subscription is owned by the pool-observability
-  // work (#944) and is asserted in that branch's tests, not here.
 });

--- a/qa/tests/tests/smoke/bridge-schema.test.ts
+++ b/qa/tests/tests/smoke/bridge-schema.test.ts
@@ -1,0 +1,138 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Smoke-level schema presence checks for the c2m-bridge GraphQL surface.
+//
+// These tests verify that every bridge type, query, and subscription declared
+// in #941 and #942 actually appears in the deployed schema. They run via
+// introspection so they cost only one HTTP round-trip each, and they fail fast
+// if a deployment is missing bridge support entirely.
+//
+// All tests are marked it.todo until the dev PRs (#938-#942) are merged and
+// the schema-v4.graphql is regenerated. Un-todo them as part of the final
+// QA sign-off on those PRs.
+//
+// Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/941
+//           https://github.com/midnightntwrk/midnight-indexer/issues/942
+
+import log from '@utils/logging/logger';
+import '@utils/logging/test-logging-hooks';
+import { IndexerHttpClient } from '@utils/indexer/http-client';
+
+const INTROSPECT_TYPE = (name: string) => `
+  query {
+    __type(name: "${name}") {
+      name
+      kind
+      fields { name }
+      enumValues { name }
+      possibleTypes { name }
+    }
+  }
+`;
+
+const INTROSPECT_QUERY_FIELDS = `
+  query {
+    __type(name: "Query") {
+      fields { name }
+    }
+  }
+`;
+
+const INTROSPECT_SUBSCRIPTION_FIELDS = `
+  query {
+    __type(name: "Subscription") {
+      fields { name }
+    }
+  }
+`;
+
+const httpClient = new IndexerHttpClient();
+
+function rawRequest<T>(query: string): Promise<{ data: T | null }> {
+  return (
+    httpClient as unknown as {
+      client: { rawRequest: (q: string) => Promise<{ data: T | null }> };
+    }
+  ).client.rawRequest(query);
+}
+
+// #941 — GraphQL types and queries for bridge events
+describe('bridge GraphQL schema — types (#941)', () => {
+  // BridgeEvent interface: shared fields across all 5 event variants.
+  it.todo('should expose BridgeEvent interface');
+
+  // Concrete types implementing BridgeEvent, one per pallet event variant.
+  it.todo('should expose BridgeUserTransfer type');
+  it.todo('should expose BridgeReserveTransfer type');
+  it.todo('should expose BridgeInvalidTransfer type');
+  it.todo('should expose BridgeUnapprovedTransfer type');
+  it.todo('should expose BridgeSubminimalFlushTransfer type');
+
+  // BridgeClaim: ClaimRewardsTransaction with kind=CardanoBridge.
+  it.todo('should expose BridgeClaim type');
+
+  // BridgeBalance: deposited / claimed / balance summary per address.
+  it.todo('should expose BridgeBalance type with deposited, claimed, balance fields');
+
+  // Discriminator enum used by bridgeEvents(variant: ...) filter.
+  it.todo('should expose BridgePalletEventVariant enum with 5 values');
+});
+
+describe('bridge GraphQL schema — queries (#941)', () => {
+  // bridgeEvents: filterable list of BridgeEvent (by block, recipient, variant).
+  it.todo('should expose bridgeEvents query on Query type');
+
+  // bridgeClaims: list of BridgeClaim, filterable by recipient.
+  it.todo('should expose bridgeClaims query on Query type');
+
+  // bridgeBalance: aggregate summary (deposited - claimed) for a recipient address.
+  it.todo('should expose bridgeBalance query on Query type');
+
+  // bridgeDeposits: convenience filter combining UserTransfer + optional UnapprovedTransfer.
+  it.todo('should expose bridgeDeposits query on Query type');
+});
+
+// #942 — GraphQL subscriptions for bridge events
+describe('bridge GraphQL schema — subscriptions (#942)', () => {
+  // Real-time push of new BridgeEvents; supports from-cursor reconnection.
+  it.todo('should expose bridgeEvents subscription on Subscription type');
+
+  // Real-time push of new BridgeClaims; supports from-cursor reconnection.
+  it.todo('should expose bridgeClaims subscription on Subscription type');
+
+  // Live BridgeBalance recomputed on every matching event for an address.
+  it.todo('should expose bridgeBalance subscription on Subscription type');
+});
+
+// Reference implementation for when it.todo is removed:
+// Replace each it.todo block with a test body like this example.
+//
+// test('should expose BridgeEvent interface', async (ctx) => {
+//   ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
+//   const response = await rawRequest<IntrospectionTypeResult>(INTROSPECT_TYPE('BridgeEvent'));
+//   expect(response.data?.__type).not.toBeNull();
+//   expect(response.data?.__type?.kind).toBe('INTERFACE');
+//   expect(response.data?.__type?.fields?.map((f) => f.name)).toContain('id');
+//   expect(response.data?.__type?.fields?.map((f) => f.name)).toContain('midnightTxHash');
+//   expect(response.data?.__type?.fields?.map((f) => f.name)).toContain('indexedAt');
+//   log.debug('BridgeEvent interface confirmed in schema');
+// });
+
+void INTROSPECT_TYPE;
+void INTROSPECT_QUERY_FIELDS;
+void INTROSPECT_SUBSCRIPTION_FIELDS;
+void log;
+void rawRequest;

--- a/qa/tests/tests/smoke/bridge-schema.test.ts
+++ b/qa/tests/tests/smoke/bridge-schema.test.ts
@@ -20,14 +20,13 @@
 // introspection so they cost only one HTTP round-trip each, and they fail fast
 // if a deployment is missing bridge support entirely.
 //
-// All tests are marked it.todo until the dev PRs (#938-#942) are merged and
-// the schema-v4.graphql is regenerated. Un-todo them as part of the final
-// QA sign-off on those PRs.
+// They require an environment whose indexer exposes the bridge surface (the
+// bridge feature is @beta and not yet on main). Run against an env that has it
+// deployed, e.g. TARGET_ENV=devnet.
 //
 // Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/941
 //           https://github.com/midnightntwrk/midnight-indexer/issues/942
 
-import log from '@utils/logging/logger';
 import '@utils/logging/test-logging-hooks';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
 
@@ -39,25 +38,29 @@ const INTROSPECT_TYPE = (name: string) => `
       fields { name }
       enumValues { name }
       possibleTypes { name }
+      interfaces { name }
     }
   }
 `;
 
-const INTROSPECT_QUERY_FIELDS = `
+const INTROSPECT_ROOT_FIELDS = (rootType: 'Query' | 'Subscription') => `
   query {
-    __type(name: "Query") {
+    __type(name: "${rootType}") {
       fields { name }
     }
   }
 `;
 
-const INTROSPECT_SUBSCRIPTION_FIELDS = `
-  query {
-    __type(name: "Subscription") {
-      fields { name }
-    }
-  }
-`;
+interface IntrospectionTypeResult {
+  __type: {
+    name: string;
+    kind: string;
+    fields: { name: string }[] | null;
+    enumValues: { name: string }[] | null;
+    possibleTypes: { name: string }[] | null;
+    interfaces: { name: string }[] | null;
+  } | null;
+}
 
 const httpClient = new IndexerHttpClient();
 
@@ -69,38 +72,133 @@ function rawRequest<T>(query: string): Promise<{ data: T | null }> {
   ).client.rawRequest(query);
 }
 
+async function introspectType(name: string) {
+  const response = await rawRequest<IntrospectionTypeResult>(INTROSPECT_TYPE(name));
+  return response.data?.__type ?? null;
+}
+
+async function rootFieldNames(rootType: 'Query' | 'Subscription') {
+  const response = await rawRequest<IntrospectionTypeResult>(INTROSPECT_ROOT_FIELDS(rootType));
+  return (response.data?.__type?.fields ?? []).map((f) => f.name);
+}
+
 // #941 — GraphQL types and queries for bridge events
 describe('bridge GraphQL schema — types (#941)', () => {
-  // BridgeEvent interface: shared fields across all 5 event variants.
-  it.todo('should expose BridgeEvent interface');
+  /**
+   * @given an indexer deployment with the bridge surface
+   * @when the BridgeEvent type is introspected
+   * @then it is an INTERFACE exposing the flat fields id, blockHeight and midnightTxHash
+   * @and it does not expose a nested indexedAt field
+   */
+  test('should expose BridgeEvent interface with flat blockHeight', async (ctx) => {
+    ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
+    const type = await introspectType('BridgeEvent');
+    expect(type).not.toBeNull();
+    expect(type?.kind).toBe('INTERFACE');
+    const fields = (type?.fields ?? []).map((f) => f.name);
+    expect(fields).toEqual(expect.arrayContaining(['id', 'blockHeight', 'midnightTxHash']));
+    expect(fields).not.toContain('indexedAt');
+  });
 
-  // Concrete types implementing BridgeEvent, one per pallet event variant.
-  it.todo('should expose BridgeUserTransfer type');
-  it.todo('should expose BridgeReserveTransfer type');
-  it.todo('should expose BridgeInvalidTransfer type');
-  it.todo('should expose BridgeUnapprovedTransfer type');
-  it.todo('should expose BridgeSubminimalFlushTransfer type');
+  /**
+   * @given an indexer deployment with the bridge surface
+   * @when each concrete bridge event type is introspected
+   * @then every variant exists and declares BridgeEvent as an implemented interface
+   */
+  test('should expose the five concrete BridgeEvent variants', async (ctx) => {
+    ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
+    const variants = [
+      'BridgeUserTransfer',
+      'BridgeReserveTransfer',
+      'BridgeInvalidTransfer',
+      'BridgeUnapprovedTransfer',
+      'BridgeSubminimalFlushTransfer',
+    ];
+    for (const name of variants) {
+      const type = await introspectType(name);
+      expect(type, `${name} should exist`).not.toBeNull();
+      const interfaces = (type?.interfaces ?? []).map((i) => i.name);
+      expect(interfaces, `${name} should implement BridgeEvent`).toContain('BridgeEvent');
+    }
+  });
 
-  // BridgeClaimTransaction: a ClaimRewards transaction with kind=CardanoBridge,
-  // surfaced as its own Transaction type (no bridge-specific query).
-  it.todo('should expose BridgeClaimTransaction type implementing Transaction');
+  /**
+   * @given an indexer deployment with the bridge surface
+   * @when the BridgeSubminimalFlushTransfer type is introspected
+   * @then it exposes amount and count and carries no Cardano tx hash
+   */
+  test('should expose BridgeSubminimalFlushTransfer without a cardanoTxHash', async (ctx) => {
+    ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
+    const type = await introspectType('BridgeSubminimalFlushTransfer');
+    expect(type).not.toBeNull();
+    const fields = (type?.fields ?? []).map((f) => f.name);
+    expect(fields).toEqual(expect.arrayContaining(['amount', 'count']));
+    expect(fields).not.toContain('cardanoTxHash');
+  });
 
-  // BridgeBalance: deposited / claimed / balance summary per address.
-  it.todo('should expose BridgeBalance type with deposited, claimed, balance fields');
+  /**
+   * @given an indexer deployment with the bridge surface
+   * @when the BridgeClaimTransaction type is introspected
+   * @then it exists and implements the Transaction interface
+   */
+  test('should expose BridgeClaimTransaction implementing Transaction', async (ctx) => {
+    ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
+    const type = await introspectType('BridgeClaimTransaction');
+    expect(type).not.toBeNull();
+    const interfaces = (type?.interfaces ?? []).map((i) => i.name);
+    expect(interfaces).toContain('Transaction');
+  });
 
-  // Discriminator enum used by bridgeEvents(variant: ...) filter.
-  it.todo('should expose BridgeEventVariant enum with 5 values');
+  /**
+   * @given an indexer deployment with the bridge surface
+   * @when the BridgeBalance type is introspected
+   * @then it exposes deposited, claimed and balance and no per-type address field
+   */
+  test('should expose BridgeBalance with deposited, claimed, balance', async (ctx) => {
+    ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
+    const type = await introspectType('BridgeBalance');
+    expect(type).not.toBeNull();
+    const fields = (type?.fields ?? []).map((f) => f.name);
+    expect(fields).toEqual(expect.arrayContaining(['deposited', 'claimed', 'balance']));
+    expect(fields).not.toContain('address');
+  });
+
+  /**
+   * @given an indexer deployment with the bridge surface
+   * @when the BridgeEventVariant enum is introspected
+   * @then it exposes exactly the five pallet event discriminators
+   */
+  test('should expose BridgeEventVariant enum with five values', async (ctx) => {
+    ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
+    const type = await introspectType('BridgeEventVariant');
+    expect(type).not.toBeNull();
+    expect(type?.kind).toBe('ENUM');
+    const values = (type?.enumValues ?? []).map((v) => v.name).sort();
+    expect(values).toEqual(
+      [
+        'INVALID_TRANSFER',
+        'RESERVE_TRANSFER',
+        'SUBMINIMAL_FLUSH_TRANSFER',
+        'UNAPPROVED_TRANSFER',
+        'USER_TRANSFER',
+      ].sort(),
+    );
+  });
 });
 
 describe('bridge GraphQL schema — queries (#941)', () => {
-  // bridgeEvents: filterable list of BridgeEvent (by recipient, variant, block range).
-  it.todo('should expose bridgeEvents query on Query type');
-
-  // bridgeBalance: deposited / claimed / balance summary for an address.
-  it.todo('should expose bridgeBalance query on Query type');
-
-  // bridgeDeposits: convenience filter combining UserTransfer + optional UnapprovedTransfer.
-  it.todo('should expose bridgeDeposits query on Query type');
+  /**
+   * @given an indexer deployment with the bridge surface
+   * @when the Query root type is introspected
+   * @then the bridgeEvents, bridgeBalance and bridgeDeposits fields are present
+   */
+  test('should expose the #941 bridge query fields on Query', async (ctx) => {
+    ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
+    const fields = await rootFieldNames('Query');
+    expect(fields).toEqual(
+      expect.arrayContaining(['bridgeEvents', 'bridgeBalance', 'bridgeDeposits']),
+    );
+  });
 
   // Note: the bridge pool query surface (bridgeReserveInflows, bridgeTreasuryInflows,
   // bridgePoolSummary) is owned by the pool-observability work (#944) and is asserted
@@ -109,32 +207,17 @@ describe('bridge GraphQL schema — queries (#941)', () => {
 
 // #942 — GraphQL subscriptions for bridge events
 describe('bridge GraphQL schema — subscriptions (#942)', () => {
-  // Real-time push of new BridgeEvents; supports from-cursor reconnection.
-  it.todo('should expose bridgeEvents subscription on Subscription type');
-
-  // Live BridgeBalance recomputed on every matching event for an address.
-  it.todo('should expose bridgeBalance subscription on Subscription type');
+  /**
+   * @given an indexer deployment with the bridge surface
+   * @when the Subscription root type is introspected
+   * @then the bridgeEvents and bridgeBalance subscription fields are present
+   */
+  test('should expose the #942 bridge subscription fields on Subscription', async (ctx) => {
+    ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
+    const fields = await rootFieldNames('Subscription');
+    expect(fields).toEqual(expect.arrayContaining(['bridgeEvents', 'bridgeBalance']));
+  });
 
   // Note: the bridgePoolUpdates subscription is owned by the pool-observability
   // work (#944) and is asserted in that branch's tests, not here.
 });
-
-// Reference implementation for when it.todo is removed:
-// Replace each it.todo block with a test body like this example.
-//
-// test('should expose BridgeEvent interface', async (ctx) => {
-//   ctx.task!.meta.custom = { labels: ['Smoke', 'Bridge', 'Schema'] };
-//   const response = await rawRequest<IntrospectionTypeResult>(INTROSPECT_TYPE('BridgeEvent'));
-//   expect(response.data?.__type).not.toBeNull();
-//   expect(response.data?.__type?.kind).toBe('INTERFACE');
-//   expect(response.data?.__type?.fields?.map((f) => f.name)).toContain('id');
-//   expect(response.data?.__type?.fields?.map((f) => f.name)).toContain('midnightTxHash');
-//   expect(response.data?.__type?.fields?.map((f) => f.name)).toContain('blockHeight');
-//   log.debug('BridgeEvent interface confirmed in schema');
-// });
-
-void INTROSPECT_TYPE;
-void INTROSPECT_QUERY_FIELDS;
-void INTROSPECT_SUBSCRIPTION_FIELDS;
-void log;
-void rawRequest;

--- a/qa/tests/utils/indexer/graphql/bridge-queries.ts
+++ b/qa/tests/utils/indexer/graphql/bridge-queries.ts
@@ -1,0 +1,54 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// GraphQL documents for the c2m-bridge query surface (#941). The BridgeUserTransfer
+// inline fragment is the only concrete variant with test data on the current
+// environments; the other variants are selected by __typename only until data
+// exists to exercise their fields.
+export const GET_BRIDGE_EVENTS = `
+query BridgeEvents($RECIPIENT: HexEncoded, $VARIANT: BridgeEventVariant, $BLOCK_HEIGHT_FROM: Int, $BLOCK_HEIGHT_TO: Int, $OFFSET: Int, $LIMIT: Int) {
+  bridgeEvents(recipient: $RECIPIENT, variant: $VARIANT, blockHeightFrom: $BLOCK_HEIGHT_FROM, blockHeightTo: $BLOCK_HEIGHT_TO, offset: $OFFSET, limit: $LIMIT) {
+    __typename
+    ... on BridgeUserTransfer {
+      id
+      blockHeight
+      midnightTxHash
+      cardanoTxHash
+      amount
+      recipient
+    }
+  }
+}`;
+
+export const GET_BRIDGE_BALANCE = `
+query BridgeBalance($ADDRESS: HexEncoded!) {
+  bridgeBalance(address: $ADDRESS) {
+    deposited
+    claimed
+    balance
+  }
+}`;
+
+export const GET_BRIDGE_DEPOSITS = `
+query BridgeDeposits($RECIPIENT: HexEncoded!, $INCLUDE_UNAPPROVED: Boolean, $OFFSET: Int, $LIMIT: Int) {
+  bridgeDeposits(recipient: $RECIPIENT, includeUnapproved: $INCLUDE_UNAPPROVED, offset: $OFFSET, limit: $LIMIT) {
+    __typename
+    ... on BridgeUserTransfer {
+      id
+      recipient
+      amount
+    }
+  }
+}`;

--- a/qa/tests/utils/indexer/http-client.ts
+++ b/qa/tests/utils/indexer/http-client.ts
@@ -41,6 +41,10 @@ import type {
   ContractEvent,
   ContractEventFilter,
   ContractEventResponse,
+  BridgeEvent,
+  BridgeEventsResponse,
+  BridgeDepositsResponse,
+  BridgeBalanceResponse,
 } from './indexer-types';
 import {
   GET_LATEST_BLOCK,
@@ -56,6 +60,11 @@ import {
   GET_DUST_COMMITMENT_MERKLE_TREE_UPDATE,
   GET_DUST_GENERATION_MERKLE_TREE_UPDATE,
 } from './graphql/dust-queries';
+import {
+  GET_BRIDGE_EVENTS,
+  GET_BRIDGE_BALANCE,
+  GET_BRIDGE_DEPOSITS,
+} from './graphql/bridge-queries';
 
 /**
  * Recognise operation-level GraphQL errors that look like *server* failures
@@ -434,6 +443,74 @@ export class IndexerHttpClient {
     log.debug(`Using variables\n${JSON.stringify(variables, null, 2)}`);
 
     const response = await this.rawRequestWithRetry<{ contractEvents: ContractEvent[] }>(
+      query,
+      variables,
+    );
+
+    log.debug(`Raw indexer response\n${JSON.stringify(response, null, 2)}`);
+
+    return response;
+  }
+
+  async getBridgeEvents(
+    filters: {
+      recipient?: string;
+      variant?: string;
+      blockHeightFrom?: number;
+      blockHeightTo?: number;
+      offset?: number;
+      limit?: number;
+    } = {},
+    queryOverride?: string,
+  ): Promise<BridgeEventsResponse> {
+    const query = queryOverride || GET_BRIDGE_EVENTS;
+    const variables = {
+      RECIPIENT: filters.recipient,
+      VARIANT: filters.variant,
+      BLOCK_HEIGHT_FROM: filters.blockHeightFrom,
+      BLOCK_HEIGHT_TO: filters.blockHeightTo,
+      OFFSET: filters.offset,
+      LIMIT: filters.limit,
+    };
+
+    const response = await this.rawRequestWithRetry<{ bridgeEvents: BridgeEvent[] }>(
+      query,
+      variables,
+    );
+
+    log.debug(`Raw indexer response\n${JSON.stringify(response, null, 2)}`);
+
+    return response;
+  }
+
+  async getBridgeBalance(address: string, queryOverride?: string): Promise<BridgeBalanceResponse> {
+    const query = queryOverride || GET_BRIDGE_BALANCE;
+    const variables = { ADDRESS: address };
+
+    const response = await this.rawRequestWithRetry<BridgeBalanceResponse['data']>(
+      query,
+      variables,
+    );
+
+    log.debug(`Raw indexer response\n${JSON.stringify(response, null, 2)}`);
+
+    return response;
+  }
+
+  async getBridgeDeposits(
+    recipient: string,
+    options: { includeUnapproved?: boolean; offset?: number; limit?: number } = {},
+    queryOverride?: string,
+  ): Promise<BridgeDepositsResponse> {
+    const query = queryOverride || GET_BRIDGE_DEPOSITS;
+    const variables = {
+      RECIPIENT: recipient,
+      INCLUDE_UNAPPROVED: options.includeUnapproved,
+      OFFSET: options.offset,
+      LIMIT: options.limit,
+    };
+
+    const response = await this.rawRequestWithRetry<{ bridgeDeposits: BridgeEvent[] }>(
       query,
       variables,
     );

--- a/qa/tests/utils/indexer/indexer-types.ts
+++ b/qa/tests/utils/indexer/indexer-types.ts
@@ -466,6 +466,39 @@ export type DustGenerationsResponse = GraphQLResponse<{
   dustGenerations: DustGenerations[];
 }>;
 
+// c2m-bridge query surface (#941). Only BridgeUserTransfer carries fully-populated
+// fields today; other variants are discriminated by __typename until data exists.
+export interface BridgeUserTransfer {
+  __typename: 'BridgeUserTransfer';
+  id: number;
+  blockHeight: number;
+  midnightTxHash: string;
+  cardanoTxHash: string;
+  amount: string;
+  recipient: string;
+}
+
+export interface BridgeEventOther {
+  __typename: string;
+  id?: number;
+  recipient?: string;
+  amount?: string;
+}
+
+export type BridgeEvent = BridgeUserTransfer | BridgeEventOther;
+
+export type BridgeEventsResponse = GraphQLResponse<{ bridgeEvents: BridgeEvent[] }>;
+
+export type BridgeDepositsResponse = GraphQLResponse<{ bridgeDeposits: BridgeEvent[] }>;
+
+export interface BridgeBalance {
+  deposited: string;
+  claimed: string;
+  balance: string;
+}
+
+export type BridgeBalanceResponse = GraphQLResponse<{ bridgeBalance: BridgeBalance }>;
+
 export interface DustCommitmentMerkleTreeUpdateResult {
   startIndex: number;
   endIndex: number;

--- a/qa/tests/utils/toolkit/toolkit-wrapper.ts
+++ b/qa/tests/utils/toolkit/toolkit-wrapper.ts
@@ -355,7 +355,7 @@ class ToolkitWrapper {
     log.debug(`Toolkit ZK cache       : ${zkCacheDir}`);
 
     this.container = new GenericContainer(
-      `midnightntwrk/midnight-node-toolkit:${this.config.nodeToolkitTag}`,
+      `ghcr.io/midnight-ntwrk/midnight-node-toolkit:${this.config.nodeToolkitTag}`,
     )
       .withName(this.config.containerName)
       .withNetworkMode('host')


### PR DESCRIPTION
## Test plan for feat(bridge): GraphQL types and queries for bridge events (#941)

### What this ticket does

Introduces the GraphQL query surface for c2m-bridge events:
- `interface BridgeEvent` + 5 concrete implementing types (`BridgeUserTransfer`, `BridgeReserveTransfer`, `BridgeInvalidTransfer`, `BridgeUnapprovedTransfer`, `BridgeSubminimalFlushTransfer`)
- `enum BridgeEventVariant` with the 5 pallet event discriminators
- `type BridgeBalance { deposited, claimed, balance }`
- Queries: `bridgeEvents`, `bridgeBalance`, `bridgeDeposits`

Claims are **not** a bridge-specific query. A claim is surfaced as a `BridgeClaimTransaction` (a `ClaimRewards` transaction with `ClaimKind = CardanoBridge`) via the existing `unshieldedTransactions` query.

### Rust-side coverage (already in #941)

| Criterion | Location | Status |
|-----------|----------|--------|
| Unit tests per query against a fixture DB | `indexer-api` Rust tests | AC6 |
| Integration test: happy-path deposit (UserTransfer → BridgeBalance) | `indexer-api` Rust integration test | AC7 |
| Integration test: claim reduces balance | `indexer-api` Rust integration test | AC7 |

The Rust tests give confidence the query logic is correct at the DB/resolver layer. The QA tests below give confidence the full deployment is correct (schema regenerated, API server running, GraphQL resolvers wired up end-to-end).

### QA framework coverage

#### Smoke — `tests/smoke/bridge-schema.test.ts` (implemented)

Introspection-based presence checks, one HTTP round-trip each. These are **implemented and active** (not `test.todo`) and run against an environment that exposes the bridge surface (e.g. `TARGET_ENV=devnet`); the bridge feature is `@beta` and not yet on `main`. They fail fast if a deployment is missing bridge support or the schema was not regenerated.

| Test | Status |
|------|--------|
| `BridgeEvent` interface exposes flat `id`/`blockHeight`/`midnightTxHash` (no `indexedAt`) | implemented |
| 5 concrete `BridgeEvent` variants exist and implement `BridgeEvent` | implemented |
| `BridgeSubminimalFlushTransfer` exposes `amount`/`count`, no `cardanoTxHash` | implemented |
| `BridgeClaimTransaction` implements `Transaction` | implemented |
| `BridgeBalance` exposes `deposited`/`claimed`/`balance` (no `address`) | implemented |
| `BridgeEventVariant` enum exposes the 5 values | implemented |
| `bridgeEvents`/`bridgeBalance`/`bridgeDeposits` present on `Query` | implemented |
| `bridgeEvents`/`bridgeBalance` present on `Subscription` (from #942) | implemented |

The pool query/subscription surface (`bridgeReserveInflows`, `bridgeTreasuryInflows`, `bridgePoolSummary`, `bridgePoolUpdates`) is owned by #944 and asserted there, not here.

#### Integration — `tests/integration/basic/queries/bridge-queries.test.ts` (skeletons)

All `test.todo` except one `test.skip`; bodies pending bridge event data in the test environment.

| Test | Status | Reason |
|------|--------|--------|
| `bridgeEvents` — empty list for a recipient with no activity | `test.todo` | Needs bridge event data |
| `bridgeEvents` — filtered by `USER_TRANSFER` variant | `test.todo` | Needs bridge event data |
| `bridgeEvents` — filtered by recipient | `test.todo` | Needs bridge event data |
| `bridgeEvents` — returns all 5 variant types when present | `test.todo` | Needs bridge event data |
| `bridgeEvents` — pagination (offset + limit) | `test.todo` | Needs bridge event data |
| `bridgeEvents` — correct field shape for `BridgeUserTransfer` | `test.todo` | Needs bridge event data |
| claims — `BridgeClaimTransaction` surfaced via `unshieldedTransactions` | `test.todo` | Needs claim data; covered via the unshielded-tx surface, not a bridge query |
| `bridgeBalance` — zero balance for unknown address | `test.todo` | Needs bridge event data |
| `bridgeBalance` — `deposited` = sum of UserTransfer amounts | `test.todo` | Needs bridge event data |
| `bridgeBalance` — zero balance once fully claimed (read from ledger) | `test.todo` | Needs event + claim data |
| `bridgeBalance` — non-zero remaining-claimable after a partial claim | `test.todo` | Needs event + claim data |
| `bridgeDeposits` — empty for unknown address | `test.todo` | Needs bridge event data |
| `bridgeDeposits` — excludes `UnapprovedTransfer` by default | `test.todo` | Needs UserTransfer + UnapprovedTransfer data |
| `bridgeDeposits(includeUnapproved: true)` | `test.skip` | **Blocked**: `UnapprovedTransfer` unreachable until governance approval logic lands (#940) |

> Note on `bridgeBalance`: `balance` is read from the ledger's remaining-claimable map; it is **not** asserted to equal `deposited − claimed`.

#### E2E

Not required. The query surface is fully exercised by the integration tests above. E2E is reserved for scenarios requiring actual on-chain transaction generation (e.g. wallet-sdk bridge flows).

### TypeScript types

Bridge types are defined inline in the test files as stubs. Once #941 is merged and field names are confirmed against the schema, move them to `utils/indexer/indexer-types.ts` following the existing pattern.

### Closes / tracks
- Provides QA test coverage for https://github.com/midnightntwrk/midnight-indexer/issues/941

