### PR TITLE
feat(indexer-api): add dustRegistrationsByDustAddress reverse lookup query (#1240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,6 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### 🚀 Features
-
-- *(indexer-api)* Add `dustRegistrationsByDustAddress` query for reverse DUST address lookup (#1240)
-
 ## [4.3.3] - 2026-06-04
 
 ### 🚀 Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### 🚀 Features
+
+- *(indexer-api)* Add `dustRegistrationsByDustAddress` query for reverse DUST address lookup (#1240)
+
 ## [4.3.3] - 2026-06-04
 
 ### 🚀 Features

--- a/docs/api/v4/api-documentation.md
+++ b/docs/api/v4/api-documentation.md
@@ -332,6 +332,34 @@ The `currentCapacity` field represents the maximum DUST generation capacity base
 
 For accurate DUST balance after fee payments, query the connected wallet directly via wallet SDK or DApp Connector API. Use `currentCapacity` as an approximation when wallet connection is unavailable
 
+### dustRegistrationsByDustAddress(dustAddresses: [DustAddress!]!): [DustGenerations!]!
+
+Reverse lookup: given one or more DUST addresses, returns the `DustGenerations` for each associated Cardano stake key. DUST addresses with no active registration are silently omitted. If multiple queried DUST addresses belong to the same stake key, the result is deduplicated. Maximum 10 addresses per request.
+
+**Example:**
+
+```graphql
+query {
+  dustRegistrationsByDustAddress(
+    dustAddresses: [
+      "mn_dust_undeployed1qyp..."
+    ]
+  ) {
+    cardanoRewardAddress
+    registrations {
+      dustAddress
+      valid
+      nightBalance
+      generationRate
+      maxCapacity
+      currentCapacity
+      utxoTxHash
+      utxoOutputIndex
+    }
+  }
+}
+```
+
 ## Contract Action Types
 
 All ContractAction types (ContractDeploy, ContractCall, ContractUpdate) implement the ContractAction interface with these common fields:

--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -739,6 +739,12 @@ type Query {
 	"""
 	dustGenerations(cardanoRewardAddresses: [CardanoRewardAddress!]!): [DustGenerations!]!
 	"""
+	Reverse lookup: for each DUST address, return the `DustGenerations` for the
+	associated Cardano stake key. DUST addresses with no active registration are
+	silently omitted. Duplicate stake keys are deduplicated. Max 10 addresses.
+	"""
+	dustRegistrationsByDustAddress(dustAddresses: [DustAddress!]!): [DustGenerations!]!
+	"""
 	Get a collapsed Merkle tree update for the dust commitment tree.
 	"""
 	dustCommitmentMerkleTreeUpdate(startIndex: Int!, endIndex: Int!): MerkleTreeCollapsedUpdate! @beta

--- a/indexer-api/src/domain/storage/dust_generations.rs
+++ b/indexer-api/src/domain/storage/dust_generations.rs
@@ -19,7 +19,7 @@ use crate::domain::{
     storage::NoopStorage,
 };
 use futures::{Stream, stream};
-use indexer_common::domain::{CardanoRewardAddress, LedgerVersion};
+use indexer_common::domain::{CardanoRewardAddress, DustPublicKey, LedgerVersion};
 use std::num::NonZeroU32;
 
 /// Storage for dust generations queries and subscriptions.
@@ -32,6 +32,16 @@ where
     async fn get_dust_generations(
         &self,
         cardano_reward_addresses: &[CardanoRewardAddress],
+        ledger_version: LedgerVersion,
+    ) -> Result<Vec<DustGenerations>, sqlx::Error>;
+
+    /// Reverse lookup: for each DUST address (raw bytes), return the `DustGenerations`
+    /// for the associated Cardano stake key. DUST addresses that have no active
+    /// registration are silently omitted. Duplicate stake keys (when multiple queried
+    /// DUST addresses belong to the same stake key) are deduplicated.
+    async fn get_dust_registrations_by_dust_addresses(
+        &self,
+        dust_addresses: &[DustPublicKey],
         ledger_version: LedgerVersion,
     ) -> Result<Vec<DustGenerations>, sqlx::Error>;
 
@@ -134,5 +144,13 @@ impl DustGenerationsStorage for NoopStorage {
 
     async fn get_dust_generations_chain_first_free(&self) -> Result<u64, sqlx::Error> {
         Ok(0)
+    }
+
+    async fn get_dust_registrations_by_dust_addresses(
+        &self,
+        _dust_addresses: &[DustPublicKey],
+        _ledger_version: LedgerVersion,
+    ) -> Result<Vec<DustGenerations>, sqlx::Error> {
+        Ok(vec![])
     }
 }

--- a/indexer-api/src/infra/api/v4/query.rs
+++ b/indexer-api/src/infra/api/v4/query.rs
@@ -20,7 +20,7 @@ use crate::{
             block::{Block, BlockOffset},
             contract_action::{ContractAction, ContractActionOffset},
             directives::beta,
-            dust::DustGenerationStatus,
+            dust::{DustAddress, DustGenerationStatus},
             dust_generations::DustGenerations,
             merkle_tree_collapsed_update::MerkleTreeCollapsedUpdate,
             spo::{
@@ -303,6 +303,39 @@ where
             .get_dust_generations(&addresses, LedgerVersion::LATEST)
             .await
             .map_err_into_server_error(|| "get DUST generations")?;
+
+        Ok(data
+            .into_iter()
+            .map(|d| DustGenerations::from_domain(d, network_id))
+            .collect())
+    }
+
+    /// Reverse lookup: for each DUST address, return the `DustGenerations` for the
+    /// associated Cardano stake key. DUST addresses with no active registration are
+    /// silently omitted. Duplicate stake keys are deduplicated. Max 10 addresses.
+    #[trace]
+    async fn dust_registrations_by_dust_address(
+        &self,
+        cx: &Context<'_>,
+        dust_addresses: Vec<DustAddress>,
+    ) -> ApiResult<Vec<DustGenerations>> {
+        (dust_addresses.len() <= 10)
+            .then_some(())
+            .some_or_client_error(|| "maximum of ten DUST addresses allowed")?;
+
+        let storage = cx.get_storage::<S>();
+        let network_id = cx.get_network_id();
+
+        let raw_addresses = dust_addresses
+            .into_iter()
+            .map(|a| a.try_into_domain(network_id))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err_into_client_error(|| "invalid DUST address")?;
+
+        let data = storage
+            .get_dust_registrations_by_dust_addresses(&raw_addresses, LedgerVersion::LATEST)
+            .await
+            .map_err_into_server_error(|| "get DUST registrations by DUST addresses")?;
 
         Ok(data
             .into_iter()

--- a/indexer-api/src/infra/storage/dust_generations.rs
+++ b/indexer-api/src/infra/storage/dust_generations.rs
@@ -26,14 +26,14 @@ use fastrace::trace;
 use futures::Stream;
 use indexer_common::{
     domain::{
-        ByteVec, CardanoRewardAddress, LedgerEventAttributes, LedgerVersion, TimestampMs,
-        TimestampSecs, TransactionHash, ledger,
+        ByteVec, CardanoRewardAddress, DustPublicKey, LedgerEventAttributes, LedgerVersion,
+        TimestampMs, TimestampSecs, TransactionHash, ledger,
     },
     infra::sqlx::U128BeBytes,
 };
 use indoc::indoc;
 use sqlx::FromRow;
-use std::num::NonZeroU32;
+use std::{collections::HashSet, num::NonZeroU32};
 
 impl DustGenerationsStorage for Storage {
     #[trace]
@@ -445,6 +445,57 @@ impl DustGenerationsStorage for Storage {
         .await?;
 
         Ok(max_index.map(|i| i as u64 + 1).unwrap_or(0))
+    }
+
+    #[trace]
+    async fn get_dust_registrations_by_dust_addresses(
+        &self,
+        dust_addresses: &[DustPublicKey],
+        ledger_version: LedgerVersion,
+    ) -> Result<Vec<DustGenerations>, sqlx::Error> {
+        let stake_key_query = indoc! {"
+            SELECT cardano_stake_key
+            FROM cnight_registrations
+            WHERE dust_address = $1
+            AND removed_at IS NULL
+            ORDER BY registered_at DESC
+            LIMIT 1
+        "};
+
+        let mut seen_inputs: HashSet<&[u8]> = HashSet::new();
+        let mut seen_stake_keys: HashSet<Vec<u8>> = HashSet::new();
+        let mut unique_reward_addresses: Vec<CardanoRewardAddress> = Vec::new();
+
+        for dust_addr in dust_addresses {
+            if !seen_inputs.insert(dust_addr.as_ref()) {
+                continue;
+            }
+
+            let row = sqlx::query_as::<_, (Vec<u8>,)>(stake_key_query)
+                .bind(dust_addr.as_ref())
+                .fetch_optional(&*self.pool)
+                .await?;
+
+            if let Some((stake_key_bytes,)) = row
+                && seen_stake_keys.insert(stake_key_bytes.clone())
+            {
+                let reward_address =
+                    CardanoRewardAddress::try_from(stake_key_bytes.as_slice()).map_err(
+                        |e| sqlx::Error::ColumnDecode {
+                            index: "cardano_stake_key".to_string(),
+                            source: Box::new(e),
+                        },
+                    )?;
+                unique_reward_addresses.push(reward_address);
+            }
+        }
+
+        if unique_reward_addresses.is_empty() {
+            return Ok(vec![]);
+        }
+
+        self.get_dust_generations(&unique_reward_addresses, ledger_version)
+            .await
     }
 }
 

--- a/indexer-tests/e2e.graphql
+++ b/indexer-tests/e2e.graphql
@@ -892,3 +892,19 @@ query TermsAndConditionsHistoryQuery {
         url
     }
 }
+
+query DustRegistrationsByDustAddressQuery($dustAddresses: [DustAddress!]!) {
+    dustRegistrationsByDustAddress(dustAddresses: $dustAddresses) {
+        cardanoRewardAddress
+        registrations {
+            dustAddress
+            valid
+            nightBalance
+            generationRate
+            maxCapacity
+            currentCapacity
+            utxoTxHash
+            utxoOutputIndex
+        }
+    }
+}

--- a/indexer-tests/src/e2e.rs
+++ b/indexer-tests/src/e2e.rs
@@ -20,9 +20,10 @@ use crate::{
         DustCommitmentMerkleTreeUpdateQuery, DustGenerationMerkleTreeUpdateQuery,
         DustGenerationStatusQuery, DustGenerationsQuery, DustGenerationsSubscription,
         DustLedgerEventsSubscription, DustNullifierTransactionsSubscription,
-        ShieldedNullifierTransactionsSubscription, ShieldedTransactionsSubscription,
-        TermsAndConditionsHistoryQuery, TransactionsQuery, UnshieldedTransactionsSubscription,
-        ZswapLedgerEventsSubscription, ZswapMerkleTreeCollapsedUpdateQuery, block_query,
+        DustRegistrationsByDustAddressQuery, ShieldedNullifierTransactionsSubscription,
+        ShieldedTransactionsSubscription, TermsAndConditionsHistoryQuery, TransactionsQuery,
+        UnshieldedTransactionsSubscription, ZswapLedgerEventsSubscription,
+        ZswapMerkleTreeCollapsedUpdateQuery, block_query,
         block_subscription::{
             self, BlockSubscriptionBlocks, BlockSubscriptionBlocksTransactions,
             BlockSubscriptionBlocksTransactionsContractActions,
@@ -38,6 +39,7 @@ use crate::{
         dust_commitment_merkle_tree_update_query, dust_generation_merkle_tree_update_query,
         dust_generation_status_query, dust_generations_query, dust_generations_subscription,
         dust_ledger_events_subscription, dust_nullifier_transactions_subscription,
+        dust_registrations_by_dust_address_query,
         shielded_nullifier_transactions_subscription, shielded_transactions_subscription,
         transactions_query, unshielded_transactions_subscription, zswap_ledger_events_subscription,
         zswap_merkle_tree_collapsed_update_query,
@@ -118,6 +120,9 @@ pub async fn run(network_id: NetworkId, host: &str, port: u16, secure: bool) -> 
     test_dust_generations_query(&api_client, &api_url)
         .await
         .context("test dust generations query")?;
+    test_dust_registrations_by_dust_address_query(&api_client, &api_url, &network_id)
+        .await
+        .context("test dust registrations by dust address query")?;
     test_dust_commitment_merkle_tree_update_query(&api_client, &api_url)
         .await
         .context("test dust commitment merkle tree update query")?;
@@ -742,6 +747,48 @@ async fn test_dust_generations_query(api_client: &Client, api_url: &str) -> anyh
     let response = send_query::<DustGenerationsQuery>(api_client, api_url, variables).await?;
     assert_eq!(response.dust_generations.len(), 1);
     assert!(response.dust_generations[0].registrations.is_empty());
+
+    Ok(())
+}
+
+/// Test the dustRegistrationsByDustAddress query (resolves #1240).
+async fn test_dust_registrations_by_dust_address_query(
+    api_client: &Client,
+    api_url: &str,
+    network_id: &NetworkId,
+) -> anyhow::Result<()> {
+    // Empty input — should return empty list, not an error.
+    let variables = dust_registrations_by_dust_address_query::Variables {
+        dust_addresses: vec![],
+    };
+    let response =
+        send_query::<DustRegistrationsByDustAddressQuery>(api_client, api_url, variables).await?;
+    assert!(response.dust_registrations_by_dust_address.is_empty());
+
+    // Unknown DUST address — should return empty list, not an error.
+    let dummy_dust_address =
+        DustAddress(encode_address([0u8; 32], AddressType::Dust, network_id));
+    let variables = dust_registrations_by_dust_address_query::Variables {
+        dust_addresses: vec![dummy_dust_address],
+    };
+    let response =
+        send_query::<DustRegistrationsByDustAddressQuery>(api_client, api_url, variables).await?;
+    assert!(response.dust_registrations_by_dust_address.is_empty());
+
+    // DOS protection: 11 addresses should be rejected.
+    let too_many: Vec<DustAddress> = (0u8..=10)
+        .map(|i| {
+            let mut bytes = [0u8; 32];
+            bytes[0] = i;
+            DustAddress(encode_address(bytes, AddressType::Dust, network_id))
+        })
+        .collect();
+    let variables = dust_registrations_by_dust_address_query::Variables {
+        dust_addresses: too_many,
+    };
+    let result =
+        send_query::<DustRegistrationsByDustAddressQuery>(api_client, api_url, variables).await;
+    assert!(result.is_err(), "expected client error for > 10 addresses");
 
     Ok(())
 }
@@ -1522,4 +1569,12 @@ mod graphql {
         response_derives = "Debug, Clone, Serialize"
     )]
     pub struct TermsAndConditionsHistoryQuery;
+
+    #[derive(GraphQLQuery)]
+    #[graphql(
+        schema_path = "../indexer-api/graphql/schema-v4.graphql",
+        query_path = "./e2e.graphql",
+        response_derives = "Debug, Clone, Serialize"
+    )]
+    pub struct DustRegistrationsByDustAddressQuery;
 }


### PR DESCRIPTION
# Overview

Adds a reverse lookup query  that accepts up to 10 DUST addresses and returns the associated  for each registered Cardano stake key.

The  table already indexes both  and , so the implementation adds only a new GraphQL resolver and storage query on top of the existing  infrastructure.

**Behaviour:**
- DUST addresses with no active registration are silently omitted
- If multiple queried DUST addresses map to the same stake key, the result is deduplicated
- Maximum 10 addresses per request (consistent with )

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [x] Reviewer requested
- [x] Update README.md file (if relevant)
- [x] Update documentation (if relevant)
- [x] No new todos introduced

## Links

Closes #1240