### PR TITLE
test: assert unshieldedBalances content for token-holding contracts

### DIFF
--- a/qa/tests/data/static/qanet/token-holding-contracts.jsonc
+++ b/qa/tests/data/static/qanet/token-holding-contracts.jsonc
@@ -1,0 +1,17 @@
+// Contracts known to hold non-zero unshielded token balances on the qanet chain.
+// Used by the unshieldedBalances regression tests (midnightntwrk/midnight-indexer#1245):
+// the field returned an empty array for every contract from 3.0.0 to 4.3.3, so these
+// tests require an indexer with the #1246 fix and repaired history (backfill or
+// re-index). Snapshot date: 2026-06-11 (verified against qanet-blue after backfill).
+[
+  {
+    // QA boundary-test contract, latest action "check_balance"; holds u64::MAX of the token.
+    "contract-address": "c2290f97355fd7fc9a4350e74ec90243a0e633336c2cd153eb559bdd122a378e",
+    "token-type": "7b0d072c08aefac4d44a2ba29b6b2b632569ba02bf7a2e27983913e3281b43d0"
+  },
+  {
+    // QA token-test contract, balance 2000 of the token at snapshot date.
+    "contract-address": "90b21fdea1ad4c5ce131448a8df3fec76f89c709510f418675c2648749494ff5",
+    "token-type": "224487674c0c8d0912dc118a4a7f404df18f7aa501ebf82f90732a3658f24b7e"
+  }
+]

--- a/qa/tests/tests/integration/basic/queries/contract-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/contract-queries.test.ts
@@ -17,11 +17,12 @@ import log from '@utils/logging/logger';
 import type { TestContext } from 'vitest';
 import '@utils/logging/test-logging-hooks';
 import {
+  ContractBalanceSchema,
   ContractDeployActionSchema,
   ContractCallActionSchema,
   ContractUpdateActionSchema,
 } from '@utils/indexer/graphql/schema';
-import dataProvider from '@utils/testdata-provider';
+import dataProvider, { type TokenHoldingContractInfo } from '@utils/testdata-provider';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
 
 const indexerHttpClient = new IndexerHttpClient();
@@ -106,6 +107,54 @@ describe('contract queries', () => {
         const response = await indexerHttpClient.getContractAction(malformedAddress);
 
         expect.soft(response).toBeError();
+      }
+    });
+
+    /**
+     * A contract known to hold unshielded tokens reports non-empty unshieldedBalances
+     *
+     * Regression test for #1245: unshieldedBalances silently returned an empty array for
+     * every contract from 3.0.0 to 4.3.3, which format-only assertions could not catch.
+     * Requires an indexer with the #1246 fix and repaired history (backfill or re-index);
+     * skipped on environments without configured token-holding contracts.
+     *
+     * @given we have contracts known to hold non-zero unshielded token balances
+     * @when we send a contract query for each of them
+     * @then unshieldedBalances is non-empty, well-formed, has positive amounts, and
+     *       contains the expected token type
+     */
+    test('should return non-empty unshieldedBalances for contracts known to hold tokens', async (ctx: TestContext) => {
+      let tokenHoldingContracts: TokenHoldingContractInfo[];
+      try {
+        tokenHoldingContracts = dataProvider.getTokenHoldingContracts();
+      } catch (error) {
+        log.warn(error);
+        ctx.skip?.(true, (error as Error).message);
+        return;
+      }
+      if (tokenHoldingContracts.length === 0) {
+        ctx.skip?.(true, 'no token-holding contracts configured for this environment');
+        return;
+      }
+
+      for (const contract of tokenHoldingContracts) {
+        const response = await indexerHttpClient.getContractAction(contract['contract-address']);
+
+        expect(response).toBeSuccess();
+        const balances = response.data?.contractAction?.unshieldedBalances;
+        expect(balances).toBeDefined();
+        expect(balances!.length).toBeGreaterThan(0);
+
+        for (const balance of balances!) {
+          expect(ContractBalanceSchema.safeParse(balance).success).toBe(true);
+          expect(BigInt(balance.amount)).toBeGreaterThan(0n);
+        }
+
+        if (contract['token-type'] !== undefined) {
+          expect(balances!.map((balance) => balance.tokenType.toLowerCase())).toContain(
+            contract['token-type'].toLowerCase(),
+          );
+        }
       }
     });
   });

