### PR TITLE
test: provide QA test evidence for indexer 4.3.3 release

### DIFF
--- a/qa/tests/evidence/4.3.3/README.md
+++ b/qa/tests/evidence/4.3.3/README.md
@@ -1,0 +1,65 @@
+# Indexer QA Test Execution and Report Summary — 4.3.3
+
+## Overview
+
+| Field | Value |
+|---|---|
+| Date | 5 June 2026 |
+| QA Contact | Giuseppe Salvatore (giuseppe.salvatore@shielded.io) |
+| Indexer version | 4.3.3 |
+| Node version | 1.0.0 |
+| Toolkit version | 1.0.0 |
+| QA Sign-off | ✅ |
+
+## Test Execution Summary
+
+```
+┌─────────────┬─────────────┬────────┬────────┬─────────┬───────┐
+│ Environment │ Suite       │ Passed │ Failed │ Skipped │ Total │
+├─────────────┼─────────────┼────────┼────────┼─────────┼───────┤
+│ undeployed  │ e2e         │     38 │      0 │       0 │    38 │
+│ qanet       │ smoke       │     18 │      0 │       1 │    19 │
+│ qanet       │ integration │    168 │      0 │       2 │   170 │
+├─────────────┼─────────────┼────────┼────────┼─────────┼───────┤
+│ Total       │             │    224 │      0 │       3 │   227 │
+└─────────────┴─────────────┴────────┴────────┴─────────┴───────┘
+```
+
+All suites passed; no failures. The skipped/todo entries are the suites' own
+conditional cases, not errors.
+
+## Test Report Details
+
+For details and the source result files used to generate this retport please look at the env folders
+
+
+## Test Execution Guide
+
+All commands are executed from `qa/tests/`. For hosted environments (e.g.
+`qanet`), `FUNDING_SEED_<ENV>` is required and must be a wallet that has
+performed **both** shielded and unshielded transactions. For undeployed e2e the funding seed is not required, as the seeds are known.
+
+```bash
+# undeployed — e2e
+export TARGET_ENV=undeployed
+export INDEXER_TAG=4.3.3
+export NODE_TAG=1.0.0
+export NODE_TOOLKIT_TAG=1.0.0
+export XRAY_COMPONENT=indexer
+export VITEST_MAX_WORKERS=4
+yarn test:e2e
+
+# qanet — smoke
+export TARGET_ENV=qanet
+export FUNDING_SEED_QANET=<wallet seed with shielded + unshielded txs>
+export XRAY_COMPONENT=indexer
+export VITEST_MAX_WORKERS=4
+yarn test:smoke
+
+# qanet — integration
+export TARGET_ENV=qanet
+export FUNDING_SEED_QANET=<wallet seed with shielded + unshielded txs>
+export XRAY_COMPONENT=indexer
+export VITEST_MAX_WORKERS=4
+yarn test:integration
+```

