### PR TITLE
test: add bridge pool observability tests (#944)

### DIFF
--- a/qa/tests/tests/integration/basic/queries/bridge-pool-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/bridge-pool-queries.test.ts
@@ -19,60 +19,135 @@
 // Pool observability tracks where NIGHT flows when bridge transactions are
 // processed: the Reserve pool (ReserveTransfer) and the Treasury (Invalid,
 // Unapproved, SubminimalFlush). Per-address balance (UserTransfer/claims) is
-// covered by #941. bridgePoolSummary returns cumulative totals per category plus
-// a count of subminimum txs aggregated into flush events.
+// covered by #941.
 //
-// These are skeletons enumerating the intended cases:
-//   test.todo → needs bridge event data in the test environment. When
-//               implemented, follow the framework conventions
-//               (how-to-write-a-qa-indexer-test): issue the query via an
-//               IndexerHttpClient method, define response types in
-//               utils/indexer/indexer-types.ts, gate on bridge availability,
-//               assert with toBeSuccess(), and set ctx.task labels.
+// Test-data reality (2026-07): no reserve or treasury events exist on any
+// environment (the only bridge data anywhere is a single UserTransfer on
+// devnet, which does not touch these pools). So the pool totals are legitimately
+// all-zero everywhere, and the inflow lists are empty. That makes the well-formed
+// zero-state and empty-list cases real, executable tests; the cases that need
+// non-zero aggregation stay test.todo until a data source can produce reserve /
+// treasury events.
+//   test.todo → needs reserve/treasury event data not producible in any env yet.
 //   test.skip → blocked on an in-flight feature: UNAPPROVED on approval
-//               governance (#940); SUBMINIMAL_FLUSH on confirming whether the
-//               flush threshold is a configurable genesis parameter (node team)
-//               so a flush can be triggered deterministically in a test env.
+//               governance (#940); SUBMINIMAL_FLUSH on a triggerable flush
+//               threshold (node team).
 //
 // Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/944
 
-describe('bridge pool queries', () => {
+import log from '@utils/logging/logger';
+import { env } from 'environment/model';
+import type { TestContext } from 'vitest';
+import '@utils/logging/test-logging-hooks';
+import { IndexerHttpClient } from '@utils/indexer/http-client';
+import { BRIDGE_TREASURY_REASONS } from '@utils/indexer/indexer-types';
+
+const httpClient = new IndexerHttpClient();
+
+const ZERO_U128 = '0'.repeat(32);
+// An early block that predates any possible bridge event, for the atBlock snapshot.
+const EARLY_BLOCK = 1;
+
+let surfacePresent = false;
+
+describe.skipIf(env.isUndeployedEnv())('bridge pool queries', () => {
+  beforeAll(async () => {
+    const probe = await httpClient.getBridgePoolSummary();
+    if (probe.errors || !probe.data) {
+      log.warn(`Bridge pool surface not present on ${env.getCurrentEnvironmentName()}; skipping`);
+      return;
+    }
+    surfacePresent = true;
+  }, 30_000);
+
   describe('bridgePoolSummary', () => {
     /**
-     * @given no bridge events have been indexed (or atBlock before the first bridge block)
-     * @when we query bridgePoolSummary
-     * @then reserveTotal is zero, every treasuryByReason total is zero,
-     *       subminimumTxCount is 0 and lastEventBlockHeight is null
+     * @given an environment with no reserve or treasury bridge events indexed
+     * @when bridgePoolSummary is queried
+     * @then reserveTotal and every treasuryByReason total are the zero-value hex
+     *       string, subminimumTxCount is 0, and the three treasury reasons
+     *       (INVALID, UNAPPROVED, SUBMINIMAL_FLUSH) are each present
      */
-    test.todo('should return all-zero totals when no bridge events have been indexed');
+    test('should return zero pool totals when no reserve or treasury events are indexed', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'Bridge', 'Pool'] };
+      if (!surfacePresent) return ctx.skip();
+
+      const response = await httpClient.getBridgePoolSummary();
+
+      expect(response).toBeSuccess();
+      const pool = response.data!.bridgePoolSummary;
+      expect(pool.reserveTotal).toBe(ZERO_U128);
+      expect(pool.subminimumTxCount).toBe(0);
+
+      const reasons = pool.treasuryByReason.map((t) => t.reason).sort();
+      expect(reasons).toEqual([...BRIDGE_TREASURY_REASONS].sort());
+      for (const aggregate of pool.treasuryByReason) {
+        expect(aggregate.total).toBe(ZERO_U128);
+      }
+    });
 
     /**
-     * @given the with-data chain has N ReserveTransfer events with known amounts
-     * @when we query bridgePoolSummary
+     * @given an environment where at least one bridge event has been indexed
+     * @when bridgePoolSummary is queried
+     * @then lastEventBlockHeight is a positive integer
+     *
+     * On environments with no bridge events at all, lastEventBlockHeight is null
+     * and the case is skipped.
+     */
+    test('should expose lastEventBlockHeight as a positive integer where bridge events exist', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'Bridge', 'Pool'] };
+      if (!surfacePresent) return ctx.skip();
+
+      const response = await httpClient.getBridgePoolSummary();
+      expect(response).toBeSuccess();
+      const lastEventBlockHeight = response.data!.bridgePoolSummary.lastEventBlockHeight;
+
+      if (lastEventBlockHeight === null) {
+        return ctx.skip(true, 'no bridge events on this env — lastEventBlockHeight is null');
+      }
+      expect(Number.isInteger(lastEventBlockHeight)).toBe(true);
+      expect(lastEventBlockHeight).toBeGreaterThan(0);
+    });
+
+    /**
+     * @given a block that predates any bridge event (block 1)
+     * @when bridgePoolSummary(atBlock: 1) is queried
+     * @then the snapshot has null lastEventBlockHeight and zero totals, confirming
+     *       the point-in-time snapshot excludes later events
+     */
+    test('should return an empty snapshot when atBlock predates all bridge events', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'Bridge', 'Pool', 'ByHeight'] };
+      if (!surfacePresent) return ctx.skip();
+
+      const response = await httpClient.getBridgePoolSummary(EARLY_BLOCK);
+
+      expect(response).toBeSuccess();
+      const pool = response.data!.bridgePoolSummary;
+      expect(pool.lastEventBlockHeight).toBeNull();
+      expect(pool.reserveTotal).toBe(ZERO_U128);
+      expect(pool.subminimumTxCount).toBe(0);
+    });
+
+    /**
+     * @given a chain with N ReserveTransfer events of known amounts
+     * @when bridgePoolSummary is queried
      * @then reserveTotal equals the sum of all ReserveTransfer.amount values
      */
     test.todo('should set reserveTotal to the cumulative sum of ReserveTransfer amounts');
 
     /**
-     * @given the with-data chain has InvalidTransfer and UnapprovedTransfer events
-     * @when we query bridgePoolSummary
+     * @given a chain with InvalidTransfer and UnapprovedTransfer events
+     * @when bridgePoolSummary is queried
      * @then treasuryByReason contains INVALID and UNAPPROVED entries with correct totals
      */
     test.todo('should aggregate treasury inflows separately by INVALID and UNAPPROVED reason');
 
     /**
-     * @given bridge events exist up to a known block height H
-     * @when we query bridgePoolSummary
-     * @then lastEventBlockHeight equals H
-     */
-    test.todo('should set lastEventBlockHeight to the most recently indexed bridge event block');
-
-    /**
-     * @given bridge events exist at blocks B1 and B2 (B1 < B2)
-     * @when we query bridgePoolSummary(atBlock: B1) and (atBlock: B2)
+     * @given reserve/treasury events exist at blocks B1 and B2 (B1 < B2)
+     * @when bridgePoolSummary(atBlock: B1) and (atBlock: B2) are queried
      * @then only events up to and including the given block contribute, and B2 totals exceed B1
      */
-    test.todo('should return a point-in-time snapshot when atBlock is given');
+    test.todo('should accumulate more pool inflow at a later atBlock than an earlier one');
 
     // Blocked: requires crossing the subminimum accumulation threshold to produce
     // a SubminimalFlushTransfer. Pending confirmation of whether the threshold is
