### PR TITLE
test: make QA framework run on a fresh checkout

### DIFF
--- a/qa/scripts/_lib.sh
+++ b/qa/scripts/_lib.sh
@@ -43,22 +43,29 @@ teardown_prior_stack() {
     fi
 }
 
-# Poll the indexer /ready endpoint until it responds or the 20s budget is spent.
-# Exits non-zero on timeout after dumping container state and indexer-api logs.
+# Poll the indexer /ready endpoint until it responds or the budget is spent.
+# The loop early-exits the moment /ready answers, so warm starts still return
+# in a couple of seconds; the budget only bounds genuinely slow cold starts
+# (image pulls plus initial chain catch-up), which exceeded the old 20s cap.
+# Override the budget with INDEXER_READY_TIMEOUT_SECONDS. Exits non-zero on
+# timeout after dumping container state and indexer-api logs.
 wait_for_indexer_ready() {
-    echo "Waiting for indexer API to become ready (20s budget)..."
+    local budget="${INDEXER_READY_TIMEOUT_SECONDS:-120}"
+    local interval=2
+    local attempts=$(( budget / interval ))
+    echo "Waiting for indexer API to become ready (${budget}s budget)..."
     local ready=0 i
-    for i in {1..10}; do
+    for (( i=1; i<=attempts; i++ )); do
         if curl -sf http://localhost:8088/ready >/dev/null; then
             echo "Indexer API is ready"
             ready=1
             break
         fi
-        echo "Not ready yet... ($i/10)"
-        sleep 2
+        echo "Not ready yet... ($i/$attempts)"
+        sleep "$interval"
     done
     if [ "$ready" -ne 1 ]; then
-        echo "ERROR: Indexer API did not become ready within 20s. Dumping container state:"
+        echo "ERROR: Indexer API did not become ready within ${budget}s. Dumping container state:"
         docker compose --profile cloud ps
         echo "Last 50 lines of indexer-api logs:"
         docker compose --profile cloud logs --tail=50 indexer-api 2>&1 || true

--- a/qa/scripts/_lib.sh
+++ b/qa/scripts/_lib.sh
@@ -77,3 +77,14 @@ clear_block_scanner_cache() {
     rm -f qa/tools/block-scanner/tmp_scan/undeployed_*.jsonl
     rm -f qa/tools/block-scanner/stats/undeployed_*.json
 }
+
+# Ensure the block-scanner's dependencies are installed before `generate:data`.
+# On a fresh checkout/worktree there is no node_modules, so the scan would fail
+# with an opaque module-resolution error (e.g. "ENOENT while resolving package
+# 'esprima'"). Install on demand so a first run on a clean worktree works.
+ensure_block_scanner_deps() {
+    if [ ! -d qa/tools/block-scanner/node_modules ]; then
+        echo "Installing block-scanner dependencies (first run on this checkout)..."
+        (cd qa/tools/block-scanner && bun install)
+    fi
+}

--- a/qa/scripts/_lib.sh
+++ b/qa/scripts/_lib.sh
@@ -52,7 +52,10 @@ teardown_prior_stack() {
 wait_for_indexer_ready() {
     local budget="${INDEXER_READY_TIMEOUT_SECONDS:-120}"
     local interval=2
-    local attempts=$(( budget / interval ))
+    # Ceiling division so elapsed time always covers the budget and there is at
+    # least one attempt even for small overrides (e.g. budget=1 → 1 attempt,
+    # not 0; budget=5 → 3 attempts → 6s rather than an undercounted 4s).
+    local attempts=$(( (budget + interval - 1) / interval ))
     echo "Waiting for indexer API to become ready (${budget}s budget)..."
     local ready=0 i
     for (( i=1; i<=attempts; i++ )); do
@@ -92,6 +95,12 @@ clear_block_scanner_cache() {
 ensure_block_scanner_deps() {
     if [ ! -d qa/tools/block-scanner/node_modules ]; then
         echo "Installing block-scanner dependencies (first run on this checkout)..."
-        (cd qa/tools/block-scanner && bun install)
+        # The startup scripts don't set errexit, so guard explicitly: otherwise
+        # a failed install falls through to `generate:data` and surfaces the
+        # same opaque module-resolution error this helper exists to prevent.
+        if ! (cd qa/tools/block-scanner && bun install); then
+            echo "ERROR: bun install failed in qa/tools/block-scanner" >&2
+            return 1
+        fi
     fi
 }

--- a/qa/scripts/startup-localenv-from-genesis.sh
+++ b/qa/scripts/startup-localenv-from-genesis.sh
@@ -96,6 +96,7 @@ echo "Plase make sure all the services are running and healthy"
 clear_block_scanner_cache
 
 echo "Regenarating new test data... "
+ensure_block_scanner_deps
 pushd qa/tools/block-scanner
 bun run generate:data
 popd

--- a/qa/scripts/startup-localenv-with-data.sh
+++ b/qa/scripts/startup-localenv-with-data.sh
@@ -120,6 +120,7 @@ echo "Plase make sure all the services are running and healthy"
 clear_block_scanner_cache
 
 echo "Regenarating new test data... "
+ensure_block_scanner_deps
 pushd qa/tools/block-scanner
 bun run generate:data
 popd

--- a/qa/tests/utils/logging/logger.ts
+++ b/qa/tests/utils/logging/logger.ts
@@ -15,7 +15,14 @@
 
 import pino, { Logger } from 'pino';
 import pretty from 'pino-pretty';
-import { existsSync, readFileSync, createWriteStream, WriteStream } from 'fs';
+import {
+  existsSync,
+  readFileSync,
+  createWriteStream,
+  WriteStream,
+  mkdirSync,
+  writeFileSync,
+} from 'fs';
 import { join, basename } from 'path';
 
 // This is an hack to have a log file per test file that is created in a
@@ -25,10 +32,37 @@ import { join, basename } from 'path';
 // The session path will be written into a file for the logger to import it,
 // avoiding race conditions
 const SESSION_PATH_FILE = 'logs/sessionPath';
-if (!existsSync(SESSION_PATH_FILE)) {
-  throw new Error('Session directory not initialized. Define a globalSetup script to create it.');
+
+// Resolve the session directory, self-healing if it is missing.
+//
+// The session dir is normally created by the logging globalSetup
+// (utils/logging/setup.ts). But that setup imports this module (via
+// environment/model), so the import below runs *before* setup() executes — and
+// on a fresh checkout/worktree, where `logs/sessionPath` does not yet exist, a
+// hard throw here aborts the whole run before globalSetup can create it. (It
+// only ever "worked" because a previous run had left the file behind.)
+//
+// Instead of throwing, create a default session dir so a first run on a clean
+// worktree works with no manual seeding. globalSetup still runs afterwards and
+// overwrites `sessionPath` with its canonical timestamped dir.
+function resolveSessionDir(): string {
+  if (existsSync(SESSION_PATH_FILE)) {
+    return readFileSync(SESSION_PATH_FILE, 'utf8').trim();
+  }
+  const base = 'logs';
+  if (!existsSync(base)) {
+    mkdirSync(base, { recursive: true });
+  }
+  const ts = new Date().toISOString().replace(/T/, '_').replace(/:/g, '-').replace(/\..+/, '');
+  const sessionDir = join(base, ts);
+  if (!existsSync(sessionDir)) {
+    mkdirSync(sessionDir, { recursive: true });
+  }
+  writeFileSync(SESSION_PATH_FILE, sessionDir, 'utf8');
+  return sessionDir;
 }
-const SESSION_DIR = readFileSync(SESSION_PATH_FILE, 'utf8').trim();
+
+const SESSION_DIR = resolveSessionDir();
 
 // Can we do this differently, lookout for a library that can help with this
 // I mean this works but it's quite horrible

--- a/qa/tests/utils/logging/logger.ts
+++ b/qa/tests/utils/logging/logger.ts
@@ -62,7 +62,14 @@ function resolveSessionDir(): string {
   return sessionDir;
 }
 
-const SESSION_DIR = resolveSessionDir();
+// Resolve lazily and memoize. Deferring resolution until the first log write
+// lets globalSetup run first and point `sessionPath` at its canonical
+// timestamped dir, so a fresh checkout no longer leaves an empty orphaned
+// `logs/<ts>/` behind from an import-time self-heal.
+let sessionDir: string | undefined;
+function getSessionDir(): string {
+  return (sessionDir ??= resolveSessionDir());
+}
 
 // Can we do this differently, lookout for a library that can help with this
 // I mean this works but it's quite horrible
@@ -99,7 +106,7 @@ function getFileStream(testPath: string): WriteStream {
   const name = basename(testPath)
     .replace(/\.[jt]sx?$/, '')
     .replace(/[^\w.-]/g, '_');
-  const filePath = join(SESSION_DIR, `${name}.log`);
+  const filePath = join(getSessionDir(), `${name}.log`);
   if (!fileStreams.has(filePath)) {
     fileStreams.set(filePath, createWriteStream(filePath, { flags: 'a' }));
   }


### PR DESCRIPTION
## Scope

Three independent fixes so the `qa/tests` framework runs cleanly on a
fresh checkout/worktree with no manual setup steps.

- **Self-heal the log session directory.** `utils/logging/logger.ts`
  resolves the session dir lazily and creates it when `logs/sessionPath`
  is missing, instead of throwing `Session directory not initialized` at
  import. The logging globalSetup still overwrites it with its canonical
  timestamped dir, so warm runs are unchanged.
- **Auto-install block-scanner deps.** A new `ensure_block_scanner_deps`
  helper in `qa/scripts/_lib.sh` runs `bun install` on demand before
  `generate:data`, wired into both undeployed startup scripts.
- **Raise the indexer readiness budget** from 20s to 120s (overridable
  via `INDEXER_READY_TIMEOUT_SECONDS`), keeping the poll loop's early
  exit so warm starts still return in a couple of seconds.

## Why

On a fresh checkout each of these aborted a first run: the session-dir
guard threw before globalSetup could create the file (it only worked
when a previous run had left it behind); the block scanner had no
`node_modules` so `generate:data` failed with an opaque module-resolution
error; and cold starts (image pulls plus initial chain catch-up) exceeded
the 20s readiness cap even though the indexer became ready moments later.

## Validation

`yarn test:smoke` on a clean worktree against undeployed (node
2.0.0-rc.1): 18 passed / 0 failed / 1 skipped, with all three paths
exercised (session dir self-healed, deps auto-installed, readiness
early-exit under the 120s budget). `yarn lint` clean, `yarn format`
applied, shell changes shellcheck-clean.