--- a/qa/tests/evidence/4.3.3/qanet/indexer-test-report.md
+++ b/qa/tests/evidence/4.3.3/qanet/indexer-test-report.md
@@ -1,0 +1,434 @@
+# Indexer Test Execution Report
+
+## Run Details
+
+| Field | Value |
+| --- | --- |
+| Component Under Test | Indexer / Node |
+| Indexer Version | 4.3.3 |
+| Node Version | 1.0.0 |
+| Test Suites | smoke, integration |
+| Tests | Indexer GraphQL API and integration with Node |
+| Environment | qanet (green instance) |
+| Date | Friday 5th Jun 2026 |
+| QA Contact | Giuseppe Salvatore (giuseppe.salvatore@shielded.io) |
+
+## Summary
+
+| Suite | Test Files | Passed | Failed | Skipped | Total | Duration | Run at |
+| --- | --- | ---: | ---: | ---: | ---: | --- | --- |
+| smoke | 3 passed, 1 skipped (4) | 18 | 0 | 1 | 19 | 1.53s | 10:07 PM BST |
+| integration | 19 passed (19) | 168 | 0 | 2 | 170 | 29.04s | 10:07 PM BST |
+| **Total** | | **186** | **0** | **3** | **189** | | |
+
+> Legend: ✓ passed · ✗ failed · ↓ skipped.
+
+## Smoke results
+
+### Graphql healthchecks
+
+File name: `tests/smoke/graphql-healthchecks.test.ts`
+
+#### Graphql Health Checks
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | an introspection message sent to the websocket channel, should return the supported graphql schema | 560 ms |
+| ✓ | an introspection message sent to the websocket channel, should return an error, given the depth of the query is > 15 | 547 ms |
+| ✓ | an introspection request sent to the http channel, should return the supported graphql schema | 129 ms |
+| ✓ | an introspection request sent to the http channel, should return an error, given the depth of the query is > 15 | 69 ms |
+
+### Graphql schema change
+
+File name: `tests/smoke/graphql-schema-change.test.ts`
+
+#### GraphQL Schema Stability Check
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ↓ | should not change the schema unexpectedly | — |
+
+### Graphql schema deprecations
+
+File name: `tests/smoke/graphql-schema-deprecations.test.ts`
+
+#### Graphql Schema Deprecations
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | RegularTransaction.merkleTreeRoot, should be marked deprecated with reason "Use zswapMerkleTreeRoot instead" | 95 ms |
+| ✓ | RegularTransaction.startIndex, should be marked deprecated with reason "Use zswapStartIndex instead" | 67 ms |
+| ✓ | RegularTransaction.endIndex, should be marked deprecated with reason "Use zswapEndIndex instead" | 22 ms |
+| ✓ | RelevantTransaction.collapsedMerkleTree, should be marked deprecated with reason "Use zswapCollapsedUpdate instead" | 20 ms |
+| ✓ | ShieldedTransactionsProgress.highestEndIndex, should be marked deprecated with reason "Use highestZswapEndIndex instead" | 24 ms |
+| ✓ | ShieldedTransactionsProgress.highestCheckedEndIndex, should be marked deprecated with reason "Use highestCheckedZswapEndIndex instead" | 24 ms |
+| ✓ | ShieldedTransactionsProgress.highestRelevantEndIndex, should be marked deprecated with reason "Use highestRelevantZswapEndIndex instead" | 23 ms |
+| ✓ | RegularTransaction.fees, should be marked deprecated with reason "Use fee instead" | 21 ms |
+| ✓ | TransactionFees.estimatedFees, should be marked deprecated with reason "Use paidFees instead" | 21 ms |
+
+### Service healthchecks
+
+File name: `tests/smoke/service-healthchecks.test.ts`
+
+#### Service Health Checks
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a request to the /ready endpoint, should return a 200 status code OK | 91 ms |
+| ✓ | a request to an unrecognised path /api/v3/__regression_unknown_path, should not 308 to a version-double-prefixed Location | 53 ms |
+| ✓ | a request to an unrecognised path /api/v3/__regression_unknown_path, should terminate when redirects are followed | 22 ms |
+| ✓ | a request to an unrecognised path /api/v4/__regression_unknown_path, should not 308 to a version-double-prefixed Location | 20 ms |
+| ✓ | a request to an unrecognised path /api/v4/__regression_unknown_path, should terminate when redirects are followed | 20 ms |
+
+## Integration results
+
+### Block queries
+
+File name: `tests/integration/basic/queries/block-queries.test.ts`
+
+#### Block Queries
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a block query without parameters, should return the latest known block | 155 ms |
+| ✓ | a block query without parameters, should respond with a block according to the requested schema | 33 ms |
+| ✓ | a block query by hash, should return the block with that hash, given that block exists | 55 ms |
+| ✓ | a block query by hash, should return blocks according to the requested schema | 68 ms |
+| ✓ | a block query by hash, should return a null block, given a block with that hash doesn't exist | 19 ms |
+| ✓ | a block query by hash, should return an error, when the hash is invalid (malformed) | 87 ms |
+| ✓ | a block query by height, should return the block with that height, given a valid height | 43 ms |
+| ✓ | a block query by height, should return a blocks according to the requested schema | 44 ms |
+| ✓ | a block query by height, should return the genesis block, given height=0 is requested | 483 ms |
+| ✓ | a block query by height, should return an empty body answer, given that block height requested is the maximum available height | 21 ms |
+| ✓ | a block query by height, should return an error, given an invalid height | 51 ms |
+| ✓ | a block query by height and hash, should return an error, as only one parameter at a time can be used | 64 ms |
+
+#### Genesis Block
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a block query to the genesis block, should contain transactions with pre-fund wallet utxos | 547 ms |
+| ✓ | a block query to the genesis block, should contain utxos related to exactly 4 pre-fund wallets | 146 ms |
+| ✓ | a block query to the genesis block, should contain utxos with exactly 1 token type | 118 ms |
+| ✓ | a block query to the genesis block, should contain utxos sorted by outputIndex in ascending order | 98 ms |
+| ✓ | a block query to the genesis block, should contain valid index ranges on regular transactions | 115 ms |
+
+### Contract queries
+
+File name: `tests/integration/basic/queries/contract-queries.test.ts`
+
+#### Contract Queries
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a contract query by address, should return success as they are valid contract addresses | 220 ms |
+| ✓ | a contract query by address, should return the most recent action for a contract with multiple actions | 54 ms |
+| ✓ | a contract query by address, should return null when contract with that address does not exist | 29 ms |
+| ✓ | a contract query by address, should return an error for malformed addresses | 288 ms |
+| ✓ | a contract query by address and offset, should return the correct action using exact block hash where it was included | 26 ms |
+| ✓ | a contract query by address and offset, should return the latest state using a future block hash | 43 ms |
+| ✓ | a contract query by address and offset, should respond with a contract action according to the expected schema | 27 ms |
+| ✓ | a contract query by address and offset, should return the correct action using exact block height where it was included | 29 ms |
+| ✓ | a contract query by address and offset, should return the latest state using a future block height | 35 ms |
+| ✓ | a contract query by address and offset, should return the most recent contract action for that address before the specified block | 56 ms |
+| ✓ | a contract query by address and offset, should return null when contract with valid address and valid offset does not exist | 19 ms |
+| ✓ | a contract query by address and offset, should return null when contract with valid address and non-existing hash does not exist | 25 ms |
+| ✓ | a contract query by address and offset, should return error when contract with invalid address and valid hash | 14 ms |
+| ✓ | a contract query by address and offset, should return error when contract with invalid address and non-existing hash | 18 ms |
+| ✓ | a contract query by address and offset, should return error when contract with valid address and invalid hash | 15 ms |
+| ✓ | a contract query by address and offset, should return error when contract with invalid address and invalid hash | 81 ms |
+| ✓ | a contract query by address and offset, should return null when contract with valid address and valid height does not exist | 25 ms |
+| ✓ | a contract query by address and offset, should return null when contract with valid address and non-existing height does not exist | 30 ms |
+| ✓ | a contract query by address and offset, should return error when contract with invalid address and valid height | 15 ms |
+| ✓ | a contract query by address and offset, should return error when contract with invalid address and invalid height | 50 ms |
+| ✓ | a contract query by address and offset, should return error for negative height | 16 ms |
+| ✓ | a contract query by address and offset, should return error for non-integer height | 15 ms |
+| ✓ | a contract query by address and offset, should return error for extremely large height | 16 ms |
+| ✓ | a contract query by address and offset, should return null when using a block hash from before the action existed | 474 ms |
+
+### Dust commitment update queries
+
+File name: `tests/integration/basic/queries/dust-commitment-update-queries.test.ts`
+
+#### Dust Commitment Merkle Tree Update Queries
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a collapsed update query with valid index range, should return a collapsed update for a valid index range | 102 ms |
+| ✓ | a collapsed update query with valid index range, should respond with a collapsed update according to the expected schema | 106 ms |
+| ✓ | a collapsed update query with valid index range, should return a collapsed update for the full genesis dust range | 614 ms |
+| ✓ | a collapsed update query with equal start and end indices, should return a valid update when startIndex equals endIndex | 19 ms |
+| ✓ | a collapsed update query idempotency, should return identical results for the same query parameters | 51 ms |
+| ✓ | a collapsed update query with invalid index range, should return an error when startIndex is greater than endIndex | 24 ms |
+| ✓ | a collapsed update query with invalid index range, should return an error when indices are negative | 18 ms |
+| ✓ | a collapsed update query with invalid index range, should return an error when endIndex is beyond the indexed range | 26 ms |
+
+### Dust generation update queries
+
+File name: `tests/integration/basic/queries/dust-generation-update-queries.test.ts`
+
+#### Dust Generation Merkle Tree Update Queries
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a collapsed update query with valid index range, should return a collapsed update for a valid index range | 97 ms |
+| ✓ | a collapsed update query with valid index range, should respond with a collapsed update according to the expected schema | 64 ms |
+| ✓ | a collapsed update query with valid index range, should return a collapsed update for the full genesis dust range | 184 ms |
+| ✓ | a collapsed update query with equal start and end indices, should return a valid update when startIndex equals endIndex | 18 ms |
+| ✓ | a collapsed update query idempotency, should return identical results for the same query parameters | 47 ms |
+| ✓ | a collapsed update query with invalid index range, should return an error when startIndex is greater than endIndex | 18 ms |
+| ✓ | a collapsed update query with invalid index range, should return an error when indices are negative | 18 ms |
+| ✓ | a collapsed update query with invalid index range, should return an error when endIndex is beyond the indexed range | 890 ms |
+
+### Dust generations queries
+
+File name: `tests/integration/basic/queries/dust-generations-queries.test.ts`
+
+#### Dust Generations Queries
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a dust generations query with a valid Cardano reward address, should return dust generations for a registered address | 104 ms |
+| ✓ | a dust generations query with a valid Cardano reward address, should respond with dust generations according to the expected schema | 80 ms |
+| ✓ | a dust generations query with a valid Cardano reward address, should return registrations with valid fields for a registered address | 27 ms |
+| ✓ | a dust generations query with multiple addresses, should return dust generations for multiple addresses | 25 ms |
+| ✓ | a dust generations query with non-registered address, should return empty registrations for a non-registered address | 28 ms |
+| ✓ | a dust generations query with invalid input, should return an empty result for an empty addresses array | 19 ms |
+| ✓ | a dust generations query with invalid input, should return an error for a malformed address | 23 ms |
+| ✓ | a dustGenerations query with a multi-UTXO stake key (#926), should aggregate nightBalance across all backing cNIGHT UTXOs | 54 ms |
+| ✓ | backwards compatibility with dustGenerationStatus, should return consistent data from both endpoints for a registered address | 74 ms |
+
+### Dust queries
+
+File name: `tests/integration/basic/queries/dust-queries.test.ts`
+
+#### Dust Generation Status Queries
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a dust generation status query with a valid Cardano reward address, should respond with a dust generation status response according to the requested schema | 91 ms |
+| ✓ | a dust generation status query with a valid Cardano reward address, should report registered status for a registered Cardano reward address | 76 ms |
+| ✓ | a dust generation status query with a valid Cardano reward address, should give the DUST destination address for the expected network when Cardano reward address is registered | 24 ms |
+| ✓ | a dust generation status query with a valid Cardano reward address, should correctly indicate registration status for a non-registered key | 23 ms |
+| ✓ | a dust generation status query with a valid Cardano reward address, should indicate zero generation for registered address without cNIGHT balance | 25 ms |
+| ✓ | a dust generation status query with a valid Cardano reward address, should report the correct value of max capacity for registered address with cNIGHT | 41 ms |
+| ✓ | a dust generation status query with a valid Cardano reward address, should correctly indicate deregistered status for a previously registered Cardano reward address | 22 ms |
+| ✓ | a dust generation status query with multiple valid Cardano reward addresses, should return statuses for multiple Cardano reward addresses in order | 80 ms |
+| ✓ | a dust generation status query with multiple valid Cardano reward addresses, should respond with dust generation statuses according to the requested schema for multiple addresses | 35 ms |
+| ✓ | a dust generation status query with multiple valid Cardano reward addresses, should return an error given the number of addresses is greater than 10 | 19 ms |
+| ✓ | a dust generation status query with malformed reward addresses, should return an error when the address is in plain hex string format | 17 ms |
+| ✓ | a dust generation status query with empty list of reward addresses, should return an empty list of dust generation statuses | 17 ms |
+| ✓ | a dust generation status query with a Cardano payment address, should return an error as only Cardano reward addresses are supported | 15 ms |
+| ✓ | a dust generation status query with a Cardano reward address not meant for this network, should return an error reporting the target network mismatch | 19 ms |
+| ✓ | a dust generation status query with duplicate reward addresses, should handle duplicate Cardano reward addresses appropriately | 33 ms |
+
+### Transaction queries
+
+File name: `tests/integration/basic/queries/transaction-queries.test.ts`
+
+#### Transaction Queries
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a transaction query by hash, should return the transaction with that hash, given that transaction exists | 1289 ms |
+| ✓ | a transaction query by hash, should return an empty transaction list, given a transaction with that hash doesn't exist | 23 ms |
+| ✓ | a transaction query by hash, should return an error, given a hash is invalid (malformed) | 80 ms |
+| ✓ | a transaction query by hash, should return an error when called with an empty offset object | 16 ms |
+| ✓ | a transaction query by identifier, should return the transaction with that identifier, given that transaction exists | 1363 ms |
+| ✓ | a transaction query by identifier, should return an empty list of transactions, given a transaction with that identifier doesn't exist | 65 ms |
+| ✓ | a transaction query by identifier, should return an error, given an invalid identifier | 48 ms |
+| ✓ | a transaction query by hash and identifier, should return an error, as only one parameter at a time can be used | 16 ms |
+
+#### Genesis Transactions
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | transaction queries to the genesis block transactions, should return utxos related to 4 pre-fund wallets | 1304 ms |
+| ✓ | transaction queries to the genesis block transactions, should return utxos with 1 token type | 793 ms |
+| ✓ | transaction queries to the genesis block transactions, should return utxos sorted by outputIndex in ascending order | 845 ms |
+| ✓ | transaction queries to the genesis block transactions, should return system transactions when queried by hash | 1012 ms |
+| ✓ | transaction queries to the genesis block transactions, should not contain RegularTransaction-specific fields on system transactions | 796 ms |
+| ✓ | schema validation, should respond with full transaction data according to the expected schema | 6 ms |
+| ✓ | schema validation, should respond with system transactions according to the expected schema | 0 ms |
+| ✓ | schema validation, should contain both regular and system transactions | 0 ms |
+| ✓ | schema validation, should respond with regular transactions according to the expected schema | 2 ms |
+| ✓ | schema validation, should respond with nested ledger events and unshielded outputs according to the expected schema | 1 ms |
+
+### Zswap collapsed update queries
+
+File name: `tests/integration/basic/queries/zswap-collapsed-update-queries.test.ts`
+
+#### Zswap Merkle Tree Collapsed Update Queries
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a collapsed update query with valid index range, should return a collapsed update for a valid index range | 87 ms |
+| ✓ | a collapsed update query with valid index range, should respond with a collapsed update according to the expected schema | 69 ms |
+| ✓ | a collapsed update query with valid index range, should return a collapsed update for the full genesis zswap range | 171 ms |
+| ✓ | a collapsed update query with equal start and end indices, should return a valid update when startIndex equals endIndex | 23 ms |
+| ✓ | a collapsed update query idempotency, should return identical results for the same query parameters | 42 ms |
+| ✓ | a collapsed update query with invalid index range, should return an error when startIndex is greater than endIndex | 17 ms |
+| ✓ | a collapsed update query with invalid index range, should return an error when indices are negative | 15 ms |
+| ✓ | a collapsed update query with invalid index range, should return an error when endIndex is beyond the indexed range | 22 ms |
+
+### Block subscriptions
+
+File name: `tests/integration/basic/subscriptions/block-subscriptions.test.ts`
+
+#### Block Subscriptions
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a subscription to block updates without parameters, should stream blocks starting from the latest block | 4513 ms |
+| ✓ | a subscription to block updates without parameters, should stream blocks adhering to the expected schema | 653 ms |
+| ✓ | a subscription to block updates by hash, should stream blocks starting from the block with that hash, given that hash exists | 1227 ms |
+| ✓ | a subscription to block updates by hash, should return an error message, given that hash doesn't exist | 597 ms |
+| ✓ | a subscription to block updates by hash, should return an error message, given that hash is invalid | 594 ms |
+| ✓ | a subscription to block updates by height, should stream blocks from the block with that height, given that height exists | 682 ms |
+| ✓ | a subscription to block updates by height, should return an error message, given that height is higher than the latest block height | 620 ms |
+| ✓ | a subscription to block updates by height, should return an error message, given that height is invalid | 592 ms |
+| ✓ | a subscription to block updates by height and hash, should return an error message, as only one parameter at a time can be used | 585 ms |
+| ↓ | regular transaction fees, should report ledger paidFees and estimatedFees on regular transactions | — |
+
+### Contract subscriptions
+
+File name: `tests/integration/basic/subscriptions/contract-subscriptions.test.ts`
+
+#### Contract Action Subscriptions
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a subscription to contract action updates without parameters, should stream contract actions from the latest available block | 612 ms |
+| ✓ | a subscription to contract action updates without parameters, should stream contract actions adhering to the expected schema | 598 ms |
+| ✓ | a subscription to contract action updates with block hash offset, should stream historical and new contract actions from a specific block hash | 588 ms |
+
+### Dust generations subscriptions
+
+File name: `tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts`
+
+#### Dust Generations Subscription
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | streaming dust generation entries, should stream dust generation events for a valid dust address in bech32m format | 1425 ms |
+| ✓ | subscription error handling, should return an error for an invalid dust address | 548 ms |
+| ✓ | subscription error handling, should return an error for a valid address that is meant for another networkid | 694 ms |
+| ✓ | subscription error handling, should return an error for a valid dust address passed in hex format | 546 ms |
+| ✓ | transactionHash on dust generation events (#1114), first item transactionHash resolves via transactions(offset) | 1021 ms |
+
+### Dust ledger subscriptions
+
+File name: `tests/integration/basic/subscriptions/dust-ledger-subscriptions.test.ts`
+
+#### Dust Ledger Event Subscriptions
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a subscription to dust ledger events without offset (default replay), streams events in ledger order | 597 ms |
+| ✓ | subscription with explicit offset, streams events in ledger order starting from the specified ID | 598 ms |
+| ✓ | subscription with explicit offset, validates historical dust events against schema | 588 ms |
+| ✓ | subscription error handling, should return an error for unknown field | 543 ms |
+| ✓ | subscription error handling, rejects negative offset ID with an error | 544 ms |
+
+### Dust nullifier subscriptions
+
+File name: `tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts`
+
+#### Dust Nullifier Transactions Subscription
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | streaming dust nullifier transactions with block range, should stream transactions within a block range and complete | 648 ms |
+| ✓ | subscription error handling, should return an error for empty nullifier prefixes | 547 ms |
+| ✓ | subscription error handling, should return an error when fromBlock is greater than toBlock | 548 ms |
+| ✓ | transactionHash on dust nullifier events (#1114), first event transactionHash resolves via transactions(offset) | 687 ms |
+
+### Shielded nullifier subscriptions
+
+File name: `tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts`
+
+#### Shielded Nullifier Transactions Subscription
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | streaming shielded nullifier transactions with block range, should stream transactions within a block range and complete | 644 ms |
+| ✓ | subscription error handling, should return an error for empty nullifier prefixes | 547 ms |
+| ✓ | subscription error handling, should return an error for an empty-string nullifier prefix element | 548 ms |
+| ✓ | subscription error handling, should return an error when fromBlock is greater than toBlock | 547 ms |
+| ↓ | transactionHash on shielded nullifier events (#1114), first event transactionHash resolves via transactions(offset) | 631 ms |
+
+### Shielded transaction subscriptions
+
+File name: `tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts`
+
+#### Shielded Transaction Subscriptions
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | opening a session with viewing key, should return a session ID, given a valid viewing key | 617 ms |
+| ✓ | opening a session with viewing key, should return an error, given an unsupported hex format viewing key | 548 ms |
+| ✓ | opening a session with viewing key, should return an error, given an invalid viewing key | 543 ms |
+| ✓ | opening a session with viewing key, should return an error, given a valid viewing key meant for a different network | 908 ms |
+| ✓ | closing a session with session ID, should terminate the session successfully, given a valid session ID | 676 ms |
+| ✓ | closing a session with session ID, should return an error, given an invalid session ID | 548 ms |
+| ✓ | a subscription to wallet updates providing viewing key only, should stream wallet events starting from the beginning, given there are relevant transactions | 2611 ms |
+| ✓ | a subscription to wallet updates providing viewing key only, should stream shielded transaction events adhering to the expected schema | 3603 ms |
+| ✓ | a subscription to wallet updates providing viewing key only, should be able to use highestZswapEndIndex from progress event in collapsed update query | 716 ms |
+| ✓ | a subscription to wallet updates providing viewing key only, should reject shieldedTransactions subscription when using expired session ID | 711 ms |
+
+### Subscription quotas
+
+File name: `tests/integration/basic/subscriptions/subscription-quotas.test.ts`
+
+#### Subscription Quotas (HAL-03 / SSE-196)
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | per-connection concurrent subscription cap, should reject a subscription beyond the per-connection cap | 1562 ms |
+| ✓ | per-connection concurrent subscription cap, should free a slot when an active subscription is closed | 2553 ms |
+
+### Unshielded transaction subscriptions
+
+File name: `tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts`
+
+#### Unshielded Transaction Subscriptions
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a subscription to unshielded transaction events by address, should stream unshielded transaction events related to that address, given that address has transactions | 498 ms |
+| ✓ | a subscription to unshielded transaction events by address, should stream unshielded transaction events up to highest transaction id | 5046 ms |
+| ✓ | a subscription to unshielded transaction events by address, should stream unshielded transaction events that adhere to the expected schema | 130 ms |
+| ✓ | a subscription to unshielded transaction events by address, should only return a transaction progress message with highest transaction = 0, given that address does not have transactions | 5049 ms |
+| ✓ | a subscription to unshielded transaction events by address, should return an error message, given the address provided is in hex format | 14 ms |
+| ✓ | a subscription to unshielded transaction events by address, should return an error message, given the address provided is for another network | 558 ms |
+| ✓ | a subscription to unshielded transaction events by address and transaction id, should return a stream of transactions containing that address, starting from transaction id = 0 | 5562 ms |
+| ✓ | a subscription to unshielded transaction events by address and transaction id, should return an error message, given the transaction id provided is negative | 70 ms |
+| ✓ | a subscription to unshielded transaction events by address and transaction id, should only return a transaction progress message without streaming transactions, given that the transaction id provided is bigger number | 5060 ms |
+| ✓ | a subscription to unshielded transaction events by address and transaction id, should start a transaction stream from the given transaction id | 5296 ms |
+| ✓ | a subscription to unshielded transaction events by address and transaction id, should return an error message, given the address is provided in hex format | 61 ms |
+
+### Wallet connect options
+
+File name: `tests/integration/basic/subscriptions/wallet-connect-options.test.ts`
+
+#### Wallet Connect Options (StartIndex)
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | opening a session with startIndex, should accept startIndex = 0 (no-op equivalent of unset options) | 612 ms |
+| ✓ | opening a session with startIndex, should skip historical scan when startIndex equals the current tip | 1216 ms |
+| ✓ | opening a session with startIndex, should accept startIndex past the current tip (fast-forward) | 1222 ms |
+
+### Zswap events subscriptions
+
+File name: `tests/integration/basic/subscriptions/zswap-events-subscriptions.test.ts`
+
+#### Zswap Ledger Event Subscriptions
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a subscription to zswap ledger events without offset (default replay), streams events in ledger order | 590 ms |
+| ✓ | subscription with explicit offset, streams events starting from the specified ID | 634 ms |
+| ✓ | subscription with explicit offset, validates historical zswap events against schema | 578 ms |
+| ✓ | subscription error handling, should return an error for unknown field | 548 ms |
+| ✓ | subscription error handling, rejects negative offset ID with an error | 548 ms |

--- a/qa/tests/evidence/4.3.3/qanet/integration/junit-test-results.xml
+++ b/qa/tests/evidence/4.3.3/qanet/integration/junit-test-results.xml
@@ -1,0 +1,383 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="170" failures="0" errors="0" time="93.317713562">
+    <testsuite name="tests/integration/basic/queries/block-queries.test.ts" timestamp="2026-06-05T08:08:08.274Z" hostname="black-box" tests="17" failures="0" errors="0" skipped="0" time="2.149565046">
+        <testcase classname="tests/integration/basic/queries/block-queries.test.ts" name="block queries &gt; a block query without parameters &gt; should return the latest known block" time="0.155339601">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/block-queries.test.ts" name="block queries &gt; a block query without parameters &gt; should respond with a block according to the requested schema" time="0.033480857">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/block-queries.test.ts" name="block queries &gt; a block query by hash &gt; should return the block with that hash, given that block exists" time="0.054588356">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/block-queries.test.ts" name="block queries &gt; a block query by hash &gt; should return blocks according to the requested schema" time="0.068118479">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/block-queries.test.ts" name="block queries &gt; a block query by hash &gt; should return a null block, given a block with that hash doesn&apos;t exist" time="0.019108562">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/block-queries.test.ts" name="block queries &gt; a block query by hash &gt; should return an error, when the hash is invalid (malformed)" time="0.086596721">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/block-queries.test.ts" name="block queries &gt; a block query by height &gt; should return the block with that height, given a valid height" time="0.043027654">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/block-queries.test.ts" name="block queries &gt; a block query by height &gt; should return a blocks according to the requested schema" time="0.043765278">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/block-queries.test.ts" name="block queries &gt; a block query by height &gt; should return the genesis block, given height=0 is requested" time="0.483089725">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/block-queries.test.ts" name="block queries &gt; a block query by height &gt; should return an empty body answer, given that block height requested is the maximum available height" time="0.020868097">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/block-queries.test.ts" name="block queries &gt; a block query by height &gt; should return an error, given an invalid height" time="0.050968177">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/block-queries.test.ts" name="block queries &gt; a block query by height and hash &gt; should return an error, as only one parameter at a time can be used" time="0.06400083">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/block-queries.test.ts" name="genesis block &gt; a block query to the genesis block &gt; should contain transactions with pre-fund wallet utxos" time="0.547456636">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/block-queries.test.ts" name="genesis block &gt; a block query to the genesis block &gt; should contain utxos related to exactly 4 pre-fund wallets" time="0.146113099">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/block-queries.test.ts" name="genesis block &gt; a block query to the genesis block &gt; should contain utxos with exactly 1 token type" time="0.118339815">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/block-queries.test.ts" name="genesis block &gt; a block query to the genesis block &gt; should contain utxos sorted by outputIndex in ascending order" time="0.098293972">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/block-queries.test.ts" name="genesis block &gt; a block query to the genesis block &gt; should contain valid index ranges on regular transactions" time="0.114925834">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/integration/basic/queries/contract-queries.test.ts" timestamp="2026-06-05T08:08:08.278Z" hostname="black-box" tests="24" failures="0" errors="0" skipped="0" time="1.621202132">
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address &gt; should return success as they are valid contract addresses" time="0.220255409">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address &gt; should return the most recent action for a contract with multiple actions" time="0.053565814">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address &gt; should return null when contract with that address does not exist" time="0.029029857">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address &gt; should return an error for malformed addresses" time="0.287682202">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should return the correct action using exact block hash where it was included" time="0.026438892">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should return the latest state using a future block hash" time="0.04317875">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should respond with a contract action according to the expected schema" time="0.026906515">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should return the correct action using exact block height where it was included" time="0.028784554">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should return the latest state using a future block height" time="0.035478631">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should return the most recent contract action for that address before the specified block" time="0.055840532">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should return null when contract with valid address and valid offset does not exist" time="0.018727783">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should return null when contract with valid address and non-existing hash does not exist" time="0.024697903">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should return error when contract with invalid address and valid hash" time="0.014430094">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should return error when contract with invalid address and non-existing hash" time="0.018293813">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should return error when contract with valid address and invalid hash" time="0.01510057">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should return error when contract with invalid address and invalid hash" time="0.081024273">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should return null when contract with valid address and valid height does not exist" time="0.025169884">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should return null when contract with valid address and non-existing height does not exist" time="0.030036119">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should return error when contract with invalid address and valid height" time="0.014768453">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should return error when contract with invalid address and invalid height" time="0.04960982">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should return error for negative height" time="0.015718788">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should return error for non-integer height" time="0.015445903">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should return error for extremely large height" time="0.01614318">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/contract-queries.test.ts" name="contract queries &gt; a contract query by address and offset &gt; should return null when using a block hash from before the action existed" time="0.473834428">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/integration/basic/queries/dust-commitment-update-queries.test.ts" timestamp="2026-06-05T08:08:08.281Z" hostname="black-box" tests="8" failures="0" errors="0" skipped="0" time="0.960068482">
+        <testcase classname="tests/integration/basic/queries/dust-commitment-update-queries.test.ts" name="dust commitment merkle tree update queries &gt; a collapsed update query with valid index range &gt; should return a collapsed update for a valid index range" time="0.101776441">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-commitment-update-queries.test.ts" name="dust commitment merkle tree update queries &gt; a collapsed update query with valid index range &gt; should respond with a collapsed update according to the expected schema" time="0.105816695">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-commitment-update-queries.test.ts" name="dust commitment merkle tree update queries &gt; a collapsed update query with valid index range &gt; should return a collapsed update for the full genesis dust range" time="0.613695403">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-commitment-update-queries.test.ts" name="dust commitment merkle tree update queries &gt; a collapsed update query with equal start and end indices &gt; should return a valid update when startIndex equals endIndex" time="0.018894398">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-commitment-update-queries.test.ts" name="dust commitment merkle tree update queries &gt; a collapsed update query idempotency &gt; should return identical results for the same query parameters" time="0.050986311">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-commitment-update-queries.test.ts" name="dust commitment merkle tree update queries &gt; a collapsed update query with invalid index range &gt; should return an error when startIndex is greater than endIndex" time="0.023547659">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-commitment-update-queries.test.ts" name="dust commitment merkle tree update queries &gt; a collapsed update query with invalid index range &gt; should return an error when indices are negative" time="0.018082755">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-commitment-update-queries.test.ts" name="dust commitment merkle tree update queries &gt; a collapsed update query with invalid index range &gt; should return an error when endIndex is beyond the indexed range" time="0.026248382">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/integration/basic/queries/dust-generation-update-queries.test.ts" timestamp="2026-06-05T08:08:08.282Z" hostname="black-box" tests="8" failures="0" errors="0" skipped="0" time="1.33736856">
+        <testcase classname="tests/integration/basic/queries/dust-generation-update-queries.test.ts" name="dust generation merkle tree update queries &gt; a collapsed update query with valid index range &gt; should return a collapsed update for a valid index range" time="0.097051193">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-generation-update-queries.test.ts" name="dust generation merkle tree update queries &gt; a collapsed update query with valid index range &gt; should respond with a collapsed update according to the expected schema" time="0.063855154">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-generation-update-queries.test.ts" name="dust generation merkle tree update queries &gt; a collapsed update query with valid index range &gt; should return a collapsed update for the full genesis dust range" time="0.184416457">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-generation-update-queries.test.ts" name="dust generation merkle tree update queries &gt; a collapsed update query with equal start and end indices &gt; should return a valid update when startIndex equals endIndex" time="0.018430391">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-generation-update-queries.test.ts" name="dust generation merkle tree update queries &gt; a collapsed update query idempotency &gt; should return identical results for the same query parameters" time="0.046576899">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-generation-update-queries.test.ts" name="dust generation merkle tree update queries &gt; a collapsed update query with invalid index range &gt; should return an error when startIndex is greater than endIndex" time="0.017898917">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-generation-update-queries.test.ts" name="dust generation merkle tree update queries &gt; a collapsed update query with invalid index range &gt; should return an error when indices are negative" time="0.018293874">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-generation-update-queries.test.ts" name="dust generation merkle tree update queries &gt; a collapsed update query with invalid index range &gt; should return an error when endIndex is beyond the indexed range" time="0.889946606">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/integration/basic/queries/dust-generations-queries.test.ts" timestamp="2026-06-05T08:08:08.284Z" hostname="black-box" tests="9" failures="0" errors="0" skipped="0" time="0.433833521">
+        <testcase classname="tests/integration/basic/queries/dust-generations-queries.test.ts" name="dust generations queries &gt; a dust generations query with a valid Cardano reward address &gt; should return dust generations for a registered address" time="0.103514405">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-generations-queries.test.ts" name="dust generations queries &gt; a dust generations query with a valid Cardano reward address &gt; should respond with dust generations according to the expected schema" time="0.079825137">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-generations-queries.test.ts" name="dust generations queries &gt; a dust generations query with a valid Cardano reward address &gt; should return registrations with valid fields for a registered address" time="0.026662114">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-generations-queries.test.ts" name="dust generations queries &gt; a dust generations query with multiple addresses &gt; should return dust generations for multiple addresses" time="0.025200002">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-generations-queries.test.ts" name="dust generations queries &gt; a dust generations query with non-registered address &gt; should return empty registrations for a non-registered address" time="0.028080053">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-generations-queries.test.ts" name="dust generations queries &gt; a dust generations query with invalid input &gt; should return an empty result for an empty addresses array" time="0.01884252">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-generations-queries.test.ts" name="dust generations queries &gt; a dust generations query with invalid input &gt; should return an error for a malformed address" time="0.022536078">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-generations-queries.test.ts" name="dust generations queries &gt; a dustGenerations query with a multi-UTXO stake key (#926) &gt; should aggregate nightBalance across all backing cNIGHT UTXOs" time="0.053881691">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-generations-queries.test.ts" name="dust generations queries &gt; backwards compatibility with dustGenerationStatus &gt; should return consistent data from both endpoints for a registered address" time="0.074399497">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/integration/basic/queries/dust-queries.test.ts" timestamp="2026-06-05T08:08:08.284Z" hostname="black-box" tests="15" failures="0" errors="0" skipped="0" time="1.461183356">
+        <testcase classname="tests/integration/basic/queries/dust-queries.test.ts" name="dust generation status queries &gt; a dust generation status query with a valid Cardano reward address &gt; should respond with a dust generation status response according to the requested schema" time="0.091335985">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-queries.test.ts" name="dust generation status queries &gt; a dust generation status query with a valid Cardano reward address &gt; should report registered status for a registered Cardano reward address" time="0.075865275">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-queries.test.ts" name="dust generation status queries &gt; a dust generation status query with a valid Cardano reward address &gt; should give the DUST destination address for the expected network when Cardano reward address is registered" time="0.024430268">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-queries.test.ts" name="dust generation status queries &gt; a dust generation status query with a valid Cardano reward address &gt; should correctly indicate registration status for a non-registered key" time="0.022846846">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-queries.test.ts" name="dust generation status queries &gt; a dust generation status query with a valid Cardano reward address &gt; should indicate zero generation for registered address without cNIGHT balance" time="0.024930803">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-queries.test.ts" name="dust generation status queries &gt; a dust generation status query with a valid Cardano reward address &gt; should report the correct value of max capacity for registered address with cNIGHT" time="0.041320248">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-queries.test.ts" name="dust generation status queries &gt; a dust generation status query with a valid Cardano reward address &gt; should correctly indicate deregistered status for a previously registered Cardano reward address" time="0.022070669">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-queries.test.ts" name="dust generation status queries &gt; a dust generation status query with multiple valid Cardano reward addresses &gt; should return statuses for multiple Cardano reward addresses in order" time="0.079978467">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-queries.test.ts" name="dust generation status queries &gt; a dust generation status query with multiple valid Cardano reward addresses &gt; should respond with dust generation statuses according to the requested schema for multiple addresses" time="0.034975872">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-queries.test.ts" name="dust generation status queries &gt; a dust generation status query with multiple valid Cardano reward addresses &gt; should return an error given the number of addresses is greater than 10" time="0.019050683">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-queries.test.ts" name="dust generation status queries &gt; a dust generation status query with malformed reward addresses &gt; should return an error when the address is in plain hex string format" time="0.016729649">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-queries.test.ts" name="dust generation status queries &gt; a dust generation status query with empty list of reward addresses &gt; should return an empty list of dust generation statuses" time="0.016914107">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-queries.test.ts" name="dust generation status queries &gt; a dust generation status query with a Cardano payment address &gt; should return an error as only Cardano reward addresses are supported" time="0.015230746">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-queries.test.ts" name="dust generation status queries &gt; a dust generation status query with a Cardano reward address not meant for this network &gt; should return an error reporting the target network mismatch" time="0.018886984">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/dust-queries.test.ts" name="dust generation status queries &gt; a dust generation status query with duplicate reward addresses &gt; should handle duplicate Cardano reward addresses appropriately" time="0.033026849">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/integration/basic/queries/transaction-queries.test.ts" timestamp="2026-06-05T08:08:08.286Z" hostname="black-box" tests="18" failures="0" errors="0" skipped="0" time="8.461910104">
+        <testcase classname="tests/integration/basic/queries/transaction-queries.test.ts" name="transaction queries &gt; a transaction query by hash &gt; should return the transaction with that hash, given that transaction exists" time="1.288549049">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/transaction-queries.test.ts" name="transaction queries &gt; a transaction query by hash &gt; should return an empty transaction list, given a transaction with that hash doesn&apos;t exist" time="0.022634745">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/transaction-queries.test.ts" name="transaction queries &gt; a transaction query by hash &gt; should return an error, given a hash is invalid (malformed)" time="0.080039192">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/transaction-queries.test.ts" name="transaction queries &gt; a transaction query by hash &gt; should return an error when called with an empty offset object" time="0.015955556">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/transaction-queries.test.ts" name="transaction queries &gt; a transaction query by identifier &gt; should return the transaction with that identifier, given that transaction exists" time="1.363019066">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/transaction-queries.test.ts" name="transaction queries &gt; a transaction query by identifier &gt; should return an empty list of transactions, given a transaction with that identifier doesn&apos;t exist" time="0.064962907">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/transaction-queries.test.ts" name="transaction queries &gt; a transaction query by identifier &gt; should return an error, given an invalid identifier" time="0.04793186">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/transaction-queries.test.ts" name="transaction queries &gt; a transaction query by hash and identifier &gt; should return an error, as only one parameter at a time can be used" time="0.015827714">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/transaction-queries.test.ts" name="genesis transactions &gt; transaction queries to the genesis block transactions &gt; should return utxos related to 4 pre-fund wallets" time="1.303880812">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/transaction-queries.test.ts" name="genesis transactions &gt; transaction queries to the genesis block transactions &gt; should return utxos with 1 token type" time="0.793020579">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/transaction-queries.test.ts" name="genesis transactions &gt; transaction queries to the genesis block transactions &gt; should return utxos sorted by outputIndex in ascending order" time="0.844993653">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/transaction-queries.test.ts" name="genesis transactions &gt; transaction queries to the genesis block transactions &gt; should return system transactions when queried by hash" time="1.012305651">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/transaction-queries.test.ts" name="genesis transactions &gt; transaction queries to the genesis block transactions &gt; should not contain RegularTransaction-specific fields on system transactions" time="0.795602905">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/transaction-queries.test.ts" name="genesis transactions &gt; schema validation &gt; should respond with full transaction data according to the expected schema" time="0.005517144">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/transaction-queries.test.ts" name="genesis transactions &gt; schema validation &gt; should respond with system transactions according to the expected schema" time="0.000359139">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/transaction-queries.test.ts" name="genesis transactions &gt; schema validation &gt; should contain both regular and system transactions" time="0.000129665">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/transaction-queries.test.ts" name="genesis transactions &gt; schema validation &gt; should respond with regular transactions according to the expected schema" time="0.001771798">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/transaction-queries.test.ts" name="genesis transactions &gt; schema validation &gt; should respond with nested ledger events and unshielded outputs according to the expected schema" time="0.000768021">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/integration/basic/queries/zswap-collapsed-update-queries.test.ts" timestamp="2026-06-05T08:08:08.288Z" hostname="black-box" tests="8" failures="0" errors="0" skipped="0" time="0.446854723">
+        <testcase classname="tests/integration/basic/queries/zswap-collapsed-update-queries.test.ts" name="zswap merkle tree collapsed update queries &gt; a collapsed update query with valid index range &gt; should return a collapsed update for a valid index range" time="0.087219689">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/zswap-collapsed-update-queries.test.ts" name="zswap merkle tree collapsed update queries &gt; a collapsed update query with valid index range &gt; should respond with a collapsed update according to the expected schema" time="0.069075387">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/zswap-collapsed-update-queries.test.ts" name="zswap merkle tree collapsed update queries &gt; a collapsed update query with valid index range &gt; should return a collapsed update for the full genesis zswap range" time="0.170516725">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/zswap-collapsed-update-queries.test.ts" name="zswap merkle tree collapsed update queries &gt; a collapsed update query with equal start and end indices &gt; should return a valid update when startIndex equals endIndex" time="0.02282247">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/zswap-collapsed-update-queries.test.ts" name="zswap merkle tree collapsed update queries &gt; a collapsed update query idempotency &gt; should return identical results for the same query parameters" time="0.042277587">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/zswap-collapsed-update-queries.test.ts" name="zswap merkle tree collapsed update queries &gt; a collapsed update query with invalid index range &gt; should return an error when startIndex is greater than endIndex" time="0.016819107">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/zswap-collapsed-update-queries.test.ts" name="zswap merkle tree collapsed update queries &gt; a collapsed update query with invalid index range &gt; should return an error when indices are negative" time="0.015117372">
+        </testcase>
+        <testcase classname="tests/integration/basic/queries/zswap-collapsed-update-queries.test.ts" name="zswap merkle tree collapsed update queries &gt; a collapsed update query with invalid index range &gt; should return an error when endIndex is beyond the indexed range" time="0.022204973">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/integration/basic/subscriptions/block-subscriptions.test.ts" timestamp="2026-06-05T08:08:08.289Z" hostname="black-box" tests="10" failures="0" errors="0" skipped="1" time="10.064208482">
+        <testcase classname="tests/integration/basic/subscriptions/block-subscriptions.test.ts" name="block subscriptions &gt; a subscription to block updates without parameters &gt; should stream blocks starting from the latest block" time="4.512852308">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/block-subscriptions.test.ts" name="block subscriptions &gt; a subscription to block updates without parameters &gt; should stream blocks adhering to the expected schema" time="0.653311311">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/block-subscriptions.test.ts" name="block subscriptions &gt; a subscription to block updates by hash &gt; should stream blocks starting from the block with that hash, given that hash exists" time="1.22666489">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/block-subscriptions.test.ts" name="block subscriptions &gt; a subscription to block updates by hash &gt; should return an error message, given that hash doesn&apos;t exist" time="0.597070189">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/block-subscriptions.test.ts" name="block subscriptions &gt; a subscription to block updates by hash &gt; should return an error message, given that hash is invalid" time="0.593529369">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/block-subscriptions.test.ts" name="block subscriptions &gt; a subscription to block updates by height &gt; should stream blocks from the block with that height, given that height exists" time="0.682338871">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/block-subscriptions.test.ts" name="block subscriptions &gt; a subscription to block updates by height &gt; should return an error message, given that height is higher than the latest block height" time="0.620429492">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/block-subscriptions.test.ts" name="block subscriptions &gt; a subscription to block updates by height &gt; should return an error message, given that height is invalid" time="0.592455168">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/block-subscriptions.test.ts" name="block subscriptions &gt; a subscription to block updates by height and hash &gt; should return an error message, as only one parameter at a time can be used" time="0.584508303">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/block-subscriptions.test.ts" name="block subscriptions &gt; regular transaction fees &gt; should report ledger paidFees and estimatedFees on regular transactions" time="0">
+            <skipped/>
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/integration/basic/subscriptions/contract-subscriptions.test.ts" timestamp="2026-06-05T08:08:08.290Z" hostname="black-box" tests="3" failures="0" errors="0" skipped="0" time="1.799041196">
+        <testcase classname="tests/integration/basic/subscriptions/contract-subscriptions.test.ts" name="contract action subscriptions &gt; a subscription to contract action updates without parameters &gt; should stream contract actions from the latest available block" time="0.611508383">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/contract-subscriptions.test.ts" name="contract action subscriptions &gt; a subscription to contract action updates without parameters &gt; should stream contract actions adhering to the expected schema" time="0.598404795">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/contract-subscriptions.test.ts" name="contract action subscriptions &gt; a subscription to contract action updates with block hash offset &gt; should stream historical and new contract actions from a specific block hash" time="0.587944832">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts" timestamp="2026-06-05T08:08:08.290Z" hostname="black-box" tests="5" failures="0" errors="0" skipped="0" time="4.234664214">
+        <testcase classname="tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts" name="dust generations subscription &gt; streaming dust generation entries &gt; should stream dust generation events for a valid dust address in bech32m format" time="1.424872141">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts" name="dust generations subscription &gt; subscription error handling &gt; should return an error for an invalid dust address" time="0.548051556">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts" name="dust generations subscription &gt; subscription error handling &gt; should return an error for a valid address that is meant for another networkid" time="0.694396752">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts" name="dust generations subscription &gt; subscription error handling &gt; should return an error for a valid dust address passed in hex format" time="0.545575608">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts" name="dust generations subscription &gt; transactionHash on dust generation events (#1114) &gt; first item transactionHash resolves via transactions(offset)" time="1.020739433">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/integration/basic/subscriptions/dust-ledger-subscriptions.test.ts" timestamp="2026-06-05T08:08:08.291Z" hostname="black-box" tests="5" failures="0" errors="0" skipped="0" time="2.870421065">
+        <testcase classname="tests/integration/basic/subscriptions/dust-ledger-subscriptions.test.ts" name="dust ledger event subscriptions &gt; a subscription to dust ledger events without offset (default replay) &gt; streams events in ledger order" time="0.59721413">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/dust-ledger-subscriptions.test.ts" name="dust ledger event subscriptions &gt; subscription with explicit offset &gt; streams events in ledger order starting from the specified ID" time="0.597530178">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/dust-ledger-subscriptions.test.ts" name="dust ledger event subscriptions &gt; subscription with explicit offset &gt; validates historical dust events against schema" time="0.588228192">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/dust-ledger-subscriptions.test.ts" name="dust ledger event subscriptions &gt; subscription error handling &gt; should return an error for unknown field" time="0.543160923">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/dust-ledger-subscriptions.test.ts" name="dust ledger event subscriptions &gt; subscription error handling &gt; rejects negative offset ID with an error" time="0.543605943">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts" timestamp="2026-06-05T08:08:08.291Z" hostname="black-box" tests="4" failures="0" errors="0" skipped="0" time="2.430240859">
+        <testcase classname="tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts" name="dust nullifier transactions subscription &gt; streaming dust nullifier transactions with block range &gt; should stream transactions within a block range and complete" time="0.647569387">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts" name="dust nullifier transactions subscription &gt; subscription error handling &gt; should return an error for empty nullifier prefixes" time="0.546971542">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts" name="dust nullifier transactions subscription &gt; subscription error handling &gt; should return an error when fromBlock is greater than toBlock" time="0.547702512">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/dust-nullifier-subscriptions.test.ts" name="dust nullifier transactions subscription &gt; transactionHash on dust nullifier events (#1114) &gt; first event transactionHash resolves via transactions(offset)" time="0.687239286">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts" timestamp="2026-06-05T08:08:08.292Z" hostname="black-box" tests="5" failures="0" errors="0" skipped="1" time="2.918864122">
+        <testcase classname="tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts" name="shielded nullifier transactions subscription &gt; streaming shielded nullifier transactions with block range &gt; should stream transactions within a block range and complete" time="0.644368304">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts" name="shielded nullifier transactions subscription &gt; subscription error handling &gt; should return an error for empty nullifier prefixes" time="0.547158158">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts" name="shielded nullifier transactions subscription &gt; subscription error handling &gt; should return an error for an empty-string nullifier prefix element" time="0.548150443">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts" name="shielded nullifier transactions subscription &gt; subscription error handling &gt; should return an error when fromBlock is greater than toBlock" time="0.546980352">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/shielded-nullifier-subscriptions.test.ts" name="shielded nullifier transactions subscription &gt; transactionHash on shielded nullifier events (#1114) &gt; first event transactionHash resolves via transactions(offset)" time="0.631430278">
+            <skipped/>
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts" timestamp="2026-06-05T08:08:08.293Z" hostname="black-box" tests="10" failures="0" errors="0" skipped="0" time="12.717497055">
+        <testcase classname="tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts" name="shielded transaction subscriptions &gt; opening a session with viewing key &gt; should return a session ID, given a valid viewing key" time="0.617137698">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts" name="shielded transaction subscriptions &gt; opening a session with viewing key &gt; should return an error, given an unsupported hex format viewing key" time="0.547540764">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts" name="shielded transaction subscriptions &gt; opening a session with viewing key &gt; should return an error, given an invalid viewing key" time="0.543238314">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts" name="shielded transaction subscriptions &gt; opening a session with viewing key &gt; should return an error, given a valid viewing key meant for a different network" time="0.907651833">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts" name="shielded transaction subscriptions &gt; closing a session with session ID &gt; should terminate the session successfully, given a valid session ID" time="0.676300195">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts" name="shielded transaction subscriptions &gt; closing a session with session ID &gt; should return an error, given an invalid session ID" time="0.548168388">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts" name="shielded transaction subscriptions &gt; a subscription to wallet updates providing viewing key only &gt; should stream wallet events starting from the beginning, given there are relevant transactions" time="2.611462539">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts" name="shielded transaction subscriptions &gt; a subscription to wallet updates providing viewing key only &gt; should stream shielded transaction events adhering to the expected schema" time="3.60339491">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts" name="shielded transaction subscriptions &gt; a subscription to wallet updates providing viewing key only &gt; should be able to use highestZswapEndIndex from progress event in collapsed update query" time="0.71644688">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts" name="shielded transaction subscriptions &gt; a subscription to wallet updates providing viewing key only &gt; should reject shieldedTransactions subscription when using expired session ID" time="0.711185139">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/integration/basic/subscriptions/subscription-quotas.test.ts" timestamp="2026-06-05T08:08:08.294Z" hostname="black-box" tests="2" failures="0" errors="0" skipped="0" time="4.115543207">
+        <testcase classname="tests/integration/basic/subscriptions/subscription-quotas.test.ts" name="subscription quotas (HAL-03 / SSE-196) &gt; per-connection concurrent subscription cap &gt; should reject a subscription beyond the per-connection cap" time="1.562369116">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/subscription-quotas.test.ts" name="subscription quotas (HAL-03 / SSE-196) &gt; per-connection concurrent subscription cap &gt; should free a slot when an active subscription is closed" time="2.552516589">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts" timestamp="2026-06-05T08:08:08.294Z" hostname="black-box" tests="11" failures="0" errors="0" skipped="0" time="28.679457079">
+        <testcase classname="tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts" name="unshielded transaction subscriptions &gt; a subscription to unshielded transaction events by address &gt; should stream unshielded transaction events related to that address, given that address has transactions" time="0.497974846">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts" name="unshielded transaction subscriptions &gt; a subscription to unshielded transaction events by address &gt; should stream unshielded transaction events up to highest transaction id" time="5.046006266">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts" name="unshielded transaction subscriptions &gt; a subscription to unshielded transaction events by address &gt; should stream unshielded transaction events that adhere to the expected schema" time="0.130422505">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts" name="unshielded transaction subscriptions &gt; a subscription to unshielded transaction events by address &gt; should only return a transaction progress message with highest transaction = 0, given that address does not have transactions" time="5.049493051">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts" name="unshielded transaction subscriptions &gt; a subscription to unshielded transaction events by address &gt; should return an error message, given the address provided is in hex format" time="0.013780056">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts" name="unshielded transaction subscriptions &gt; a subscription to unshielded transaction events by address &gt; should return an error message, given the address provided is for another network" time="0.557500835">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts" name="unshielded transaction subscriptions &gt; a subscription to unshielded transaction events by address and transaction id &gt; should return a stream of transactions containing that address, starting from transaction id = 0" time="5.562404131">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts" name="unshielded transaction subscriptions &gt; a subscription to unshielded transaction events by address and transaction id &gt; should return an error message, given the transaction id provided is negative" time="0.070227103">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts" name="unshielded transaction subscriptions &gt; a subscription to unshielded transaction events by address and transaction id &gt; should only return a transaction progress message without streaming transactions, given that the transaction id provided is bigger number" time="5.060313034">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts" name="unshielded transaction subscriptions &gt; a subscription to unshielded transaction events by address and transaction id &gt; should start a transaction stream from the given transaction id" time="5.295930342">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts" name="unshielded transaction subscriptions &gt; a subscription to unshielded transaction events by address and transaction id &gt; should return an error message, given the address is provided in hex format" time="0.060881465">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/integration/basic/subscriptions/wallet-connect-options.test.ts" timestamp="2026-06-05T08:08:08.296Z" hostname="black-box" tests="3" failures="0" errors="0" skipped="0" time="3.716930183">
+        <testcase classname="tests/integration/basic/subscriptions/wallet-connect-options.test.ts" name="wallet connect options (startIndex) &gt; opening a session with startIndex &gt; should accept startIndex = 0 (no-op equivalent of unset options)" time="0.61168424">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/wallet-connect-options.test.ts" name="wallet connect options (startIndex) &gt; opening a session with startIndex &gt; should skip historical scan when startIndex equals the current tip" time="1.215500873">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/wallet-connect-options.test.ts" name="wallet connect options (startIndex) &gt; opening a session with startIndex &gt; should accept startIndex past the current tip (fast-forward)" time="1.221500818">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/integration/basic/subscriptions/zswap-events-subscriptions.test.ts" timestamp="2026-06-05T08:08:08.296Z" hostname="black-box" tests="5" failures="0" errors="0" skipped="0" time="2.898860176">
+        <testcase classname="tests/integration/basic/subscriptions/zswap-events-subscriptions.test.ts" name="zswap ledger event subscriptions &gt; a subscription to zswap ledger events without offset (default replay) &gt; streams events in ledger order" time="0.590370829">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/zswap-events-subscriptions.test.ts" name="zswap ledger event subscriptions &gt; subscription with explicit offset &gt; streams events starting from the specified ID" time="0.633514412">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/zswap-events-subscriptions.test.ts" name="zswap ledger event subscriptions &gt; subscription with explicit offset &gt; validates historical zswap events against schema" time="0.578273672">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/zswap-events-subscriptions.test.ts" name="zswap ledger event subscriptions &gt; subscription error handling &gt; should return an error for unknown field" time="0.547849751">
+        </testcase>
+        <testcase classname="tests/integration/basic/subscriptions/zswap-events-subscriptions.test.ts" name="zswap ledger event subscriptions &gt; subscription error handling &gt; rejects negative offset ID with an error" time="0.548025251">
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/qa/tests/evidence/4.3.3/qanet/smoke/junit-test-results.xml
+++ b/qa/tests/evidence/4.3.3/qanet/smoke/junit-test-results.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="19" failures="0" errors="0" time="1.83101637">
+    <testsuite name="tests/smoke/graphql-healthchecks.test.ts" timestamp="2026-06-05T08:07:19.060Z" hostname="black-box" tests="4" failures="0" errors="0" skipped="0" time="1.305804959">
+        <testcase classname="tests/smoke/graphql-healthchecks.test.ts" name="graphql health checks &gt; an introspection message sent to the websocket channel &gt; should return the supported graphql schema" time="0.56017949">
+        </testcase>
+        <testcase classname="tests/smoke/graphql-healthchecks.test.ts" name="graphql health checks &gt; an introspection message sent to the websocket channel &gt; should return an error, given the depth of the query is &gt; 15" time="0.546758632">
+        </testcase>
+        <testcase classname="tests/smoke/graphql-healthchecks.test.ts" name="graphql health checks &gt; an introspection request sent to the http channel &gt; should return the supported graphql schema" time="0.129196674">
+        </testcase>
+        <testcase classname="tests/smoke/graphql-healthchecks.test.ts" name="graphql health checks &gt; an introspection request sent to the http channel &gt; should return an error, given the depth of the query is &gt; 15" time="0.068970934">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/smoke/graphql-schema-change.test.ts" timestamp="2026-06-05T08:07:19.061Z" hostname="black-box" tests="1" failures="0" errors="0" skipped="1" time="0">
+        <testcase classname="tests/smoke/graphql-schema-change.test.ts" name="GraphQL Schema Stability Check &gt; should not change the schema unexpectedly" time="0">
+            <skipped/>
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/smoke/graphql-schema-deprecations.test.ts" timestamp="2026-06-05T08:07:19.061Z" hostname="black-box" tests="9" failures="0" errors="0" skipped="0" time="0.318615791">
+        <testcase classname="tests/smoke/graphql-schema-deprecations.test.ts" name="graphql schema deprecations &gt; RegularTransaction.merkleTreeRoot &gt; should be marked deprecated with reason &quot;Use zswapMerkleTreeRoot instead&quot;" time="0.095358009">
+        </testcase>
+        <testcase classname="tests/smoke/graphql-schema-deprecations.test.ts" name="graphql schema deprecations &gt; RegularTransaction.startIndex &gt; should be marked deprecated with reason &quot;Use zswapStartIndex instead&quot;" time="0.067381891">
+        </testcase>
+        <testcase classname="tests/smoke/graphql-schema-deprecations.test.ts" name="graphql schema deprecations &gt; RegularTransaction.endIndex &gt; should be marked deprecated with reason &quot;Use zswapEndIndex instead&quot;" time="0.021813585">
+        </testcase>
+        <testcase classname="tests/smoke/graphql-schema-deprecations.test.ts" name="graphql schema deprecations &gt; RelevantTransaction.collapsedMerkleTree &gt; should be marked deprecated with reason &quot;Use zswapCollapsedUpdate instead&quot;" time="0.020084738">
+        </testcase>
+        <testcase classname="tests/smoke/graphql-schema-deprecations.test.ts" name="graphql schema deprecations &gt; ShieldedTransactionsProgress.highestEndIndex &gt; should be marked deprecated with reason &quot;Use highestZswapEndIndex instead&quot;" time="0.024236903">
+        </testcase>
+        <testcase classname="tests/smoke/graphql-schema-deprecations.test.ts" name="graphql schema deprecations &gt; ShieldedTransactionsProgress.highestCheckedEndIndex &gt; should be marked deprecated with reason &quot;Use highestCheckedZswapEndIndex instead&quot;" time="0.023917881">
+        </testcase>
+        <testcase classname="tests/smoke/graphql-schema-deprecations.test.ts" name="graphql schema deprecations &gt; ShieldedTransactionsProgress.highestRelevantEndIndex &gt; should be marked deprecated with reason &quot;Use highestRelevantZswapEndIndex instead&quot;" time="0.022617023">
+        </testcase>
+        <testcase classname="tests/smoke/graphql-schema-deprecations.test.ts" name="graphql schema deprecations &gt; RegularTransaction.fees &gt; should be marked deprecated with reason &quot;Use fee instead&quot;" time="0.020932109">
+        </testcase>
+        <testcase classname="tests/smoke/graphql-schema-deprecations.test.ts" name="graphql schema deprecations &gt; TransactionFees.estimatedFees &gt; should be marked deprecated with reason &quot;Use paidFees instead&quot;" time="0.021360539">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/smoke/service-healthchecks.test.ts" timestamp="2026-06-05T08:07:19.062Z" hostname="black-box" tests="5" failures="0" errors="0" skipped="0" time="0.20659562">
+        <testcase classname="tests/smoke/service-healthchecks.test.ts" name="service health checks &gt; a request to the /ready endpoint &gt; should return a 200 status code OK" time="0.090841746">
+        </testcase>
+        <testcase classname="tests/smoke/service-healthchecks.test.ts" name="service health checks &gt; a request to an unrecognised path /api/v3/__regression_unknown_path &gt; should not 308 to a version-double-prefixed Location" time="0.052950525">
+        </testcase>
+        <testcase classname="tests/smoke/service-healthchecks.test.ts" name="service health checks &gt; a request to an unrecognised path /api/v3/__regression_unknown_path &gt; should terminate when redirects are followed" time="0.022005968">
+        </testcase>
+        <testcase classname="tests/smoke/service-healthchecks.test.ts" name="service health checks &gt; a request to an unrecognised path /api/v4/__regression_unknown_path &gt; should not 308 to a version-double-prefixed Location" time="0.020137007">
+        </testcase>
+        <testcase classname="tests/smoke/service-healthchecks.test.ts" name="service health checks &gt; a request to an unrecognised path /api/v4/__regression_unknown_path &gt; should terminate when redirects are followed" time="0.019923324">
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/qa/tests/evidence/4.3.3/undeployed/e2e/junit-test-results.xml
+++ b/qa/tests/evidence/4.3.3/undeployed/e2e/junit-test-results.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="42" failures="0" errors="0" time="234.14545271">
+    <testsuite name="tests/e2e/contract-actions-sequential.test.ts" timestamp="2026-06-05T08:14:13.267Z" hostname="black-box" tests="9" failures="0" errors="0" skipped="0" time="84.995617945">
+        <testcase classname="tests/e2e/contract-actions-sequential.test.ts" name="contract actions &gt; a transaction to deploy a smart contract &gt; should be reported by the indexer through a transaction query by hash" time="0.007384855">
+        </testcase>
+        <testcase classname="tests/e2e/contract-actions-sequential.test.ts" name="contract actions &gt; a transaction to deploy a smart contract &gt; should be reported by the indexer through a block query by hash" time="0.00837319">
+        </testcase>
+        <testcase classname="tests/e2e/contract-actions-sequential.test.ts" name="contract actions &gt; a transaction to deploy a smart contract &gt; should be reported by the indexer through a contract action query by address" time="0.005750782">
+        </testcase>
+        <testcase classname="tests/e2e/contract-actions-sequential.test.ts" name="contract actions &gt; a transaction to call a smart contract &gt; should be reported by the indexer through a transaction query by hash" time="0.005743027">
+        </testcase>
+        <testcase classname="tests/e2e/contract-actions-sequential.test.ts" name="contract actions &gt; a transaction to call a smart contract &gt; should be reported by the indexer through a block query by hash" time="0.006456954">
+        </testcase>
+        <testcase classname="tests/e2e/contract-actions-sequential.test.ts" name="contract actions &gt; a transaction to call a smart contract &gt; should be reported by the indexer through a contract action query by address" time="0.002303376">
+        </testcase>
+        <testcase classname="tests/e2e/contract-actions-sequential.test.ts" name="contract actions &gt; a transaction to update a smart contract &gt; should be reported by the indexer through a transaction query by hash" time="0.005909682">
+        </testcase>
+        <testcase classname="tests/e2e/contract-actions-sequential.test.ts" name="contract actions &gt; a transaction to update a smart contract &gt; should be reported by the indexer through a block query by hash" time="0.010234452">
+        </testcase>
+        <testcase classname="tests/e2e/contract-actions-sequential.test.ts" name="contract actions &gt; a transaction to update a smart contract &gt; should be reported by the indexer through a contract action query by address" time="0.008575702">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/e2e/shielded-transactions.test.ts" timestamp="2026-06-05T08:14:13.269Z" hostname="black-box" tests="8" failures="0" errors="0" skipped="0" time="51.788023167">
+        <testcase classname="tests/e2e/shielded-transactions.test.ts" name="shielded transactions &gt; a successful shielded transaction transferring 1 Shielded Token between two wallets &gt; should be reported by the indexer through a block query by hash" time="0.010298663">
+        </testcase>
+        <testcase classname="tests/e2e/shielded-transactions.test.ts" name="shielded transactions &gt; a successful shielded transaction transferring 1 Shielded Token between two wallets &gt; should be reported by the indexer through a transaction query by hash" time="0.008618593">
+        </testcase>
+        <testcase classname="tests/e2e/shielded-transactions.test.ts" name="shielded transactions &gt; a successful shielded transaction transferring 1 Shielded Token between two wallets &gt; should stream Zswap events followed by DustSpendProcessed after a shielded transaction" time="0.508136457">
+        </testcase>
+        <testcase classname="tests/e2e/shielded-transactions.test.ts" name="shielded transactions &gt; a successful shielded transaction transferring 1 Shielded Token between two wallets &gt; should increase the zswap Merkle tree end index" time="0.009378507">
+        </testcase>
+        <testcase classname="tests/e2e/shielded-transactions.test.ts" name="shielded transactions &gt; a successful shielded transaction transferring 1 Shielded Token between two wallets &gt; should increase the dust commitment Merkle tree end index" time="0.005303237">
+        </testcase>
+        <testcase classname="tests/e2e/shielded-transactions.test.ts" name="shielded transactions &gt; a confirmed shielded transfer streamed to wallet sessions by viewing key &gt; should stream the transaction to the source viewing key with a matching hash" time="4.984353123">
+        </testcase>
+        <testcase classname="tests/e2e/shielded-transactions.test.ts" name="shielded transactions &gt; a confirmed shielded transfer streamed to wallet sessions by viewing key &gt; should stream the transaction to the destination viewing key with a matching hash" time="2.025331976">
+        </testcase>
+        <testcase classname="tests/e2e/shielded-transactions.test.ts" name="shielded transactions &gt; a confirmed shielded transfer streamed to wallet sessions by viewing key &gt; should not stream the transaction to an unrelated viewing key" time="20.568223998">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/e2e/unshielded-transactions.test.ts" timestamp="2026-06-05T08:14:13.271Z" hostname="black-box" tests="9" failures="0" errors="0" skipped="0" time="34.778001682">
+        <testcase classname="tests/e2e/unshielded-transactions.test.ts" name="unshielded transactions &gt; a successful unshielded transaction transferring 1 STAR between two addresses &gt; should be reported by the indexer through a block query by hash" time="0.010477451">
+        </testcase>
+        <testcase classname="tests/e2e/unshielded-transactions.test.ts" name="unshielded transactions &gt; a successful unshielded transaction transferring 1 STAR between two addresses &gt; should be reported by the indexer through a transaction query by hash" time="0.007161915">
+        </testcase>
+        <testcase classname="tests/e2e/unshielded-transactions.test.ts" name="unshielded transactions &gt; a successful unshielded transaction transferring 1 STAR between two addresses &gt; should be reported by the indexer through an unshielded transaction event for the source address" time="0.000246656">
+        </testcase>
+        <testcase classname="tests/e2e/unshielded-transactions.test.ts" name="unshielded transactions &gt; a successful unshielded transaction transferring 1 STAR between two addresses &gt; should be reported by the indexer through an unshielded transaction event for the destination address" time="0.000182836">
+        </testcase>
+        <testcase classname="tests/e2e/unshielded-transactions.test.ts" name="unshielded transactions &gt; a successful unshielded transaction transferring 1 STAR between two addresses &gt; should have transferred 1 STAR from the source to the destination address" time="0.009011414">
+        </testcase>
+        <testcase classname="tests/e2e/unshielded-transactions.test.ts" name="unshielded transactions &gt; a successful unshielded transaction transferring 1 STAR between two addresses &gt; should be reported by the indexer through a progress update event for the source address" time="9.005493542">
+        </testcase>
+        <testcase classname="tests/e2e/unshielded-transactions.test.ts" name="unshielded transactions &gt; a successful unshielded transaction transferring 1 STAR between two addresses &gt; should be reported by the indexer through a progress update event for the destination address" time="3.001204601">
+        </testcase>
+        <testcase classname="tests/e2e/unshielded-transactions.test.ts" name="unshielded transactions &gt; a successful unshielded transaction transferring 1 STAR between two addresses &gt; should increase the dust commitment Merkle tree end index" time="0.008364804">
+        </testcase>
+        <testcase classname="tests/e2e/unshielded-transactions.test.ts" name="unshielded transactions &gt; a successful unshielded transaction transferring 1 STAR between two addresses &gt; should deliver dust events in correct sequence after unshielded transaction" time="0.002790957">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/e2e/wallet-subscriptions.test.ts" timestamp="2026-06-05T08:14:13.273Z" hostname="black-box" tests="7" failures="0" errors="0" skipped="4" time="59.438454268">
+        <testcase classname="tests/e2e/wallet-subscriptions.test.ts" name="wallet event subscriptions &gt; empty wallet scenario &gt; should emit only ProgressUpdate for empty wallet" time="2.553794797">
+        </testcase>
+        <testcase classname="tests/e2e/wallet-subscriptions.test.ts" name="wallet event subscriptions &gt; multi-destination transaction scenario &gt; should emit UnshieldedTransaction only for the target wallet (A &gt; B1)" time="30.090927604">
+        </testcase>
+        <testcase classname="tests/e2e/wallet-subscriptions.test.ts" name="wallet event subscriptions &gt; multi-destination transaction scenario &gt; should emit UnshieldedTransaction only for the target wallet (A &gt; B2)" time="21.664849809">
+        </testcase>
+        <testcase classname="tests/e2e/wallet-subscriptions.test.ts" name="wallet event subscriptions &gt; future coverage &gt; should not duplicate events after resubscription" time="0">
+            <skipped/>
+        </testcase>
+        <testcase classname="tests/e2e/wallet-subscriptions.test.ts" name="wallet event subscriptions &gt; future coverage &gt; should correctly handle multiple sequential A &gt; B transactions" time="0">
+            <skipped/>
+        </testcase>
+        <testcase classname="tests/e2e/wallet-subscriptions.test.ts" name="wallet event subscriptions &gt; future coverage &gt; should correctly handle mixed historical and new wallet subscriptions" time="0">
+            <skipped/>
+        </testcase>
+        <testcase classname="tests/e2e/wallet-subscriptions.test.ts" name="wallet event subscriptions &gt; future coverage &gt; should segregate shielded and unshielded events correctly" time="0">
+            <skipped/>
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/e2e/toolkit/dust-balance.test.ts" timestamp="2026-06-05T08:14:13.275Z" hostname="black-box" tests="1" failures="0" errors="0" skipped="0" time="0.676649312">
+        <testcase classname="tests/e2e/toolkit/dust-balance.test.ts" name="dust balance query using toolkit &gt; a dust balance query with a valid wallet seed &gt; should respond with a dust balance according to the requested schema" time="0.181578372">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/e2e/toolkit/key-material.test.ts" timestamp="2026-06-05T08:14:13.276Z" hostname="black-box" tests="6" failures="0" errors="0" skipped="0" time="0.972488729">
+        <testcase classname="tests/e2e/toolkit/key-material.test.ts" name="key material derivation validation &gt; a midnight shielded address &gt; should show with the expected prefix for the current network ID" time="0.037743721">
+        </testcase>
+        <testcase classname="tests/e2e/toolkit/key-material.test.ts" name="key material derivation validation &gt; a midnight shielded address &gt; should show with the expected prefix for all network IDs" time="0.163154306">
+        </testcase>
+        <testcase classname="tests/e2e/toolkit/key-material.test.ts" name="key material derivation validation &gt; a midnight unshielded address &gt; should show with the expected prefix for the current network ID" time="0.03702745">
+        </testcase>
+        <testcase classname="tests/e2e/toolkit/key-material.test.ts" name="key material derivation validation &gt; a midnight unshielded address &gt; should show with the expected prefix for all network IDs" time="0.126244339">
+        </testcase>
+        <testcase classname="tests/e2e/toolkit/key-material.test.ts" name="key material derivation validation &gt; a midnight viewing key &gt; should show with the expected prefix for the current network ID" time="0.023108575">
+        </testcase>
+        <testcase classname="tests/e2e/toolkit/key-material.test.ts" name="key material derivation validation &gt; a midnight viewing key &gt; should show with the expected prefix for all network IDs" time="0.121334844">
+        </testcase>
+    </testsuite>
+    <testsuite name="tests/e2e/toolkit/show-wallet-queries.test.ts" timestamp="2026-06-05T08:14:13.276Z" hostname="black-box" tests="2" failures="0" errors="0" skipped="0" time="1.496217607">
+        <testcase classname="tests/e2e/toolkit/show-wallet-queries.test.ts" name="show wallet queries using toolkit &gt; private wallet state query using toolkit &gt; should respond with a private wallet state according to the requested schema" time="0.546307572">
+        </testcase>
+        <testcase classname="tests/e2e/toolkit/show-wallet-queries.test.ts" name="show wallet queries using toolkit &gt; public wallet state query using toolkit &gt; should respond with a public wallet state according to the requested schema" time="0.464343278">
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/qa/tests/evidence/4.3.3/undeployed/indexer-test-report.md
+++ b/qa/tests/evidence/4.3.3/undeployed/indexer-test-report.md
@@ -1,0 +1,130 @@
+# Indexer Test Execution Report
+
+## Run Details
+
+| Field | Value |
+| --- | --- |
+| Component Under Test | Indexer / Node |
+| Indexer Version | 4.3.3 |
+| Node Version | 1.0.0 |
+| Test Suites | e2e |
+| Tests | Indexer GraphQL API and integration with Node |
+| Environment | undeployed (INDEXER_TAG=4.3.3, NODE_TAG=1.0.0) |
+| Date | Friday 5th Jun 2026 |
+| QA Contact | Giuseppe Salvatore (giuseppe.salvatore@shielded.io) |
+
+## Summary
+
+| Suite | Test Files | Passed | Failed | Skipped | Total | Duration | Run at |
+| --- | --- | ---: | ---: | ---: | ---: | --- | --- |
+| e2e | — | 38 | 0 | 0 | 38 | — | 9:09 AM BST |
+| **Total** | | **38** | **0** | **0** | **38** | | |
+
+> Legend: ✓ passed · ✗ failed · ↓ skipped.
+
+## E2e results
+
+### Contract actions sequential
+
+File name: `tests/e2e/contract-actions-sequential.test.ts`
+
+#### Contract Actions
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a transaction to deploy a smart contract, should be reported by the indexer through a transaction query by hash | 7 ms |
+| ✓ | a transaction to deploy a smart contract, should be reported by the indexer through a block query by hash | 8 ms |
+| ✓ | a transaction to deploy a smart contract, should be reported by the indexer through a contract action query by address | 6 ms |
+| ✓ | a transaction to call a smart contract, should be reported by the indexer through a transaction query by hash | 6 ms |
+| ✓ | a transaction to call a smart contract, should be reported by the indexer through a block query by hash | 6 ms |
+| ✓ | a transaction to call a smart contract, should be reported by the indexer through a contract action query by address | 2 ms |
+| ✓ | a transaction to update a smart contract, should be reported by the indexer through a transaction query by hash | 6 ms |
+| ✓ | a transaction to update a smart contract, should be reported by the indexer through a block query by hash | 10 ms |
+| ✓ | a transaction to update a smart contract, should be reported by the indexer through a contract action query by address | 9 ms |
+
+### Shielded transactions
+
+File name: `tests/e2e/shielded-transactions.test.ts`
+
+#### Shielded Transactions
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a successful shielded transaction transferring 1 Shielded Token between two wallets, should be reported by the indexer through a block query by hash | 10 ms |
+| ✓ | a successful shielded transaction transferring 1 Shielded Token between two wallets, should be reported by the indexer through a transaction query by hash | 9 ms |
+| ✓ | a successful shielded transaction transferring 1 Shielded Token between two wallets, should stream Zswap events followed by DustSpendProcessed after a shielded transaction | 508 ms |
+| ✓ | a successful shielded transaction transferring 1 Shielded Token between two wallets, should increase the zswap Merkle tree end index | 9 ms |
+| ✓ | a successful shielded transaction transferring 1 Shielded Token between two wallets, should increase the dust commitment Merkle tree end index | 5 ms |
+| ✓ | a confirmed shielded transfer streamed to wallet sessions by viewing key, should stream the transaction to the source viewing key with a matching hash | 4984 ms |
+| ✓ | a confirmed shielded transfer streamed to wallet sessions by viewing key, should stream the transaction to the destination viewing key with a matching hash | 2025 ms |
+| ✓ | a confirmed shielded transfer streamed to wallet sessions by viewing key, should not stream the transaction to an unrelated viewing key | 20568 ms |
+
+### Unshielded transactions
+
+File name: `tests/e2e/unshielded-transactions.test.ts`
+
+#### Unshielded Transactions
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a successful unshielded transaction transferring 1 STAR between two addresses, should be reported by the indexer through a block query by hash | 10 ms |
+| ✓ | a successful unshielded transaction transferring 1 STAR between two addresses, should be reported by the indexer through a transaction query by hash | 7 ms |
+| ✓ | a successful unshielded transaction transferring 1 STAR between two addresses, should be reported by the indexer through an unshielded transaction event for the source address | 0 ms |
+| ✓ | a successful unshielded transaction transferring 1 STAR between two addresses, should be reported by the indexer through an unshielded transaction event for the destination address | 0 ms |
+| ✓ | a successful unshielded transaction transferring 1 STAR between two addresses, should have transferred 1 STAR from the source to the destination address | 9 ms |
+| ✓ | a successful unshielded transaction transferring 1 STAR between two addresses, should be reported by the indexer through a progress update event for the source address | 9005 ms |
+| ✓ | a successful unshielded transaction transferring 1 STAR between two addresses, should be reported by the indexer through a progress update event for the destination address | 3001 ms |
+| ✓ | a successful unshielded transaction transferring 1 STAR between two addresses, should increase the dust commitment Merkle tree end index | 8 ms |
+| ✓ | a successful unshielded transaction transferring 1 STAR between two addresses, should deliver dust events in correct sequence after unshielded transaction | 3 ms |
+
+### Wallet subscriptions
+
+File name: `tests/e2e/wallet-subscriptions.test.ts`
+
+#### Wallet Event Subscriptions
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | empty wallet scenario, should emit only ProgressUpdate for empty wallet | 2554 ms |
+| ✓ | multi-destination transaction scenario, should emit UnshieldedTransaction only for the target wallet (A > B1) | 30091 ms |
+| ✓ | multi-destination transaction scenario, should emit UnshieldedTransaction only for the target wallet (A > B2) | 21665 ms |
+| ↓ | future coverage, should not duplicate events after resubscription | — |
+| ↓ | future coverage, should correctly handle multiple sequential A > B transactions | — |
+| ↓ | future coverage, should correctly handle mixed historical and new wallet subscriptions | — |
+| ↓ | future coverage, should segregate shielded and unshielded events correctly | — |
+
+### Dust balance
+
+File name: `tests/e2e/toolkit/dust-balance.test.ts`
+
+#### Dust Balance Query Using Toolkit
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a dust balance query with a valid wallet seed, should respond with a dust balance according to the requested schema | 182 ms |
+
+### Key material
+
+File name: `tests/e2e/toolkit/key-material.test.ts`
+
+#### Key Material Derivation Validation
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | a midnight shielded address, should show with the expected prefix for the current network ID | 38 ms |
+| ✓ | a midnight shielded address, should show with the expected prefix for all network IDs | 163 ms |
+| ✓ | a midnight unshielded address, should show with the expected prefix for the current network ID | 37 ms |
+| ✓ | a midnight unshielded address, should show with the expected prefix for all network IDs | 126 ms |
+| ✓ | a midnight viewing key, should show with the expected prefix for the current network ID | 23 ms |
+| ✓ | a midnight viewing key, should show with the expected prefix for all network IDs | 121 ms |
+
+### Show wallet queries
+
+File name: `tests/e2e/toolkit/show-wallet-queries.test.ts`
+
+#### Show Wallet Queries Using Toolkit
+
+| Status | Name | Duration |
+| :---: | --- | ---: |
+| ✓ | private wallet state query using toolkit, should respond with a private wallet state according to the requested schema | 546 ms |
+| ✓ | public wallet state query using toolkit, should respond with a public wallet state according to the requested schema | 464 ms |


### PR DESCRIPTION
## What this is

Adds QA test execution evidence for the **indexer 4.3.3** release under `qa/tests/evidence/4.3.3/`.

It captures the full test run used for QA sign-off:

- **Summary** (`README.md`) — run metadata (indexer 4.3.3, node 1.0.0, toolkit 1.0.0), aggregate results, and the exact commands used to reproduce each suite.
- **qanet** — `smoke` (18 passed / 1 skipped) and `integration` (168 passed / 2 skipped) reports plus their JUnit result files.
- **undeployed** — `e2e` (38 passed) report and JUnit result file.

Totals: **224 passed, 0 failed, 3 skipped (227)**. All suites green; skips are the suites' own conditional cases. Docs/evidence only — no production code changes.

This is QA sign-off  :heavy_check_mark: 