### PR TITLE
feat: per-block dust merkle roots

### DIFF
--- a/chain-indexer/src/application.rs
+++ b/chain-indexer/src/application.rs
@@ -400,6 +400,12 @@ where
     block.zswap_end_index = ledger_state.zswap_first_free();
     block.dust_commitment_end_index = ledger_state.dust_commitments_first_free();
     block.dust_generation_end_index = ledger_state.dust_generations_first_free();
+    block.dust_commitment_merkle_tree_root = ledger_state
+        .dust_commitment_merkle_tree_root()
+        .context("get dust commitment merkle tree root")?;
+    block.dust_generation_merkle_tree_root = ledger_state
+        .dust_generation_merkle_tree_root()
+        .context("get dust generation merkle tree root")?;
 
     // Validate ledger state.
     // TODO: Only use ledger state root comparison once support for Node < 0.22 is dropped!

--- a/chain-indexer/src/domain/block.rs
+++ b/chain-indexer/src/domain/block.rs
@@ -13,7 +13,8 @@
 
 use crate::domain::DustRegistrationEvent;
 use indexer_common::domain::{
-    BlockAuthor, BlockHash, ByteVec, ProtocolVersion, SerializedLedgerParameters,
+    BlockAuthor, BlockHash, ByteVec, ProtocolVersion, SerializedDustCommitmentMerkleTreeRoot,
+    SerializedDustGenerationMerkleTreeRoot, SerializedLedgerParameters,
     SerializedZswapMerkleTreeRoot,
 };
 use std::fmt::Debug;
@@ -37,6 +38,8 @@ pub struct Block {
     pub zswap_end_index: u64,
     pub dust_commitment_end_index: u64,
     pub dust_generation_end_index: u64,
+    pub dust_commitment_merkle_tree_root: SerializedDustCommitmentMerkleTreeRoot,
+    pub dust_generation_merkle_tree_root: SerializedDustGenerationMerkleTreeRoot,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/chain-indexer/src/domain/node.rs
+++ b/chain-indexer/src/domain/node.rs
@@ -93,6 +93,8 @@ impl TryFrom<Block> for (domain::Block, Vec<Transaction>) {
             zswap_end_index: 0,
             dust_commitment_end_index: 0,
             dust_generation_end_index: 0,
+            dust_commitment_merkle_tree_root: Default::default(),
+            dust_generation_merkle_tree_root: Default::default(),
         };
 
         Ok((block, transactions))

--- a/chain-indexer/src/infra/storage.rs
+++ b/chain-indexer/src/infra/storage.rs
@@ -267,7 +267,9 @@ async fn save_block(
             ledger_state_key,
             zswap_end_index,
             dust_commitment_end_index,
-            dust_generation_end_index
+            dust_generation_end_index,
+            dust_commitment_merkle_tree_root,
+            dust_generation_merkle_tree_root
         )
     "};
 
@@ -285,6 +287,8 @@ async fn save_block(
                 zswap_end_index,
                 dust_commitment_end_index,
                 dust_generation_end_index,
+                dust_commitment_merkle_tree_root,
+                dust_generation_merkle_tree_root,
                 ..
             } = block;
 
@@ -299,7 +303,9 @@ async fn save_block(
                 .push_bind(ledger_state_key)
                 .push_bind(*zswap_end_index as i64)
                 .push_bind(*dust_commitment_end_index as i64)
-                .push_bind(*dust_generation_end_index as i64);
+                .push_bind(*dust_generation_end_index as i64)
+                .push_bind(dust_commitment_merkle_tree_root.as_ref())
+                .push_bind(dust_generation_merkle_tree_root.as_ref());
         })
         .push(" RETURNING id")
         .build_query_as::<(i64,)>()

