### PR TITLE
feat: rehash merkle tree before building collapsed updates

### DIFF
--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -713,7 +713,7 @@ impl LedgerState {
     ) -> Result<ByteVec, Error> {
         match self {
             Self::V8 { ledger_state, .. } => MerkleTreeCollapsedUpdate::new(
-                &ledger_state.zswap.coin_coms,
+                &ledger_state.zswap.coin_coms.rehash(),
                 start_index,
                 end_index,
             )
@@ -721,7 +721,7 @@ impl LedgerState {
             .tagged_serialize()
             .map_err(|error| Error::Serialize("MerkleTreeCollapsedUpdate", error)),
             Self::V9 { ledger_state, .. } => MerkleTreeCollapsedUpdateV9::new(
-                &ledger_state.zswap.coin_coms,
+                &ledger_state.zswap.coin_coms.rehash(),
                 start_index,
                 end_index,
             )
@@ -739,7 +739,7 @@ impl LedgerState {
     ) -> Result<ByteVec, Error> {
         match self {
             Self::V8 { ledger_state, .. } => MerkleTreeCollapsedUpdate::new(
-                &ledger_state.dust.generation.generating_tree,
+                &ledger_state.dust.generation.generating_tree.rehash(),
                 start_index,
                 end_index,
             )
@@ -747,7 +747,7 @@ impl LedgerState {
             .tagged_serialize()
             .map_err(|error| Error::Serialize("DustGenerationsMerkleTreeCollapsedUpdate", error)),
             Self::V9 { ledger_state, .. } => MerkleTreeCollapsedUpdateV9::new(
-                &ledger_state.dust.generation.generating_tree,
+                &ledger_state.dust.generation.generating_tree.rehash(),
                 start_index,
                 end_index,
             )
@@ -765,7 +765,7 @@ impl LedgerState {
     ) -> Result<ByteVec, Error> {
         match self {
             Self::V8 { ledger_state, .. } => MerkleTreeCollapsedUpdate::new(
-                &ledger_state.dust.utxo.commitments,
+                &ledger_state.dust.utxo.commitments.rehash(),
                 start_index,
                 end_index,
             )
@@ -773,7 +773,7 @@ impl LedgerState {
             .tagged_serialize()
             .map_err(|error| Error::Serialize("DustCommitmentsMerkleTreeCollapsedUpdate", error)),
             Self::V9 { ledger_state, .. } => MerkleTreeCollapsedUpdateV9::new(
-                &ledger_state.dust.utxo.commitments,
+                &ledger_state.dust.utxo.commitments.rehash(),
                 start_index,
                 end_index,
             )


### PR DESCRIPTION
## Summary
The collapsed-update endpoints built the `MerkleTreeCollapsedUpdate` from the cached ledger tree without rehashing, while the root accessors (`zswap_merkle_tree_root`, `dust_commitment_merkle_tree_root`, `dust_generation_merkle_tree_root`) rehash. Since the ledger state is loaded lazily from the storage-core arena (`get_lazy`, #871), a lazily loaded tree can leave the most recently added leaf's hash unmaterialised, so the collapsed update carried a stale hash for the newest leaf. A wallet rebuilding its tree from those collapsed updates diverged from the indexer's served root at the newest leaf.

This adds `.rehash()` before `MerkleTreeCollapsedUpdate::new` in all three collapsed-update methods (V8 and V9 arms), so their output is consistent with the rehashed roots.

## Change
`indexer-common/src/domain/ledger/ledger_state.rs`, 6 lines, each now passes `&tree.rehash()` (matching the root accessors):
* `make_zswap_collapsed_update`
* `dust_generations_collapsed_update`
* `dust_commitments_collapsed_update`

## Why it surfaced now
The root accessors have rehashed since 2025 (#345), because reading a root needs finalised hashes. The collapsed-update methods were written without it (zswap in the ledger-v8 work #766/#810, dust in #980) and stayed harmless because the load was eager (`get`), which returned a materialised tree. #871 (2026-03) switched the load to lazy (`get` to `get_lazy`) to avoid a recursion depth limit, and a lazily loaded tree does not materialise the newest leaf's hash, which exposed the gap.

## Reported by
Jegor Sidorenko (wallet) in #efficient-wallet-syncing: for the same seed the dust generation tree rebuilt from the indexer's collapsed updates diverged from event-based sync at the newest leaf. The indexer's rehashed root field was correct (c192a341), the collapsed update was stale (de0246c3).

## Testing
* compiles and `clippy -D warnings` clean, both `cloud` and `standalone`
* ran against a live local stack (ledger 9): the fix runs cleanly and is a safe no-op there, the V9 / transient-crypto 3.0.0 trees are not stale. The staleness is on the ledger-8 / transient-crypto 2.1.0 path Jegor reproduced, so a V9 stack cannot reproduce it.

## Notes / follow-ups
* An automated regression test is not feasible on the current (V9) test infra: the bug only manifests on a stale lazily loaded tree, which is V8 side and needs dust-bearing test data. The rehash mirrors the already-tested root accessors. A V8 / stale-state regression test can follow once that data exists.
* Possible perf optimisation: rehash once when `LedgerStateCache` loads the state, instead of per collapsed-update call. The root accessors already rehash per call, so the current change matches the established cost.

closes #1265
