### PR TITLE
test: add contract event integration coverage

### DIFF
--- a/indexer-standalone/src/main.rs
+++ b/indexer-standalone/src/main.rs
@@ -89,6 +89,25 @@ fn run() -> anyhow::Result<()> {
         "starting"
     );
 
+    // Retention/freshness invariant, enforceable only here where both configs share a process
+    // (in cloud they live in separate binaries, so there it is an operator responsibility): the
+    // dust generations subscription accepts snapshots up to `max_snapshot_age` blocks old, but
+    // the chain-indexer only keeps the newest `ledger_state_retention` blocks' ledger states
+    // loadable. If retention does not exceed the freshness window, an accepted snapshot can
+    // resolve to garbage-collected state and panic inside storage-core on load.
+    let ledger_state_retention = application_config.ledger_state_retention.get();
+    let max_snapshot_age = infra_config
+        .api_config
+        .subscription_config
+        .dust_generations
+        .max_snapshot_age;
+    assert!(
+        u64::try_from(ledger_state_retention).unwrap_or(u64::MAX) > u64::from(max_snapshot_age),
+        "ledger_state_retention ({ledger_state_retention}) must exceed \
+         dust_generations.max_snapshot_age ({max_snapshot_age}): otherwise a snapshot can pass \
+         the freshness check yet resolve to garbage-collected ledger state and panic on load"
+    );
+
     let InfraConfig {
         run_migrations,
         storage_config,

--- a/qa/tests/data/static/stagenet/contract-events.jsonc
+++ b/qa/tests/data/static/stagenet/contract-events.jsonc
@@ -1,0 +1,14 @@
+// Contracts known to have emitted public contract events (MIP-0002) on the
+// stagenet chain, for the contract-event integration tests
+// (getEventEmittingContracts). Each contract has an Unpaused and a Misc event
+// persisted; the addresses are permanent on stagenet.
+[
+  {
+    "contract-address": "d97d7ac8f51b0f32ed809ba486ddca3ef010de9b4a74cb1b9bc8d0414f8bad2b",
+    "event-types": ["UNPAUSED", "MISC"]
+  },
+  {
+    "contract-address": "239db5fc5c62f1b375cf833d21aff95c6bc43adbc36317d74d938437689fffbb",
+    "event-types": ["UNPAUSED", "MISC"]
+  }
+]

--- a/qa/tests/tests/integration/basic/queries/contract-event-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/contract-event-queries.test.ts
@@ -1,0 +1,396 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import log from '@utils/logging/logger';
+import { env } from 'environment/model';
+import type { TestContext } from 'vitest';
+import '@utils/logging/test-logging-hooks';
+import { IndexerHttpClient } from '@utils/indexer/http-client';
+import { contractEventsSurfacePresent } from '@utils/indexer/contract-events-support';
+import { ContractEventUnionSchema } from '@utils/indexer/graphql/schema';
+import { CONTRACT_EVENT_TYPES } from '@utils/indexer/indexer-types';
+import dataProvider, { type EventEmittingContractInfo } from '@utils/testdata-provider';
+
+const httpClient = new IndexerHttpClient();
+
+// Maps each concrete event __typename to its ContractEventType enum value, so a
+// type-filtered query result can be checked against the requested type.
+const TYPE_BY_TYPENAME: Record<string, (typeof CONTRACT_EVENT_TYPES)[number]> = {
+  ShieldedSpendEvent: 'SHIELDED_SPEND',
+  ShieldedReceiveEvent: 'SHIELDED_RECEIVE',
+  ShieldedMintEvent: 'SHIELDED_MINT',
+  ShieldedBurnEvent: 'SHIELDED_BURN',
+  UnshieldedSpendEvent: 'UNSHIELDED_SPEND',
+  UnshieldedReceiveEvent: 'UNSHIELDED_RECEIVE',
+  UnshieldedMintEvent: 'UNSHIELDED_MINT',
+  UnshieldedBurnEvent: 'UNSHIELDED_BURN',
+  PausedEvent: 'PAUSED',
+  UnpausedEvent: 'UNPAUSED',
+  MiscContractEvent: 'MISC',
+};
+
+type IntrospectedType = {
+  kind: string;
+  fields: { name: string }[] | null;
+  inputFields: { name: string }[] | null;
+  enumValues: { name: string }[] | null;
+  possibleTypes: { name: string }[] | null;
+};
+
+// Per-type introspection issued directly (mirrors the schema smoke tests). The
+// contractEvents surface (PR #1185) is not yet on every environment, so the
+// whole suite gates on a one-shot presence probe: it asserts the contract where
+// the surface exists and skips where it does not, instead of failing on envs
+// that have not yet received the feature.
+async function introspect(typeName: string): Promise<IntrospectedType | null> {
+  const query = `query Introspect($name: String!) {
+    __type(name: $name) {
+      kind
+      fields { name }
+      inputFields { name }
+      enumValues { name }
+      possibleTypes { name }
+    }
+  }`;
+  const response = await fetch(env.getIndexerHttpBaseURL() + '/api/v4/graphql', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, variables: { name: typeName } }),
+  });
+  const json = (await response.json()) as { data?: { __type: IntrospectedType | null } };
+  return json.data?.__type ?? null;
+}
+
+describe('contract event queries', () => {
+  let surfacePresent = false;
+
+  beforeAll(async () => {
+    surfacePresent = await contractEventsSurfacePresent();
+    if (!surfacePresent) {
+      log.warn(
+        `Contract events surface absent on ${env.getCurrentEnvironmentName()}; ` +
+          `contract event query tests will be skipped.`,
+      );
+    }
+  }, 30_000);
+
+  describe('the contract event GraphQL schema', () => {
+    /**
+     * The ContractEvent interface exposes the common fields shared by every variant.
+     *
+     * @given a deployed indexer exposing the contract events surface
+     * @when the ContractEvent type is introspected
+     * @then it is an interface carrying the eight common fields, including the
+     *       transaction navigation field
+     */
+    test('should expose ContractEvent as an interface with the common fields', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents', 'SchemaValidation'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      const type = await introspect('ContractEvent');
+      expect(type, 'ContractEvent type not found in schema').not.toBeNull();
+      expect(type!.kind).toBe('INTERFACE');
+
+      const fieldNames = (type!.fields ?? []).map((f) => f.name);
+      for (const expected of [
+        'id',
+        'raw',
+        'maxId',
+        'protocolVersion',
+        'version',
+        'contractAddress',
+        'transactionId',
+        'transaction',
+      ]) {
+        expect(fieldNames, `ContractEvent.${expected} missing`).toContain(expected);
+      }
+    });
+
+    /**
+     * The ContractEvent interface is implemented by all eleven concrete event types.
+     *
+     * @given a deployed indexer exposing the contract events surface
+     * @when the ContractEvent interface possible types are introspected
+     * @then the eleven MIP-0002 variants (Shielded*, Unshielded*, Paused, Unpaused, Misc) are present
+     */
+    test('should expose all eleven concrete contract event types', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents', 'SchemaValidation'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      const type = await introspect('ContractEvent');
+      const possible = (type!.possibleTypes ?? []).map((t) => t.name).sort();
+      expect(possible).toEqual(
+        [
+          'MiscContractEvent',
+          'PausedEvent',
+          'ShieldedBurnEvent',
+          'ShieldedMintEvent',
+          'ShieldedReceiveEvent',
+          'ShieldedSpendEvent',
+          'UnpausedEvent',
+          'UnshieldedBurnEvent',
+          'UnshieldedMintEvent',
+          'UnshieldedReceiveEvent',
+          'UnshieldedSpendEvent',
+        ].sort(),
+      );
+    });
+
+    /**
+     * The ContractEventType enum carries the eleven filterable event-type variants.
+     *
+     * @given a deployed indexer exposing the contract events surface
+     * @when the ContractEventType enum is introspected
+     * @then the eleven variants (SHIELDED_SPEND … MISC) are present
+     */
+    test('should expose the ContractEventType enum with eleven variants', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents', 'SchemaValidation'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      const type = await introspect('ContractEventType');
+      const values = (type!.enumValues ?? []).map((v) => v.name).sort();
+      expect(values).toEqual([...CONTRACT_EVENT_TYPES].sort());
+    });
+
+    /**
+     * The ContractEventFilter input exposes the documented filter fields.
+     *
+     * @given a deployed indexer exposing the contract events surface
+     * @when the ContractEventFilter input type is introspected
+     * @then contractAddress, types, fieldPrefixes, fromBlock, toBlock and transactionHash are present
+     */
+    test('should expose the ContractEventFilter input fields', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents', 'SchemaValidation'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      const type = await introspect('ContractEventFilter');
+      const inputs = (type!.inputFields ?? []).map((f) => f.name);
+      for (const expected of [
+        'contractAddress',
+        'types',
+        'fieldPrefixes',
+        'fromBlock',
+        'toBlock',
+        'transactionHash',
+      ]) {
+        expect(inputs, `ContractEventFilter.${expected} missing`).toContain(expected);
+      }
+    });
+
+    /**
+     * The FieldPrefixFilter input exposes the field-name and prefix fields.
+     *
+     * @given a deployed indexer exposing the contract events surface
+     * @when the FieldPrefixFilter input type is introspected
+     * @then fieldName and prefix are present
+     */
+    test('should expose the FieldPrefixFilter input fields', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents', 'SchemaValidation'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      const type = await introspect('FieldPrefixFilter');
+      const inputs = (type!.inputFields ?? []).map((f) => f.name).sort();
+      expect(inputs).toEqual(['fieldName', 'prefix']);
+    });
+  });
+
+  describe('a contract events query for an address with no emitted events', () => {
+    const validAddress = dataProvider.getNonExistingContractAddress();
+
+    /**
+     * A query for a valid address that emitted nothing returns an empty list.
+     *
+     * @given a valid-format contract address that has emitted no events
+     * @when a contract events query is issued for that address
+     * @then the response is successful and the event list is empty
+     */
+    test('should return an empty list', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      const response = await httpClient.getContractEvents({ contractAddress: validAddress });
+      expect(response).toBeSuccess();
+      expect(response.data?.contractEvents).toEqual([]);
+    });
+
+    /**
+     * A query narrowed by event types for an address that emitted nothing is still empty.
+     *
+     * @given a valid-format contract address that has emitted no events
+     * @when a contract events query is issued filtering on a subset of event types
+     * @then the response is successful and the event list is empty
+     */
+    test('should return an empty list when filtered by event types', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      const response = await httpClient.getContractEvents({
+        contractAddress: validAddress,
+        types: ['SHIELDED_SPEND', 'UNSHIELDED_MINT'],
+      });
+      expect(response).toBeSuccess();
+      expect(response.data?.contractEvents).toEqual([]);
+    });
+
+    /**
+     * A query narrowed by a block range for an address that emitted nothing is still empty.
+     *
+     * @given a valid-format contract address that has emitted no events
+     * @when a contract events query is issued bounded by fromBlock and toBlock
+     * @then the response is successful and the event list is empty
+     */
+    test('should return an empty list when filtered by a block range', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      const response = await httpClient.getContractEvents({
+        contractAddress: validAddress,
+        fromBlock: 0,
+        toBlock: 1,
+      });
+      expect(response).toBeSuccess();
+      expect(response.data?.contractEvents).toEqual([]);
+    });
+  });
+
+  describe('a contract events query with an invalid filter', () => {
+    /**
+     * An empty contractAddress is rejected by the filter validation.
+     *
+     * @given a contract events filter whose contractAddress is the empty string
+     * @when a contract events query is issued with that filter
+     * @then the indexer responds with an error
+     */
+    test('should return an error when the contract address is empty', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents', 'Negative'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      const response = await httpClient.getContractEvents({ contractAddress: '' });
+      expect(response).toBeError();
+    });
+
+    /**
+     * Malformed contract addresses are rejected.
+     *
+     * @given a set of fabricated malformed contract addresses
+     * @when a contract events query is issued for each malformed address
+     * @then the indexer responds with an error for each
+     */
+    test('should return an error for malformed contract addresses', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents', 'Negative'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      const malformedAddresses = dataProvider.getFabricatedMalformedContractAddresses();
+      for (const malformedAddress of malformedAddresses) {
+        const response = await httpClient.getContractEvents({ contractAddress: malformedAddress });
+        expect.soft(response).toBeError();
+      }
+    });
+  });
+
+  describe('a contract events query for a contract with emitted events', () => {
+    /**
+     * Emitted events conform to the contract event schema and belong to the queried contract.
+     *
+     * Skipped until an event-emitting contract fixture is configured for the
+     * environment (see testdata-provider.getEventEmittingContracts); the
+     * emit-bearing toolchain path is tracked by midnight-indexer#1163.
+     *
+     * @given a contract known to have emitted public contract events
+     * @when a contract events query is issued for that contract
+     * @then the response is successful and every event matches the contract event
+     *       schema and reports the queried contract address
+     */
+    test('should return events conforming to the contract event schema', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      let contracts: EventEmittingContractInfo[];
+      try {
+        contracts = dataProvider.getEventEmittingContracts();
+      } catch (error) {
+        log.warn(error);
+        return ctx.skip?.(true, (error as Error).message);
+      }
+
+      for (const contract of contracts) {
+        const address = contract['contract-address'];
+        const response = await httpClient.getContractEvents({ contractAddress: address });
+        expect(response).toBeSuccess();
+
+        const events = response.data?.contractEvents ?? [];
+        expect(events.length).toBeGreaterThan(0);
+        for (const event of events) {
+          const parsed = ContractEventUnionSchema.safeParse(event);
+          expect(
+            parsed.success,
+            `Contract event schema validation failed: ${JSON.stringify(parsed.error, null, 2)}`,
+          ).toBe(true);
+          expect(event.contractAddress).toBe(address);
+        }
+      }
+    });
+
+    /**
+     * Filtering by a single event type returns only events of that type.
+     *
+     * Skipped until an event-emitting contract fixture is configured for the
+     * environment; tracked by midnight-indexer#1163.
+     *
+     * @given a contract that emitted events of more than one type (e.g. an
+     *        UNPAUSED and a MISC event)
+     * @when a contract events query is issued filtering on a single type
+     * @then the response contains at least one event and every returned event is
+     *       of the requested type
+     */
+    test('should return only events of the requested type when filtered', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      let contracts: EventEmittingContractInfo[];
+      try {
+        contracts = dataProvider.getEventEmittingContracts();
+      } catch (error) {
+        log.warn(error);
+        return ctx.skip?.(true, (error as Error).message);
+      }
+
+      const withTypes = contracts.find((contract) =>
+        (contract['event-types'] ?? []).some((type) =>
+          CONTRACT_EVENT_TYPES.includes(type as (typeof CONTRACT_EVENT_TYPES)[number]),
+        ),
+      );
+      if (!withTypes) {
+        return ctx.skip?.(true, 'no event-emitting contract fixture declares a known event-type');
+      }
+
+      const requestedType = withTypes['event-types']!.find((type) =>
+        CONTRACT_EVENT_TYPES.includes(type as (typeof CONTRACT_EVENT_TYPES)[number]),
+      ) as (typeof CONTRACT_EVENT_TYPES)[number];
+
+      const response = await httpClient.getContractEvents({
+        contractAddress: withTypes['contract-address'],
+        types: [requestedType],
+      });
+      expect(response).toBeSuccess();
+
+      const events = response.data?.contractEvents ?? [];
+      expect(events.length).toBeGreaterThan(0);
+      for (const event of events) {
+        expect(TYPE_BY_TYPENAME[event.__typename]).toBe(requestedType);
+      }
+    });
+  });
+});

