### PR TITLE
perf(indexer-api): jitter and idle-backoff subscription polling, throttle keep-alive

### DIFF
--- a/indexer-api/config.yaml
+++ b/indexer-api/config.yaml
@@ -46,7 +46,10 @@ infra:
       shielded_transactions:
         batch_size: 20
         progress_update_interval: "30s"
-        keep_wallet_alive_interval: "1m"
+        # Heartbeat that keeps a subscribed wallet marked active for indexing.
+        # Must stay comfortably below the wallet-indexer's active_wallets_ttl (30m);
+        # 10m leaves a safe margin while minimising keep-alive writes.
+        keep_wallet_alive_interval: "10m"
       unshielded_transactions:
         batch_size: 20
         progress_update_interval: "30s"

--- a/indexer-api/src/infra/api/v4/subscription.rs
+++ b/indexer-api/src/infra/api/v4/subscription.rs
@@ -16,6 +16,7 @@ mod contract_action;
 mod dust_generations;
 mod dust_ledger_events;
 mod dust_nullifier_transactions;
+mod polling;
 mod shielded;
 mod shielded_nullifier_transactions;
 mod unshielded;

--- a/indexer-api/src/infra/api/v4/subscription/polling.rs
+++ b/indexer-api/src/infra/api/v4/subscription/polling.rs
@@ -1,0 +1,101 @@
+// This file is part of midnight-indexer.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Helpers shared by the periodic polling of the shielded and unshielded
+//! transaction subscriptions: interval jitter (so concurrent subscribers do not
+//! synchronise their database hits) and idle backoff (so an unchanging
+//! subscription polls less often).
+
+use chacha20poly1305::aead::{OsRng, rand_core::RngCore};
+use futures::{Stream, stream};
+use std::time::Duration;
+use tokio::time::sleep;
+
+/// Fraction by which an interval is randomly shortened or lengthened (±20%).
+const JITTER_FRACTION: f64 = 0.2; // TODO: make configurable if tuning is needed.
+
+/// Upper bound on idle backoff, expressed as a multiple of the base interval.
+const IDLE_BACKOFF_MAX_MULTIPLE: u32 = 8; // TODO: make configurable if tuning is needed.
+
+/// Apply ±[`JITTER_FRACTION`] random jitter to `base`, so that subscribers that
+/// started at the same time do not keep firing their periodic work in lockstep.
+pub(super) fn jittered(base: Duration) -> Duration {
+    let unit = f64::from(OsRng.next_u32()) / f64::from(u32::MAX);
+    let factor = 1.0 + JITTER_FRACTION * (2.0 * unit - 1.0);
+    base.mul_f64(factor)
+}
+
+/// An unbounded stream that yields `()` immediately, then after each jittered
+/// `base` interval. Like [`tokio::time::interval`] the first item fires
+/// immediately (so the first keep-alive refreshes `last_active` right away);
+/// only the subsequent, steady-state ticks carry jitter.
+pub(super) fn jittered_interval(base: Duration) -> impl Stream<Item = ()> {
+    stream::unfold(true, move |first| async move {
+        if !first {
+            sleep(jittered(base)).await;
+        }
+        Some(((), false))
+    })
+}
+
+/// Next polling interval for idle backoff: reset to `base` when the polled state
+/// changed since the previous tick, otherwise double the current interval up to
+/// a cap of [`IDLE_BACKOFF_MAX_MULTIPLE`] × `base`.
+pub(super) fn next_poll_interval(
+    current_interval: Duration,
+    base: Duration,
+    changed: bool,
+) -> Duration {
+    if changed {
+        base
+    } else {
+        (current_interval * 2).min(base * IDLE_BACKOFF_MAX_MULTIPLE)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::infra::api::v4::subscription::polling::{
+        IDLE_BACKOFF_MAX_MULTIPLE, JITTER_FRACTION, jittered, next_poll_interval,
+    };
+    use std::time::Duration;
+
+    #[test]
+    fn jittered_stays_within_bounds() {
+        let base = Duration::from_secs(30);
+        let lo = base.mul_f64(1.0 - JITTER_FRACTION);
+        let hi = base.mul_f64(1.0 + JITTER_FRACTION);
+        for _ in 0..10_000 {
+            let d = jittered(base);
+            assert!(d >= lo && d <= hi, "{d:?} not in [{lo:?}, {hi:?}]");
+        }
+    }
+
+    #[test]
+    fn backoff_resets_to_base_on_change() {
+        let base = Duration::from_secs(30);
+        assert_eq!(next_poll_interval(base * 4, base, true), base);
+    }
+
+    #[test]
+    fn backoff_doubles_when_idle_up_to_cap() {
+        let base = Duration::from_secs(30);
+        let cap = base * IDLE_BACKOFF_MAX_MULTIPLE;
+        assert_eq!(next_poll_interval(base, base, false), base * 2);
+        assert_eq!(next_poll_interval(base * 2, base, false), base * 4);
+        assert_eq!(next_poll_interval(base * 4, base, false), cap);
+        // Already at or beyond the cap stays capped.
+        assert_eq!(next_poll_interval(cap, base, false), cap);
+        assert_eq!(next_poll_interval(base * 6, base, false), cap);
+    }
+}

--- a/indexer-api/src/infra/api/v4/subscription/shielded.rs
+++ b/indexer-api/src/infra/api/v4/subscription/shielded.rs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::polling::{jittered, jittered_interval, next_poll_interval};
 use crate::{
     domain::{self, LedgerStateCache, storage::Storage},
     infra::api::{
@@ -37,8 +38,7 @@ use indexer_common::domain::{Subscriber, WalletIndexed};
 use log::{debug, warn};
 use std::{future::ready, marker::PhantomData, pin::pin};
 use stream_cancel::{StreamExt as _, Trigger, Tripwire};
-use tokio::time::interval;
-use tokio_stream::wrappers::IntervalStream;
+use tokio::time::sleep;
 use uuid::Uuid;
 
 /// An event of the shielded transactions subscription.
@@ -185,7 +185,7 @@ where
             .get_subscription_config()
             .shielded_transactions
             .keep_wallet_alive_interval;
-        let keep_wallet_active = IntervalStream::new(interval(keep_wallet_alive_interval))
+        let keep_wallet_active = jittered_interval(keep_wallet_alive_interval)
             .then(move |_| async move { storage.keep_wallet_active(wallet_id).await })
             .map_err(|error| ApiError::server("keep wallet active", error));
         let events = stream::select(events.map_ok(Some), keep_wallet_active.map_ok(|_| None))
@@ -334,39 +334,45 @@ where
     S: Storage,
 {
     let storage = cx.get_storage::<S>();
-    let progress_update_interval = cx
+    let base = cx
         .get_subscription_config()
         .shielded_transactions
         .progress_update_interval;
 
-    let intervals = IntervalStream::new(interval(progress_update_interval));
-    intervals.then(move |_| make_progress_update(wallet_id, storage))
+    // Emit progress immediately, then re-poll after a jittered interval that
+    // backs off while the indices are unchanged (idle) and resets when they move.
+    let mut current_interval = base;
+    let mut last_indices = None;
+    try_stream! {
+        loop {
+            let indices = storage
+                .get_highest_zswap_end_indices(wallet_id)
+                .await
+                .map_err_into_server_error(|| "get highest indices")?;
+            current_interval =
+                next_poll_interval(current_interval, base, last_indices.as_ref() != Some(&indices));
+            last_indices = Some(indices);
+            yield to_progress(indices);
+            sleep(jittered(current_interval)).await;
+        }
+    }
 }
 
-async fn make_progress_update<S>(
-    wallet_id: Uuid,
-    storage: &S,
-) -> ApiResult<ShieldedTransactionsProgress>
-where
-    S: Storage,
-{
-    let (highest, highest_checked, highest_relevant) = storage
-        .get_highest_zswap_end_indices(wallet_id)
-        .await
-        .map_err_into_server_error(|| "get highest indices")?;
-
+fn to_progress(
+    (highest, highest_checked, highest_relevant): (Option<u64>, Option<u64>, Option<u64>),
+) -> ShieldedTransactionsProgress {
     let highest_zswap_end_index = highest.unwrap_or_default();
     let highest_checked_zswap_end_index = highest_checked.unwrap_or_default();
     let highest_relevant_zswap_end_index = highest_relevant.unwrap_or_default();
 
-    Ok(ShieldedTransactionsProgress {
+    ShieldedTransactionsProgress {
         highest_zswap_end_index,
         highest_end_index: highest_zswap_end_index,
         highest_checked_zswap_end_index,
         highest_checked_end_index: highest_checked_zswap_end_index,
         highest_relevant_zswap_end_index,
         highest_relevant_end_index: highest_relevant_zswap_end_index,
-    })
+    }
 }
 
 async fn get_next_transaction<E>(

--- a/indexer-api/src/infra/api/v4/subscription/unshielded.rs
+++ b/indexer-api/src/infra/api/v4/subscription/unshielded.rs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::polling::{jittered, next_poll_interval};
 use crate::{
     domain::{self, storage::Storage},
     infra::api::{
@@ -26,13 +27,12 @@ use async_stream::try_stream;
 use derive_more::Debug;
 use drop_stream::DropStreamExt;
 use fastrace::{Span, future::FutureExt, prelude::SpanContext, trace};
-use futures::{Stream, StreamExt, TryStreamExt};
+use futures::{Stream, TryStreamExt};
 use indexer_common::domain::{NetworkId, Subscriber, UnshieldedUtxoIndexed};
 use log::{debug, warn};
 use std::{future::ready, marker::PhantomData, pin::pin};
 use stream_cancel::{StreamExt as _, Trigger, Tripwire};
-use tokio::time::interval;
-use tokio_stream::wrappers::IntervalStream;
+use tokio::time::sleep;
 
 /// An event of the unshielded transactions subscription.
 #[derive(Debug, Union)]
@@ -270,33 +270,35 @@ where
     S: Storage,
 {
     let storage = cx.get_storage::<S>();
-    let progress_update_interval = cx
+    let base = cx
         .get_subscription_config()
         .unshielded_transactions
         .progress_update_interval;
 
-    let intervals = IntervalStream::new(interval(progress_update_interval));
-    intervals.then(move |_| make_progress_update(address, storage))
-}
-
-async fn make_progress_update<S>(
-    address: indexer_common::domain::UnshieldedAddress,
-    storage: &S,
-) -> ApiResult<UnshieldedTransactionsProgress>
-where
-    S: Storage,
-{
-    // Calculate progress information using transaction IDs.
-    let highest_transaction_id = storage
-        .get_highest_transaction_id_for_unshielded_address(address)
-        .await
-        .map_err_into_server_error(|| "get highest transaction ID for address")?;
-
-    let highest_transaction_id = highest_transaction_id.unwrap_or(0);
-
-    Ok(UnshieldedTransactionsProgress {
-        highest_transaction_id,
-    })
+    // Emit progress immediately, then re-poll after a jittered interval that
+    // backs off while the highest transaction ID is unchanged (idle) and resets
+    // when it moves.
+    let mut current_interval = base;
+    let mut last_highest_transaction_id = None;
+    try_stream! {
+        loop {
+            let highest_transaction_id = storage
+                .get_highest_transaction_id_for_unshielded_address(address)
+                .await
+                .map_err_into_server_error(|| "get highest transaction ID for address")?
+                .unwrap_or(0);
+            current_interval = next_poll_interval(
+                current_interval,
+                base,
+                last_highest_transaction_id != Some(highest_transaction_id),
+            );
+            last_highest_transaction_id = Some(highest_transaction_id);
+            yield UnshieldedTransactionsProgress {
+                highest_transaction_id,
+            };
+            sleep(jittered(current_interval)).await;
+        }
+    }
 }
 
 async fn get_next_transaction<E>(


### PR DESCRIPTION
## Summary

The shielded and unshielded subscriptions poll the database on fixed timers (progress every 30s, a `keep_wallet_active` heartbeat every 1m) regardless of activity, so load scales linearly with subscribers and they tend to hit the DB in lockstep. This reduces that pressure; GraphQL surface unchanged.

## Changes

New `subscription/polling.rs` helpers: ±20% `jittered` (desync subscribers), `jittered_interval` (immediate first tick, then jittered), and `next_poll_interval` (idle backoff: base on change, else double up to 8×).

- Progress polling (shielded + unshielded): emit immediately, then re-poll on a jittered interval that backs off while the indices are unchanged and resets when they move — an idle subscription polls far less often.
- `keep_wallet_active` heartbeat jittered, default raised 1m → 10m. The wallet-indexer marks wallets inactive after `active_wallets_ttl` (30m), so 10m keeps a ~3× margin while cutting these writes ~10× (documented in config.yaml).

First progress emit stays immediate; when idle it slows to ≤8× base (~4m) and snaps back on change. Schema unchanged.

## Testing
Verified live on a local stack: immediate first emit, idle-backoff gaps doubling 28.8 → 51.8 → 100.7s, keep-alive no longer firing every minute.