--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -43,6 +43,14 @@ type Block {
 	"""
 	dustGenerationEndIndex: Int! @beta
 	"""
+	The hex-encoded dust commitment Merkle tree root at this block.
+	"""
+	dustCommitmentMerkleTreeRoot: HexEncoded @beta
+	"""
+	The hex-encoded dust generation Merkle tree root at this block.
+	"""
+	dustGenerationMerkleTreeRoot: HexEncoded @beta
+	"""
 	The parent of this block.
 	"""
 	parent: Block
@@ -54,14 +62,6 @@ type Block {
 	The system parameters (governance) at this block height.
 	"""
 	systemParameters: SystemParameters!
-	"""
-	The hex-encoded dust commitment Merkle tree root at the latest indexed state.
-	"""
-	dustCommitmentMerkleTreeRoot: HexEncoded
-	"""
-	The hex-encoded dust generation Merkle tree root at the latest indexed state.
-	"""
-	dustGenerationMerkleTreeRoot: HexEncoded
 }
 
 """

--- a/indexer-api/src/domain/block.rs
+++ b/indexer-api/src/domain/block.rs
@@ -12,7 +12,8 @@
 // limitations under the License.
 
 use indexer_common::domain::{
-    BlockAuthor, BlockHash, ProtocolVersion, SerializedLedgerParameters,
+    BlockAuthor, BlockHash, ProtocolVersion, SerializedDustCommitmentMerkleTreeRoot,
+    SerializedDustGenerationMerkleTreeRoot, SerializedLedgerParameters,
     SerializedZswapMerkleTreeRoot,
 };
 use sqlx::prelude::FromRow;
@@ -54,4 +55,8 @@ pub struct Block {
 
     #[sqlx(try_from = "i64")]
     pub dust_generation_end_index: u64,
+
+    pub dust_commitment_merkle_tree_root: Option<SerializedDustCommitmentMerkleTreeRoot>,
+
+    pub dust_generation_merkle_tree_root: Option<SerializedDustGenerationMerkleTreeRoot>,
 }

--- a/indexer-api/src/domain/ledger_state.rs
+++ b/indexer-api/src/domain/ledger_state.rs
@@ -175,50 +175,6 @@ impl LedgerStateCache {
 
         Ok(collapsed_update)
     }
-
-    /// Get dust Merkle tree roots from the latest ledger state.
-    pub async fn dust_merkle_tree_roots(
-        &self,
-        storage: &impl Storage,
-    ) -> Result<DustMerkleTreeRoots, LedgerStateCacheError> {
-        let mut ledger_state_read = self.0.read().await;
-
-        if ledger_state_read.is_none() {
-            drop(ledger_state_read);
-            let mut ledger_state_write = self.0.write().await;
-
-            if ledger_state_write.is_none() {
-                let Some((protocol_version, ledger_state_key)) =
-                    storage.get_highest_ledger_state().await?
-                else {
-                    return Err(LedgerStateCacheError::NotFound);
-                };
-
-                let ledger_state =
-                    LedgerState::load(&ledger_state_key, protocol_version.ledger_version())?;
-                *ledger_state_write = Some(ledger_state);
-            }
-
-            ledger_state_read = ledger_state_write.downgrade();
-        }
-
-        let ledger_state = ledger_state_read
-            .as_ref()
-            .expect("ledger state should exist after loading");
-        let commitment_root = ledger_state.dust_commitment_merkle_tree_root()?;
-        let generation_root = ledger_state.dust_generation_merkle_tree_root()?;
-
-        Ok(DustMerkleTreeRoots {
-            commitment_root,
-            generation_root,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct DustMerkleTreeRoots {
-    pub commitment_root: ByteVec,
-    pub generation_root: ByteVec,
 }
 
 #[derive(Debug, Error)]

--- a/indexer-api/src/infra/api/v4/block.rs
+++ b/indexer-api/src/infra/api/v4/block.rs
@@ -68,6 +68,14 @@ where
     #[graphql(directive = beta::apply())]
     dust_generation_end_index: u64,
 
+    /// The hex-encoded dust commitment Merkle tree root at this block.
+    #[graphql(directive = beta::apply())]
+    dust_commitment_merkle_tree_root: Option<HexEncoded>,
+
+    /// The hex-encoded dust generation Merkle tree root at this block.
+    #[graphql(directive = beta::apply())]
+    dust_generation_merkle_tree_root: Option<HexEncoded>,
+
     #[graphql(skip)]
     id: u64,
 
@@ -133,34 +141,6 @@ where
             terms_and_conditions,
         })
     }
-
-    /// The hex-encoded dust commitment Merkle tree root at the latest indexed state.
-    async fn dust_commitment_merkle_tree_root(
-        &self,
-        cx: &Context<'_>,
-    ) -> ApiResult<Option<HexEncoded>> {
-        let ledger_state_cache = cx.get_ledger_state_cache();
-        let storage = cx.get_storage::<S>();
-
-        match ledger_state_cache.dust_merkle_tree_roots(storage).await {
-            Ok(roots) => Ok(Some(roots.commitment_root.hex_encode())),
-            Err(_) => Ok(None),
-        }
-    }
-
-    /// The hex-encoded dust generation Merkle tree root at the latest indexed state.
-    async fn dust_generation_merkle_tree_root(
-        &self,
-        cx: &Context<'_>,
-    ) -> ApiResult<Option<HexEncoded>> {
-        let ledger_state_cache = cx.get_ledger_state_cache();
-        let storage = cx.get_storage::<S>();
-
-        match ledger_state_cache.dust_merkle_tree_roots(storage).await {
-            Ok(roots) => Ok(Some(roots.generation_root.hex_encode())),
-            Err(_) => Ok(None),
-        }
-    }
 }
 
 impl<S> From<domain::Block> for Block<S>
@@ -181,6 +161,8 @@ where
             zswap_end_index,
             dust_commitment_end_index,
             dust_generation_end_index,
+            dust_commitment_merkle_tree_root,
+            dust_generation_merkle_tree_root,
         } = value;
 
         Block {
@@ -194,6 +176,10 @@ where
             zswap_end_index,
             dust_commitment_end_index,
             dust_generation_end_index,
+            dust_commitment_merkle_tree_root: dust_commitment_merkle_tree_root
+                .map(|root| root.hex_encode()),
+            dust_generation_merkle_tree_root: dust_generation_merkle_tree_root
+                .map(|root| root.hex_encode()),
             id,
             parent_hash,
             _s: PhantomData,

--- a/indexer-api/src/infra/storage/block.rs
+++ b/indexer-api/src/infra/storage/block.rs
@@ -38,7 +38,9 @@ impl BlockStorage for Storage {
                 ledger_parameters,
                 zswap_end_index,
                 dust_commitment_end_index,
-                dust_generation_end_index
+                dust_generation_end_index,
+                dust_commitment_merkle_tree_root,
+                dust_generation_merkle_tree_root
             FROM blocks
             ORDER BY height DESC
             LIMIT 1
@@ -69,7 +71,9 @@ impl BlockStorage for Storage {
                 ledger_parameters,
                 zswap_end_index,
                 dust_commitment_end_index,
-                dust_generation_end_index
+                dust_generation_end_index,
+                dust_commitment_merkle_tree_root,
+                dust_generation_merkle_tree_root
             FROM blocks
             WHERE height = $1
             LIMIT 1
@@ -121,7 +125,9 @@ impl Storage {
                 ledger_parameters,
                 zswap_end_index,
                 dust_commitment_end_index,
-                dust_generation_end_index
+                dust_generation_end_index,
+                dust_commitment_merkle_tree_root,
+                dust_generation_merkle_tree_root
             FROM blocks
             WHERE hash = ANY($1)
         "};
@@ -149,7 +155,9 @@ impl Storage {
                 ledger_parameters,
                 zswap_end_index,
                 dust_commitment_end_index,
-                dust_generation_end_index
+                dust_generation_end_index,
+                dust_commitment_merkle_tree_root,
+                dust_generation_merkle_tree_root
             FROM blocks
             WHERE hash IN (
         "};
@@ -183,7 +191,9 @@ impl Storage {
                 ledger_parameters,
                 zswap_end_index,
                 dust_commitment_end_index,
-                dust_generation_end_index
+                dust_generation_end_index,
+                dust_commitment_merkle_tree_root,
+                dust_generation_merkle_tree_root
             FROM blocks
             WHERE height >= $1
             ORDER BY height

--- a/indexer-common/migrations/postgres/004_block_dust_merkle_roots.sql
+++ b/indexer-common/migrations/postgres/004_block_dust_merkle_roots.sql
@@ -1,0 +1,13 @@
+-- Per-block dust commitment/generation Merkle tree roots (as of this block), so
+-- `Block.dustCommitmentMerkleTreeRoot` / `dustGenerationMerkleTreeRoot` return
+-- the root for the queried block rather than the latest indexed (tip) state.
+-- The chain-indexer computes these from the post-apply ledger state in
+-- `save_block` for new blocks.
+--
+-- Nullable, with no backfill: unlike the end-index columns these roots cannot be
+-- derived in SQL (they require the ledger Merkle trees), so existing rows stay
+-- NULL until the chain is reset or backfilled. The GraphQL fields are nullable
+-- accordingly.
+
+ALTER TABLE blocks ADD COLUMN dust_commitment_merkle_tree_root BYTEA;
+ALTER TABLE blocks ADD COLUMN dust_generation_merkle_tree_root BYTEA;

--- a/indexer-common/migrations/sqlite/006_block_dust_merkle_roots.sql
+++ b/indexer-common/migrations/sqlite/006_block_dust_merkle_roots.sql
@@ -1,0 +1,13 @@
+-- Per-block dust commitment/generation Merkle tree roots (as of this block), so
+-- `Block.dustCommitmentMerkleTreeRoot` / `dustGenerationMerkleTreeRoot` return
+-- the root for the queried block rather than the latest indexed (tip) state.
+-- The chain-indexer computes these from the post-apply ledger state in
+-- `save_block` for new blocks.
+--
+-- Nullable, with no backfill: unlike the end-index columns these roots cannot be
+-- derived in SQL (they require the ledger Merkle trees), so existing rows stay
+-- NULL until the chain is reset or backfilled. The GraphQL fields are nullable
+-- accordingly.
+
+ALTER TABLE blocks ADD COLUMN dust_commitment_merkle_tree_root BLOB;
+ALTER TABLE blocks ADD COLUMN dust_generation_merkle_tree_root BLOB;

--- a/indexer-common/src/domain.rs
+++ b/indexer-common/src/domain.rs
@@ -52,6 +52,8 @@ pub type DustUtxoId = ByteVec;
 pub type SerializedLedgerStateKey = ByteVec;
 pub type SerializedTransactionIdentifier = ByteVec;
 pub type SerializedZswapMerkleTreeRoot = ByteVec;
+pub type SerializedDustCommitmentMerkleTreeRoot = ByteVec;
+pub type SerializedDustGenerationMerkleTreeRoot = ByteVec;
 
 // Tagged serialization: complex types that may evolve; tags allow version-awareness.
 pub type SerializedContractAddress = ByteVec;


### PR DESCRIPTION
## Summary

`Block.dustCommitmentMerkleTreeRoot` and `Block.dustGenerationMerkleTreeRoot` returned the **latest indexed (tip)** root for every block, so they could not be used for per-block verification. This computes and stores them **per block during indexing** from the post-apply ledger state (the same way the zswap root is handled) and serves them from storage, so they now reflect the queried block.

Closes #1260.

## What changed

**Write path (chain-indexer)** — compute and store both roots per block, mirroring the zswap root:
- `application.rs` computes `dust_commitment/generation_merkle_tree_root()` from the post-apply ledger state (these rehash, so the stored value is correct).
- `save_block` writes them; the new fields are carried on the domain `Block` (`domain/block.rs`, `domain/node.rs`).

**Migration** — new incremental files `postgres/004_block_dust_merkle_roots.sql` and `sqlite/006_block_dust_merkle_roots.sql`: `ALTER TABLE blocks ADD COLUMN … ` **nullable**. The roots cannot be derived in SQL, so existing rows stay NULL until a reset/backfill; new blocks are populated by the chain-indexer.

**Read path (indexer-api)** — serve per-block instead of the tip:
- Replaced the two tip-based async resolver methods with plain per-block `Option<HexEncoded>` fields wired through `From<domain::Block>` and the block SELECTs.
- Removed the now-dead `dust_merkle_tree_roots` cache method and `DustMerkleTreeRoots`.

**Types** — added `SerializedDustCommitmentMerkleTreeRoot` / `SerializedDustGenerationMerkleTreeRoot` aliases (untagged group, next to `SerializedZswapMerkleTreeRoot`).

**Schema** — the two roots move to per-block position, comments change to "at this block", and they are now `@beta` (consistent with the dust end-index fields).

## Notes and decisions

- **Migration convention**: incremental files, matching `003_block_tree_end_indexes.sql`; per the post-4.1.0 convention (no `001` edits, runs cleanly on a populated DB).
- **Deployed data**: the migration runs cleanly, but historic roots stay NULL; populate them with a chain reset or a backfill. New blocks get them automatically. The GraphQL fields are nullable accordingly.
- **Perf**: rehashes the two dust trees once per block during indexing (the zswap root already rehashes for node validation).
- Independent of #1265 (collapsed-update rehash): the `*_merkle_tree_root()` methods rehash, so the stored per-block roots are correct.

## Validation

- `cargo check` cloud and standalone, `clippy --all-targets -D warnings` clean, schema regenerated.
- End-to-end on a live local stack (node + chain-indexer + indexer-api + Postgres): roots are populated per block and genuinely per-block. e.g. block 20's 91-leaf commitment root (`732ce22a…`) differs from the tip's 93-leaf root (`7366e22b…`); under the old behaviour both returned the tip root. Blocks with the same tree state return identical roots.
