### PR TITLE
test: add HTTP response compression integration tests

### DIFF
--- a/qa/tests/tests/integration/basic/queries/graphql-http-compression.test.ts
+++ b/qa/tests/tests/integration/basic/queries/graphql-http-compression.test.ts
@@ -32,7 +32,7 @@ describe('graphql http response compression', () => {
      * @When a POST request is sent to the GraphQL endpoint with Accept-Encoding: gzip
      * @Then the response status should be 200
      * @And the Content-Encoding header should be gzip
-     * @And the response body should be valid GraphQL data
+     * @And the response body decompresses and parses as JSON
      */
     test('should return a gzip-compressed response', async () => {
       const result = await probeGraphQLCompression('gzip');
@@ -49,7 +49,7 @@ describe('graphql http response compression', () => {
      * @When a POST request is sent to the GraphQL endpoint with Accept-Encoding: br
      * @Then the response status should be 200
      * @And the Content-Encoding header should be br
-     * @And the response body should be valid GraphQL data
+     * @And the response body decompresses and parses as JSON
      */
     test('should return a brotli-compressed response', async () => {
       const result = await probeGraphQLCompression('br');
@@ -66,7 +66,7 @@ describe('graphql http response compression', () => {
      * @When a POST request is sent to the GraphQL endpoint with Accept-Encoding: zstd
      * @Then the response status should be 200
      * @And the Content-Encoding header should be zstd
-     * @And the response body should be valid GraphQL data
+     * @And the response body decompresses and parses as JSON
      */
     test('should return a zstd-compressed response', async () => {
       const result = await probeGraphQLCompression('zstd');
@@ -83,7 +83,7 @@ describe('graphql http response compression', () => {
      * @When a POST request is sent to the GraphQL endpoint with Accept-Encoding: identity
      * @Then the response status should be 200
      * @And no Content-Encoding header should be present
-     * @And the response body should be valid GraphQL data
+     * @And the response body parses as JSON
      *
      * Note: Accept-Encoding: identity is sent explicitly rather than omitting
      * the header. Node.js's fetch (undici) unconditionally appends its own

--- a/qa/tests/tests/integration/basic/queries/graphql-http-compression.test.ts
+++ b/qa/tests/tests/integration/basic/queries/graphql-http-compression.test.ts
@@ -1,0 +1,103 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This test verifies a transport-level protocol property (HTTP
+// Content-Encoding negotiation) rather than domain-level data correctness. It
+// sits in the integration suite for lack of a better home, but it belongs to a
+// class of "protocol contract" tests — things like WebSocket subprotocol
+// negotiation, CORS headers, request size limits, content-type enforcement —
+// that do not yet have their own tier. If more tests of this shape accumulate,
+// extracting them into a dedicated `contract` (or `protocol`) suite would give
+// them a permanent home and keep integration clean for data-level assertions.
+
+import '@utils/logging/test-logging-hooks';
+import { probeGraphQLCompression } from '@utils/indexer/http-compression-probe';
+
+describe('graphql http response compression', () => {
+  describe('a GraphQL HTTP request with Accept-Encoding: gzip', () => {
+    /**
+     * @Given a running indexer with HTTP response compression enabled
+     * @When a POST request is sent to the GraphQL endpoint with Accept-Encoding: gzip
+     * @Then the response status should be 200
+     * @And the Content-Encoding header should be gzip
+     * @And the response body should be valid GraphQL data
+     */
+    test('should return a gzip-compressed response', async () => {
+      const result = await probeGraphQLCompression('gzip');
+
+      expect(result.status).toBe(200);
+      expect(result.contentEncoding).toBe('gzip');
+      expect(result.data).toBeDefined();
+    });
+  });
+
+  describe('a GraphQL HTTP request with Accept-Encoding: br', () => {
+    /**
+     * @Given a running indexer with HTTP response compression enabled
+     * @When a POST request is sent to the GraphQL endpoint with Accept-Encoding: br
+     * @Then the response status should be 200
+     * @And the Content-Encoding header should be br
+     * @And the response body should be valid GraphQL data
+     */
+    test('should return a brotli-compressed response', async () => {
+      const result = await probeGraphQLCompression('br');
+
+      expect(result.status).toBe(200);
+      expect(result.contentEncoding).toBe('br');
+      expect(result.data).toBeDefined();
+    });
+  });
+
+  describe('a GraphQL HTTP request with Accept-Encoding: zstd', () => {
+    /**
+     * @Given a running indexer with HTTP response compression enabled
+     * @When a POST request is sent to the GraphQL endpoint with Accept-Encoding: zstd
+     * @Then the response status should be 200
+     * @And the Content-Encoding header should be zstd
+     * @And the response body should be valid GraphQL data
+     */
+    test('should return a zstd-compressed response', async () => {
+      const result = await probeGraphQLCompression('zstd');
+
+      expect(result.status).toBe(200);
+      expect(result.contentEncoding).toBe('zstd');
+      expect(result.data).toBeDefined();
+    });
+  });
+
+  describe('a GraphQL HTTP request with Accept-Encoding: identity', () => {
+    /**
+     * @Given a running indexer with HTTP response compression enabled
+     * @When a POST request is sent to the GraphQL endpoint with Accept-Encoding: identity
+     * @Then the response status should be 200
+     * @And no Content-Encoding header should be present
+     * @And the response body should be valid GraphQL data
+     *
+     * Note: Accept-Encoding: identity is sent explicitly rather than omitting
+     * the header. Node.js's fetch (undici) unconditionally appends its own
+     * Accept-Encoding to every outgoing request, so omitting the header in
+     * test code does not produce a headerless wire request. Sending `identity`
+     * explicitly overrides that behaviour and instructs the server to serve
+     * the response uncompressed.
+     */
+    test('should return an uncompressed response', async () => {
+      const result = await probeGraphQLCompression('identity');
+
+      expect(result.status).toBe(200);
+      expect(result.contentEncoding).toBeNull();
+      expect(result.data).toBeDefined();
+    });
+  });
+});

--- a/qa/tests/utils/indexer/http-compression-probe.ts
+++ b/qa/tests/utils/indexer/http-compression-probe.ts
@@ -22,11 +22,12 @@ export interface CompressionProbeResult {
   data: unknown;
 }
 
-// Large enough to exceed tower-http's default minimum-size threshold for
-// compression (~1 KiB). A minimal domain query (e.g. `{ block { hash } }`)
-// can return a body smaller than the threshold, causing the server to skip
-// compression even when the client advertises Accept-Encoding — which would
-// make the gzip/br/zstd assertions below fail spuriously.
+// Large enough to reliably exceed tower-http's default minimum-size threshold
+// for compression (SizeAbove(32), i.e. 32 bytes). A minimal domain query
+// (e.g. `{ block { hash } }`) can return a body smaller than the threshold,
+// causing the server to skip compression even when the client advertises
+// Accept-Encoding — which would make the gzip/br/zstd assertions below fail
+// spuriously.
 const INTROSPECTION_QUERY = `{
   __schema {
     types {

--- a/qa/tests/utils/indexer/http-compression-probe.ts
+++ b/qa/tests/utils/indexer/http-compression-probe.ts
@@ -1,0 +1,90 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { env } from 'environment/model';
+
+export interface CompressionProbeResult {
+  status: number;
+  // The raw Content-Encoding header value, or null if the server sent none.
+  contentEncoding: string | null;
+  data: unknown;
+}
+
+// Large enough to exceed tower-http's default minimum-size threshold for
+// compression (~1 KiB). A minimal domain query (e.g. `{ block { hash } }`)
+// can return a body smaller than the threshold, causing the server to skip
+// compression even when the client advertises Accept-Encoding — which would
+// make the gzip/br/zstd assertions below fail spuriously.
+const INTROSPECTION_QUERY = `{
+  __schema {
+    types {
+      name
+      fields {
+        name
+        type { name kind ofType { name kind } }
+      }
+    }
+  }
+}`;
+
+/**
+ * Sends a raw GraphQL POST and returns the HTTP status, Content-Encoding
+ * header, and parsed body.
+ *
+ * Uses native fetch rather than graphql-request so that response headers
+ * remain accessible — graphql-request parses and discards them before
+ * surfacing the response to callers.
+ *
+ * Note on Node.js fetch (undici): undici automatically decompresses the
+ * response body when Content-Encoding is present, so `response.json()` works
+ * transparently regardless of the encoding. The Content-Encoding header is
+ * still preserved in `response.headers` and reflects what the server actually
+ * sent.
+ *
+ * Note on identity responses: undici unconditionally appends its own
+ * `Accept-Encoding` (gzip, deflate, br) to every outgoing request. To test
+ * the server's identity (uncompressed) path, pass `Accept-Encoding: identity`
+ * explicitly — that overrides undici's default and instructs the server not
+ * to compress.
+ */
+export async function probeGraphQLCompression(
+  acceptEncoding?: string,
+  query: string = INTROSPECTION_QUERY,
+): Promise<CompressionProbeResult> {
+  const apiVersion = process.env.INDEXER_API_VERSION?.trim() || 'v4';
+  const url = `${env.getIndexerHttpBaseURL()}/api/${apiVersion}/graphql`;
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (acceptEncoding !== undefined) {
+    headers['Accept-Encoding'] = acceptEncoding;
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ query }),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  const data = await response.json();
+
+  return {
+    status: response.status,
+    contentEncoding: response.headers.get('content-encoding'),
+    data,
+  };
+}


### PR DESCRIPTION
## Scope

Integration tests for midnight-indexer#1250 — HTTP response compression (gzip/br/zstd) on the GraphQL API.

## Why

The `qa/tests` framework uses `graphql-request` which parses and discards HTTP response headers, making it impossible to assert `Content-Encoding` through the existing `IndexerHttpClient`. A purpose-built probe using native `fetch` was needed to keep headers accessible.

## What was added

- `qa/tests/utils/indexer/http-compression-probe.ts` — a fetch-based probe that sends a raw GraphQL POST and returns the HTTP status, `Content-Encoding` header, and parsed body alongside each other. Uses an introspection query to ensure the response body exceeds tower-http's minimum compression threshold.
- `qa/tests/tests/integration/basic/queries/graphql-http-compression.test.ts` — 4 integration tests covering `gzip`, `br`, `zstd`, and the identity fallback (`Accept-Encoding: identity`). A comment in the file notes these tests belong to a "protocol contract" tier that does not yet exist, and names the other transport-level tests that would eventually join them there.

## Validation

All 4 tests passed on stagenet against the deployed build from PR #1252.