### PR TITLE
test: drop ghcr registry prefix from toolkit image

### DIFF
--- a/qa/tests/utils/toolkit/toolkit-wrapper.ts
+++ b/qa/tests/utils/toolkit/toolkit-wrapper.ts
@@ -346,7 +346,7 @@ class ToolkitWrapper {
     log.debug(`Toolkit ZK cache       : ${zkCacheDir}`);
 
     this.container = new GenericContainer(
-      `ghcr.io/midnight-ntwrk/midnight-node-toolkit:${this.config.nodeToolkitTag}`,
+      `midnightntwrk/midnight-node-toolkit:${this.config.nodeToolkitTag}`,
     )
       .withName(this.config.containerName)
       .withNetworkMode('host')


### PR DESCRIPTION
## Scope

Single-line change in the QA toolkit wrapper: reference the node toolkit
container as `midnightntwrk/midnight-node-toolkit` instead of the fully
qualified `ghcr.io/midnight-ntwrk/midnight-node-toolkit`.

## Why

Local Docker image resolution expects the org-prefixed image name used by
the QA toolkit wrapper; the fully qualified `ghcr.io` reference did not
resolve against the locally available image.

## Validation

- `yarn lint` — passed
- `yarn format` — passed (target file already formatted)
- `yarn audit` — only a pre-existing transitive advisory on `ws`, unrelated
  to this change
