### PR TITLE
feat(indexer-api): compress HTTP responses and subscription WebSockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3302,6 +3302,7 @@ dependencies = [
  "drop-stream",
  "fastrace",
  "fastrace-axum",
+ "flate2",
  "futures",
  "humantime-serde",
  "indexer-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "alloca"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +225,19 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98ec5f6c2f8bc326c994cb9e241cc257ddaba9afa8555a43cffbb5dd86efaa37"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -964,6 +992,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1279,6 +1328,26 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7ac3e5b97fdce45e8922fb05cae2c37f7bbd63d30dd94821dacfd8f3f2bf2"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "concurrent-queue"
@@ -8102,13 +8171,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -9553,3 +9626,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ fastrace-axum               = { version = "0.2" }
 fastrace-opentelemetry      = { version = "0.16" }
 fastrace-tracing            = { version = "0.1" }
 figment                     = { version = "0.10" }
+flate2                      = { version = "1.1" }
 fs_extra                    = { version = "1.3" }
 futures                     = { version = "0.3" }
 graphql_client              = { version = "0.16" }

--- a/indexer-api/Cargo.toml
+++ b/indexer-api/Cargo.toml
@@ -47,7 +47,7 @@ thiserror          = { workspace = true }
 tokio              = { workspace = true, features = [ "macros", "rt-multi-thread", "time", "signal" ] }
 tokio-stream       = { workspace = true }
 tower              = { workspace = true }
-tower-http         = { workspace = true, features = [ "cors", "limit" ] }
+tower-http         = { workspace = true, features = [ "compression-br", "compression-gzip", "compression-zstd", "cors", "limit" ] }
 trait-variant      = { workspace = true }
 uuid               = { workspace = true, features = [ "v7" ] }
 

--- a/indexer-api/Cargo.toml
+++ b/indexer-api/Cargo.toml
@@ -30,6 +30,7 @@ drop-stream        = { workspace = true }
 derive_more        = { workspace = true, features = [ "debug", "display", "from" ] }
 fastrace           = { workspace = true, features = [ "enable" ] }
 fastrace-axum      = { workspace = true }
+flate2             = { workspace = true }
 futures            = { workspace = true }
 humantime-serde    = { workspace = true }
 indexer-common     = { path = "../indexer-common" }

--- a/indexer-api/src/infra/api.rs
+++ b/indexer-api/src/infra/api.rs
@@ -61,7 +61,7 @@ use tokio::{
     signal::unix::{SignalKind, signal},
 };
 use tower::ServiceBuilder;
-use tower_http::{cors::CorsLayer, limit::RequestBodyLimitLayer};
+use tower_http::{compression::CompressionLayer, cors::CorsLayer, limit::RequestBodyLimitLayer};
 
 /// Attention: This could change if the used libraries change!
 /// See https://docs.rs/http-body-util/0.1.2/src/http_body_util/limited.rs.html#93.
@@ -287,6 +287,7 @@ where
                 .and_then(transform_lentgh_limit_exceeded),
         )
         .layer(CorsLayer::permissive())
+        .layer(CompressionLayer::new())
 }
 
 // Returns 200 when reachable. If the runtime is parked (e.g. storage-core deadlock during

--- a/indexer-api/src/infra/api/v4.rs
+++ b/indexer-api/src/infra/api/v4.rs
@@ -27,6 +27,7 @@ pub mod system_parameters;
 pub mod transaction;
 pub mod unshielded;
 pub mod viewing_key;