@@ -87,29 +162,37 @@ describe('bridge pool queries', () => {
 
   describe('bridgeReserveInflows', () => {
     /**
-     * @given no ReserveTransfer events have been indexed
-     * @when we query bridgeReserveInflows
+     * @given an environment with no ReserveTransfer events indexed
+     * @when bridgeReserveInflows is queried
      * @then the response is successful and returns an empty array
      */
-    test.todo('should return an empty list when no ReserveTransfer events are indexed');
+    test('should return an empty list when no ReserveTransfer events are indexed', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'Bridge', 'Pool', 'Negative'] };
+      if (!surfacePresent) return ctx.skip();
+
+      const response = await httpClient.getBridgeReserveInflows();
+
+      expect(response).toBeSuccess();
+      expect(response.data?.bridgeReserveInflows).toEqual([]);
+    });
 
     /**
-     * @given the with-data chain has ReserveTransfer events across multiple blocks
-     * @when we query bridgeReserveInflows(blockHeightFrom: B1, blockHeightTo: B2)
+     * @given a chain with ReserveTransfer events across multiple blocks
+     * @when bridgeReserveInflows(blockHeightFrom: B1, blockHeightTo: B2) is queried
      * @then only events with blockHeight in [B1, B2] are returned
      */
     test.todo('should return ReserveTransfer events within the specified block range');
 
     /**
      * @given at least one ReserveTransfer is indexed
-     * @when we query bridgeReserveInflows(limit: 1)
-     * @then the event exposes id, blockHeight, midnightTxHash, cardanoTxHash, amount as non-empty
+     * @when bridgeReserveInflows(limit: 1) is queried
+     * @then the event exposes id, blockHeight, midnightTxHash, cardanoTxHash, amount
      */
     test.todo('should return events with correct BridgeReserveTransfer field shape');
 
     /**
      * @given at least 3 ReserveTransfer events are indexed
-     * @when we query with limit=2 offset=0 and limit=2 offset=1
+     * @when queried with limit=2 offset=0 and limit=2 offset=1
      * @then results are consistent and ids are in ascending order
      */
     test.todo('should paginate ReserveTransfer events with offset and limit');
@@ -117,29 +200,37 @@ describe('bridge pool queries', () => {
 
   describe('bridgeTreasuryInflows', () => {
     /**
-     * @given no treasury-redirected events (Invalid, Unapproved, SubminimalFlush) are indexed
-     * @when we query bridgeTreasuryInflows
+     * @given an environment with no treasury-redirected events indexed
+     * @when bridgeTreasuryInflows is queried
      * @then the response is successful and returns an empty array
      */
-    test.todo('should return an empty list when no treasury-redirected events are indexed');
+    test('should return an empty list when no treasury-redirected events are indexed', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'Bridge', 'Pool', 'Negative'] };
+      if (!surfacePresent) return ctx.skip();
+
+      const response = await httpClient.getBridgeTreasuryInflows();
+
+      expect(response).toBeSuccess();
+      expect(response.data?.bridgeTreasuryInflows).toEqual([]);
+    });
 
     /**
-     * @given the with-data chain has InvalidTransfer events
-     * @when we query bridgeTreasuryInflows with no reason filter
+     * @given a chain with InvalidTransfer events
+     * @when bridgeTreasuryInflows is queried with no reason filter
      * @then the results include BridgeInvalidTransfer events
      */
     test.todo('should return all treasury event types when no reason filter is given');
 
     /**
-     * @given the with-data chain has both Invalid and Reserve events
-     * @when we query bridgeTreasuryInflows(reason: INVALID)
+     * @given a chain with both Invalid and Reserve events
+     * @when bridgeTreasuryInflows(reason: INVALID) is queried
      * @then every returned event has __typename BridgeInvalidTransfer
      */
     test.todo('should return only BridgeInvalidTransfer when reason=INVALID');
 
     /**
      * @given treasury events exist at blocks B1 and B3
-     * @when we query bridgeTreasuryInflows(blockHeightFrom: B1, blockHeightTo: B2) where B2 < B3
+     * @when bridgeTreasuryInflows(blockHeightFrom: B1, blockHeightTo: B2) where B2 < B3
      * @then only events at B1 are returned (B3 is outside the range)
      */
     test.todo('should respect blockHeightFrom and blockHeightTo filters for treasury inflows');

--- a/qa/tests/tests/integration/basic/queries/bridge-pool-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/bridge-pool-queries.test.ts
@@ -13,356 +13,141 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Integration tests for c2m-bridge pool observability queries (#944).
+// Integration tests for c2m-bridge pool observability queries: bridgePoolSummary,
+// bridgeReserveInflows, bridgeTreasuryInflows (#944).
 //
-// Covers: bridgePoolSummary, bridgeReserveInflows, bridgeTreasuryInflows.
+// Pool observability tracks where NIGHT flows when bridge transactions are
+// processed: the Reserve pool (ReserveTransfer) and the Treasury (Invalid,
+// Unapproved, SubminimalFlush). Per-address balance (UserTransfer/claims) is
+// covered by #941. bridgePoolSummary returns cumulative totals per category plus
+// a count of subminimum txs aggregated into flush events.
 //
-// ── What this ticket adds ─────────────────────────────────────────────────────
+// These are skeletons enumerating the intended cases:
+//   test.todo → needs bridge event data in the test environment. When
+//               implemented, follow the framework conventions
+//               (how-to-write-a-qa-indexer-test): issue the query via an
+//               IndexerHttpClient method, define response types in
+//               utils/indexer/indexer-types.ts, gate on bridge availability,
+//               assert with toBeSuccess(), and set ctx.task labels.
+//   test.skip → blocked on an in-flight feature: UNAPPROVED on approval
+//               governance (#940); SUBMINIMAL_FLUSH on confirming whether the
+//               flush threshold is a configurable genesis parameter (node team)
+//               so a flush can be triggered deterministically in a test env.
 //
-// Protocol-level observability for where NIGHT flows when bridge transactions
-// are processed. Three distinct token destinations exist:
-//
-//   Reserve pool  — ReserveTransfer events (`bridgeReserveInflows`)
-//   Treasury      — Invalid, Unapproved, SubminimalFlush events (`bridgeTreasuryInflows`)
-//   User address  — UserTransfer events (covered by #941 queries)
-//
-// `bridgePoolSummary` returns an aggregate snapshot: cumulative totals per
-// category and a count of subminimum txs aggregated into flush events.
-//
-// ── Status of tests ──────────────────────────────────────────────────────────
-//
-//   it.todo   → Requires bridge event data in the test environment.
-//               Same Q1 blocker as #941/#942 test PRs. See PR #1219.
-//               Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/944
-//
-//   it.skip   → Blocked on specific in-flight features (noted inline).
-//
-// ── SubminimalFlush threshold investigation ───────────────────────────────────
-//
-// The SubminimalFlushTransfer event fires only when accumulated subminimum
-// transfers cross a configured pallet threshold. It is currently unknown
-// whether this threshold can be configured to a low value (e.g. 2 txs) in
-// the test environment genesis, or whether the toolkit can trigger a flush
-// directly.
-//
-// My recommendation: investigate with the node team (Lech) whether the
-// threshold is a genesis parameter or a hardcoded constant. If it is a
-// genesis parameter, set it to 2 in the local undeployed env and submit
-// 2 subminimum transactions to trigger a flush deterministically. If it
-// cannot be configured, consider adding a toolkit command that directly
-// submits a flush-triggering sequence, or defer the test until the
-// production chain naturally produces flush events (post-mainnet bridge launch).
-//
-// Until resolved: SubminimalFlush-dependent assertions are marked it.skip.
-//
-// ── Types ─────────────────────────────────────────────────────────────────────
-//
-// Types defined inline as stubs. Move to indexer-types.ts once #944 lands.
+// Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/944
 
-import log from '@utils/logging/logger';
-import '@utils/logging/test-logging-hooks';
-import type { TestContext } from 'vitest';
-import { IndexerHttpClient } from '@utils/indexer/http-client';
-import type { GraphQLResponse } from '@utils/indexer/indexer-types';
+describe('bridge pool queries', () => {
+  describe('bridgePoolSummary', () => {
+    /**
+     * @given no bridge events have been indexed (or atBlock before the first bridge block)
+     * @when we query bridgePoolSummary
+     * @then reserveTotal is zero, every treasuryByReason total is zero,
+     *       subminimumTxCount is 0 and lastEventBlockHeight is null
+     */
+    test.todo('should return all-zero totals when no bridge events have been indexed');
 
-// ── Stub types (move to indexer-types.ts once #944 lands) ──────────────────
+    /**
+     * @given the with-data chain has N ReserveTransfer events with known amounts
+     * @when we query bridgePoolSummary
+     * @then reserveTotal equals the sum of all ReserveTransfer.amount values
+     */
+    test.todo('should set reserveTotal to the cumulative sum of ReserveTransfer amounts');
 
-export type BridgeTreasuryReason = 'INVALID' | 'UNAPPROVED' | 'SUBMINIMAL_FLUSH';
+    /**
+     * @given the with-data chain has InvalidTransfer and UnapprovedTransfer events
+     * @when we query bridgePoolSummary
+     * @then treasuryByReason contains INVALID and UNAPPROVED entries with correct totals
+     */
+    test.todo('should aggregate treasury inflows separately by INVALID and UNAPPROVED reason');
 
-export interface BridgeTreasuryAggregate {
-  reason: BridgeTreasuryReason;
-  total: string;
-  count: number;
-}
+    /**
+     * @given bridge events exist up to a known block height H
+     * @when we query bridgePoolSummary
+     * @then lastEventBlockHeight equals H
+     */
+    test.todo('should set lastEventBlockHeight to the most recently indexed bridge event block');
 
-export interface BridgePoolSummary {
-  reserveTotal: string;
-  treasuryByReason: BridgeTreasuryAggregate[];
-  subminimumTxCount: number;
-  lastEventBlockHeight: number | null;
-}
+    /**
+     * @given bridge events exist at blocks B1 and B2 (B1 < B2)
+     * @when we query bridgePoolSummary(atBlock: B1) and (atBlock: B2)
+     * @then only events up to and including the given block contribute, and B2 totals exceed B1
+     */
+    test.todo('should return a point-in-time snapshot when atBlock is given');
 
-export interface BridgeReserveTransfer {
-  id: number;
-  blockHeight: number;
-  midnightTxHash: string;
-  cardanoTxHash: string;
-  amount: string;
-}
+    // Blocked: requires crossing the subminimum accumulation threshold to produce
+    // a SubminimalFlushTransfer. Pending confirmation of whether the threshold is
+    // a configurable genesis parameter (node team) so a flush can be triggered.
+    // Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/944
+    test.skip('should count SubminimalFlushTransfer.count in subminimumTxCount', () => {});
 
-export interface BridgeInvalidTransfer {
-  id: number;
-  blockHeight: number;
-  midnightTxHash: string;
-  cardanoTxHash: string;
-  amount: string;
-}
-
-export interface BridgeUnapprovedTransfer {
-  id: number;
-  blockHeight: number;
-  midnightTxHash: string;
-  cardanoTxHash: string;
-  amount: string;
-  recipient: string;
-}
-
-export interface BridgeSubminimalFlushTransfer {
-  id: number;
-  blockHeight: number;
-  midnightTxHash: string;
-  amount: string;
-  count: number;
-}
-
-export type BridgeTreasuryEvent =
-  | BridgeInvalidTransfer
-  | BridgeUnapprovedTransfer
-  | BridgeSubminimalFlushTransfer;
-
-// ── GraphQL query strings ───────────────────────────────────────────────────
-
-const BRIDGE_POOL_SUMMARY_QUERY = `
-  query BridgePoolSummary($atBlock: Int) {
-    bridgePoolSummary(atBlock: $atBlock) {
-      reserveTotal
-      treasuryByReason {
-        reason
-        total
-        count
-      }
-      subminimumTxCount
-      lastEventBlockHeight
-    }
-  }
-`;
-
-const BRIDGE_RESERVE_INFLOWS_QUERY = `
-  query BridgeReserveInflows($blockHeightFrom: Int, $blockHeightTo: Int, $offset: Int, $limit: Int) {
-    bridgeReserveInflows(blockHeightFrom: $blockHeightFrom, blockHeightTo: $blockHeightTo, offset: $offset, limit: $limit) {
-      ... on BridgeReserveTransfer {
-        __typename id blockHeight midnightTxHash cardanoTxHash amount
-      }
-    }
-  }
-`;
-
-const BRIDGE_TREASURY_INFLOWS_QUERY = `
-  query BridgeTreasuryInflows(
-    $blockHeightFrom: Int
-    $blockHeightTo: Int
-    $reason: BridgeTreasuryReason
-    $offset: Int
-    $limit: Int
-  ) {
-    bridgeTreasuryInflows(
-      blockHeightFrom: $blockHeightFrom
-      blockHeightTo: $blockHeightTo
-      reason: $reason
-      offset: $offset
-      limit: $limit
-    ) {
-      ... on BridgeInvalidTransfer {
-        __typename id blockHeight midnightTxHash cardanoTxHash amount
-      }
-      ... on BridgeUnapprovedTransfer {
-        __typename id blockHeight midnightTxHash cardanoTxHash amount recipient
-      }
-      ... on BridgeSubminimalFlushTransfer {
-        __typename id blockHeight midnightTxHash amount count
-      }
-    }
-  }
-`;
-
-// ── Helpers ─────────────────────────────────────────────────────────────────
-
-const httpClient = new IndexerHttpClient();
-
-function rawRequest<T>(
-  query: string,
-  variables?: Record<string, unknown>,
-): Promise<GraphQLResponse<T>> {
-  return (
-    httpClient as unknown as {
-      client: {
-        rawRequest: (q: string, vars?: Record<string, unknown>) => Promise<GraphQLResponse<T>>;
-      };
-    }
-  ).client.rawRequest(query, variables);
-}
-
-// ── Tests ────────────────────────────────────────────────────────────────────
-
-describe('bridge pool queries — bridgePoolSummary', () => {
-  /**
-   * bridgePoolSummary with no bridge events returns all-zero totals.
-   * The zero value for HexEncoded u128 is the 16-byte big-endian representation "0".
-   * This test is deterministic only if the with-data chain has no bridge events.
-   * Once bridge events are present, use atBlock=<blockBeforeFirstBridgeEvent>.
-   *
-   * @given no bridge pallet events have been indexed (or atBlock before first bridge block)
-   * @when we query bridgePoolSummary
-   * @then reserveTotal is zero, all treasuryByReason totals are zero,
-   *       subminimumTxCount is 0, and lastEventBlockHeight is null
-   */
-  it.todo('should return all-zero totals when no bridge events have been indexed');
-
-  /**
-   * bridgePoolSummary.reserveTotal reflects cumulative ReserveTransfer amounts.
-   *
-   * @given the with-data chain has N ReserveTransfer events with known amounts
-   * @when we query bridgePoolSummary
-   * @then reserveTotal equals the sum of all ReserveTransfer.amount values
-   */
-  it.todo('should set reserveTotal to the cumulative sum of ReserveTransfer amounts');
-
-  /**
-   * bridgePoolSummary.treasuryByReason breaks treasury inflows down by reason.
-   * Each of the three treasury reasons should appear with its correct aggregate.
-   *
-   * @given the with-data chain has InvalidTransfer and UnapprovedTransfer events
-   * @when we query bridgePoolSummary
-   * @then treasuryByReason contains entries for INVALID and UNAPPROVED with correct totals
-   */
-  it.todo('should aggregate treasury inflows separately by INVALID and UNAPPROVED reason');
-
-  /**
-   * bridgePoolSummary.lastEventBlockHeight references the most recently indexed bridge event block.
-   *
-   * @given bridge events exist up to a known block height H
-   * @when we query bridgePoolSummary
-   * @then lastEventBlockHeight equals H
-   */
-  it.todo('should set lastEventBlockHeight to the most recently indexed bridge event block');
-
-  /**
-   * bridgePoolSummary respects the atBlock snapshot parameter.
-   *
-   * @given bridge events exist at blocks B1 and B2 (B1 < B2)
-   * @when we query bridgePoolSummary(atBlock: B1)
-   * @then only events up to and including B1 contribute to the totals
-   * @and a second query at B2 returns a higher reserveTotal
-   */
-  it.todo('should return a point-in-time snapshot when atBlock is given');
-
-  // Skipped: SubminimalFlushTransfer aggregation in bridgePoolSummary.
-  // Requires crossing the subminimum accumulation threshold in the test environment.
-  // Investigation required: is the threshold a configurable genesis parameter?
-  // If yes, set to 2 in local undeployed env and submit 2 subminimum txs to
-  // trigger a flush. If no, defer until production chain produces flush events.
-  // See: https://github.com/midnightntwrk/midnight-indexer/issues/944
-  test.skip('should count SubminimalFlushTransfer.count in subminimumTxCount', async (_ctx: TestContext) => {
-    // TODO: implement once SubminimalFlushTransfer can be generated in test env.
-    // 1. Trigger enough subminimum transfers to cross the flush threshold.
-    // 2. Query bridgePoolSummary.
-    // 3. Assert subminimumTxCount equals the number of individual subminimum txs aggregated.
-    // 4. Assert treasuryByReason contains a SUBMINIMAL_FLUSH entry with the correct total.
+    // Blocked: approval governance not landed yet, so UnapprovedTransfer cannot
+    // be produced. Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/940
+    test.skip('should aggregate UnapprovedTransfer amounts under UNAPPROVED treasury reason', () => {});
   });
 
-  // Skipped: UnapprovedTransfer treasury contribution.
-  // Same blocker as other UnapprovedTransfer tests: approval governance not landed yet.
-  // Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/940
-  test.skip('should aggregate UnapprovedTransfer amounts under UNAPPROVED treasury reason', async (_ctx: TestContext) => {
-    // TODO: implement once UnapprovedTransfer can be generated in test env.
+  describe('bridgeReserveInflows', () => {
+    /**
+     * @given no ReserveTransfer events have been indexed
+     * @when we query bridgeReserveInflows
+     * @then the response is successful and returns an empty array
+     */
+    test.todo('should return an empty list when no ReserveTransfer events are indexed');
+
+    /**
+     * @given the with-data chain has ReserveTransfer events across multiple blocks
+     * @when we query bridgeReserveInflows(blockHeightFrom: B1, blockHeightTo: B2)
+     * @then only events with blockHeight in [B1, B2] are returned
+     */
+    test.todo('should return ReserveTransfer events within the specified block range');
+
+    /**
+     * @given at least one ReserveTransfer is indexed
+     * @when we query bridgeReserveInflows(limit: 1)
+     * @then the event exposes id, blockHeight, midnightTxHash, cardanoTxHash, amount as non-empty
+     */
+    test.todo('should return events with correct BridgeReserveTransfer field shape');
+
+    /**
+     * @given at least 3 ReserveTransfer events are indexed
+     * @when we query with limit=2 offset=0 and limit=2 offset=1
+     * @then results are consistent and ids are in ascending order
+     */
+    test.todo('should paginate ReserveTransfer events with offset and limit');
+  });
+
+  describe('bridgeTreasuryInflows', () => {
+    /**
+     * @given no treasury-redirected events (Invalid, Unapproved, SubminimalFlush) are indexed
+     * @when we query bridgeTreasuryInflows
+     * @then the response is successful and returns an empty array
+     */
+    test.todo('should return an empty list when no treasury-redirected events are indexed');
+
+    /**
+     * @given the with-data chain has InvalidTransfer events
+     * @when we query bridgeTreasuryInflows with no reason filter
+     * @then the results include BridgeInvalidTransfer events
+     */
+    test.todo('should return all treasury event types when no reason filter is given');
+
+    /**
+     * @given the with-data chain has both Invalid and Reserve events
+     * @when we query bridgeTreasuryInflows(reason: INVALID)
+     * @then every returned event has __typename BridgeInvalidTransfer
+     */
+    test.todo('should return only BridgeInvalidTransfer when reason=INVALID');
+
+    /**
+     * @given treasury events exist at blocks B1 and B3
+     * @when we query bridgeTreasuryInflows(blockHeightFrom: B1, blockHeightTo: B2) where B2 < B3
+     * @then only events at B1 are returned (B3 is outside the range)
+     */
+    test.todo('should respect blockHeightFrom and blockHeightTo filters for treasury inflows');
+
+    // Blocked: approval governance not landed yet (#940).
+    test.skip('should return only BridgeUnapprovedTransfer when reason=UNAPPROVED', () => {});
+
+    // Blocked: SubminimalFlush threshold not yet confirmed (see header note, #944).
+    test.skip('should return only BridgeSubminimalFlushTransfer when reason=SUBMINIMAL_FLUSH', () => {});
   });
 });
-
-describe('bridge pool queries — bridgeReserveInflows', () => {
-  /**
-   * bridgeReserveInflows with no data returns an empty list.
-   *
-   * @given no ReserveTransfer events have been indexed
-   * @when we query bridgeReserveInflows
-   * @then the response is successful and returns an empty array
-   */
-  it.todo('should return an empty list when no ReserveTransfer events are indexed');
-
-  /**
-   * bridgeReserveInflows returns ReserveTransfer events in the specified block range.
-   *
-   * @given the with-data chain has ReserveTransfer events across multiple blocks
-   * @when we query bridgeReserveInflows(blockHeightFrom: B1, blockHeightTo: B2)
-   * @then only events with blockHeight in [B1, B2] are returned
-   */
-  it.todo('should return ReserveTransfer events within the specified block range');
-
-  /**
-   * bridgeReserveInflows returns events with the correct field shape.
-   *
-   * @given at least one ReserveTransfer is indexed
-   * @when we query bridgeReserveInflows(limit: 1)
-   * @then the event has id, blockHeight, midnightTxHash, cardanoTxHash, amount
-   * @and all hex fields are non-empty strings
-   */
-  it.todo('should return events with correct BridgeReserveTransfer field shape');
-
-  /**
-   * bridgeReserveInflows supports offset and limit pagination.
-   *
-   * @given at least 3 ReserveTransfer events are indexed
-   * @when we query with limit=2 offset=0 and limit=2 offset=1
-   * @then results are consistent and ids are in ascending order
-   */
-  it.todo('should paginate ReserveTransfer events with offset and limit');
-});
-
-describe('bridge pool queries — bridgeTreasuryInflows', () => {
-  /**
-   * bridgeTreasuryInflows with no data returns an empty list.
-   *
-   * @given no treasury-redirected events (Invalid, Unapproved, SubminimalFlush) are indexed
-   * @when we query bridgeTreasuryInflows
-   * @then the response is successful and returns an empty array
-   */
-  it.todo('should return an empty list when no treasury-redirected events are indexed');
-
-  /**
-   * bridgeTreasuryInflows without a reason filter returns all treasury event types.
-   *
-   * @given the with-data chain has InvalidTransfer events
-   * @when we query bridgeTreasuryInflows (no reason filter)
-   * @then results include BridgeInvalidTransfer events
-   */
-  it.todo('should return all treasury event types when no reason filter is given');
-
-  /**
-   * bridgeTreasuryInflows filtered by reason=INVALID returns only InvalidTransfer events.
-   *
-   * @given the with-data chain has both Invalid and Reserve events
-   * @when we query bridgeTreasuryInflows(reason: INVALID)
-   * @then every returned event has __typename BridgeInvalidTransfer
-   */
-  it.todo('should return only BridgeInvalidTransfer when reason=INVALID');
-
-  /**
-   * bridgeTreasuryInflows respects the block range filter.
-   *
-   * @given treasury events exist at blocks B1 and B3
-   * @when we query bridgeTreasuryInflows(blockHeightFrom: B1, blockHeightTo: B2) where B2 < B3
-   * @then only events at B1 are returned (B3 is outside the range)
-   */
-  it.todo('should respect blockHeightFrom and blockHeightTo filters for treasury inflows');
-
-  // Skipped: UNAPPROVED reason filter — blocked on approval governance logic.
-  // Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/940
-  test.skip('should return only BridgeUnapprovedTransfer when reason=UNAPPROVED', async (_ctx: TestContext) => {
-    // TODO: implement once UnapprovedTransfer can be generated in test env.
-  });
-
-  // Skipped: SUBMINIMAL_FLUSH reason filter — blocked on threshold investigation.
-  // See SubminimalFlushTransfer note at top of file.
-  test.skip('should return only BridgeSubminimalFlushTransfer when reason=SUBMINIMAL_FLUSH', async (_ctx: TestContext) => {
-    // TODO: implement once SubminimalFlushTransfer can be generated in test env.
-  });
-});
-
-// Suppress unused import warnings until test bodies are implemented.
-void BRIDGE_POOL_SUMMARY_QUERY;
-void BRIDGE_RESERVE_INFLOWS_QUERY;
-void BRIDGE_TREASURY_INFLOWS_QUERY;
-void rawRequest;
-void log;
-
-type _SuppressUnused = BridgeTreasuryEvent | GraphQLResponse<unknown>;
-void (undefined as unknown as _SuppressUnused);

--- a/qa/tests/tests/integration/basic/queries/bridge-pool-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/bridge-pool-queries.test.ts
@@ -1,0 +1,378 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Integration tests for c2m-bridge pool observability queries (#944).
+//
+// Covers: bridgePoolSummary, bridgeReserveInflows, bridgeTreasuryInflows.
+//
+// ── What this ticket adds ─────────────────────────────────────────────────────
+//
+// Protocol-level observability for where NIGHT flows when bridge transactions
+// are processed. Three distinct token destinations exist:
+//
+//   Reserve pool  — ReserveTransfer events (`bridgeReserveInflows`)
+//   Treasury      — Invalid, Unapproved, SubminimalFlush events (`bridgeTreasuryInflows`)
+//   User address  — UserTransfer events (covered by #941 queries)
+//
+// `bridgePoolSummary` returns an aggregate snapshot: cumulative totals per
+// category and a count of subminimum txs aggregated into flush events.
+//
+// ── Status of tests ──────────────────────────────────────────────────────────
+//
+//   it.todo   → Requires bridge event data in the test environment.
+//               Same Q1 blocker as #941/#942 test PRs. See PR #1219.
+//               Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/944
+//
+//   it.skip   → Blocked on specific in-flight features (noted inline).
+//
+// ── SubminimalFlush threshold investigation ───────────────────────────────────
+//
+// The SubminimalFlushTransfer event fires only when accumulated subminimum
+// transfers cross a configured pallet threshold. It is currently unknown
+// whether this threshold can be configured to a low value (e.g. 2 txs) in
+// the test environment genesis, or whether the toolkit can trigger a flush
+// directly.
+//
+// My recommendation: investigate with the node team (Lech) whether the
+// threshold is a genesis parameter or a hardcoded constant. If it is a
+// genesis parameter, set it to 2 in the local undeployed env and submit
+// 2 subminimum transactions to trigger a flush deterministically. If it
+// cannot be configured, consider adding a toolkit command that directly
+// submits a flush-triggering sequence, or defer the test until the
+// production chain naturally produces flush events (post-mainnet bridge launch).
+//
+// Until resolved: SubminimalFlush-dependent assertions are marked it.skip.
+//
+// ── Types ─────────────────────────────────────────────────────────────────────
+//
+// Types defined inline as stubs. Move to indexer-types.ts once #944 lands.
+
+import log from '@utils/logging/logger';
+import '@utils/logging/test-logging-hooks';
+import type { TestContext } from 'vitest';
+import { IndexerHttpClient } from '@utils/indexer/http-client';
+import type { GraphQLResponse } from '@utils/indexer/indexer-types';
+
+// ── Stub types (move to indexer-types.ts once #944 lands) ──────────────────
+
+export type BridgeTreasuryReason = 'INVALID' | 'UNAPPROVED' | 'SUBMINIMAL_FLUSH';
+
+export interface BridgeTreasuryAggregate {
+  reason: BridgeTreasuryReason;
+  total: string;
+  count: number;
+}
+
+export interface BlockReference {
+  blockHeight: number;
+  blockHash: string;
+}
+
+export interface BridgePoolSummary {
+  reserveTotal: string;
+  treasuryByReason: BridgeTreasuryAggregate[];
+  subminimumTxCount: number;
+  lastEventAt: BlockReference | null;
+}
+
+export interface BridgeReserveTransfer {
+  id: number;
+  midnightTxHash: string;
+  cardanoTxHash: string;
+  amount: string;
+  indexedAt: BlockReference;
+}
+
+export interface BridgeInvalidTransfer {
+  id: number;
+  midnightTxHash: string;
+  cardanoTxHash: string;
+  amount: string;
+  indexedAt: BlockReference;
+}
+
+export interface BridgeUnapprovedTransfer {
+  id: number;
+  midnightTxHash: string;
+  cardanoTxHash: string;
+  amount: string;
+  recipient: string;
+  indexedAt: BlockReference;
+}
+
+export interface BridgeSubminimalFlushTransfer {
+  id: number;
+  midnightTxHash: string;
+  amount: string;
+  count: number;
+  indexedAt: BlockReference;
+}
+
+export type BridgeTreasuryEvent =
+  | BridgeInvalidTransfer
+  | BridgeUnapprovedTransfer
+  | BridgeSubminimalFlushTransfer;
+
+// ── GraphQL query strings ───────────────────────────────────────────────────
+
+const BRIDGE_POOL_SUMMARY_QUERY = `
+  query BridgePoolSummary($atBlock: Int) {
+    bridgePoolSummary(atBlock: $atBlock) {
+      reserveTotal
+      treasuryByReason {
+        reason
+        total
+        count
+      }
+      subminimumTxCount
+      lastEventAt { blockHeight blockHash }
+    }
+  }
+`;
+
+const BRIDGE_RESERVE_INFLOWS_QUERY = `
+  query BridgeReserveInflows($fromBlock: Int, $toBlock: Int, $offset: Int, $limit: Int) {
+    bridgeReserveInflows(fromBlock: $fromBlock, toBlock: $toBlock, offset: $offset, limit: $limit) {
+      id
+      midnightTxHash
+      cardanoTxHash
+      amount
+      indexedAt { blockHeight blockHash }
+    }
+  }
+`;
+
+const BRIDGE_TREASURY_INFLOWS_QUERY = `
+  query BridgeTreasuryInflows(
+    $fromBlock: Int
+    $toBlock: Int
+    $reason: BridgeTreasuryReason
+    $offset: Int
+    $limit: Int
+  ) {
+    bridgeTreasuryInflows(
+      fromBlock: $fromBlock
+      toBlock: $toBlock
+      reason: $reason
+      offset: $offset
+      limit: $limit
+    ) {
+      ... on BridgeInvalidTransfer {
+        __typename id midnightTxHash cardanoTxHash amount
+        indexedAt { blockHeight blockHash }
+      }
+      ... on BridgeUnapprovedTransfer {
+        __typename id midnightTxHash cardanoTxHash amount recipient
+        indexedAt { blockHeight blockHash }
+      }
+      ... on BridgeSubminimalFlushTransfer {
+        __typename id midnightTxHash amount count
+        indexedAt { blockHeight blockHash }
+      }
+    }
+  }
+`;
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const httpClient = new IndexerHttpClient();
+
+function rawRequest<T>(
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<GraphQLResponse<T>> {
+  return (
+    httpClient as unknown as {
+      client: {
+        rawRequest: (q: string, vars?: Record<string, unknown>) => Promise<GraphQLResponse<T>>;
+      };
+    }
+  ).client.rawRequest(query, variables);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('bridge pool queries — bridgePoolSummary', () => {
+  /**
+   * bridgePoolSummary with no bridge events returns all-zero totals.
+   * The zero value for HexEncoded u128 is the 16-byte big-endian representation "0".
+   * This test is deterministic only if the with-data chain has no bridge events.
+   * Once bridge events are present, use atBlock=<blockBeforeFirstBridgeEvent>.
+   *
+   * @given no bridge pallet events have been indexed (or atBlock before first bridge block)
+   * @when we query bridgePoolSummary
+   * @then reserveTotal is zero, all treasuryByReason totals are zero,
+   *       subminimumTxCount is 0, and lastEventAt is null
+   */
+  it.todo('should return all-zero totals when no bridge events have been indexed');
+
+  /**
+   * bridgePoolSummary.reserveTotal reflects cumulative ReserveTransfer amounts.
+   *
+   * @given the with-data chain has N ReserveTransfer events with known amounts
+   * @when we query bridgePoolSummary
+   * @then reserveTotal equals the sum of all ReserveTransfer.amount values
+   */
+  it.todo('should set reserveTotal to the cumulative sum of ReserveTransfer amounts');
+
+  /**
+   * bridgePoolSummary.treasuryByReason breaks treasury inflows down by reason.
+   * Each of the three treasury reasons should appear with its correct aggregate.
+   *
+   * @given the with-data chain has InvalidTransfer and UnapprovedTransfer events
+   * @when we query bridgePoolSummary
+   * @then treasuryByReason contains entries for INVALID and UNAPPROVED with correct totals
+   */
+  it.todo('should aggregate treasury inflows separately by INVALID and UNAPPROVED reason');
+
+  /**
+   * bridgePoolSummary.lastEventAt references the most recently indexed bridge event block.
+   *
+   * @given bridge events exist up to a known block height H
+   * @when we query bridgePoolSummary
+   * @then lastEventAt.blockHeight equals H
+   */
+  it.todo('should set lastEventAt to the most recently indexed bridge event block');
+
+  /**
+   * bridgePoolSummary respects the atBlock snapshot parameter.
+   *
+   * @given bridge events exist at blocks B1 and B2 (B1 < B2)
+   * @when we query bridgePoolSummary(atBlock: B1)
+   * @then only events up to and including B1 contribute to the totals
+   * @and a second query at B2 returns a higher reserveTotal
+   */
+  it.todo('should return a point-in-time snapshot when atBlock is given');
+
+  // Skipped: SubminimalFlushTransfer aggregation in bridgePoolSummary.
+  // Requires crossing the subminimum accumulation threshold in the test environment.
+  // Investigation required: is the threshold a configurable genesis parameter?
+  // If yes, set to 2 in local undeployed env and submit 2 subminimum txs to
+  // trigger a flush. If no, defer until production chain produces flush events.
+  // See: https://github.com/midnightntwrk/midnight-indexer/issues/944
+  test.skip('should count SubminimalFlushTransfer.count in subminimumTxCount', async (_ctx: TestContext) => {
+    // TODO: implement once SubminimalFlushTransfer can be generated in test env.
+    // 1. Trigger enough subminimum transfers to cross the flush threshold.
+    // 2. Query bridgePoolSummary.
+    // 3. Assert subminimumTxCount equals the number of individual subminimum txs aggregated.
+    // 4. Assert treasuryByReason contains a SUBMINIMAL_FLUSH entry with the correct total.
+  });
+
+  // Skipped: UnapprovedTransfer treasury contribution.
+  // Same blocker as other UnapprovedTransfer tests: approval governance not landed yet.
+  // Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/940
+  test.skip('should aggregate UnapprovedTransfer amounts under UNAPPROVED treasury reason', async (_ctx: TestContext) => {
+    // TODO: implement once UnapprovedTransfer can be generated in test env.
+  });
+});
+
+describe('bridge pool queries — bridgeReserveInflows', () => {
+  /**
+   * bridgeReserveInflows with no data returns an empty list.
+   *
+   * @given no ReserveTransfer events have been indexed
+   * @when we query bridgeReserveInflows
+   * @then the response is successful and returns an empty array
+   */
+  it.todo('should return an empty list when no ReserveTransfer events are indexed');
+
+  /**
+   * bridgeReserveInflows returns ReserveTransfer events in the specified block range.
+   *
+   * @given the with-data chain has ReserveTransfer events across multiple blocks
+   * @when we query bridgeReserveInflows(fromBlock: B1, toBlock: B2)
+   * @then only events with indexedAt.blockHeight in [B1, B2] are returned
+   */
+  it.todo('should return ReserveTransfer events within the specified block range');
+
+  /**
+   * bridgeReserveInflows returns events with the correct field shape.
+   *
+   * @given at least one ReserveTransfer is indexed
+   * @when we query bridgeReserveInflows(limit: 1)
+   * @then the event has id, midnightTxHash, cardanoTxHash, amount, indexedAt
+   * @and all hex fields are non-empty strings
+   */
+  it.todo('should return events with correct BridgeReserveTransfer field shape');
+
+  /**
+   * bridgeReserveInflows supports offset and limit pagination.
+   *
+   * @given at least 3 ReserveTransfer events are indexed
+   * @when we query with limit=2 offset=0 and limit=2 offset=1
+   * @then results are consistent and ids are in ascending order
+   */
+  it.todo('should paginate ReserveTransfer events with offset and limit');
+});
+
+describe('bridge pool queries — bridgeTreasuryInflows', () => {
+  /**
+   * bridgeTreasuryInflows with no data returns an empty list.
+   *
+   * @given no treasury-redirected events (Invalid, Unapproved, SubminimalFlush) are indexed
+   * @when we query bridgeTreasuryInflows
+   * @then the response is successful and returns an empty array
+   */
+  it.todo('should return an empty list when no treasury-redirected events are indexed');
+
+  /**
+   * bridgeTreasuryInflows without a reason filter returns all treasury event types.
+   *
+   * @given the with-data chain has InvalidTransfer events
+   * @when we query bridgeTreasuryInflows (no reason filter)
+   * @then results include BridgeInvalidTransfer events
+   */
+  it.todo('should return all treasury event types when no reason filter is given');
+
+  /**
+   * bridgeTreasuryInflows filtered by reason=INVALID returns only InvalidTransfer events.
+   *
+   * @given the with-data chain has both Invalid and Reserve events
+   * @when we query bridgeTreasuryInflows(reason: INVALID)
+   * @then every returned event has __typename BridgeInvalidTransfer
+   */
+  it.todo('should return only BridgeInvalidTransfer when reason=INVALID');
+
+  /**
+   * bridgeTreasuryInflows respects the block range filter.
+   *
+   * @given treasury events exist at blocks B1 and B3
+   * @when we query bridgeTreasuryInflows(fromBlock: B1, toBlock: B2) where B2 < B3
+   * @then only events at B1 are returned (B3 is outside the range)
+   */
+  it.todo('should respect fromBlock and toBlock filters for treasury inflows');
+
+  // Skipped: UNAPPROVED reason filter — blocked on approval governance logic.
+  // Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/940
+  test.skip('should return only BridgeUnapprovedTransfer when reason=UNAPPROVED', async (_ctx: TestContext) => {
+    // TODO: implement once UnapprovedTransfer can be generated in test env.
+  });
+
+  // Skipped: SUBMINIMAL_FLUSH reason filter — blocked on threshold investigation.
+  // See SubminimalFlushTransfer note at top of file.
+  test.skip('should return only BridgeSubminimalFlushTransfer when reason=SUBMINIMAL_FLUSH', async (_ctx: TestContext) => {
+    // TODO: implement once SubminimalFlushTransfer can be generated in test env.
+  });
+});
+
+// Suppress unused import warnings until test bodies are implemented.
+void BRIDGE_POOL_SUMMARY_QUERY;
+void BRIDGE_RESERVE_INFLOWS_QUERY;
+void BRIDGE_TREASURY_INFLOWS_QUERY;
+void rawRequest;
+void log;
+
+type _SuppressUnused = BridgeTreasuryEvent | GraphQLResponse<unknown>;
+void (undefined as unknown as _SuppressUnused);

--- a/qa/tests/tests/integration/basic/queries/bridge-pool-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/bridge-pool-queries.test.ts
@@ -75,49 +75,44 @@ export interface BridgeTreasuryAggregate {
   count: number;
 }
 
-export interface BlockReference {
-  blockHeight: number;
-  blockHash: string;
-}
-
 export interface BridgePoolSummary {
   reserveTotal: string;
   treasuryByReason: BridgeTreasuryAggregate[];
   subminimumTxCount: number;
-  lastEventAt: BlockReference | null;
+  lastEventBlockHeight: number | null;
 }
 
 export interface BridgeReserveTransfer {
   id: number;
+  blockHeight: number;
   midnightTxHash: string;
   cardanoTxHash: string;
   amount: string;
-  indexedAt: BlockReference;
 }
 
 export interface BridgeInvalidTransfer {
   id: number;
+  blockHeight: number;
   midnightTxHash: string;
   cardanoTxHash: string;
   amount: string;
-  indexedAt: BlockReference;
 }
 
 export interface BridgeUnapprovedTransfer {
   id: number;
+  blockHeight: number;
   midnightTxHash: string;
   cardanoTxHash: string;
   amount: string;
   recipient: string;
-  indexedAt: BlockReference;
 }
 
 export interface BridgeSubminimalFlushTransfer {
   id: number;
+  blockHeight: number;
   midnightTxHash: string;
   amount: string;
   count: number;
-  indexedAt: BlockReference;
 }
 
 export type BridgeTreasuryEvent =
@@ -137,49 +132,44 @@ const BRIDGE_POOL_SUMMARY_QUERY = `
         count
       }
       subminimumTxCount
-      lastEventAt { blockHeight blockHash }
+      lastEventBlockHeight
     }
   }
 `;
 
 const BRIDGE_RESERVE_INFLOWS_QUERY = `
-  query BridgeReserveInflows($fromBlock: Int, $toBlock: Int, $offset: Int, $limit: Int) {
-    bridgeReserveInflows(fromBlock: $fromBlock, toBlock: $toBlock, offset: $offset, limit: $limit) {
-      id
-      midnightTxHash
-      cardanoTxHash
-      amount
-      indexedAt { blockHeight blockHash }
+  query BridgeReserveInflows($blockHeightFrom: Int, $blockHeightTo: Int, $offset: Int, $limit: Int) {
+    bridgeReserveInflows(blockHeightFrom: $blockHeightFrom, blockHeightTo: $blockHeightTo, offset: $offset, limit: $limit) {
+      ... on BridgeReserveTransfer {
+        __typename id blockHeight midnightTxHash cardanoTxHash amount
+      }
     }
   }
 `;
 
 const BRIDGE_TREASURY_INFLOWS_QUERY = `
   query BridgeTreasuryInflows(
-    $fromBlock: Int
-    $toBlock: Int
+    $blockHeightFrom: Int
+    $blockHeightTo: Int
     $reason: BridgeTreasuryReason
     $offset: Int
     $limit: Int
   ) {
     bridgeTreasuryInflows(
-      fromBlock: $fromBlock
-      toBlock: $toBlock
+      blockHeightFrom: $blockHeightFrom
+      blockHeightTo: $blockHeightTo
       reason: $reason
       offset: $offset
       limit: $limit
     ) {
       ... on BridgeInvalidTransfer {
-        __typename id midnightTxHash cardanoTxHash amount
-        indexedAt { blockHeight blockHash }
+        __typename id blockHeight midnightTxHash cardanoTxHash amount
       }
       ... on BridgeUnapprovedTransfer {
-        __typename id midnightTxHash cardanoTxHash amount recipient
-        indexedAt { blockHeight blockHash }
+        __typename id blockHeight midnightTxHash cardanoTxHash amount recipient
       }
       ... on BridgeSubminimalFlushTransfer {
-        __typename id midnightTxHash amount count
-        indexedAt { blockHeight blockHash }
+        __typename id blockHeight midnightTxHash amount count
       }
     }
   }
@@ -214,7 +204,7 @@ describe('bridge pool queries — bridgePoolSummary', () => {
    * @given no bridge pallet events have been indexed (or atBlock before first bridge block)
    * @when we query bridgePoolSummary
    * @then reserveTotal is zero, all treasuryByReason totals are zero,
-   *       subminimumTxCount is 0, and lastEventAt is null
+   *       subminimumTxCount is 0, and lastEventBlockHeight is null
    */
   it.todo('should return all-zero totals when no bridge events have been indexed');
 
@@ -238,13 +228,13 @@ describe('bridge pool queries — bridgePoolSummary', () => {
   it.todo('should aggregate treasury inflows separately by INVALID and UNAPPROVED reason');
 
   /**
-   * bridgePoolSummary.lastEventAt references the most recently indexed bridge event block.
+   * bridgePoolSummary.lastEventBlockHeight references the most recently indexed bridge event block.
    *
    * @given bridge events exist up to a known block height H
    * @when we query bridgePoolSummary
-   * @then lastEventAt.blockHeight equals H
+   * @then lastEventBlockHeight equals H
    */
-  it.todo('should set lastEventAt to the most recently indexed bridge event block');
+  it.todo('should set lastEventBlockHeight to the most recently indexed bridge event block');
 
   /**
    * bridgePoolSummary respects the atBlock snapshot parameter.
@@ -292,8 +282,8 @@ describe('bridge pool queries — bridgeReserveInflows', () => {
    * bridgeReserveInflows returns ReserveTransfer events in the specified block range.
    *
    * @given the with-data chain has ReserveTransfer events across multiple blocks
-   * @when we query bridgeReserveInflows(fromBlock: B1, toBlock: B2)
-   * @then only events with indexedAt.blockHeight in [B1, B2] are returned
+   * @when we query bridgeReserveInflows(blockHeightFrom: B1, blockHeightTo: B2)
+   * @then only events with blockHeight in [B1, B2] are returned
    */
   it.todo('should return ReserveTransfer events within the specified block range');
 
@@ -302,7 +292,7 @@ describe('bridge pool queries — bridgeReserveInflows', () => {
    *
    * @given at least one ReserveTransfer is indexed
    * @when we query bridgeReserveInflows(limit: 1)
-   * @then the event has id, midnightTxHash, cardanoTxHash, amount, indexedAt
+   * @then the event has id, blockHeight, midnightTxHash, cardanoTxHash, amount
    * @and all hex fields are non-empty strings
    */
   it.todo('should return events with correct BridgeReserveTransfer field shape');
@@ -349,10 +339,10 @@ describe('bridge pool queries — bridgeTreasuryInflows', () => {
    * bridgeTreasuryInflows respects the block range filter.
    *
    * @given treasury events exist at blocks B1 and B3
-   * @when we query bridgeTreasuryInflows(fromBlock: B1, toBlock: B2) where B2 < B3
+   * @when we query bridgeTreasuryInflows(blockHeightFrom: B1, blockHeightTo: B2) where B2 < B3
    * @then only events at B1 are returned (B3 is outside the range)
    */
-  it.todo('should respect fromBlock and toBlock filters for treasury inflows');
+  it.todo('should respect blockHeightFrom and blockHeightTo filters for treasury inflows');
 
   // Skipped: UNAPPROVED reason filter — blocked on approval governance logic.
   // Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/940

--- a/qa/tests/tests/integration/basic/subscriptions/bridge-pool-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/bridge-pool-subscriptions.test.ts
@@ -19,16 +19,16 @@
 //
 // ── What bridgePoolUpdates does ───────────────────────────────────────────────
 //
-// `bridgePoolUpdates(from: Int)` pushes a `BridgePoolUpdate` frame on every
-// newly indexed bridge event that affects a protocol pool (Reserve or Treasury).
-// Each frame contains:
-//   - `newEvent: BridgeEvent` — the event that triggered the update
+// `bridgePoolUpdates` pushes a `BridgePoolUpdate` frame on every newly indexed
+// bridge event that affects a protocol pool (Reserve or Treasury). Each frame
+// contains:
+//   - `newEvent: BridgeEvent` — the event that triggered the update; null on
+//     the initial snapshot emitted on subscribe
 //   - `pool: BridgePoolSummary` — the recomputed pool snapshot after the event
 //
 // The subscription emits the current summary immediately on connect (similar
-// to `bridgeBalance` in #942). If `from` is provided, it also replays past
-// pool-affecting events with their at-time summaries before switching to
-// live mode.
+// to `bridgeBalance` in #942), with `newEvent` null, then switches to live
+// mode. It takes no arguments.
 //
 // ── Status of tests ──────────────────────────────────────────────────────────
 //
@@ -50,11 +50,6 @@ import type { TestContext } from 'vitest';
 
 // ── Stub types (consolidate with bridge-pool-queries.test.ts once #944 lands) ─
 
-interface BlockReference {
-  blockHeight: number;
-  blockHash: string;
-}
-
 interface BridgeTreasuryAggregate {
   reason: string;
   total: string;
@@ -65,13 +60,13 @@ interface BridgePoolSummary {
   reserveTotal: string;
   treasuryByReason: BridgeTreasuryAggregate[];
   subminimumTxCount: number;
-  lastEventAt: BlockReference | null;
+  lastEventBlockHeight: number | null;
 }
 
 interface BridgeEventBase {
   id: number;
+  blockHeight: number;
   midnightTxHash: string;
-  indexedAt: BlockReference;
 }
 
 interface BridgeReserveTransfer extends BridgeEventBase {
@@ -92,44 +87,37 @@ interface BridgeSubminimalFlushTransfer extends BridgeEventBase {
   count: number;
 }
 
-type PoolAffectingEvent =
-  | BridgeReserveTransfer
-  | BridgeInvalidTransfer
-  | BridgeSubminimalFlushTransfer;
+type BridgeEvent = BridgeReserveTransfer | BridgeInvalidTransfer | BridgeSubminimalFlushTransfer;
 
 interface BridgePoolUpdate {
-  newEvent: PoolAffectingEvent;
+  newEvent: BridgeEvent | null;
   pool: BridgePoolSummary;
 }
 
 // ── GraphQL subscription string ──────────────────────────────────────────────
 
 const BRIDGE_POOL_UPDATES_SUBSCRIPTION = `
-  subscription BridgePoolUpdates($from: Int) {
-    bridgePoolUpdates(from: $from) {
+  subscription BridgePoolUpdates {
+    bridgePoolUpdates {
       newEvent {
         ... on BridgeReserveTransfer {
-          __typename id midnightTxHash cardanoTxHash amount
-          indexedAt { blockHeight blockHash }
+          __typename id blockHeight midnightTxHash cardanoTxHash amount
         }
         ... on BridgeInvalidTransfer {
-          __typename id midnightTxHash cardanoTxHash amount
-          indexedAt { blockHeight blockHash }
+          __typename id blockHeight midnightTxHash cardanoTxHash amount
         }
         ... on BridgeUnapprovedTransfer {
-          __typename id midnightTxHash cardanoTxHash amount recipient
-          indexedAt { blockHeight blockHash }
+          __typename id blockHeight midnightTxHash cardanoTxHash amount recipient
         }
         ... on BridgeSubminimalFlushTransfer {
-          __typename id midnightTxHash amount count
-          indexedAt { blockHeight blockHash }
+          __typename id blockHeight midnightTxHash amount count
         }
       }
       pool {
         reserveTotal
         treasuryByReason { reason total count }
         subminimumTxCount
-        lastEventAt { blockHeight blockHash }
+        lastEventBlockHeight
       }
     }
   }
@@ -156,19 +144,9 @@ describe('bridge pool subscription — bridgePoolUpdates', () => {
    * @given no pool-affecting bridge events have been indexed
    * @when we subscribe to bridgePoolUpdates
    * @then the first frame has pool.reserveTotal=0, all treasury totals=0,
-   *       subminimumTxCount=0, and pool.lastEventAt=null
+   *       subminimumTxCount=0, pool.lastEventBlockHeight=null, and newEvent=null
    */
   it.todo('should emit current pool summary immediately on subscribe');
-
-  /**
-   * bridgePoolUpdates replays historical pool updates from the given cursor.
-   *
-   * @given the with-data chain has ReserveTransfer events with known ids
-   * @when we subscribe with from=<firstEventId - 1>
-   * @then we receive a BridgePoolUpdate frame for each pool-affecting event in id order
-   * @and each frame's pool.reserveTotal is the running sum at that point in time
-   */
-  it.todo('should replay historical pool updates from the given cursor id');
 
   /**
    * bridgePoolUpdates pushes a live update when a new ReserveTransfer is indexed.
@@ -205,11 +183,11 @@ describe('bridge pool subscription — bridgePoolUpdates', () => {
    * After N pool-affecting events, the Nth frame's pool totals equal the sum
    * of all previous events' amounts.
    *
-   * @given the with-data chain has 3 ReserveTransfer events with known amounts A1, A2, A3
-   * @when we subscribe with from=0 and receive 3 frames
-   * @then frame[0].pool.reserveTotal = A1
-   * @and frame[1].pool.reserveTotal = A1 + A2
-   * @and frame[2].pool.reserveTotal = A1 + A2 + A3
+   * @given 3 ReserveTransfer events with known amounts A1, A2, A3 are indexed while subscribed
+   * @when we subscribe and receive a frame per pool-affecting event
+   * @then the frame after A1 has pool.reserveTotal = A1
+   * @and the frame after A2 has pool.reserveTotal = A1 + A2
+   * @and the frame after A3 has pool.reserveTotal = A1 + A2 + A3
    */
   it.todo('should carry a running pool total in each frame (cumulative consistency)');
 

--- a/qa/tests/tests/integration/basic/subscriptions/bridge-pool-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/bridge-pool-subscriptions.test.ts
@@ -1,0 +1,239 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Integration tests for c2m-bridge pool observability subscription (#944).
+//
+// Covers: bridgePoolUpdates subscription.
+//
+// ── What bridgePoolUpdates does ───────────────────────────────────────────────
+//
+// `bridgePoolUpdates(from: Int)` pushes a `BridgePoolUpdate` frame on every
+// newly indexed bridge event that affects a protocol pool (Reserve or Treasury).
+// Each frame contains:
+//   - `newEvent: BridgeEvent` — the event that triggered the update
+//   - `pool: BridgePoolSummary` — the recomputed pool snapshot after the event
+//
+// The subscription emits the current summary immediately on connect (similar
+// to `bridgeBalance` in #942). If `from` is provided, it also replays past
+// pool-affecting events with their at-time summaries before switching to
+// live mode.
+//
+// ── Status of tests ──────────────────────────────────────────────────────────
+//
+//   it.todo   → Requires bridge schema + event data in the test environment.
+//               Same Q1 blocker as #941–#944 test PRs. See PR #1219.
+//               Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/944
+//
+//   it.skip   → Blocked on specific in-flight features (noted inline).
+//
+// ── Types ─────────────────────────────────────────────────────────────────────
+//
+// Types defined inline as stubs. Consolidate with bridge-pool-queries.test.ts
+// types into indexer-types.ts once #944 lands.
+
+import log from '@utils/logging/logger';
+import '@utils/logging/test-logging-hooks';
+import { IndexerWsClient } from '@utils/indexer/websocket-client';
+import type { TestContext } from 'vitest';
+
+// ── Stub types (consolidate with bridge-pool-queries.test.ts once #944 lands) ─
+
+interface BlockReference {
+  blockHeight: number;
+  blockHash: string;
+}
+
+interface BridgeTreasuryAggregate {
+  reason: string;
+  total: string;
+  count: number;
+}
+
+interface BridgePoolSummary {
+  reserveTotal: string;
+  treasuryByReason: BridgeTreasuryAggregate[];
+  subminimumTxCount: number;
+  lastEventAt: BlockReference | null;
+}
+
+interface BridgeEventBase {
+  id: number;
+  midnightTxHash: string;
+  indexedAt: BlockReference;
+}
+
+interface BridgeReserveTransfer extends BridgeEventBase {
+  __typename: 'BridgeReserveTransfer';
+  cardanoTxHash: string;
+  amount: string;
+}
+
+interface BridgeInvalidTransfer extends BridgeEventBase {
+  __typename: 'BridgeInvalidTransfer';
+  cardanoTxHash: string;
+  amount: string;
+}
+
+interface BridgeSubminimalFlushTransfer extends BridgeEventBase {
+  __typename: 'BridgeSubminimalFlushTransfer';
+  amount: string;
+  count: number;
+}
+
+type PoolAffectingEvent =
+  | BridgeReserveTransfer
+  | BridgeInvalidTransfer
+  | BridgeSubminimalFlushTransfer;
+
+interface BridgePoolUpdate {
+  newEvent: PoolAffectingEvent;
+  pool: BridgePoolSummary;
+}
+
+// ── GraphQL subscription string ──────────────────────────────────────────────
+
+const BRIDGE_POOL_UPDATES_SUBSCRIPTION = `
+  subscription BridgePoolUpdates($from: Int) {
+    bridgePoolUpdates(from: $from) {
+      newEvent {
+        ... on BridgeReserveTransfer {
+          __typename id midnightTxHash cardanoTxHash amount
+          indexedAt { blockHeight blockHash }
+        }
+        ... on BridgeInvalidTransfer {
+          __typename id midnightTxHash cardanoTxHash amount
+          indexedAt { blockHeight blockHash }
+        }
+        ... on BridgeUnapprovedTransfer {
+          __typename id midnightTxHash cardanoTxHash amount recipient
+          indexedAt { blockHeight blockHash }
+        }
+        ... on BridgeSubminimalFlushTransfer {
+          __typename id midnightTxHash amount count
+          indexedAt { blockHeight blockHash }
+        }
+      }
+      pool {
+        reserveTotal
+        treasuryByReason { reason total count }
+        subminimumTxCount
+        lastEventAt { blockHeight blockHash }
+      }
+    }
+  }
+`;
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('bridge pool subscription — bridgePoolUpdates', () => {
+  let wsClient: IndexerWsClient;
+
+  beforeEach(async () => {
+    wsClient = new IndexerWsClient();
+    await wsClient.connectionInit();
+  }, 30_000);
+
+  afterEach(async () => {
+    await wsClient.connectionClose();
+  });
+
+  /**
+   * bridgePoolUpdates emits the current pool summary immediately on connect.
+   * When no pool-affecting events exist, the initial frame has all-zero totals.
+   *
+   * @given no pool-affecting bridge events have been indexed
+   * @when we subscribe to bridgePoolUpdates
+   * @then the first frame has pool.reserveTotal=0, all treasury totals=0,
+   *       subminimumTxCount=0, and pool.lastEventAt=null
+   */
+  it.todo('should emit current pool summary immediately on subscribe');
+
+  /**
+   * bridgePoolUpdates replays historical pool updates from the given cursor.
+   *
+   * @given the with-data chain has ReserveTransfer events with known ids
+   * @when we subscribe with from=<firstEventId - 1>
+   * @then we receive a BridgePoolUpdate frame for each pool-affecting event in id order
+   * @and each frame's pool.reserveTotal is the running sum at that point in time
+   */
+  it.todo('should replay historical pool updates from the given cursor id');
+
+  /**
+   * bridgePoolUpdates pushes a live update when a new ReserveTransfer is indexed.
+   *
+   * @given we are subscribed to bridgePoolUpdates in live mode
+   * @when a new ReserveTransfer event is indexed
+   * @then we receive a BridgePoolUpdate where newEvent.__typename = BridgeReserveTransfer
+   * @and pool.reserveTotal is updated to include the new event's amount
+   */
+  it.todo('should push an update when a new ReserveTransfer is indexed');
+
+  /**
+   * bridgePoolUpdates pushes a live update when an InvalidTransfer is indexed.
+   *
+   * @given we are subscribed to bridgePoolUpdates in live mode
+   * @when a new InvalidTransfer event is indexed
+   * @then we receive a BridgePoolUpdate where newEvent.__typename = BridgeInvalidTransfer
+   * @and the INVALID treasury aggregate in pool.treasuryByReason is increased
+   */
+  it.todo('should push an update when a new InvalidTransfer is indexed');
+
+  /**
+   * bridgePoolUpdates does NOT push an update for UserTransfer events.
+   * UserTransfer goes to a user address, not to a protocol pool.
+   *
+   * @given we are subscribed to bridgePoolUpdates in live mode
+   * @when a UserTransfer event is indexed
+   * @then no BridgePoolUpdate is pushed (pool is unaffected by user transfers)
+   */
+  it.todo('should not push a pool update for UserTransfer events (user address, not pool)');
+
+  /**
+   * bridgePoolUpdates frames carry a self-consistent pool snapshot at each point.
+   * After N pool-affecting events, the Nth frame's pool totals equal the sum
+   * of all previous events' amounts.
+   *
+   * @given the with-data chain has 3 ReserveTransfer events with known amounts A1, A2, A3
+   * @when we subscribe with from=0 and receive 3 frames
+   * @then frame[0].pool.reserveTotal = A1
+   * @and frame[1].pool.reserveTotal = A1 + A2
+   * @and frame[2].pool.reserveTotal = A1 + A2 + A3
+   */
+  it.todo('should carry a running pool total in each frame (cumulative consistency)');
+
+  // Skipped: UnapprovedTransfer pool update — blocked on approval governance.
+  // Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/940
+  test.skip('should push an update when an UnapprovedTransfer is indexed', async (_ctx: TestContext) => {
+    // TODO: implement once UnapprovedTransfer can be generated in test env.
+    // Expect newEvent.__typename = BridgeUnapprovedTransfer and
+    // UNAPPROVED treasury aggregate to be increased.
+  });
+
+  // Skipped: SubminimalFlushTransfer pool update — blocked on threshold investigation.
+  // See SubminimalFlushTransfer note in bridge-pool-queries.test.ts.
+  test.skip('should push an update and increment subminimumTxCount when a flush is indexed', async (_ctx: TestContext) => {
+    // TODO: implement once SubminimalFlushTransfer can be generated in test env.
+    // Expect newEvent.__typename = BridgeSubminimalFlushTransfer,
+    // SUBMINIMAL_FLUSH treasury aggregate to be increased,
+    // and pool.subminimumTxCount to be incremented by newEvent.count.
+  });
+});
+
+// Suppress unused import warnings until test bodies are implemented.
+void BRIDGE_POOL_UPDATES_SUBSCRIPTION;
+void log;
+
+type _SuppressUnused = BridgePoolUpdate;
+void (undefined as unknown as _SuppressUnused);

--- a/qa/tests/tests/integration/basic/subscriptions/bridge-pool-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/bridge-pool-subscriptions.test.ts
@@ -18,57 +18,134 @@
 //
 // bridgePoolUpdates takes no arguments. It emits the current BridgePoolSummary
 // immediately on connect (with newEvent null), then live-tails a BridgePoolUpdate
-// frame on every newly indexed pool-affecting event (Reserve or Treasury). Each
-// frame carries the triggering event (newEvent) and the recomputed pool snapshot
-// (pool). There is no cursor / historical-replay parameter.
+// frame on every newly indexed pool-affecting event (Reserve or Treasury). There
+// is no cursor / historical-replay parameter.
 //
-// These are skeletons enumerating the intended cases:
-//   test.todo → needs bridge schema + live event generation in the test
-//               environment. When implemented, follow the framework conventions
-//               (how-to-write-a-qa-indexer-test): use IndexerWsClient with the
-//               beforeEach/afterEach connect lifecycle, define response types in
-//               utils/indexer/websocket-client.ts, gate on bridge availability,
-//               and set ctx.task labels.
+// Test-data reality (2026-07): no reserve or treasury events exist on any
+// environment, so the immediate-snapshot frame is testable (its pool totals are
+// legitimately zero) but the live-push cases need pool-affecting events that no
+// environment can currently produce.
+//   test.todo → needs pool-affecting event generation not available in any env.
 //   test.skip → blocked on an in-flight feature: UNAPPROVED on approval
-//               governance (#940); SUBMINIMAL_FLUSH on confirming the flush
-//               threshold with the node team so a flush can be triggered.
+//               governance (#940); SUBMINIMAL_FLUSH on a triggerable flush
+//               threshold (node team).
 //
 // Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/944
 
-describe('bridge pool subscription', () => {
+import log from '@utils/logging/logger';
+import { env } from 'environment/model';
+import type { TestContext } from 'vitest';
+import '@utils/logging/test-logging-hooks';
+import {
+  IndexerWsClient,
+  BridgePoolUpdateSubscriptionResponse,
+} from '@utils/indexer/websocket-client';
+import { IndexerHttpClient } from '@utils/indexer/http-client';
+import { BRIDGE_TREASURY_REASONS } from '@utils/indexer/indexer-types';
+
+const httpClient = new IndexerHttpClient();
+const ZERO_U128 = '0'.repeat(32);
+
+let surfacePresent = false;
+
+function safeUnsubscribe(unsubscribe: () => void): void {
+  try {
+    unsubscribe();
+  } catch (error) {
+    log.debug(`Ignoring unsubscribe error during teardown: ${String(error)}`);
+  }
+}
+
+describe.skipIf(env.isUndeployedEnv())('bridge pool subscription', () => {
+  let wsClient: IndexerWsClient;
+
+  beforeAll(async () => {
+    const probe = await httpClient.getBridgePoolSummary();
+    if (probe.errors || !probe.data) {
+      log.warn(`Bridge pool surface not present on ${env.getCurrentEnvironmentName()}; skipping`);
+      return;
+    }
+    surfacePresent = true;
+  }, 30_000);
+
+  beforeEach(async () => {
+    wsClient = new IndexerWsClient();
+    await wsClient.connectionInit();
+  }, 30_000);
+
+  afterEach(async () => {
+    await wsClient.connectionClose();
+  });
+
   describe('bridgePoolUpdates', () => {
     /**
      * @given no pool-affecting bridge events have been indexed
-     * @when we subscribe to bridgePoolUpdates
-     * @then the first frame has all-zero pool totals, lastEventBlockHeight null and newEvent null
+     * @when a bridgePoolUpdates subscription is opened
+     * @then the first frame has newEvent null and a pool summary with zero
+     *       reserveTotal, zero subminimumTxCount and the three treasury reasons
      */
-    test.todo('should emit current pool summary immediately on subscribe');
+    test('should emit current pool summary immediately on subscribe', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Subscription', 'Bridge', 'Pool'] };
+      if (!surfacePresent) return ctx.skip();
+
+      const firstFrame = await new Promise<BridgePoolUpdateSubscriptionResponse>(
+        (resolve, reject) => {
+          let unsubscribe = () => {};
+          const timeout = setTimeout(() => {
+            safeUnsubscribe(unsubscribe);
+            reject(new Error('no bridgePoolUpdates frame received within timeout'));
+          }, 15_000);
+
+          const subscription = wsClient.subscribeToBridgePoolUpdates({
+            next: (payload) => {
+              clearTimeout(timeout);
+              safeUnsubscribe(unsubscribe);
+              resolve(payload);
+            },
+            error: (error) => {
+              clearTimeout(timeout);
+              safeUnsubscribe(unsubscribe);
+              reject(new Error(`Subscription error: ${JSON.stringify(error)}`));
+            },
+          });
+          unsubscribe = subscription.unsubscribe;
+        },
+      );
+
+      expect(firstFrame).toBeSuccess();
+      const update = firstFrame.data!.bridgePoolUpdates;
+      expect(update.newEvent).toBeNull();
+      expect(update.pool.reserveTotal).toBe(ZERO_U128);
+      expect(update.pool.subminimumTxCount).toBe(0);
+      const reasons = update.pool.treasuryByReason.map((t) => t.reason).sort();
+      expect(reasons).toEqual([...BRIDGE_TREASURY_REASONS].sort());
+    }, 30_000);
 
     /**
-     * @given we are subscribed to bridgePoolUpdates in live mode
+     * @given a live bridgePoolUpdates subscription
      * @when a new ReserveTransfer event is indexed
-     * @then we receive a frame with newEvent BridgeReserveTransfer and an updated pool.reserveTotal
+     * @then a frame arrives with newEvent BridgeReserveTransfer and an updated pool.reserveTotal
      */
     test.todo('should push an update when a new ReserveTransfer is indexed');
 
     /**
-     * @given we are subscribed to bridgePoolUpdates in live mode
+     * @given a live bridgePoolUpdates subscription
      * @when a new InvalidTransfer event is indexed
-     * @then we receive a frame with newEvent BridgeInvalidTransfer and an increased INVALID treasury aggregate
+     * @then a frame arrives with newEvent BridgeInvalidTransfer and an increased INVALID aggregate
      */
     test.todo('should push an update when a new InvalidTransfer is indexed');
 
     /**
-     * @given we are subscribed to bridgePoolUpdates in live mode
+     * @given a live bridgePoolUpdates subscription
      * @when a UserTransfer event is indexed
      * @then no frame is pushed (a user transfer affects a user address, not a pool)
      */
     test.todo('should not push a pool update for UserTransfer events (user address, not pool)');
 
     /**
-     * @given 3 ReserveTransfer events with known amounts A1, A2, A3 are indexed while subscribed
-     * @when we receive a frame per pool-affecting event
-     * @then pool.reserveTotal is A1, then A1+A2, then A1+A2+A3 across successive frames
+     * @given 3 ReserveTransfer events with known amounts indexed while subscribed
+     * @when a frame arrives per pool-affecting event
+     * @then pool.reserveTotal carries the running cumulative sum across frames
      */
     test.todo('should carry a running pool total in each frame (cumulative consistency)');
 

--- a/qa/tests/tests/integration/basic/subscriptions/bridge-pool-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/bridge-pool-subscriptions.test.ts
@@ -13,205 +13,70 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Integration tests for c2m-bridge pool observability subscription (#944).
+// Integration tests for the c2m-bridge pool observability subscription:
+// bridgePoolUpdates (#944).
 //
-// Covers: bridgePoolUpdates subscription.
+// bridgePoolUpdates takes no arguments. It emits the current BridgePoolSummary
+// immediately on connect (with newEvent null), then live-tails a BridgePoolUpdate
+// frame on every newly indexed pool-affecting event (Reserve or Treasury). Each
+// frame carries the triggering event (newEvent) and the recomputed pool snapshot
+// (pool). There is no cursor / historical-replay parameter.
 //
-// ── What bridgePoolUpdates does ───────────────────────────────────────────────
+// These are skeletons enumerating the intended cases:
+//   test.todo → needs bridge schema + live event generation in the test
+//               environment. When implemented, follow the framework conventions
+//               (how-to-write-a-qa-indexer-test): use IndexerWsClient with the
+//               beforeEach/afterEach connect lifecycle, define response types in
+//               utils/indexer/websocket-client.ts, gate on bridge availability,
+//               and set ctx.task labels.
+//   test.skip → blocked on an in-flight feature: UNAPPROVED on approval
+//               governance (#940); SUBMINIMAL_FLUSH on confirming the flush
+//               threshold with the node team so a flush can be triggered.
 //
-// `bridgePoolUpdates` pushes a `BridgePoolUpdate` frame on every newly indexed
-// bridge event that affects a protocol pool (Reserve or Treasury). Each frame
-// contains:
-//   - `newEvent: BridgeEvent` — the event that triggered the update; null on
-//     the initial snapshot emitted on subscribe
-//   - `pool: BridgePoolSummary` — the recomputed pool snapshot after the event
-//
-// The subscription emits the current summary immediately on connect (similar
-// to `bridgeBalance` in #942), with `newEvent` null, then switches to live
-// mode. It takes no arguments.
-//
-// ── Status of tests ──────────────────────────────────────────────────────────
-//
-//   it.todo   → Requires bridge schema + event data in the test environment.
-//               Same Q1 blocker as #941–#944 test PRs. See PR #1219.
-//               Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/944
-//
-//   it.skip   → Blocked on specific in-flight features (noted inline).
-//
-// ── Types ─────────────────────────────────────────────────────────────────────
-//
-// Types defined inline as stubs. Consolidate with bridge-pool-queries.test.ts
-// types into indexer-types.ts once #944 lands.
+// Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/944
 
-import log from '@utils/logging/logger';
-import '@utils/logging/test-logging-hooks';
-import { IndexerWsClient } from '@utils/indexer/websocket-client';
-import type { TestContext } from 'vitest';
+describe('bridge pool subscription', () => {
+  describe('bridgePoolUpdates', () => {
+    /**
+     * @given no pool-affecting bridge events have been indexed
+     * @when we subscribe to bridgePoolUpdates
+     * @then the first frame has all-zero pool totals, lastEventBlockHeight null and newEvent null
+     */
+    test.todo('should emit current pool summary immediately on subscribe');
 
-// ── Stub types (consolidate with bridge-pool-queries.test.ts once #944 lands) ─
+    /**
+     * @given we are subscribed to bridgePoolUpdates in live mode
+     * @when a new ReserveTransfer event is indexed
+     * @then we receive a frame with newEvent BridgeReserveTransfer and an updated pool.reserveTotal
+     */
+    test.todo('should push an update when a new ReserveTransfer is indexed');
 
-interface BridgeTreasuryAggregate {
-  reason: string;
-  total: string;
-  count: number;
-}
+    /**
+     * @given we are subscribed to bridgePoolUpdates in live mode
+     * @when a new InvalidTransfer event is indexed
+     * @then we receive a frame with newEvent BridgeInvalidTransfer and an increased INVALID treasury aggregate
+     */
+    test.todo('should push an update when a new InvalidTransfer is indexed');
 
-interface BridgePoolSummary {
-  reserveTotal: string;
-  treasuryByReason: BridgeTreasuryAggregate[];
-  subminimumTxCount: number;
-  lastEventBlockHeight: number | null;
-}
+    /**
+     * @given we are subscribed to bridgePoolUpdates in live mode
+     * @when a UserTransfer event is indexed
+     * @then no frame is pushed (a user transfer affects a user address, not a pool)
+     */
+    test.todo('should not push a pool update for UserTransfer events (user address, not pool)');
 
-interface BridgeEventBase {
-  id: number;
-  blockHeight: number;
-  midnightTxHash: string;
-}
+    /**
+     * @given 3 ReserveTransfer events with known amounts A1, A2, A3 are indexed while subscribed
+     * @when we receive a frame per pool-affecting event
+     * @then pool.reserveTotal is A1, then A1+A2, then A1+A2+A3 across successive frames
+     */
+    test.todo('should carry a running pool total in each frame (cumulative consistency)');
 
-interface BridgeReserveTransfer extends BridgeEventBase {
-  __typename: 'BridgeReserveTransfer';
-  cardanoTxHash: string;
-  amount: string;
-}
+    // Blocked: approval governance not landed yet (#940), so UnapprovedTransfer
+    // cannot be produced.
+    test.skip('should push an update when an UnapprovedTransfer is indexed', () => {});
 
-interface BridgeInvalidTransfer extends BridgeEventBase {
-  __typename: 'BridgeInvalidTransfer';
-  cardanoTxHash: string;
-  amount: string;
-}
-
-interface BridgeSubminimalFlushTransfer extends BridgeEventBase {
-  __typename: 'BridgeSubminimalFlushTransfer';
-  amount: string;
-  count: number;
-}
-
-type BridgeEvent = BridgeReserveTransfer | BridgeInvalidTransfer | BridgeSubminimalFlushTransfer;
-
-interface BridgePoolUpdate {
-  newEvent: BridgeEvent | null;
-  pool: BridgePoolSummary;
-}
-
-// ── GraphQL subscription string ──────────────────────────────────────────────
-
-const BRIDGE_POOL_UPDATES_SUBSCRIPTION = `
-  subscription BridgePoolUpdates {
-    bridgePoolUpdates {
-      newEvent {
-        ... on BridgeReserveTransfer {
-          __typename id blockHeight midnightTxHash cardanoTxHash amount
-        }
-        ... on BridgeInvalidTransfer {
-          __typename id blockHeight midnightTxHash cardanoTxHash amount
-        }
-        ... on BridgeUnapprovedTransfer {
-          __typename id blockHeight midnightTxHash cardanoTxHash amount recipient
-        }
-        ... on BridgeSubminimalFlushTransfer {
-          __typename id blockHeight midnightTxHash amount count
-        }
-      }
-      pool {
-        reserveTotal
-        treasuryByReason { reason total count }
-        subminimumTxCount
-        lastEventBlockHeight
-      }
-    }
-  }
-`;
-
-// ── Tests ────────────────────────────────────────────────────────────────────
-
-describe('bridge pool subscription — bridgePoolUpdates', () => {
-  let wsClient: IndexerWsClient;
-
-  beforeEach(async () => {
-    wsClient = new IndexerWsClient();
-    await wsClient.connectionInit();
-  }, 30_000);
-
-  afterEach(async () => {
-    await wsClient.connectionClose();
-  });
-
-  /**
-   * bridgePoolUpdates emits the current pool summary immediately on connect.
-   * When no pool-affecting events exist, the initial frame has all-zero totals.
-   *
-   * @given no pool-affecting bridge events have been indexed
-   * @when we subscribe to bridgePoolUpdates
-   * @then the first frame has pool.reserveTotal=0, all treasury totals=0,
-   *       subminimumTxCount=0, pool.lastEventBlockHeight=null, and newEvent=null
-   */
-  it.todo('should emit current pool summary immediately on subscribe');
-
-  /**
-   * bridgePoolUpdates pushes a live update when a new ReserveTransfer is indexed.
-   *
-   * @given we are subscribed to bridgePoolUpdates in live mode
-   * @when a new ReserveTransfer event is indexed
-   * @then we receive a BridgePoolUpdate where newEvent.__typename = BridgeReserveTransfer
-   * @and pool.reserveTotal is updated to include the new event's amount
-   */
-  it.todo('should push an update when a new ReserveTransfer is indexed');
-
-  /**
-   * bridgePoolUpdates pushes a live update when an InvalidTransfer is indexed.
-   *
-   * @given we are subscribed to bridgePoolUpdates in live mode
-   * @when a new InvalidTransfer event is indexed
-   * @then we receive a BridgePoolUpdate where newEvent.__typename = BridgeInvalidTransfer
-   * @and the INVALID treasury aggregate in pool.treasuryByReason is increased
-   */
-  it.todo('should push an update when a new InvalidTransfer is indexed');
-
-  /**
-   * bridgePoolUpdates does NOT push an update for UserTransfer events.
-   * UserTransfer goes to a user address, not to a protocol pool.
-   *
-   * @given we are subscribed to bridgePoolUpdates in live mode
-   * @when a UserTransfer event is indexed
-   * @then no BridgePoolUpdate is pushed (pool is unaffected by user transfers)
-   */
-  it.todo('should not push a pool update for UserTransfer events (user address, not pool)');
-
-  /**
-   * bridgePoolUpdates frames carry a self-consistent pool snapshot at each point.
-   * After N pool-affecting events, the Nth frame's pool totals equal the sum
-   * of all previous events' amounts.
-   *
-   * @given 3 ReserveTransfer events with known amounts A1, A2, A3 are indexed while subscribed
-   * @when we subscribe and receive a frame per pool-affecting event
-   * @then the frame after A1 has pool.reserveTotal = A1
-   * @and the frame after A2 has pool.reserveTotal = A1 + A2
-   * @and the frame after A3 has pool.reserveTotal = A1 + A2 + A3
-   */
-  it.todo('should carry a running pool total in each frame (cumulative consistency)');
-
-  // Skipped: UnapprovedTransfer pool update — blocked on approval governance.
-  // Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/940
-  test.skip('should push an update when an UnapprovedTransfer is indexed', async (_ctx: TestContext) => {
-    // TODO: implement once UnapprovedTransfer can be generated in test env.
-    // Expect newEvent.__typename = BridgeUnapprovedTransfer and
-    // UNAPPROVED treasury aggregate to be increased.
-  });
-
-  // Skipped: SubminimalFlushTransfer pool update — blocked on threshold investigation.
-  // See SubminimalFlushTransfer note in bridge-pool-queries.test.ts.
-  test.skip('should push an update and increment subminimumTxCount when a flush is indexed', async (_ctx: TestContext) => {
-    // TODO: implement once SubminimalFlushTransfer can be generated in test env.
-    // Expect newEvent.__typename = BridgeSubminimalFlushTransfer,
-    // SUBMINIMAL_FLUSH treasury aggregate to be increased,
-    // and pool.subminimumTxCount to be incremented by newEvent.count.
+    // Blocked: SubminimalFlush threshold not yet confirmed (see header note, #944).
+    test.skip('should push an update and increment subminimumTxCount when a flush is indexed', () => {});
   });
 });
-
-// Suppress unused import warnings until test bodies are implemented.
-void BRIDGE_POOL_UPDATES_SUBSCRIPTION;
-void log;
-
-type _SuppressUnused = BridgePoolUpdate;
-void (undefined as unknown as _SuppressUnused);

--- a/qa/tests/utils/indexer/graphql/bridge-pool-queries.ts
+++ b/qa/tests/utils/indexer/graphql/bridge-pool-queries.ts
@@ -1,0 +1,53 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// GraphQL documents for the c2m-bridge pool observability surface (#944):
+// bridgePoolSummary (optionally at a block), and the reserve/treasury inflow
+// event lists. Only the BridgeReserveTransfer inline fragment is expanded on
+// the inflow lists; the treasury variants are discriminated by __typename until
+// data exists to exercise their fields.
+export const GET_BRIDGE_POOL_SUMMARY = `
+query BridgePoolSummary($AT_BLOCK: Int) {
+  bridgePoolSummary(atBlock: $AT_BLOCK) {
+    reserveTotal
+    treasuryByReason {
+      reason
+      total
+    }
+    subminimumTxCount
+    lastEventBlockHeight
+  }
+}`;
+
+export const GET_BRIDGE_RESERVE_INFLOWS = `
+query BridgeReserveInflows($BLOCK_HEIGHT_FROM: Int, $BLOCK_HEIGHT_TO: Int, $OFFSET: Int, $LIMIT: Int) {
+  bridgeReserveInflows(blockHeightFrom: $BLOCK_HEIGHT_FROM, blockHeightTo: $BLOCK_HEIGHT_TO, offset: $OFFSET, limit: $LIMIT) {
+    __typename
+    ... on BridgeReserveTransfer {
+      id
+      blockHeight
+      midnightTxHash
+      cardanoTxHash
+      amount
+    }
+  }
+}`;
+
+export const GET_BRIDGE_TREASURY_INFLOWS = `
+query BridgeTreasuryInflows($REASON: BridgeTreasuryReason, $BLOCK_HEIGHT_FROM: Int, $BLOCK_HEIGHT_TO: Int, $OFFSET: Int, $LIMIT: Int) {
+  bridgeTreasuryInflows(reason: $REASON, blockHeightFrom: $BLOCK_HEIGHT_FROM, blockHeightTo: $BLOCK_HEIGHT_TO, offset: $OFFSET, limit: $LIMIT) {
+    __typename
+  }
+}`;

--- a/qa/tests/utils/indexer/graphql/subscriptions.ts
+++ b/qa/tests/utils/indexer/graphql/subscriptions.ts
@@ -469,3 +469,25 @@ export const BRIDGE_BALANCE_SUBSCRIPTION = `
     }
   }
 `;
+
+// c2m-bridge pool observability stream (#944). Emits an initial snapshot on
+// subscribe (newEvent = null), then a refreshed summary paired with each new
+// pool-affecting event.
+export const BRIDGE_POOL_UPDATES_SUBSCRIPTION = `
+  subscription BridgePoolUpdates {
+    bridgePoolUpdates {
+      newEvent {
+        __typename
+      }
+      pool {
+        reserveTotal
+        treasuryByReason {
+          reason
+          total
+        }
+        subminimumTxCount
+        lastEventBlockHeight
+      }
+    }
+  }
+`;

--- a/qa/tests/utils/indexer/http-client.ts
+++ b/qa/tests/utils/indexer/http-client.ts
@@ -45,6 +45,10 @@ import type {
   BridgeEventsResponse,
   BridgeDepositsResponse,
   BridgeBalanceResponse,
+  BridgePoolSummaryResponse,
+  BridgeReserveInflowsResponse,
+  BridgeTreasuryInflowsResponse,
+  BridgeTreasuryReason,
 } from './indexer-types';
 import {
   GET_LATEST_BLOCK,
@@ -65,6 +69,11 @@ import {
   GET_BRIDGE_BALANCE,
   GET_BRIDGE_DEPOSITS,
 } from './graphql/bridge-queries';
+import {
+  GET_BRIDGE_POOL_SUMMARY,
+  GET_BRIDGE_RESERVE_INFLOWS,
+  GET_BRIDGE_TREASURY_INFLOWS,
+} from './graphql/bridge-pool-queries';
 
 /**
  * Recognise operation-level GraphQL errors that look like *server* failures
@@ -511,6 +520,79 @@ export class IndexerHttpClient {
     };
 
     const response = await this.rawRequestWithRetry<{ bridgeDeposits: BridgeEvent[] }>(
+      query,
+      variables,
+    );
+
+    log.debug(`Raw indexer response\n${JSON.stringify(response, null, 2)}`);
+
+    return response;
+  }
+
+  async getBridgePoolSummary(
+    atBlock?: number,
+    queryOverride?: string,
+  ): Promise<BridgePoolSummaryResponse> {
+    const query = queryOverride || GET_BRIDGE_POOL_SUMMARY;
+    const variables = { AT_BLOCK: atBlock };
+
+    const response = await this.rawRequestWithRetry<BridgePoolSummaryResponse['data']>(
+      query,
+      variables,
+    );
+
+    log.debug(`Raw indexer response\n${JSON.stringify(response, null, 2)}`);
+
+    return response;
+  }
+
+  async getBridgeReserveInflows(
+    range: {
+      blockHeightFrom?: number;
+      blockHeightTo?: number;
+      offset?: number;
+      limit?: number;
+    } = {},
+    queryOverride?: string,
+  ): Promise<BridgeReserveInflowsResponse> {
+    const query = queryOverride || GET_BRIDGE_RESERVE_INFLOWS;
+    const variables = {
+      BLOCK_HEIGHT_FROM: range.blockHeightFrom,
+      BLOCK_HEIGHT_TO: range.blockHeightTo,
+      OFFSET: range.offset,
+      LIMIT: range.limit,
+    };
+
+    const response = await this.rawRequestWithRetry<{ bridgeReserveInflows: BridgeEvent[] }>(
+      query,
+      variables,
+    );
+
+    log.debug(`Raw indexer response\n${JSON.stringify(response, null, 2)}`);
+
+    return response;
+  }
+
+  async getBridgeTreasuryInflows(
+    options: {
+      reason?: BridgeTreasuryReason;
+      blockHeightFrom?: number;
+      blockHeightTo?: number;
+      offset?: number;
+      limit?: number;
+    } = {},
+    queryOverride?: string,
+  ): Promise<BridgeTreasuryInflowsResponse> {
+    const query = queryOverride || GET_BRIDGE_TREASURY_INFLOWS;
+    const variables = {
+      REASON: options.reason,
+      BLOCK_HEIGHT_FROM: options.blockHeightFrom,
+      BLOCK_HEIGHT_TO: options.blockHeightTo,
+      OFFSET: options.offset,
+      LIMIT: options.limit,
+    };
+
+    const response = await this.rawRequestWithRetry<{ bridgeTreasuryInflows: BridgeEvent[] }>(
       query,
       variables,
     );

--- a/qa/tests/utils/indexer/indexer-types.ts
+++ b/qa/tests/utils/indexer/indexer-types.ts
@@ -478,6 +478,40 @@ export interface BridgeUserTransfer {
   recipient: string;
 }
 
+// c2m-bridge pool observability surface (#944).
+export type BridgeTreasuryReason = 'INVALID' | 'UNAPPROVED' | 'SUBMINIMAL_FLUSH';
+
+export const BRIDGE_TREASURY_REASONS: BridgeTreasuryReason[] = [
+  'INVALID',
+  'UNAPPROVED',
+  'SUBMINIMAL_FLUSH',
+];
+
+export interface BridgeTreasuryAggregate {
+  reason: BridgeTreasuryReason;
+  total: string;
+}
+
+export interface BridgePoolSummary {
+  reserveTotal: string;
+  treasuryByReason: BridgeTreasuryAggregate[];
+  subminimumTxCount: number;
+  lastEventBlockHeight: number | null;
+}
+
+export type BridgePoolSummaryResponse = GraphQLResponse<{ bridgePoolSummary: BridgePoolSummary }>;
+
+// Inflow event lists. Only BridgeReserveTransfer carries populated fields today;
+// treasury variants are discriminated by __typename until data exists.
+export interface BridgeReserveTransfer {
+  __typename: 'BridgeReserveTransfer';
+  id: number;
+  blockHeight: number;
+  midnightTxHash: string;
+  cardanoTxHash: string;
+  amount: string;
+}
+
 export interface BridgeEventOther {
   __typename: string;
   id?: number;
@@ -485,7 +519,7 @@ export interface BridgeEventOther {
   amount?: string;
 }
 
-export type BridgeEvent = BridgeUserTransfer | BridgeEventOther;
+export type BridgeEvent = BridgeUserTransfer | BridgeReserveTransfer | BridgeEventOther;
 
 export type BridgeEventsResponse = GraphQLResponse<{ bridgeEvents: BridgeEvent[] }>;
 
@@ -498,6 +532,12 @@ export interface BridgeBalance {
 }
 
 export type BridgeBalanceResponse = GraphQLResponse<{ bridgeBalance: BridgeBalance }>;
+
+export type BridgeReserveInflowsResponse = GraphQLResponse<{ bridgeReserveInflows: BridgeEvent[] }>;
+
+export type BridgeTreasuryInflowsResponse = GraphQLResponse<{
+  bridgeTreasuryInflows: BridgeEvent[];
+}>;
 
 export interface DustCommitmentMerkleTreeUpdateResult {
   startIndex: number;

--- a/qa/tests/utils/indexer/websocket-client.ts
+++ b/qa/tests/utils/indexer/websocket-client.ts
@@ -33,6 +33,7 @@ import type {
   GraphQLResponse,
   BridgeEvent,
   BridgeBalance,
+  BridgePoolSummary,
 } from './indexer-types';
 import { CONTRACT_EVENTS_SUBSCRIPTION } from './graphql/contract-event-queries';
 import {
@@ -53,9 +54,19 @@ import {
   BRIDGE_EVENTS_SUBSCRIPTION_DEFAULT,
   BRIDGE_EVENTS_SUBSCRIPTION_FROM,
   BRIDGE_BALANCE_SUBSCRIPTION,
+  BRIDGE_POOL_UPDATES_SUBSCRIPTION,
 } from './graphql/subscriptions';
 
 export type BlockSubscriptionResponse = GraphQLResponse<{ blocks: Block }>;
+
+export interface BridgePoolUpdate {
+  newEvent: BridgeEvent | null;
+  pool: BridgePoolSummary;
+}
+
+export type BridgePoolUpdateSubscriptionResponse = GraphQLResponse<{
+  bridgePoolUpdates: BridgePoolUpdate;
+}>;
 
 export type UnshieldedTxSubscriptionResponse = GraphQLResponse<{
   unshieldedTransactions: UnshieldedTransactionEvent;
@@ -1328,6 +1339,44 @@ export class IndexerWsClient {
     };
 
     log.debug(`Bridge Balance payload:\n${JSON.stringify(payload, null, 2)}`);
+
+    this.handlersMap.set(subscriptionId, handlers as SubscriptionHandlers<unknown>);
+    this.getWs().send(JSON.stringify(payload));
+
+    return {
+      id: subscriptionId,
+      unsubscribe: () => {
+        const stopMessage: GraphQLStopMessage = { id: subscriptionId, type: 'stop' };
+        this.getWs().send(JSON.stringify(stopMessage));
+        this.handlersMap.delete(subscriptionId);
+      },
+    };
+  }
+
+  /**
+   * Subscribes to c2m-bridge pool updates (#944). Emits an initial snapshot on
+   * connect (newEvent = null, pool = current summary), then a refreshed summary
+   * paired with each new pool-affecting event. There is no completion sentinel.
+   *
+   * @param handlers - Callbacks for incoming pool update messages
+   * @param queryOverride - Optional custom GraphQL subscription query
+   * @returns An object with subscription ID and unsubscribe function
+   */
+  subscribeToBridgePoolUpdates(
+    handlers: SubscriptionHandlers<BridgePoolUpdateSubscriptionResponse>,
+    queryOverride?: string,
+  ): { unsubscribe: () => void; id: string } {
+    const query = queryOverride || BRIDGE_POOL_UPDATES_SUBSCRIPTION;
+
+    const subscriptionId = this.getNextId();
+
+    const payload: GraphQLStartMessage = {
+      id: subscriptionId,
+      type: 'start',
+      payload: { query },
+    };
+
+    log.debug(`Bridge Pool Updates payload:\n${JSON.stringify(payload, null, 2)}`);
 
     this.handlersMap.set(subscriptionId, handlers as SubscriptionHandlers<unknown>);
     this.getWs().send(JSON.stringify(payload));


### PR DESCRIPTION
## Test plan for feat(bridge): observability for bridge token pools (#944)

### What this ticket does

Adds protocol-level observability for where NIGHT flows when bridge transactions are processed. Three token destinations tracked:

| Destination | Event type | Query surface |
|-------------|------------|---------------|
| Reserve pool | `ReserveTransfer` | `bridgeReserveInflows`, `bridgePoolSummary.reserveTotal` |
| Treasury (malformed metadata) | `InvalidTransfer` | `bridgeTreasuryInflows(reason: INVALID)` |
| Treasury (no approval) | `UnapprovedTransfer` | `bridgeTreasuryInflows(reason: UNAPPROVED)` |
| Treasury (subminimum flush) | `SubminimalFlushTransfer` | `bridgeTreasuryInflows(reason: SUBMINIMAL_FLUSH)`, `bridgePoolSummary.subminimumTxCount` |

Per-address balance (UserTransfer / claims) is handled by #941, not this ticket.

### Rust-side coverage (already in #944)

| Criterion | Location | Status |
|-----------|----------|--------|
| Fixture with one event per category → expected summary | `indexer-api` Rust unit test | AC5 |
| Aggregation over multi-block range matches individual sum | `indexer-api` Rust integration test | AC5 |
| `SubminimalFlushTransfer.count` summed correctly | `indexer-api` Rust unit test | AC5 |

### QA framework coverage

#### Integration — queries: `tests/integration/basic/queries/bridge-pool-queries.test.ts`

##### `bridgePoolSummary`

| Test | Status | Reason |
|------|--------|--------|
| All-zero totals with no events | `test.todo` | Needs bridge pool queries in schema |
| `reserveTotal` = cumulative ReserveTransfer sum | `test.todo` | Needs bridge event data in test env |
| `treasuryByReason` splits INVALID and UNAPPROVED | `test.todo` | Needs bridge event data in test env |
| `lastEventBlockHeight` points to latest bridge event block | `test.todo` | Needs bridge event data in test env |
| `atBlock` snapshot parameter | `test.todo` | Needs bridge event data across multiple blocks |
| `subminimumTxCount` correct for flush events | `test.skip` | **Blocked**: SubminimalFlush threshold not yet confirmed with node team |
| UNAPPROVED treasury aggregate | `test.skip` | **Blocked**: approval governance not landed (#940) |

##### `bridgeReserveInflows`

| Test | Status | Reason |
|------|--------|--------|
| Empty list with no events | `test.todo` | Needs bridge pool queries in schema |
| Block range filter | `test.todo` | Needs bridge event data in test env |
| Correct field shape | `test.todo` | Needs bridge event data in test env |
| Pagination | `test.todo` | Needs ≥3 ReserveTransfer events |

##### `bridgeTreasuryInflows`

| Test | Status | Reason |
|------|--------|--------|
| Empty list with no events | `test.todo` | Needs bridge pool queries in schema |
| Returns all types without reason filter | `test.todo` | Needs InvalidTransfer data |
| `reason=INVALID` filter | `test.todo` | Needs InvalidTransfer data |
| Block range filter | `test.todo` | Needs bridge event data in test env |
| `reason=UNAPPROVED` filter | `test.skip` | **Blocked**: approval governance (#940) |
| `reason=SUBMINIMAL_FLUSH` filter | `test.skip` | **Blocked**: SubminimalFlush threshold not yet confirmed |

#### Integration — subscription: `tests/integration/basic/subscriptions/bridge-pool-subscriptions.test.ts`

`bridgePoolUpdates` takes **no arguments**: it emits the current `BridgePoolSummary` immediately on connect (with `newEvent` null), then live-tails a `BridgePoolUpdate` frame on every newly indexed pool-affecting event. There is no cursor/historical-replay parameter.

| Test | Status | Reason |
|------|--------|--------|
| Emits current summary immediately on connect (`newEvent` null) | `test.todo` | Needs bridge schema |
| Live push on new ReserveTransfer | `test.todo` | Needs live bridge tx generation |
| Live push on new InvalidTransfer | `test.todo` | Needs live bridge tx generation |
| No push for UserTransfer (user address, not pool) | `test.todo` | Needs live bridge tx generation |
| Cumulative consistency of pool frames | `test.todo` | Needs ≥3 pool-affecting events |
| UnapprovedTransfer push | `test.skip` | **Blocked**: approval governance (#940) |
| SubminimalFlush push + `subminimumTxCount` increment | `test.skip` | **Blocked**: SubminimalFlush threshold not yet confirmed |

#### Smoke

No separate smoke file needed. Schema-level bridge presence checks are covered by PR #1219.

#### E2E

Not required. Pool query and subscription coverage is fully exercised at integration level.

### TypeScript types

Stub types are defined inline in each file. Once #944 lands, consolidate:
- `BridgePoolSummary`, `BridgeTreasuryAggregate`, `BridgeTreasuryReason` → `utils/indexer/indexer-types.ts`
- `BridgePoolUpdate` → `utils/indexer/indexer-types.ts`

### Depends on
- #939 (DB schema), #940 (data populated), #941 (query infrastructure + types)
- PR #1219 (schema smoke tests)
- PR #1220 (subscription pattern reference)

### Closes / tracks
- Provides QA test coverage for https://github.com/midnightntwrk/midnight-indexer/issues/944