--- a/qa/tests/tests/integration/basic/queries/contract-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/contract-queries.test.ts
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 import log from '@utils/logging/logger';
+import { env } from 'environment/model';
 import type { TestContext } from 'vitest';
 import '@utils/logging/test-logging-hooks';
 import {
@@ -24,6 +25,22 @@ import {
 } from '@utils/indexer/graphql/schema';
 import dataProvider, { type TokenHoldingContractInfo } from '@utils/testdata-provider';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
+import { contractEventsSurfacePresent } from '@utils/indexer/contract-events-support';
+
+/** Introspect the field names on a GraphQL type (null when the type is absent). */
+async function introspectFieldNames(typeName: string): Promise<string[] | null> {
+  const query = `query Fields($name: String!) { __type(name: $name) { fields { name } } }`;
+  const response = await fetch(env.getIndexerHttpBaseURL() + '/api/v4/graphql', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, variables: { name: typeName } }),
+  });
+  const json = (await response.json()) as {
+    data?: { __type: { fields: { name: string }[] } | null };
+  };
+  const fields = json.data?.__type?.fields;
+  return fields ? fields.map((f) => f.name) : null;
+}
 
 const indexerHttpClient = new IndexerHttpClient();
 
@@ -595,6 +612,55 @@ describe('contract queries', () => {
 
       expect(response).toBeSuccess();
       expect(response.data?.contractAction).toBeNull();
+    });
+  });
+
+  describe('the contractEvents field on contract actions', () => {
+    let surfacePresent = false;
+
+    beforeAll(async () => {
+      surfacePresent = await contractEventsSurfacePresent();
+    }, 30_000);
+
+    /**
+     * ContractCall exposes the nested contractEvents field.
+     *
+     * Only ContractCall executes circuits and can therefore emit events, so the
+     * field is exposed there. Gated on the contract events surface being present.
+     *
+     * @given a deployed indexer exposing the contract events surface
+     * @when the ContractCall type is introspected
+     * @then it exposes a contractEvents field
+     */
+    test('should expose contractEvents on ContractCall', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents', 'SchemaValidation'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      const fields = await introspectFieldNames('ContractCall');
+      expect(fields, 'ContractCall type not found in schema').not.toBeNull();
+      expect(fields).toContain('contractEvents');
+    });
+
+    /**
+     * ContractDeploy and ContractUpdate never expose the contractEvents field.
+     *
+     * They do not execute circuits and therefore emit no events; the nested field
+     * must not leak onto them. This invariant holds on every environment.
+     *
+     * @given the deployed indexer GraphQL schema
+     * @when the ContractDeploy and ContractUpdate types are introspected
+     * @then neither exposes a contractEvents field
+     */
+    test('should not expose contractEvents on ContractDeploy or ContractUpdate', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents', 'SchemaValidation'] };
+
+      for (const typeName of ['ContractDeploy', 'ContractUpdate']) {
+        const fields = await introspectFieldNames(typeName);
+        expect(fields, `${typeName} type not found in schema`).not.toBeNull();
+        expect(fields, `${typeName} must not expose contractEvents`).not.toContain(
+          'contractEvents',
+        );
+      }
     });
   });
 });