+pub mod ws_deflate;
 
 use crate::{
     domain::{
@@ -418,6 +419,11 @@ where
 /// Custom WebSocket handler that wires `on_connection_init` to attach a [`PerConnectionCounter`]
 /// to each connection's async-graphql `Data`. The default `GraphQLSubscription` axum service does
 /// not expose `on_connection_init`, so we open the WebSocket directly via `GraphQLWebSocket`.
+///
+/// In addition to the standard GraphQL WebSocket subprotocols this handler offers the opt-in
+/// [`ws_deflate::GRAPHQL_TRANSPORT_WS_DEFLATE`] subprotocol: clients selecting it exchange
+/// zlib-compressed payloads as binary frames (see [`ws_deflate`] for the wire format), all other
+/// clients are byte-for-byte unaffected.
 #[allow(clippy::type_complexity)]
 async fn graphql_ws<S, B>(
     Extension(schema): Extension<Schema<Query<S>, Mutation<S>, Subscription<S, B>>>,
@@ -429,16 +435,43 @@ where
     B: Subscriber,
 {
     upgrade
-        .protocols(ALL_WEBSOCKET_PROTOCOLS)
-        .on_upgrade(move |stream| {
-            GraphQLWebSocket::new(stream, schema, protocol)
-                .on_connection_init(|_payload: serde_json::Value| async move {
-                    let mut data = Data::default();
-                    data.insert(PerConnectionCounter::default());
-                    Ok(data)
-                })
-                .serve()
+        .protocols(
+            std::iter::once(ws_deflate::GRAPHQL_TRANSPORT_WS_DEFLATE)
+                .chain(ALL_WEBSOCKET_PROTOCOLS.iter().copied()),
+        )
+        .on_upgrade(move |stream| async move {
+            let deflate = stream.protocol().is_some_and(|p| {
+                p.as_bytes() == ws_deflate::GRAPHQL_TRANSPORT_WS_DEFLATE.as_bytes()
+            });
+
+            if deflate {
+                serve_graphql_ws(ws_deflate::DeflateWebSocket::new(stream), schema, protocol).await
+            } else {
+                serve_graphql_ws(stream, schema, protocol).await
+            }
         })
+}
+
+/// Runs the GraphQL-over-WebSocket protocol on the given (possibly compression-wrapped) socket,
+/// attaching a fresh [`PerConnectionCounter`] on connection init.
+async fn serve_graphql_ws<St, S, B>(
+    stream: St,
+    schema: Schema<Query<S>, Mutation<S>, Subscription<S, B>>,
+    protocol: GraphQLProtocol,
+) where
+    St: futures::Stream<Item = Result<axum::extract::ws::Message, axum::Error>>
+        + futures::Sink<axum::extract::ws::Message, Error = axum::Error>,
+    S: Storage,
+    B: Subscriber,
+{
+    GraphQLWebSocket::new(stream, schema, protocol)
+        .on_connection_init(|_payload: serde_json::Value| async move {
+            let mut data = Data::default();
+            data.insert(PerConnectionCounter::default());
+            Ok(data)
+        })
+        .serve()
+        .await
 }
 
 // This prevents batch requests, because `GraphQLRequest` only accepts single requests.

--- a/indexer-api/src/infra/api/v4/ws_deflate.rs
+++ b/indexer-api/src/infra/api/v4/ws_deflate.rs
@@ -1,0 +1,239 @@
+// This file is part of midnight-indexer.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Opt-in deflate compression for GraphQL subscription WebSockets.
+//!
+//! Wire format for the `graphql-transport-ws+deflate` subprotocol:
+//!
+//! - Server to client: graphql-transport-ws JSON messages of at least [`MIN_COMPRESS_LEN`] bytes
+//!   are sent as binary frames containing the zlib-compressed (RFC 1950) UTF-8 JSON, which browsers
+//!   decompress with the built-in `DecompressionStream('deflate')`. Smaller messages remain plain
+//!   text frames, so clients must handle both frame types.
+//! - Client to server: text frames carry plain JSON as usual; binary frames are treated as
+//!   zlib-compressed JSON and are inflated subject to [`MAX_INFLATED_LEN`].
+//! - Control frames (ping/pong/close) are never compressed.
+//!
+//! Clients must offer the standard `graphql-transport-ws` subprotocol alongside
+//! `graphql-transport-ws+deflate`: the former satisfies the GraphQL protocol negotiation, the
+//! latter enables compression. Clients that do not offer the deflate variant are byte-for-byte
+//! unaffected.
+//!
+//! Compression uses a fresh context per message, so there is no per-connection compressor state
+//! and no shared-window memory cost per connection.
+
+use axum::extract::ws::Message;
+use flate2::{Compression, read::ZlibDecoder, write::ZlibEncoder};
+use futures::{Sink, Stream};
+use std::{
+    io::{Read, Write},
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// The subprotocol identifier offered in addition to the standard `graphql-transport-ws`.
+pub const GRAPHQL_TRANSPORT_WS_DEFLATE: &str = "graphql-transport-ws+deflate";
+
+/// Outbound messages shorter than this are left uncompressed: at this size the deflate overhead
+/// outweighs the gain and the wire format permits mixing text and binary frames.
+const MIN_COMPRESS_LEN: usize = 256;
+
+/// Upper bound for inflated client-to-server payloads (decompression bomb guard); aligned with
+/// the default HTTP `request_body_limit`.
+const MAX_INFLATED_LEN: usize = 1024 * 1024;
+
+/// Wraps a WebSocket such that outbound text messages are zlib-compressed into binary frames and
+/// inbound binary frames are inflated back into text messages.
+pub struct DeflateWebSocket<S> {
+    inner: S,
+}
+
+impl<S> DeflateWebSocket<S> {
+    pub fn new(inner: S) -> Self {
+        Self { inner }
+    }
+}
+
+impl<S> Stream for DeflateWebSocket<S>
+where
+    S: Stream<Item = Result<Message, axum::Error>> + Unpin,
+{
+    type Item = Result<Message, axum::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.inner).poll_next(cx) {
+            Poll::Ready(Some(Ok(Message::Binary(data)))) => Poll::Ready(Some(
+                inflate_capped(&data)
+                    .map(|text| Message::Text(text.into()))
+                    .map_err(axum::Error::new),
+            )),
+
+            other => other,
+        }
+    }
+}
+
+impl<S> Sink<Message> for DeflateWebSocket<S>
+where
+    S: Sink<Message, Error = axum::Error> + Unpin,
+{
+    type Error = axum::Error;
+
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.inner).poll_ready(cx)
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, message: Message) -> Result<(), Self::Error> {
+        let message = match message {
+            Message::Text(text) if text.len() >= MIN_COMPRESS_LEN => {
+                let compressed = compress(text.as_bytes()).map_err(axum::Error::new)?;
+                Message::Binary(compressed.into())
+            }
+
+            other => other,
+        };
+
+        Pin::new(&mut self.inner).start_send(message)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.inner).poll_close(cx)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum InflateError {
+    #[error("cannot inflate WebSocket payload")]
+    Inflate(#[from] std::io::Error),
+
+    #[error("inflated WebSocket payload exceeds {MAX_INFLATED_LEN} bytes")]
+    TooLarge,
+
+    #[error("inflated WebSocket payload is not valid UTF-8")]
+    Utf8(#[from] std::string::FromUtf8Error),
+}
+
+fn compress(payload: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut encoder = ZlibEncoder::new(
+        Vec::with_capacity(payload.len() / 4),
+        Compression::default(),
+    );
+    encoder.write_all(payload)?;
+    encoder.finish()
+}
+
+fn inflate_capped(payload: &[u8]) -> Result<String, InflateError> {
+    let mut inflated = Vec::new();
+    ZlibDecoder::new(payload)
+        .take(MAX_INFLATED_LEN as u64 + 1)
+        .read_to_end(&mut inflated)?;
+
+    if inflated.len() > MAX_INFLATED_LEN {
+        return Err(InflateError::TooLarge);
+    }
+
+    Ok(String::from_utf8(inflated)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{SinkExt, StreamExt, stream};
+
+    #[test]
+    fn compress_inflate_roundtrip() {
+        let payload =
+            r#"{"type":"next","id":"1","payload":{"data":{"blocks":{"height":42}}}}"#.repeat(10);
+        let compressed = compress(payload.as_bytes()).unwrap();
+        assert!(compressed.len() < payload.len());
+        assert_eq!(inflate_capped(&compressed).unwrap(), payload);
+    }
+
+    #[test]
+    fn inflate_rejects_oversized_payload() {
+        let bomb = compress(&vec![0u8; MAX_INFLATED_LEN + 1]).unwrap();
+        assert!(matches!(inflate_capped(&bomb), Err(InflateError::TooLarge)));
+    }
+
+    #[test]
+    fn inflate_rejects_garbage() {
+        assert!(matches!(
+            inflate_capped(b"not zlib data"),
+            Err(InflateError::Inflate(_))
+        ));
+    }
+
+    #[test]
+    fn inflate_rejects_invalid_utf8() {
+        let compressed = compress(&[0xff, 0xfe, 0xfd]).unwrap();
+        assert!(matches!(
+            inflate_capped(&compressed),
+            Err(InflateError::Utf8(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn sink_compresses_large_text_only() {
+        let mut messages = Vec::new();
+        {
+            let sink = futures::sink::unfold((), |(), message: Message| {
+                messages.push(message);
+                async move { Ok::<_, axum::Error>(()) }
+            });
+            futures::pin_mut!(sink);
+
+            let large = "x".repeat(MIN_COMPRESS_LEN);
+            let small = "y".repeat(MIN_COMPRESS_LEN - 1);
+            // DeflateWebSocket requires Unpin, the pinned unfold sink is used via &mut.
+            let mut socket = DeflateWebSocket::new(&mut sink);
+            socket
+                .send(Message::Text(large.clone().into()))
+                .await
+                .unwrap();
+            socket
+                .send(Message::Text(small.clone().into()))
+                .await
+                .unwrap();
+
+            let [first, second] = &messages[..] else {
+                panic!("expected two messages");
+            };
+            match first {
+                Message::Binary(data) => assert_eq!(inflate_capped(data).unwrap(), large),
+                other => panic!("expected binary frame, got {other:?}"),
+            }
+            assert!(matches!(second, Message::Text(text) if text.as_str() == small));
+        }
+    }
+
+    #[tokio::test]
+    async fn stream_inflates_binary_and_passes_text_through() {
+        let compressed = compress(b"inflated payload").unwrap();
+        let inner = stream::iter([
+            Ok::<_, axum::Error>(Message::Binary(compressed.into())),
+            Ok(Message::Text("plain".into())),
+        ]);
+        futures::pin_mut!(inner);
+
+        let mut socket = DeflateWebSocket::new(&mut inner);
+
+        let first = socket.next().await.unwrap().unwrap();
+        assert!(matches!(first, Message::Text(text) if text.as_str() == "inflated payload"));
+
+        let second = socket.next().await.unwrap().unwrap();
+        assert!(matches!(second, Message::Text(text) if text.as_str() == "plain"));
+    }
+}

--- a/indexer-api/src/infra/api/v4/ws_deflate.rs
+++ b/indexer-api/src/infra/api/v4/ws_deflate.rs
@@ -15,12 +15,12 @@
 //!
 //! Wire format for the `graphql-transport-ws+deflate` subprotocol:
 //!
-//! - Server to client: graphql-transport-ws JSON messages of at least [`MIN_COMPRESS_LEN`] bytes
-//!   are sent as binary frames containing the zlib-compressed (RFC 1950) UTF-8 JSON, which browsers
-//!   decompress with the built-in `DecompressionStream('deflate')`. Smaller messages remain plain
-//!   text frames, so clients must handle both frame types.
+//! - Server to client: graphql-transport-ws JSON messages of at least `MIN_COMPRESS_LEN` (256)
+//!   bytes are sent as binary frames containing the zlib-compressed (RFC 1950) UTF-8 JSON, which
+//!   browsers decompress with the built-in `DecompressionStream('deflate')`. Smaller messages
+//!   remain plain text frames, so clients must handle both frame types.
 //! - Client to server: text frames carry plain JSON as usual; binary frames are treated as
-//!   zlib-compressed JSON and are inflated subject to [`MAX_INFLATED_LEN`].
+//!   zlib-compressed JSON and are inflated subject to `MAX_INFLATED_LEN` (1 MiB).
 //! - Control frames (ping/pong/close) are never compressed.
 //!
 //! Clients must offer the standard `graphql-transport-ws` subprotocol alongside


### PR DESCRIPTION
## Overview

Cuts indexer egress, motivated by the May ELB cost review in `topic-node-ops`: preprod alone was $4,967 / 60.5 TB, and 98.1% of it went through the indexer ALB. Two commits, one per ticket:

**HTTP responses (#1250)** — adds tower-http's `CompressionLayer` as the outermost layer with gzip, brotli, and zstd enabled, negotiating per request via `Accept-Encoding`. Clients without the header keep receiving identity responses; tower-http's default predicate exempts tiny bodies (kubelet probes unaffected).

**Subscription WebSockets (#1251)** — offers an additional opt-in `graphql-transport-ws+deflate` subprotocol on `/api/v4/graphql/ws`, since `CompressionLayer` does not touch WebSocket upgrades and tungstenite has no permessage-deflate. Clients selecting it receive payloads of 256 B or more as zlib-compressed binary frames (browser-decompressible via `DecompressionStream('deflate')`); smaller messages stay text. Inbound binary frames are inflated behind a 1 MiB decompression-bomb guard. Compression uses a fresh context per message, so there is no per-connection compressor state to count against subscription quotas. Implemented as a ~120-line `Sink`/`Stream` adapter above the frame layer, the wire format is documented in the `ws_deflate` module.

**Backward compatibility**: the server never compresses unless the client explicitly opts in (`Accept-Encoding` header, or offering the deflate subprotocol). Vanilla `graphql-ws` / `graphql-transport-ws` clients negotiate exactly as before and run on the raw socket with no adapter in line, verified byte-for-byte below.

## Measurements

HTTP (local branch build + offline codec matrix on a real 8-block preprod payload):

| Payload | identity | compressed |
|---|---|---|
| Introspection (repetitive JSON), 112,464 B | 100% | gzip 9.5%, zstd 10.4% |
| 8 blocks with raw tx hex, 37,550 B | 100% | gzip 49.3%, zstd 43.6% |

Multi-encoding clients (browsers, most libraries) negotiate zstd at no measurable latency over identity. Blended query traffic expected to land 2-4x.

WebSocket (live against the full local stack, script in `docs/interactions/.../ws-deflate-live-test.mjs`):

| Client | Negotiated | Block payload |
|---|---|---|
| vanilla `graphql-transport-ws` | standard | TEXT 1,787 B, unchanged |
| offers `+deflate` | `graphql-transport-ws+deflate` | BINARY 909 B, inflates to the identical 1,787 B |
| `+deflate`, subscribe sent zlib-compressed | `graphql-transport-ws+deflate` | inbound inflated and served |

~2x on hash-heavy block payloads (hex compresses poorly); repetitive subscription JSON compresses further.

## Testing

- 6 unit tests on the adapter (roundtrip, bomb-cap rejection, garbage rejection, UTF-8 rejection, compress-threshold, text passthrough)
- `cargo check` on both `cloud` and `standalone`, clippy with `-D warnings`, nightly fmt
- Live three-scenario WebSocket validation above; `curl --compressed` matrix for HTTP

## Follow-ups

- Client SDK adoption of the deflate subprotocol (midnight-js / wallet SDK bundle `ws` and undici, both deflate-capable) — issue to be filed and linked on #1251 per its last checklist item
- e2e test in `indexer-tests` codifying the vanilla-unaffected + deflate scenarios

## Links

Closes #1250
Closes #1251