### PR TITLE
fix: contract action unshieldedBalances always empty

### DIFF
--- a/indexer-common/src/domain/ledger/contract_state.rs
+++ b/indexer-common/src/domain/ledger/contract_state.rs
@@ -20,7 +20,7 @@ use midnight_coin_structure_v2::coin::TokenType as MidnightTokenType;
 use midnight_onchain_runtime_v3::state::ContractState as ContractStateV3;
 use midnight_onchain_runtime_v4::state::ContractState as ContractStateV4;
 use midnight_serialize_v1::tagged_deserialize;
-use midnight_storage_core_v1::{DefaultDB, arena::Sp};
+use midnight_storage_core_v1::DefaultDB;
 
 /// Facade for `ContractState` from `midnight_ledger` across supported (protocol) versions.
 #[derive(Debug, Clone)]
@@ -60,9 +60,10 @@ impl ContractState {
                     .balance
                     .iter()
                     .filter_map(|entry| {
-                        let (token_type_sp, amount_sp) = Sp::into_inner(entry)?;
-                        let token_type = Sp::into_inner(token_type_sp)?;
-                        let amount = Sp::into_inner(amount_sp)?;
+                        // Read via deref: `Sp::into_inner` returns `None` for lazy or shared
+                        // entries, silently dropping all balances.
+                        let (token_type, amount) = &*entry;
+                        let (token_type, amount) = (**token_type, **amount);
 
                         (amount > 0).then_some((token_type, amount))
                     })
@@ -95,9 +96,10 @@ impl ContractState {
                     .balance
                     .iter()
                     .filter_map(|entry| {
-                        let (token_type_sp, amount_sp) = Sp::into_inner(entry)?;
-                        let token_type = Sp::into_inner(token_type_sp)?;
-                        let amount = Sp::into_inner(amount_sp)?;
+                        // Read via deref: `Sp::into_inner` returns `None` for lazy or shared
+                        // entries, silently dropping all balances.
+                        let (token_type, amount) = &*entry;
+                        let (token_type, amount) = (**token_type, **amount);
 
                         (amount > 0).then_some((token_type, amount))
                     })
@@ -126,4 +128,62 @@ impl ContractState {
             }
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::domain::{
+        ByteArray, LedgerVersion, TokenType,
+        ledger::{ContractState, TaggedSerializableExt},
+    };
+    use midnight_base_crypto_v1::hash::HashOutput;
+    use midnight_coin_structure_v2::coin::{TokenType as MidnightTokenType, UnshieldedTokenType};
+    use midnight_onchain_runtime_v3::state::ContractState as ContractStateV3;
+    use midnight_onchain_runtime_v4::state::ContractState as ContractStateV4;
+    use midnight_storage_core_v1::DefaultDB;
+
+    #[test]
+    fn test_balances_v8() {
+        let mut contract_state = ContractStateV3::<DefaultDB>::default();
+        contract_state.balance = contract_state.balance.insert(
+            MidnightTokenType::Unshielded(UnshieldedTokenType(HashOutput(TOKEN_TYPE.0))),
+            AMOUNT,
+        );
+        let contract_state = contract_state
+            .tagged_serialize()
+            .expect("contract state can be serialized");
+
+        let balances = ContractState::deserialize(contract_state, LedgerVersion::V8)
+            .expect("contract state can be deserialized")
+            .balances()
+            .expect("balances can be extracted");
+
+        assert_eq!(balances.len(), 1);
+        assert_eq!(balances[0].token_type, TOKEN_TYPE);
+        assert_eq!(balances[0].amount, AMOUNT);
+    }
+
+    #[test]
+    fn test_balances_v9() {
+        let mut contract_state = ContractStateV4::<DefaultDB>::default();
+        contract_state.balance = contract_state.balance.insert(
+            MidnightTokenType::Unshielded(UnshieldedTokenType(HashOutput(TOKEN_TYPE.0))),
+            AMOUNT,
+        );
+        let contract_state = contract_state
+            .tagged_serialize()
+            .expect("contract state can be serialized");
+
+        let balances = ContractState::deserialize(contract_state, LedgerVersion::V9)
+            .expect("contract state can be deserialized")
+            .balances()
+            .expect("balances can be extracted");
+
+        assert_eq!(balances.len(), 1);
+        assert_eq!(balances[0].token_type, TOKEN_TYPE);
+        assert_eq!(balances[0].amount, AMOUNT);
+    }
+
+    const TOKEN_TYPE: TokenType = ByteArray([7; 32]);
+    const AMOUNT: u128 = 1_000_000;
 }


### PR DESCRIPTION
# Overview

`ContractAction.unshieldedBalances` has returned `[]` for every contract action since the field shipped in 3.0.0 (#97 introduced the field and this extraction together, so no release has ever returned a non-empty result), including contracts verifiably holding unshielded tokens on chain (reported by MNF for a mint-to-self flow; on preprod-green a DEX pool holding 16 token types reports `[]`).

Root cause: `ContractState::balances()` walks the ledger balance map with `Sp::into_inner(...)?` inside a `filter_map`. `Sp::into_inner` returns `None` for lazy (not yet loaded) entries, it deliberately does not force, and for entries whose `Arc` is shared with the map itself, which covers every entry yielded by `balance.iter()`. Each entry mapped to `None` and was silently dropped, so the extraction always returned `Ok([])`, on both the V8 and V9 arms.

The fix reads entries via deref instead, which forces lazy loads and works on shared entries. Regression tests build a synthetic contract state with a non-zero balance per version arm and assert the extracted entry; they fail on the old code.

Validation beyond the tests: the fixed extraction was run over all 6,531 stored contract states from preview and preprod-green, 571/571 contracts with positive on-chain balances now extract correctly, 0 mismatches against a ground-truth walk of the same maps, 0 decode errors.

Deploy note: no schema change and no reset, a rolling image bump. The fix is forward-only (balances are extracted at index time); repairing already-indexed history is covered by the backfill plan in #1245 and will be a follow-up PR.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [ ] Update README.md file (if relevant)
- [ ] Update documentation (if relevant)
- [x] No new todos introduced

## Links

Closes #1245