--- a/qa/tests/tests/integration/basic/subscriptions/contract-event-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/contract-event-subscriptions.test.ts
@@ -1,0 +1,221 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import log from '@utils/logging/logger';
+import { env } from 'environment/model';
+import type { TestContext } from 'vitest';
+import '@utils/logging/test-logging-hooks';
+import { IndexerWsClient } from '@utils/indexer/websocket-client';
+import { extractSubscriptionErrorMessage } from '@utils/indexer/subscription-error';
+import { contractEventsSurfacePresent } from '@utils/indexer/contract-events-support';
+import { ContractEventUnionSchema } from '@utils/indexer/graphql/schema';
+import { IndexerHttpClient } from '@utils/indexer/http-client';
+import type { ContractEvent } from '@utils/indexer/indexer-types';
+import dataProvider, { type EventEmittingContractInfo } from '@utils/testdata-provider';
+
+const httpClient = new IndexerHttpClient();
+
+describe('contract event subscription', () => {
+  let surfacePresent = false;
+  let wsClient: IndexerWsClient;
+
+  beforeAll(async () => {
+    surfacePresent = await contractEventsSurfacePresent();
+    if (!surfacePresent) {
+      log.warn(
+        `Contract events surface absent on ${env.getCurrentEnvironmentName()}; ` +
+          `contract event subscription tests will be skipped.`,
+      );
+    }
+  }, 30_000);
+
+  beforeEach(async () => {
+    if (!surfacePresent) return;
+    wsClient = new IndexerWsClient();
+    await wsClient.connectionInit();
+  }, 30_000);
+
+  afterEach(async () => {
+    if (!surfacePresent) return;
+    await wsClient.connectionClose();
+  });
+
+  describe('a contract events subscription for an address with no emitted events', () => {
+    /**
+     * A bounded subscription for an idle address streams nothing and terminates.
+     *
+     * @given a valid-format contract address that has emitted no events and a
+     *        toBlock the chain has already passed
+     * @when a contract events subscription is opened with that bounded filter
+     * @then the stream completes via the toBlock terminator without delivering events
+     */
+    test('should complete via the toBlock terminator without delivering events', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Subscription', 'ContractEvents'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      const blockResponse = await httpClient.getLatestBlock();
+      expect(blockResponse).toBeSuccess();
+      const toBlock = Math.min(blockResponse.data!.block.height, 5);
+      const contractAddress = dataProvider.getNonExistingContractAddress();
+
+      const settled = await new Promise<{ completed: boolean; eventCount: number }>(
+        (resolve, reject) => {
+          let eventCount = 0;
+          const timeout = setTimeout(() => {
+            subscription.unsubscribe();
+            reject(new Error('Timed out waiting for the toBlock terminator'));
+          }, 20_000);
+
+          const subscription = wsClient.subscribeToContractEvents(
+            {
+              next: () => {
+                eventCount++;
+              },
+              error: (error) => {
+                clearTimeout(timeout);
+                subscription.unsubscribe();
+                reject(new Error(`Subscription error: ${JSON.stringify(error)}`));
+              },
+              complete: () => {
+                clearTimeout(timeout);
+                resolve({ completed: true, eventCount });
+              },
+            },
+            { contractAddress, fromBlock: 0, toBlock },
+            0,
+          );
+        },
+      );
+
+      expect(settled.completed).toBe(true);
+      expect(settled.eventCount).toBe(0);
+    }, 30_000);
+  });
+
+  describe('a contract events subscription with an invalid filter', () => {
+    /**
+     * An empty contractAddress is rejected by the subscription.
+     *
+     * @given a contract events filter whose contractAddress is the empty string
+     * @when a contract events subscription is opened with that filter
+     * @then the subscription surfaces an error rather than streaming events
+     */
+    test('should return an error when the contract address is empty', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Subscription', 'ContractEvents', 'Negative'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      const settled = await new Promise<{ error: string | null; eventCount: number }>((resolve) => {
+        let eventCount = 0;
+        const timeout = setTimeout(() => {
+          subscription.unsubscribe();
+          resolve({ error: null, eventCount });
+        }, 10_000);
+
+        const subscription = wsClient.subscribeToContractEvents(
+          {
+            next: () => {
+              eventCount++;
+            },
+            error: (error) => {
+              clearTimeout(timeout);
+              subscription.unsubscribe();
+              resolve({ error: extractSubscriptionErrorMessage(error), eventCount });
+            },
+            complete: () => {
+              clearTimeout(timeout);
+              resolve({ error: null, eventCount });
+            },
+          },
+          { contractAddress: '' },
+          0,
+        );
+      });
+
+      expect(settled.error).not.toBeNull();
+      expect(settled.eventCount).toBe(0);
+    }, 20_000);
+  });
+
+  describe('a contract events subscription for a contract with emitted events', () => {
+    /**
+     * Streamed events conform to the contract event schema and belong to the contract.
+     *
+     * Skipped until an event-emitting contract fixture is configured for the
+     * environment (see testdata-provider.getEventEmittingContracts); the
+     * emit-bearing toolchain path is tracked by midnight-indexer#1163.
+     *
+     * @given a contract known to have emitted public contract events
+     * @when a contract events subscription is opened for that contract from the
+     *       start of the chain and bounded by the latest block
+     * @then the stream delivers at least one event, each conforming to the
+     *       contract event schema and reporting the subscribed contract address
+     */
+    test('should stream events conforming to the contract event schema', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Subscription', 'ContractEvents'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      let contracts: EventEmittingContractInfo[];
+      try {
+        contracts = dataProvider.getEventEmittingContracts();
+      } catch (error) {
+        log.warn(error);
+        return ctx.skip?.(true, (error as Error).message);
+      }
+
+      const blockResponse = await httpClient.getLatestBlock();
+      expect(blockResponse).toBeSuccess();
+      const toBlock = blockResponse.data!.block.height;
+      const contractAddress = contracts[0]['contract-address'];
+
+      const received: ContractEvent[] = [];
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          subscription.unsubscribe();
+          resolve();
+        }, 20_000);
+
+        const subscription = wsClient.subscribeToContractEvents(
+          {
+            next: (payload) => {
+              const event = payload.data?.contractEvents;
+              if (event) received.push(event);
+            },
+            error: (error) => {
+              clearTimeout(timeout);
+              subscription.unsubscribe();
+              reject(new Error(`Subscription error: ${JSON.stringify(error)}`));
+            },
+            complete: () => {
+              clearTimeout(timeout);
+              resolve();
+            },
+          },
+          { contractAddress, fromBlock: 0, toBlock },
+          0,
+        );
+      });
+
+      expect(received.length).toBeGreaterThan(0);
+      for (const event of received) {
+        const parsed = ContractEventUnionSchema.safeParse(event);
+        expect(
+          parsed.success,
+          `Contract event schema validation failed: ${JSON.stringify(parsed.error, null, 2)}`,
+        ).toBe(true);
+        expect(event.contractAddress).toBe(contractAddress);
+      }
+    }, 30_000);
+  });
+});