--- a/qa/tests/utils/indexer/graphql/schema.ts
+++ b/qa/tests/utils/indexer/graphql/schema.ts
@@ -220,10 +220,11 @@ export const ContractActionSchema = z.discriminatedUnion('type', [
   ContractUpdateSchema,
 ]);
 
-// Contract balance schema
+// Contract balance schema. tokenType is a 32-byte hex string and amount a decimal
+// u128 string; enforcing the shape here makes every parse a format assertion.
 export const ContractBalanceSchema = z.object({
-  tokenType: z.string(),
-  amount: z.string(),
+  tokenType: z.string().regex(/^[0-9a-fA-F]{64}$/),
+  amount: z.string().regex(/^[0-9]+$/),
 });
 
 // Updated contract action schemas to match current API

--- a/qa/tests/utils/testdata-provider.ts
+++ b/qa/tests/utils/testdata-provider.ts
@@ -33,6 +33,19 @@ export interface ContractInfo {
 }
 
 /**
+ * A contract known to hold a non-zero unshielded token balance on the current
+ * environment's chain. Used by the unshieldedBalances regression tests (#1245):
+ * the field silently returned an empty array for every contract from 3.0.0 to
+ * 4.3.3, which format-only assertions could not catch.
+ */
+export interface TokenHoldingContractInfo {
+  /** Hex-encoded contract address. */
+  'contract-address': string;
+  /** Hex-encoded unshielded token type expected among the contract's balances. */
+  'token-type'?: string;
+}
+
+/**
  * Snapshot of a Cardano stake credential whose wallet has multiple backing
  * cNIGHT UTXOs. Used by the `dustGenerationStatus` aggregation test (#926):
  * the test asserts the indexer's reported `nightBalance` matches
@@ -459,6 +472,26 @@ class TestDataProvider {
         : [];
     }
     return this.multiUtxoCandidates;
+  }
+
+  /**
+   * Gets the contracts known to hold non-zero unshielded token balances on the current
+   * environment's chain. Used by the unshieldedBalances regression tests (#1245).
+   * @returns An array of token-holding contract entries.
+   * @throws Error if the current environment has no token-holding contracts file.
+   */
+  getTokenHoldingContracts(): TokenHoldingContractInfo[] {
+    const envName = env.getCurrentEnvironmentName();
+    const baseDir = `data/static/${envName}`;
+    let contracts: JsonValue;
+    try {
+      contracts = importJsoncData(`${baseDir}/token-holding-contracts.jsonc`);
+    } catch (_) {
+      throw new Error(
+        `Test data provider is missing the token holding contracts file for ${envName} environment`,
+      );
+    }
+    return Array.isArray(contracts) ? (contracts as unknown as TokenHoldingContractInfo[]) : [];
   }
 
   /**


### PR DESCRIPTION
# Overview

Closes the QA-side gap behind #1245: the suite selected `unshieldedBalances` in four queries but never asserted on its content, so a field that returned `[]` for every contract since 3.0.0 passed every run. Three changes:

- `ContractBalanceSchema` tightened (tokenType must be 64-char hex, amount a decimal string), so every schema parse is now a format assertion.
- New env data file `data/static/qanet/token-holding-contracts.jsonc` with two QA contracts verified to hold unshielded balances (snapshot 2026-06-11, qanet-blue after the #1245 backfill), plus `dataProvider.getTokenHoldingContracts()` following the existing per-env data conventions.
- New integration test: for each configured token-holding contract, `contractAction` must return non-empty `unshieldedBalances`, schema-valid, all amounts > 0, and containing the expected token type. Skips (with warning) on environments without configured contracts, mirroring the existing known-data idiom.

Note on expectations: this test is the regression guard for #1245-class bugs, so it FAILS against an indexer without the #1246 fix + repaired history. On qanet that means it passes against qanet-blue today and goes green for qanet-green with the 4.3.4 rollout + backfill; a red run against a 4.3.3 env is a true positive.

## Links

Relates to #1245 (the fix itself is #1246).

## Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [ ] Update README.md file (if relevant)
- [ ] Update documentation (if relevant)
- [x] No new todos introduced