--- a/qa/tests/tests/integration/basic/subscriptions/contract-event-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/contract-event-subscriptions.test.ts
@@ -116,32 +116,39 @@ describe('contract event subscription', () => {
       ctx.task!.meta.custom = { labels: ['Subscription', 'ContractEvents', 'Negative'] };
       if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
 
-      const settled = await new Promise<{ error: string | null; eventCount: number }>((resolve) => {
-        let eventCount = 0;
-        const timeout = setTimeout(() => {
-          subscription.unsubscribe();
-          resolve({ error: null, eventCount });
-        }, 10_000);
+      const settled = await new Promise<{ error: string | null; eventCount: number }>(
+        (resolve, reject) => {
+          let eventCount = 0;
+          const timeout = setTimeout(() => {
+            subscription.unsubscribe();
+            // Validation errors are immediate; a 10s silence is a real problem,
+            // so fail loudly with a timeout message rather than resolving
+            // `error: null` and tripping the assertion with a misleading value.
+            reject(
+              new Error('Timed out after 10s waiting for the empty-address subscription to error'),
+            );
+          }, 10_000);
 
-        const subscription = wsClient.subscribeToContractEvents(
-          {
-            next: () => {
-              eventCount++;
+          const subscription = wsClient.subscribeToContractEvents(
+            {
+              next: () => {
+                eventCount++;
+              },
+              error: (error) => {
+                clearTimeout(timeout);
+                subscription.unsubscribe();
+                resolve({ error: extractSubscriptionErrorMessage(error), eventCount });
+              },
+              complete: () => {
+                clearTimeout(timeout);
+                resolve({ error: null, eventCount });
+              },
             },
-            error: (error) => {
-              clearTimeout(timeout);
-              subscription.unsubscribe();
-              resolve({ error: extractSubscriptionErrorMessage(error), eventCount });
-            },
-            complete: () => {
-              clearTimeout(timeout);
-              resolve({ error: null, eventCount });
-            },
-          },
-          { contractAddress: '' },
-          0,
-        );
-      });
+            { contractAddress: '' },
+            0,
+          );
+        },
+      );
 
       expect(settled.error).not.toBeNull();
       expect(settled.eventCount).toBe(0);
@@ -183,7 +190,11 @@ describe('contract event subscription', () => {
       await new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
           subscription.unsubscribe();
-          resolve();
+          reject(
+            new Error(
+              `Timed out after 20s waiting for a streamed contract event for ${contractAddress}`,
+            ),
+          );
         }, 20_000);
 
         const subscription = wsClient.subscribeToContractEvents(
@@ -191,6 +202,16 @@ describe('contract event subscription', () => {
             next: (payload) => {
               const event = payload.data?.contractEvents;
               if (event) received.push(event);
+              // Resolve as soon as an event streams, rather than waiting for the
+              // `toBlock` terminator: the terminator's timing is exercised by the
+              // idle-address test, and depending on it here would turn a healthy
+              // stream into a flaky empty result whenever `complete` lands slower
+              // than the timeout. Late in-flight events are validated too.
+              if (received.length > 0) {
+                clearTimeout(timeout);
+                subscription.unsubscribe();
+                resolve();
+              }
             },
             error: (error) => {
               clearTimeout(timeout);

--- a/qa/tests/utils/indexer/contract-events-support.ts
+++ b/qa/tests/utils/indexer/contract-events-support.ts
@@ -15,6 +15,7 @@
 
 import log from '@utils/logging/logger';
 import { env } from 'environment/model';
+import { retry } from '@utils/retry-helper';
 
 /**
  * Probes whether the deployed indexer exposes the public contract-events surface
@@ -23,23 +24,36 @@ import { env } from 'environment/model';
  * this rather than a hardcoded environment list: they assert where the surface
  * exists and skip where it does not, tracking the feature as it rolls out.
  *
- * @returns true when the `ContractEvent` type is present in the schema.
+ * A healthy schema response that simply lacks the type returns `false` (the
+ * tests skip). A probe that cannot reach a healthy answer — transport error,
+ * timeout, non-2xx — is retried and then THROWS rather than returning `false`:
+ * a transient blip must not be indistinguishable from "feature absent", or the
+ * whole suite would silently skip and report green having tested nothing.
+ *
+ * @returns true when the `ContractEvent` type is present in the schema, false
+ *          when a healthy response reports it absent.
+ * @throws if the surface cannot be determined after retries.
  */
 export async function contractEventsSurfacePresent(): Promise<boolean> {
   const query = `query { __type(name: "ContractEvent") { name kind } }`;
-  try {
-    const response = await fetch(env.getIndexerHttpBaseURL() + '/api/v4/graphql', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query }),
-      signal: AbortSignal.timeout(15_000),
-    });
-    const json = (await response.json()) as { data?: { __type: { name: string } | null } };
-    const present = json.data?.__type?.name === 'ContractEvent';
-    log.debug(`Contract events surface present on ${env.getCurrentEnvironmentName()}: ${present}`);
-    return present;
-  } catch (error) {
-    log.warn(`Contract events surface probe failed: ${(error as Error).message}`);
-    return false;
-  }
+  return retry(
+    async () => {
+      const response = await fetch(env.getIndexerHttpBaseURL() + '/api/v4/graphql', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query }),
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!response.ok) {
+        throw new Error(`contract events surface probe got HTTP ${response.status}`);
+      }
+      const json = (await response.json()) as { data?: { __type: { name: string } | null } };
+      const present = json.data?.__type?.name === 'ContractEvent';
+      log.debug(
+        `Contract events surface present on ${env.getCurrentEnvironmentName()}: ${present}`,
+      );
+      return present;
+    },
+    { maxRetries: 2, delayMs: 1000, retryLabel: 'contract events surface probe' },
+  );
 }

--- a/qa/tests/utils/indexer/contract-events-support.ts
+++ b/qa/tests/utils/indexer/contract-events-support.ts
@@ -1,0 +1,45 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import log from '@utils/logging/logger';
+import { env } from 'environment/model';
+
+/**
+ * Probes whether the deployed indexer exposes the public contract-events surface
+ * (the `ContractEvent` GraphQL type). The surface ships behind PR #1185 and is
+ * not yet on every environment, so the contract-event integration tests gate on
+ * this rather than a hardcoded environment list: they assert where the surface
+ * exists and skip where it does not, tracking the feature as it rolls out.
+ *
+ * @returns true when the `ContractEvent` type is present in the schema.
+ */
+export async function contractEventsSurfacePresent(): Promise<boolean> {
+  const query = `query { __type(name: "ContractEvent") { name kind } }`;
+  try {
+    const response = await fetch(env.getIndexerHttpBaseURL() + '/api/v4/graphql', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    const json = (await response.json()) as { data?: { __type: { name: string } | null } };
+    const present = json.data?.__type?.name === 'ContractEvent';
+    log.debug(`Contract events surface present on ${env.getCurrentEnvironmentName()}: ${present}`);
+    return present;
+  } catch (error) {
+    log.warn(`Contract events surface probe failed: ${(error as Error).message}`);
+    return false;
+  }
+}

--- a/qa/tests/utils/indexer/graphql/contract-event-queries.ts
+++ b/qa/tests/utils/indexer/graphql/contract-event-queries.ts
@@ -1,0 +1,103 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Selection set shared by the contractEvents query and subscription. ContractEvent
+// is a polymorphic interface; clients discriminate on `__typename` and read the
+// per-variant payload fields via inline fragments. PausedEvent / UnpausedEvent carry
+// no payload beyond the interface fields, so they need no fragment.
+const CONTRACT_EVENT_SELECTION = `
+    __typename
+    id
+    raw
+    maxId
+    protocolVersion
+    version
+    contractAddress
+    transactionId
+    transaction {
+      hash
+    }
+    ... on ShieldedSpendEvent {
+      nullifier
+    }
+    ... on ShieldedReceiveEvent {
+      commitment
+      ciphertext
+      receivingContractAddress
+    }
+    ... on ShieldedMintEvent {
+      commitment
+      domainSep
+      amount
+    }
+    ... on ShieldedBurnEvent {
+      nullifier
+      amount
+    }
+    ... on UnshieldedSpendEvent {
+      sender {
+        kind
+        userAddress
+        contractAddress
+      }
+      domainSep
+      tokenType
+      amount
+    }
+    ... on UnshieldedReceiveEvent {
+      recipient {
+        kind
+        userAddress
+        contractAddress
+      }
+      domainSep
+      tokenType
+      amount
+    }
+    ... on UnshieldedMintEvent {
+      domainSep
+      tokenType
+      amount
+    }
+    ... on UnshieldedBurnEvent {
+      sender {
+        kind
+        userAddress
+        contractAddress
+      }
+      tokenType
+      amount
+    }
+    ... on MiscContractEvent {
+      name
+      payload
+    }
+`;
+
+export const GET_CONTRACT_EVENTS = `
+  query ContractEvents($FILTER: ContractEventFilter!, $LIMIT: Int, $OFFSET: Int) {
+    contractEvents(filter: $FILTER, limit: $LIMIT, offset: $OFFSET) {
+${CONTRACT_EVENT_SELECTION}
+    }
+  }
+`;
+
+export const CONTRACT_EVENTS_SUBSCRIPTION = `
+  subscription ContractEventsSubscription($FILTER: ContractEventFilter!, $ID: Int) {
+    contractEvents(filter: $FILTER, id: $ID) {
+${CONTRACT_EVENT_SELECTION}
+    }
+  }
+`;

--- a/qa/tests/utils/indexer/graphql/schema.ts
+++ b/qa/tests/utils/indexer/graphql/schema.ts
@@ -263,6 +263,124 @@ export const ContractActionUnionSchema = z.discriminatedUnion('__typename', [
   ContractUpdateActionSchema,
 ]);
 
+// Contract event schemas (MIP-0002 public contract log emission). HexEncoded
+// fields are hex strings (optional `0x` prefix); `amount` is a decimal u128
+// string. `transaction` is left as `z.any()` like the contract-action schemas
+// — its shape is asserted by the transaction schemas, not here.
+const HexEncoded = z.string().regex(/^(0x)?[0-9a-fA-F]+$/);
+const U128Decimal = z.string().regex(/^[0-9]+$/);
+
+const ContractEventBaseFields = {
+  id: z.number(),
+  raw: HexEncoded,
+  maxId: z.number(),
+  protocolVersion: z.number(),
+  version: z.number(),
+  contractAddress: HexEncoded,
+  transactionId: z.number(),
+  transaction: z.any(),
+};
+
+export const AddressOrContractSchema = z.object({
+  kind: z.enum(['USER', 'CONTRACT']),
+  userAddress: HexEncoded.nullable().optional(),
+  contractAddress: HexEncoded.nullable().optional(),
+});
+
+export const ShieldedSpendEventSchema = z.object({
+  __typename: z.literal('ShieldedSpendEvent'),
+  ...ContractEventBaseFields,
+  nullifier: HexEncoded,
+});
+
+export const ShieldedReceiveEventSchema = z.object({
+  __typename: z.literal('ShieldedReceiveEvent'),
+  ...ContractEventBaseFields,
+  commitment: HexEncoded,
+  ciphertext: HexEncoded.nullable().optional(),
+  receivingContractAddress: HexEncoded.nullable().optional(),
+});
+
+export const ShieldedMintEventSchema = z.object({
+  __typename: z.literal('ShieldedMintEvent'),
+  ...ContractEventBaseFields,
+  commitment: HexEncoded,
+  domainSep: HexEncoded,
+  amount: U128Decimal.nullable().optional(),
+});
+
+export const ShieldedBurnEventSchema = z.object({
+  __typename: z.literal('ShieldedBurnEvent'),
+  ...ContractEventBaseFields,
+  nullifier: HexEncoded,
+  amount: U128Decimal.nullable().optional(),
+});
+
+export const UnshieldedSpendEventSchema = z.object({
+  __typename: z.literal('UnshieldedSpendEvent'),
+  ...ContractEventBaseFields,
+  sender: AddressOrContractSchema,
+  domainSep: HexEncoded,
+  tokenType: HexEncoded,
+  amount: U128Decimal,
+});
+
+export const UnshieldedReceiveEventSchema = z.object({
+  __typename: z.literal('UnshieldedReceiveEvent'),
+  ...ContractEventBaseFields,
+  recipient: AddressOrContractSchema,
+  domainSep: HexEncoded,
+  tokenType: HexEncoded,
+  amount: U128Decimal,
+});
+
+export const UnshieldedMintEventSchema = z.object({
+  __typename: z.literal('UnshieldedMintEvent'),
+  ...ContractEventBaseFields,
+  domainSep: HexEncoded,
+  tokenType: HexEncoded,
+  amount: U128Decimal,
+});
+
+export const UnshieldedBurnEventSchema = z.object({
+  __typename: z.literal('UnshieldedBurnEvent'),
+  ...ContractEventBaseFields,
+  sender: AddressOrContractSchema,
+  tokenType: HexEncoded,
+  amount: U128Decimal,
+});
+
+export const PausedEventSchema = z.object({
+  __typename: z.literal('PausedEvent'),
+  ...ContractEventBaseFields,
+});
+
+export const UnpausedEventSchema = z.object({
+  __typename: z.literal('UnpausedEvent'),
+  ...ContractEventBaseFields,
+});
+
+export const MiscContractEventSchema = z.object({
+  __typename: z.literal('MiscContractEvent'),
+  ...ContractEventBaseFields,
+  name: HexEncoded,
+  payload: HexEncoded,
+});
+
+export const ContractEventUnionSchema = z.discriminatedUnion('__typename', [
+  ShieldedSpendEventSchema,
+  ShieldedReceiveEventSchema,
+  ShieldedMintEventSchema,
+  ShieldedBurnEventSchema,
+  UnshieldedSpendEventSchema,
+  UnshieldedReceiveEventSchema,
+  UnshieldedMintEventSchema,
+  UnshieldedBurnEventSchema,
+  PausedEventSchema,
+  UnpausedEventSchema,
+  MiscContractEventSchema,
+]);
+
 // DUST Generation Status schema
 const isCardanoRewardAddress = (value: string) => {
   try {

--- a/qa/tests/utils/indexer/http-client.ts
+++ b/qa/tests/utils/indexer/http-client.ts
@@ -38,6 +38,9 @@ import type {
   DustGenerationMerkleTreeUpdateResponse,
   ZswapMerkleTreeCollapsedUpdateResponse,
   ZswapMerkleTreeCollapsedUpdateResult,
+  ContractEvent,
+  ContractEventFilter,
+  ContractEventResponse,
 } from './indexer-types';
 import {
   GET_LATEST_BLOCK,
@@ -45,6 +48,7 @@ import {
   GET_ZSWAP_MERKLE_TREE_COLLAPSED_UPDATE,
 } from './graphql/block-queries';
 import { GET_TRANSACTION_BY_OFFSET } from './graphql/transaction-queries';
+import { GET_CONTRACT_EVENTS } from './graphql/contract-event-queries';
 import { GET_CONTRACT_ACTION, GET_CONTRACT_ACTION_BY_OFFSET } from './graphql/contract-queries';
 import {
   GET_DUST_GENERATION_STATUS,
@@ -398,6 +402,41 @@ export class IndexerHttpClient {
     const response = await this.rawRequestWithRetry<{
       dustGenerationMerkleTreeUpdate: DustGenerationMerkleTreeUpdateResult;
     }>(query, variables);
+
+    log.debug(`Raw indexer response\n${JSON.stringify(response, null, 2)}`);
+
+    return response;
+  }
+
+  /**
+   * Retrieves public contract events matching a filter from the indexer.
+   *
+   * @param filter - The contract event filter (contractAddress is required; types,
+   *                 fieldPrefixes, fromBlock, toBlock, transactionHash are optional)
+   * @param limit - Optional maximum number of events to return
+   * @param offset - Optional number of events to skip
+   * @param queryOverride - Optional custom GraphQL query to override the default
+   *
+   * @returns Promise resolving to the contract events response
+   */
+  async getContractEvents(
+    filter: ContractEventFilter,
+    limit?: number,
+    offset?: number,
+    queryOverride?: string,
+  ): Promise<ContractEventResponse> {
+    log.debug(`Target URL endpoint ${this.getTargetUrl()}`);
+
+    const query = queryOverride || GET_CONTRACT_EVENTS;
+    const variables = { FILTER: filter, LIMIT: limit, OFFSET: offset };
+
+    log.debug(`Using query\n${query}`);
+    log.debug(`Using variables\n${JSON.stringify(variables, null, 2)}`);
+
+    const response = await this.rawRequestWithRetry<{ contractEvents: ContractEvent[] }>(
+      query,
+      variables,
+    );
 
     log.debug(`Raw indexer response\n${JSON.stringify(response, null, 2)}`);
 

--- a/qa/tests/utils/indexer/indexer-types.ts
+++ b/qa/tests/utils/indexer/indexer-types.ts
@@ -239,6 +239,160 @@ export interface ContractBalance {
   amount: string;
 }
 
+export type ContractEventResponse = GraphQLResponse<{ contractEvents: ContractEvent[] }>;
+
+/**
+ * The 11 standard contract-event variants per MIP-0002 Appendix A. Mirrors the
+ * `ContractEventType` GraphQL enum used by `ContractEventFilter.types`.
+ */
+export type ContractEventType =
+  | 'SHIELDED_SPEND'
+  | 'SHIELDED_RECEIVE'
+  | 'SHIELDED_MINT'
+  | 'SHIELDED_BURN'
+  | 'UNSHIELDED_SPEND'
+  | 'UNSHIELDED_RECEIVE'
+  | 'UNSHIELDED_MINT'
+  | 'UNSHIELDED_BURN'
+  | 'PAUSED'
+  | 'UNPAUSED'
+  | 'MISC';
+
+export const CONTRACT_EVENT_TYPES: ContractEventType[] = [
+  'SHIELDED_SPEND',
+  'SHIELDED_RECEIVE',
+  'SHIELDED_MINT',
+  'SHIELDED_BURN',
+  'UNSHIELDED_SPEND',
+  'UNSHIELDED_RECEIVE',
+  'UNSHIELDED_MINT',
+  'UNSHIELDED_BURN',
+  'PAUSED',
+  'UNPAUSED',
+  'MISC',
+];
+
+/** Prefix filter on an indexed contract-event field (e.g. nullifier, tokenType). */
+export interface FieldPrefixFilter {
+  fieldName: string;
+  prefix: string;
+}
+
+export interface ContractEventFilter {
+  contractAddress: string;
+  types?: ContractEventType[];
+  fieldPrefixes?: FieldPrefixFilter[];
+  fromBlock?: number;
+  toBlock?: number;
+  transactionHash?: string;
+}
+
+/**
+ * Tagged union for `Either<ZswapCoinPublicKey, ContractAddress>` fields
+ * (UnshieldedSpend/Receive `sender`/`recipient`, UnshieldedBurn `sender`).
+ * Exactly one of `userAddress` / `contractAddress` is populated per `kind`.
+ */
+export interface AddressOrContract {
+  kind: 'USER' | 'CONTRACT';
+  userAddress?: string;
+  contractAddress?: string;
+}
+
+/** Fields common to every concrete contract event (the `ContractEvent` interface). */
+export interface ContractEventBase {
+  __typename: string;
+  id: number;
+  raw: string;
+  maxId: number;
+  protocolVersion: number;
+  version: number;
+  contractAddress: string;
+  transactionId: number;
+  transaction: Transaction;
+}
+
+export interface ShieldedSpendEvent extends ContractEventBase {
+  __typename: 'ShieldedSpendEvent';
+  nullifier: string;
+}
+
+export interface ShieldedReceiveEvent extends ContractEventBase {
+  __typename: 'ShieldedReceiveEvent';
+  commitment: string;
+  ciphertext?: string | null;
+  receivingContractAddress?: string | null;
+}
+
+export interface ShieldedMintEvent extends ContractEventBase {
+  __typename: 'ShieldedMintEvent';
+  commitment: string;
+  domainSep: string;
+  amount?: string | null;
+}
+
+export interface ShieldedBurnEvent extends ContractEventBase {
+  __typename: 'ShieldedBurnEvent';
+  nullifier: string;
+  amount?: string | null;
+}
+
+export interface UnshieldedSpendEvent extends ContractEventBase {
+  __typename: 'UnshieldedSpendEvent';
+  sender: AddressOrContract;
+  domainSep: string;
+  tokenType: string;
+  amount: string;
+}
+
+export interface UnshieldedReceiveEvent extends ContractEventBase {
+  __typename: 'UnshieldedReceiveEvent';
+  recipient: AddressOrContract;
+  domainSep: string;
+  tokenType: string;
+  amount: string;
+}
+
+export interface UnshieldedMintEvent extends ContractEventBase {
+  __typename: 'UnshieldedMintEvent';
+  domainSep: string;
+  tokenType: string;
+  amount: string;
+}
+
+export interface UnshieldedBurnEvent extends ContractEventBase {
+  __typename: 'UnshieldedBurnEvent';
+  sender: AddressOrContract;
+  tokenType: string;
+  amount: string;
+}
+
+export interface PausedEvent extends ContractEventBase {
+  __typename: 'PausedEvent';
+}
+
+export interface UnpausedEvent extends ContractEventBase {
+  __typename: 'UnpausedEvent';
+}
+
+export interface MiscContractEvent extends ContractEventBase {
+  __typename: 'MiscContractEvent';
+  name: string;
+  payload: string;
+}
+
+export type ContractEvent =
+  | ShieldedSpendEvent
+  | ShieldedReceiveEvent
+  | ShieldedMintEvent
+  | ShieldedBurnEvent
+  | UnshieldedSpendEvent
+  | UnshieldedReceiveEvent
+  | UnshieldedMintEvent
+  | UnshieldedBurnEvent
+  | PausedEvent
+  | UnpausedEvent
+  | MiscContractEvent;
+
 export interface DustGenerationStatus {
   cardanoRewardAddress: string;
   dustAddress?: string;

--- a/qa/tests/utils/indexer/websocket-client.ts
+++ b/qa/tests/utils/indexer/websocket-client.ts
@@ -28,8 +28,11 @@ import type {
   ShieldedTransactionsEvent,
   UnshieldedTransactionEvent,
   ContractAction,
+  ContractEvent,
+  ContractEventFilter,
   GraphQLResponse,
 } from './indexer-types';
+import { CONTRACT_EVENTS_SUBSCRIPTION } from './graphql/contract-event-queries';
 import {
   BLOCKS_SUBSCRIPTION_FROM_BLOCK_BY_OFFSET,
   BLOCKS_SUBSCRIPTION_FROM_LATEST_BLOCK,
@@ -79,6 +82,10 @@ export type ShieldedNullifierTransactionSubscriptionResponse = GraphQLResponse<{
 
 export type ZswapLedgerEventSubscriptionResponse = GraphQLResponse<{
   zswapLedgerEvents: ZswapLedgerEvent;
+}>;
+
+export type ContractEventSubscriptionResponse = GraphQLResponse<{
+  contractEvents: ContractEvent;
 }>;
 
 /**
@@ -431,6 +438,60 @@ export class IndexerWsClient {
       const stopMessage: GraphQLStopMessage = { id, type: 'stop' };
       this.getWs().send(JSON.stringify(stopMessage));
       this.handlersMap.delete(id);
+    };
+  }
+
+  /**
+   * Subscribes to public contract events matching a filter.
+   *
+   * The stream starts from the later of `id` (event-id resumption cursor) and
+   * `filter.fromBlock`; if `filter.toBlock` is set the stream terminates once the
+   * chain reaches that block (the server sends a `complete` message).
+   *
+   * @param handlers - Object containing callback functions for subscription events
+   * @param filter - The contract event filter (contractAddress is required)
+   * @param id - Optional event-id resumption cursor
+   * @param queryOverride - Optional custom GraphQL subscription. If provided, the
+   *                        caller is responsible for matching the variables
+   *
+   * @returns An object with subscription ID and unsubscribe function
+   */
+  subscribeToContractEvents(
+    handlers: SubscriptionHandlers<ContractEventSubscriptionResponse>,
+    filter: ContractEventFilter,
+    id?: number,
+    queryOverride?: string,
+  ): { unsubscribe: () => void; id: string } {
+    const subscriptionId = this.getNextId();
+
+    const query = queryOverride ?? CONTRACT_EVENTS_SUBSCRIPTION;
+    const variables: Record<string, unknown> = {
+      FILTER: filter,
+      ...(id !== undefined && { ID: id }),
+    };
+
+    log.debug(`Contract events subscription query:\n${query}`);
+    log.debug(`Contract events subscription variables:\n${JSON.stringify(variables, null, 2)}`);
+
+    const payload: GraphQLStartMessage = {
+      id: subscriptionId,
+      type: 'start',
+      payload: {
+        query,
+        variables,
+      },
+    };
+
+    this.handlersMap.set(subscriptionId, handlers as SubscriptionHandlers<unknown>);
+    this.getWs().send(JSON.stringify(payload));
+
+    return {
+      id: subscriptionId,
+      unsubscribe: () => {
+        const stopMessage: GraphQLStopMessage = { id: subscriptionId, type: 'stop' };
+        this.getWs().send(JSON.stringify(stopMessage));
+        this.handlersMap.delete(subscriptionId);
+      },
     };
   }
 

--- a/qa/tests/utils/testdata-provider.ts
+++ b/qa/tests/utils/testdata-provider.ts
@@ -33,6 +33,21 @@ export interface ContractInfo {
 }
 
 /**
+ * A contract known to have emitted public contract events (MIP-0002) on the
+ * current environment's chain. Used by the contract-event integration tests to
+ * assert real emitted-event payloads. Sourced from
+ * `data/static/<env>/contract-events.jsonc`; absent until a test-data path that
+ * deploys and calls an emit-bearing contract is wired for the environment, so
+ * the data-dependent assertions skip until then.
+ */
+export interface EventEmittingContractInfo {
+  /** Hex-encoded contract address that emitted at least one contract event. */
+  'contract-address': string;
+  /** Optional contract-event type names expected among the emitted events. */
+  'event-types'?: string[];
+}
+
+/**
  * A contract known to hold a non-zero unshielded token balance on the current
  * environment's chain. Used by the unshieldedBalances regression tests (#1245):
  * the field silently returned an empty array for every contract from 3.0.0 to
@@ -353,6 +368,34 @@ class TestDataProvider {
       );
     }
     return contracts[0]['contract-address'];
+  }
+
+  /**
+   * Returns the contracts known to have emitted public contract events on the
+   * current environment's chain, for the contract-event integration tests.
+   * @returns A non-empty list of event-emitting contracts.
+   * @throws Error if the fixture file is missing or empty for the current
+   *         environment, so the data-dependent event assertions skip cleanly.
+   */
+  getEventEmittingContracts(): EventEmittingContractInfo[] {
+    const envName = env.getCurrentEnvironmentName();
+    const baseDir = `data/static/${envName}`;
+    let contracts: EventEmittingContractInfo[];
+    try {
+      contracts = importJsoncData(
+        `${baseDir}/contract-events.jsonc`,
+      ) as unknown as EventEmittingContractInfo[];
+    } catch (_) {
+      throw new Error(
+        `Test data provider is missing the contract events file for ${envName} environment`,
+      );
+    }
+    if (contracts.length === 0 || !contracts[0]['contract-address']) {
+      throw new Error(
+        `Test data provider is missing event-emitting contract data for ${envName} environment`,
+      );
+    }
+    return contracts;
   }
 
   /**


### PR DESCRIPTION
## Scope

Black-box QA integration coverage for the public **contract events** GraphQL surface (the `contractEvents` query and subscription) exposed by the contract events feature. QA-owned tests under `qa/tests` only — no production code changes.

## Why

The contract events surface had no QA black-box coverage. The Rust unit tests exercise the decoder/`TryFrom`/filter internals; this adds the complementary black-box layer asserting the GraphQL contract and query/subscription behaviour against a deployed indexer.

## What it covers

- **Schema contract** — the `ContractEvent` interface and its common fields (incl. the `transaction` navigation field), all eleven concrete event types, the `ContractEventType` enum, and the `ContractEventFilter` / `FieldPrefixFilter` inputs (incl. `transactionHash`).
- **Query behaviour** — empty results for an address that emitted nothing, type and block-range filters, and single-type filtering that returns only the requested type.
- **Negative/validation** — empty and malformed `contractAddress` rejected.
- **Nested field** — `contractEvents` resolvable on `ContractCall`, and absent on `ContractDeploy` / `ContractUpdate`.
- **Subscription** — registration, `toBlock` terminator on an idle address, empty-address error, and real emitted-event streaming.

## Gating

The suite gates on a runtime schema-presence probe: it asserts where the surface is deployed and **skips** elsewhere (no hardcoded environment list). Data-dependent assertions read event-emitting contract fixtures and skip until those are configured for an environment.

## Validation

Run against **stagenet** (surface present):
- `contract-event-queries` — 12/12 pass
- `contract-event-subscriptions` — 3/3 pass
- `contract-queries` (extended nested-field) — pass

Gate verified on **qanet** (surface absent): all contract-event tests skip, none fail.

`yarn lint` · `yarn audit` · `yarn format` clean.