### PR TITLE
feat(indexer-api): block-hash dust generations sync

### DIFF
--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -1178,11 +1178,15 @@ type Subscription {
 	"""
 	contractActions(address: HexEncoded!, offset: BlockOffset): ContractAction!
 	"""
-	Subscribe to dust generation entries for a dust address in `[start_index, end_index]`
-	inclusive. `dustGenerationEndIndex` is exclusive, pass `dustGenerationEndIndex - 1`.
-	Entries interleaved with collapsed Merkle tree updates and owned-entry dtime updates.
+	Subscribe to a dust address's generations as a consistent snapshot at `block_hash`. The
+	wallet's owned generation entries, interleaved with collapsed Merkle tree updates for the
+	non-owned gaps, are served at that block's state (deterministic, independent of the tip).
+	The dtime updates for the wallet's own generations in `(dtime_cutoff_height, block_hash]`
+	are issued first, as a clean delta for the generations set rather than the tree (pass `0`
+	to replay all). The subscription completes once emitted; re-subscribe at a newer
+	`block_hash` to advance.
 	"""
-	dustGenerations(dustAddress: DustAddress!, startIndex: Int!, endIndex: Int!): DustGenerationsEvent! @beta
+	dustGenerations(dustAddress: DustAddress!, blockHash: HexEncoded!, dtimeCutoffHeight: Int!): DustGenerationsEvent! @beta
 	"""
 	Subscribe to dust ledger events starting at the given ID or at the very start if omitted.
 	"""

--- a/indexer-api/src/domain/storage/dust_generations.rs
+++ b/indexer-api/src/domain/storage/dust_generations.rs
@@ -48,24 +48,15 @@ where
         batch_size: NonZeroU32,
     ) -> impl Stream<Item = Result<DustGenerationEntry, sqlx::Error>> + Send;
 
-    /// Look up the block_id of the wallet's most recent owned entry below
-    /// `start_index`. Returns `None` for fresh subscriptions or wallets with
-    /// no prior entries (in which case dtime backfill is skipped entirely).
-    async fn get_dust_generation_dtime_cutoff_block_id(
-        &self,
-        dust_address: &[u8],
-        start_index: u64,
-    ) -> Result<Option<u64>, sqlx::Error>;
-
     /// Get dust generation dtime update events for a dust address whose
-    /// transaction's block_id exceeds the cutoff and whose ledger event id
-    /// exceeds `after_event_id`. Used both for initial backfill (with the
-    /// cutoff derived above) and live tail (with the cutoff being the latest
-    /// processed block). The stream is ordered by ledger event id.
+    /// transaction's block_id is in `(cutoff_block_id, upper_block_id]` and
+    /// whose ledger event id exceeds `after_event_id`. The stream is ordered
+    /// by ledger event id.
     async fn get_dust_generation_dtime_updates(
         &self,
         dust_address: &[u8],
         cutoff_block_id: u64,
+        upper_block_id: u64,
         after_event_id: u64,
         batch_size: NonZeroU32,
     ) -> impl Stream<Item = Result<DustGenerationDtimeUpdateEntry, sqlx::Error>> + Send;
@@ -78,10 +69,6 @@ where
         to_block: u64,
         batch_size: NonZeroU32,
     ) -> impl Stream<Item = Result<DustNullifierTransaction, sqlx::Error>> + Send;
-
-    /// Returns the chain's current dust-generation first-free index
-    /// (`MAX(generation_index) + 1`, or `0` for an empty table).
-    async fn get_dust_generations_chain_first_free(&self) -> Result<u64, sqlx::Error>;
 }
 
 #[allow(unused_variables)]
@@ -104,18 +91,11 @@ impl DustGenerationsStorage for NoopStorage {
         stream::empty()
     }
 
-    async fn get_dust_generation_dtime_cutoff_block_id(
-        &self,
-        dust_address: &[u8],
-        start_index: u64,
-    ) -> Result<Option<u64>, sqlx::Error> {
-        Ok(None)
-    }
-
     async fn get_dust_generation_dtime_updates(
         &self,
         dust_address: &[u8],
         cutoff_block_id: u64,
+        upper_block_id: u64,
         after_event_id: u64,
         batch_size: NonZeroU32,
     ) -> impl Stream<Item = Result<DustGenerationDtimeUpdateEntry, sqlx::Error>> + Send {
@@ -130,9 +110,5 @@ impl DustGenerationsStorage for NoopStorage {
         batch_size: NonZeroU32,
     ) -> impl Stream<Item = Result<DustNullifierTransaction, sqlx::Error>> + Send {
         stream::empty()
-    }
-
-    async fn get_dust_generations_chain_first_free(&self) -> Result<u64, sqlx::Error> {
-        Ok(0)
     }
 }

--- a/indexer-api/src/domain/storage/ledger_state.rs
+++ b/indexer-api/src/domain/storage/ledger_state.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use indexer_common::domain::{ProtocolVersion, SerializedLedgerStateKey};
+use indexer_common::domain::{BlockHash, ProtocolVersion, SerializedLedgerStateKey};
 
 use crate::domain::storage::NoopStorage;
 
@@ -20,10 +20,16 @@ pub trait LedgerStateStorage
 where
     Self: Clone + Send + Sync + 'static,
 {
-    /// Get the ledger state key and protocol version.
+    /// Get the protocol version and ledger state key of the highest (tip) block.
     async fn get_highest_ledger_state(
         &self,
     ) -> Result<Option<(ProtocolVersion, SerializedLedgerStateKey)>, sqlx::Error>;
+
+    /// Get the block id, protocol version, and ledger state key at a specific block, by hash.
+    async fn get_ledger_state_at(
+        &self,
+        block_hash: BlockHash,
+    ) -> Result<Option<(u64, ProtocolVersion, SerializedLedgerStateKey)>, sqlx::Error>;
 }
 
 #[allow(unused_variables)]
@@ -31,6 +37,13 @@ impl LedgerStateStorage for NoopStorage {
     async fn get_highest_ledger_state(
         &self,
     ) -> Result<Option<(ProtocolVersion, SerializedLedgerStateKey)>, sqlx::Error> {
+        unimplemented!()
+    }
+
+    async fn get_ledger_state_at(
+        &self,
+        block_hash: BlockHash,
+    ) -> Result<Option<(u64, ProtocolVersion, SerializedLedgerStateKey)>, sqlx::Error> {
         unimplemented!()
     }
 }

--- a/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
@@ -12,9 +12,9 @@
 // limitations under the License.
 
 use crate::{
-    domain::{LedgerStateCache, dust::DustGenerationDtimeUpdateEntry, storage::Storage},
+    domain::{LedgerState, dust::DustGenerationDtimeUpdateEntry, storage::Storage},
     infra::api::{
-        ApiResult, ContextExt, ResultExt,
+        ApiResult, ContextExt, OptionExt, ResultExt,
         v4::{
             HexEncodable, HexEncoded, directives::beta, dust::DustAddress,
             merkle_tree_collapsed_update::MerkleTreeCollapsedUpdate,
@@ -24,8 +24,7 @@ use crate::{
 use async_graphql::{Context, SimpleObject, Subscription, Union};
 use async_stream::try_stream;
 use futures::{Stream, TryStreamExt};
-use indexer_common::domain::{BlockIndexed, Subscriber};
-use log::{debug, warn};
+use indexer_common::domain::{ProtocolVersion, Subscriber};
 use std::{marker::PhantomData, pin::pin};
 
 /// An event of the dust generations subscription.
@@ -118,26 +117,26 @@ where
     S: Storage,
     B: Subscriber,
 {
-    /// Subscribe to dust generation entries for a dust address in `[start_index, end_index]`
-    /// inclusive. `dustGenerationEndIndex` is exclusive, pass `dustGenerationEndIndex - 1`.
-    /// Entries interleaved with collapsed Merkle tree updates and owned-entry dtime updates.
+    /// Subscribe to a dust address's generations as a consistent snapshot at `block_hash`. The
+    /// wallet's owned generation entries, interleaved with collapsed Merkle tree updates for the
+    /// non-owned gaps, are served at that block's state (deterministic, independent of the tip).
+    /// The dtime updates for the wallet's own generations in `(dtime_cutoff_height, block_hash]`
+    /// are issued first, as a clean delta for the generations set rather than the tree (pass `0`
+    /// to replay all). The subscription completes once emitted; re-subscribe at a newer
+    /// `block_hash` to advance.
     #[graphql(directive = beta::apply())]
     async fn dust_generations<'a>(
         &self,
         cx: &'a Context<'a>,
         dust_address: DustAddress,
-        start_index: u64,
-        end_index: u64,
+        block_hash: HexEncoded,
+        dtime_cutoff_height: u64,
     ) -> impl Stream<Item = ApiResult<DustGenerationsEvent>> {
         let storage = cx.get_storage::<S>();
-        let subscriber = cx.get_subscriber::<B>();
-        let ledger_state_cache = cx.get_ledger_state_cache();
         let batch_size = cx.get_subscription_config().dust_generations.batch_size;
         let network_id = cx.get_network_id();
         let quotas = cx.get_subscription_quotas();
         let per_connection_counter = cx.get_per_connection_counter();
-
-        let block_indexed_stream = subscriber.subscribe::<BlockIndexed>();
 
         try_stream! {
             let _quota_guard = quotas
@@ -147,28 +146,51 @@ where
             let dust_address_bytes = dust_address
                 .try_into_domain(network_id)
                 .map_err_into_client_error(|| "invalid bech32m dust address")?;
-            let mut cursor = start_index;
 
-            // Fall back to 0 (= replay all dtime updates for this address) when
-            // the wallet has no entry below `start_index`. The dtime SQL filters
-            // by owner and per-stream event-id cursor, so cutoff = 0 is safe.
-            let dtime_cutoff_block_id = storage
-                .get_dust_generation_dtime_cutoff_block_id(&dust_address_bytes, start_index)
+            let block_hash = block_hash
+                .hex_decode()
+                .map_err_into_client_error(|| "invalid block hash")?;
+
+            // Pin the whole snapshot to one block: load the ledger state at `block_hash` so the
+            // generation tree (and every collapsed update built from it) reflects the state as of
+            // that block. This is what makes the response deterministic and free of tip-drift.
+            let (snapshot_block_id, protocol_version, ledger_state_key) = storage
+                .get_ledger_state_at(block_hash)
                 .await
-                .map_err_into_server_error(|| "get dtime cutoff block id")?
-                .unwrap_or(0);
+                .map_err_into_server_error(|| "get ledger state at block")?
+                .some_or_client_error(|| "unknown block hash")?;
 
-            // Single dtime cursor across initial backfill and live tail. It
-            // advances past every emitted DustGenerationDtimeUpdateItem so
-            // subsequent block-driven polls don't re-emit.
-            let mut dtime_after_event_id = 0u64;
+            let ledger_state =
+                LedgerState::load(&ledger_state_key, protocol_version.ledger_version())
+                    .map_err_into_server_error(|| "load ledger state at block")?;
 
-            debug!(cutoff = dtime_cutoff_block_id; "replaying dtime updates after cutoff");
+            // Exclusive end of the generation tree at this block.
+            let end_index = ledger_state.dust_generations_first_free();
+            let last_index = end_index.saturating_sub(1);
+
+            // 1. dtime delta: the wallet's own generations spent in `(cutoff, block_hash]`. Map the
+            //    cutoff height to the internal block id; `snapshot_block_id` bounds the delta at
+            //    `block_hash` so the response is deterministic (independent of the current tip).
+            //    `0` means "from the start" (no prior sync).
+            let cutoff_block_id = if dtime_cutoff_height == 0 {
+                0
+            } else {
+                let height = u32::try_from(dtime_cutoff_height)
+                    .map_err_into_client_error(|| "dtime_cutoff_height out of range")?;
+                storage
+                    .get_block_by_height(height)
+                    .await
+                    .map_err_into_server_error(|| "get block by height for dtime cutoff")?
+                    .map(|block| block.id)
+                    .unwrap_or(0)
+            };
+
             let updates = storage
                 .get_dust_generation_dtime_updates(
                     &dust_address_bytes,
-                    dtime_cutoff_block_id,
-                    dtime_after_event_id,
+                    cutoff_block_id,
+                    snapshot_block_id,
+                    0,
                     batch_size,
                 )
                 .await;
@@ -178,16 +200,14 @@ where
                 .await
                 .map_err_into_server_error(|| "get next dtime update")?
             {
-                dtime_after_event_id = update.ledger_event_id;
-                yield DustGenerationsEvent::DustGenerationDtimeUpdateItem(
-                    dtime_update_item(update),
-                );
+                yield DustGenerationsEvent::DustGenerationDtimeUpdateItem(dtime_update_item(update));
             }
 
-            debug!(start_index, end_index; "streaming existing dust generation entries");
-
+            // 2. The wallet's owned generation entries up to the block, interleaved with collapsed
+            //    Merkle tree updates (pinned to the block) filling the non-owned gaps.
+            let mut cursor = 0u64;
             let entries = storage
-                .get_dust_generation_entries(&dust_address_bytes, cursor, end_index, batch_size)
+                .get_dust_generation_entries(&dust_address_bytes, 0, last_index, batch_size)
                 .await;
             let mut entries = pin!(entries);
             while let Some(entry) = entries
@@ -196,11 +216,11 @@ where
                 .map_err_into_server_error(|| "get next dust generation entry")?
             {
                 let collapsed_merkle_tree = make_collapsed_update(
+                    &ledger_state,
                     cursor,
                     entry.generation_mt_index,
-                    storage,
-                    ledger_state_cache,
-                ).await?;
+                    protocol_version,
+                )?;
 
                 cursor = entry.generation_mt_index + 1;
 
@@ -218,232 +238,57 @@ where
                 });
             }
 
-            // Terminate on chain progress, not the subscriber's `cursor`,
-            // which only crosses `end_index` when the wallet owns an
-            // entry there.
-            let chain_first_free = storage
-                .get_dust_generations_chain_first_free()
-                .await
-                .map_err_into_server_error(|| "get dust generations chain first free")?;
-            if chain_first_free > end_index {
-                // Re-drain to catch entries committed in the window between
-                // the backfill drain ending and the chain-progress read.
-                let entries = storage
-                    .get_dust_generation_entries(&dust_address_bytes, cursor, end_index, batch_size)
-                    .await;
-                let mut entries = pin!(entries);
-                while let Some(entry) = entries
-                    .try_next()
-                    .await
-                    .map_err_into_server_error(|| "get next dust generation entry")?
-                {
-                    let collapsed_merkle_tree = make_collapsed_update(
-                        cursor,
-                        entry.generation_mt_index,
-                        storage,
-                        ledger_state_cache,
-                    ).await?;
-
-                    cursor = entry.generation_mt_index + 1;
-
-                    yield DustGenerationsEvent::DustGenerationsItem(DustGenerationsItem {
-                        commitment_mt_index: entry.commitment_mt_index,
-                        generation_mt_index: entry.generation_mt_index,
-                        owner: entry.owner.hex_encode(),
-                        value: entry.value.to_string(),
-                        initial_value: entry.initial_value.to_string(),
-                        backing_night: entry.backing_night.hex_encode(),
-                        ctime: entry.ctime,
-                        transaction_id: entry.transaction_id,
-                        transaction_hash: entry.transaction_hash.hex_encode(),
-                        collapsed_merkle_tree,
-                    });
-                }
-
-                let final_update = make_final_collapsed_update(
-                    cursor, end_index, storage, ledger_state_cache,
-                ).await?;
-
-                yield DustGenerationsEvent::DustGenerationsProgress(DustGenerationsProgress {
-                    highest_index: end_index,
-                    collapsed_merkle_tree: final_update,
-                });
-
-                return;
-            }
-
-            debug!(cursor; "streaming live dust generation entries");
-            let mut block_indexed_stream = pin!(block_indexed_stream);
-            while block_indexed_stream
-                .try_next()
-                .await
-                .map_err_into_server_error(|| "get next BlockIndexed event")?
-                .is_some()
-            {
-                let entries = storage
-                    .get_dust_generation_entries(&dust_address_bytes, cursor, end_index, batch_size)
-                    .await;
-                let mut entries = pin!(entries);
-                while let Some(entry) = entries
-                    .try_next()
-                    .await
-                    .map_err_into_server_error(|| "get next dust generation entry")?
-                {
-                    let collapsed_merkle_tree = make_collapsed_update(
-                        cursor,
-                        entry.generation_mt_index,
-                        storage,
-                        ledger_state_cache,
-                    ).await?;
-
-                    cursor = entry.generation_mt_index + 1;
-
-                    yield DustGenerationsEvent::DustGenerationsItem(DustGenerationsItem {
-                        commitment_mt_index: entry.commitment_mt_index,
-                        generation_mt_index: entry.generation_mt_index,
-                        owner: entry.owner.hex_encode(),
-                        value: entry.value.to_string(),
-                        initial_value: entry.initial_value.to_string(),
-                        backing_night: entry.backing_night.hex_encode(),
-                        ctime: entry.ctime,
-                        transaction_id: entry.transaction_id,
-                        transaction_hash: entry.transaction_hash.hex_encode(),
-                        collapsed_merkle_tree,
-                    });
-                }
-
-                // Drain any new dtime updates for entries the subscriber
-                // owns. Reuses the same cutoff (initial entry-block anchor)
-                // and the running event cursor so we don't re-emit.
-                let updates = storage
-                    .get_dust_generation_dtime_updates(
-                        &dust_address_bytes,
-                        dtime_cutoff_block_id,
-                        dtime_after_event_id,
-                        batch_size,
-                    )
-                    .await;
-                let mut updates = pin!(updates);
-                while let Some(update) = updates
-                    .try_next()
-                    .await
-                    .map_err_into_server_error(|| "get next dtime update")?
-                {
-                    dtime_after_event_id = update.ledger_event_id;
-                    yield DustGenerationsEvent::DustGenerationDtimeUpdateItem(
-                        dtime_update_item(update),
-                    );
-                }
-
-                let chain_first_free = storage
-                    .get_dust_generations_chain_first_free()
-                    .await
-                    .map_err_into_server_error(|| "get dust generations chain first free")?;
-                if chain_first_free > end_index {
-                    // Re-drain to catch entries committed in the window between
-                    // the live-tail drain ending and the chain-progress read.
-                    let entries = storage
-                        .get_dust_generation_entries(&dust_address_bytes, cursor, end_index, batch_size)
-                        .await;
-                    let mut entries = pin!(entries);
-                    while let Some(entry) = entries
-                        .try_next()
-                        .await
-                        .map_err_into_server_error(|| "get next dust generation entry")?
-                    {
-                        let collapsed_merkle_tree = make_collapsed_update(
-                            cursor,
-                            entry.generation_mt_index,
-                            storage,
-                            ledger_state_cache,
-                        ).await?;
-
-                        cursor = entry.generation_mt_index + 1;
-
-                        yield DustGenerationsEvent::DustGenerationsItem(DustGenerationsItem {
-                            commitment_mt_index: entry.commitment_mt_index,
-                            generation_mt_index: entry.generation_mt_index,
-                            owner: entry.owner.hex_encode(),
-                            value: entry.value.to_string(),
-                            initial_value: entry.initial_value.to_string(),
-                            backing_night: entry.backing_night.hex_encode(),
-                            ctime: entry.ctime,
-                            transaction_id: entry.transaction_id,
-                            transaction_hash: entry.transaction_hash.hex_encode(),
-                            collapsed_merkle_tree,
-                        });
-                    }
-
-                    let final_update = make_final_collapsed_update(
-                        cursor, end_index, storage, ledger_state_cache,
-                    ).await?;
-
-                    yield DustGenerationsEvent::DustGenerationsProgress(DustGenerationsProgress {
-                        highest_index: end_index,
-                        collapsed_merkle_tree: final_update,
-                    });
-
-                    return;
-                }
-            }
-
-            warn!("stream of BlockIndexed events completed unexpectedly");
+            // 3. Final collapsed update covering the remaining range, then complete the snapshot.
+            //    An empty generation tree (no leaves) has no final segment.
+            let final_update = if end_index == 0 {
+                None
+            } else {
+                make_final_collapsed_update(&ledger_state, cursor, last_index, protocol_version)?
+            };
+            yield DustGenerationsEvent::DustGenerationsProgress(DustGenerationsProgress {
+                highest_index: last_index,
+                collapsed_merkle_tree: final_update,
+            });
         }
     }
 }
 
-/// Compute a collapsed Merkle tree update to fill the gap between cursor and entry's index.
-async fn make_collapsed_update<S: Storage>(
+/// Compute a collapsed Merkle tree update to fill the gap between `cursor` and `entry_index`,
+/// built from the block-pinned ledger state.
+fn make_collapsed_update(
+    ledger_state: &LedgerState,
     cursor: u64,
     entry_index: u64,
-    storage: &S,
-    ledger_state_cache: &LedgerStateCache,
+    protocol_version: ProtocolVersion,
 ) -> ApiResult<Option<MerkleTreeCollapsedUpdate>> {
     if cursor >= entry_index || entry_index == 0 {
         return Ok(None);
     }
 
-    let block = storage
-        .get_latest_block()
-        .await
-        .map_err_into_server_error(|| "get latest block for collapsed update")?;
-
-    let Some(block) = block else {
-        return Ok(None);
-    };
-
-    let update = ledger_state_cache
-        .dust_generations_collapsed_update(cursor, entry_index - 1, storage, block.protocol_version)
-        .await
+    let update = ledger_state
+        .dust_generations_collapsed_update(cursor, entry_index - 1, protocol_version)
         .map_err_into_server_error(|| "create dust generations collapsed update")?;
 
     Ok(Some(update.into()))
 }
 
-/// Compute the final collapsed Merkle tree update covering the remaining range.
-async fn make_final_collapsed_update<S: Storage>(
+/// Compute the final collapsed Merkle tree update covering the remaining range, built from the
+/// block-pinned ledger state.
+fn make_final_collapsed_update(
+    ledger_state: &LedgerState,
     cursor: u64,
     end_index: u64,
-    storage: &S,
-    ledger_state_cache: &LedgerStateCache,
+    protocol_version: ProtocolVersion,
 ) -> ApiResult<Option<MerkleTreeCollapsedUpdate>> {
-    let block = storage
-        .get_latest_block()
-        .await
-        .map_err_into_server_error(|| "get latest block for final collapsed update")?;
-
-    let Some(block) = block else {
+    if cursor > end_index {
         return Ok(None);
-    };
-
-    let update = ledger_state_cache
-        .dust_generations_collapsed_update(cursor, end_index, storage, block.protocol_version)
-        .await;
-
-    match update {
-        Ok(update) => Ok(Some(update.into())),
-        Err(_) => Ok(None),
     }
+
+    let update = ledger_state
+        .dust_generations_collapsed_update(cursor, end_index, protocol_version)
+        .map_err_into_server_error(|| "create final dust generations collapsed update")?;
+
+    Ok(Some(update.into()))
 }
 
 /// Convert a domain dtime update entry into the GraphQL item.

--- a/indexer-api/src/infra/storage/dust_generations.rs
+++ b/indexer-api/src/infra/storage/dust_generations.rs
@@ -199,37 +199,11 @@ impl DustGenerationsStorage for Storage {
         }
     }
 
-    #[trace(properties = { "start_index": "{start_index}" })]
-    async fn get_dust_generation_dtime_cutoff_block_id(
-        &self,
-        dust_address: &[u8],
-        start_index: u64,
-    ) -> Result<Option<u64>, sqlx::Error> {
-        // Highest owned entry strictly below `start_index` gives the block we
-        // last fully synced through. `generation_index < start_index` also
-        // implicitly skips legacy NULL rows (NULL fails the comparison).
-        let query = indoc! {"
-            SELECT t.block_id
-            FROM dust_generation_info dgi
-            JOIN transactions t ON t.id = dgi.transaction_id
-            WHERE dgi.owner = $1
-            AND dgi.generation_index < $2
-            ORDER BY dgi.generation_index DESC
-            LIMIT 1
-        "};
-
-        sqlx::query_as::<_, (i64,)>(query)
-            .bind(dust_address)
-            .bind(start_index as i64)
-            .fetch_optional(&*self.pool)
-            .await
-            .map(|row| row.map(|(block_id,)| block_id as u64))
-    }
-
     async fn get_dust_generation_dtime_updates(
         &self,
         dust_address: &[u8],
         cutoff_block_id: u64,
+        upper_block_id: u64,
         mut after_event_id: u64,
         batch_size: NonZeroU32,
     ) -> impl Stream<Item = Result<DustGenerationDtimeUpdateEntry, sqlx::Error>> + Send {
@@ -274,6 +248,7 @@ impl DustGenerationsStorage for Storage {
                            'hex')
                     WHERE le.variant = 'DustGenerationDtimeUpdate'
                     AND t.block_id > $1
+                    AND t.block_id <= $5
                     AND dgi.owner = $2
                     AND le.id > $3
                     ORDER BY le.id
@@ -310,6 +285,7 @@ impl DustGenerationsStorage for Storage {
                             substr(e.hash_hex, 3),
                             e.hash_hex))
                     WHERE t.block_id > $1
+                    AND t.block_id <= $5
                     AND dgi.owner = $2
                     ORDER BY e.ledger_event_id
                     LIMIT $4
@@ -320,6 +296,7 @@ impl DustGenerationsStorage for Storage {
                     .bind(&dust_address[..])
                     .bind(after_event_id as i64)
                     .bind(batch_size.get() as i64)
+                    .bind(upper_block_id as i64)
                     .fetch_all(&*pool)
                     .await?;
 
@@ -433,18 +410,6 @@ impl DustGenerationsStorage for Storage {
                 }
             }
         }
-    }
-
-    #[trace]
-    async fn get_dust_generations_chain_first_free(&self) -> Result<u64, sqlx::Error> {
-        // `IS NOT NULL` skips legacy rows pre-dating the generation/commitment split.
-        let (max_index,) = sqlx::query_as::<_, (Option<i64>,)>(
-            "SELECT MAX(generation_index) FROM dust_generation_info WHERE generation_index IS NOT NULL",
-        )
-        .fetch_one(&*self.pool)
-        .await?;
-
-        Ok(max_index.map(|i| i as u64 + 1).unwrap_or(0))
     }
 }
 

--- a/indexer-api/src/infra/storage/ledger_state.rs
+++ b/indexer-api/src/infra/storage/ledger_state.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 use crate::{domain::storage::ledger_state::LedgerStateStorage, infra::storage::Storage};
-use indexer_common::domain::{ProtocolVersion, SerializedLedgerStateKey};
+use indexer_common::domain::{BlockHash, ProtocolVersion, SerializedLedgerStateKey};
 use indoc::indoc;
 
 impl LedgerStateStorage for Storage {
@@ -33,6 +33,30 @@ impl LedgerStateStorage for Storage {
                 let protocol_version = ProtocolVersion::try_from(protocol_version)
                     .map_err(|error| sqlx::Error::Decode(error.into()))?;
                 Ok((protocol_version, key))
+            })
+            .transpose()
+    }
+
+    async fn get_ledger_state_at(
+        &self,
+        block_hash: BlockHash,
+    ) -> Result<Option<(u64, ProtocolVersion, SerializedLedgerStateKey)>, sqlx::Error> {
+        let query = indoc! {"
+            SELECT id, protocol_version, ledger_state_key
+            FROM blocks
+            WHERE hash = $1
+        "};
+
+        sqlx::query_as::<_, (i64, i64, SerializedLedgerStateKey)>(query)
+            .bind(block_hash.as_ref())
+            .fetch_optional(&*self.pool)
+            .await?
+            .map(|(block_id, protocol_version, key)| {
+                let block_id =
+                    u64::try_from(block_id).map_err(|error| sqlx::Error::Decode(error.into()))?;
+                let protocol_version = ProtocolVersion::try_from(protocol_version)
+                    .map_err(|error| sqlx::Error::Decode(error.into()))?;
+                Ok((block_id, protocol_version, key))
             })
             .transpose()
     }

--- a/indexer-tests/e2e.graphql
+++ b/indexer-tests/e2e.graphql
@@ -753,13 +753,13 @@ subscription DustLedgerEventsSubscription($id: Int) {
 
 subscription DustGenerationsSubscription(
     $dustAddress: DustAddress!
-    $startIndex: Int!
-    $endIndex: Int!
+    $blockHash: HexEncoded!
+    $dtimeCutoffHeight: Int!
 ) {
     dustGenerations(
         dustAddress: $dustAddress
-        startIndex: $startIndex
-        endIndex: $endIndex
+        blockHash: $blockHash
+        dtimeCutoffHeight: $dtimeCutoffHeight
     ) {
         __typename
         ... on DustGenerationsItem {

--- a/indexer-tests/src/e2e.rs
+++ b/indexer-tests/src/e2e.rs
@@ -147,7 +147,7 @@ pub async fn run(network_id: NetworkId, host: &str, port: u16, secure: bool) -> 
     test_dust_ledger_events_subscription(&indexer_data, &ws_api_url)
         .await
         .context("test dust ledger events subscription")?;
-    test_dust_generations_subscription(&ws_api_url)
+    test_dust_generations_subscription(&indexer_data, &ws_api_url)
         .await
         .context("test dust generations subscription")?;
     test_shielded_nullifier_transactions_subscription(&ws_api_url)
@@ -1074,14 +1074,22 @@ async fn test_dust_ledger_events_subscription(
 /// it), yielding a single final `DustGenerationsProgress` event and closing.
 /// Verifies wire-format compatibility for all three union variants and the
 /// completion-event shape on the empty case.
-async fn test_dust_generations_subscription(ws_api_url: &str) -> anyhow::Result<()> {
-    let end_index: i64 = 0;
+async fn test_dust_generations_subscription(
+    indexer_data: &IndexerData,
+    ws_api_url: &str,
+) -> anyhow::Result<()> {
     let network_id: NetworkId = "undeployed".try_into().unwrap();
     let dust_address = DustAddress(encode_address([0u8; 32], AddressType::Dust, &network_id));
+    let block_hash = indexer_data
+        .blocks
+        .last()
+        .expect("there is at least one indexed block")
+        .hash
+        .to_owned();
     let variables = dust_generations_subscription::Variables {
         dust_address,
-        start_index: 1,
-        end_index,
+        block_hash,
+        dtime_cutoff_height: 0,
     };
     let events = graphql_ws_client::subscribe::<DustGenerationsSubscription>(ws_api_url, variables)
         .await
@@ -1103,12 +1111,7 @@ async fn test_dust_generations_subscription(ws_api_url: &str) -> anyhow::Result<
     assert_eq!(
         event.get("__typename").and_then(|v| v.as_str()),
         Some("DustGenerationsProgress"),
-        "expected DustGenerationsProgress variant, got: {event:?}"
-    );
-    assert_eq!(
-        event.get("highestIndex").and_then(|v| v.as_i64()),
-        Some(end_index),
-        "highestIndex should match the requested endIndex"
+        "expected DustGenerationsProgress for an address with no owned generations, got: {event:?}"
     );
 
     Ok(())


### PR DESCRIPTION
Closes #1283

# Overview

Re-scopes the `dustGenerations` subscription so a wallet rebuilds its dust generation Merkle tree from a consistent block snapshot instead of the moving chain tip, and receives a clean delta of its own generations' `dtime` transitions. Agreed design with Andrzej Kopeć (indexer architecture) and Jegor Sidorenko (wallet).

The dust generation tree is not append-only: when a backing Night UTXO is spent, the ledger sets that entry's `dtime` and rehashes the existing leaf in place. The old `dustGenerations(dustAddress, startIndex, endIndex)` built its collapsed gaps at `get_latest_block()` (the tip) at emission time, so the collapsed hashes drifted across a single sync and non-owned `dtime` mutations to already-passed ranges were never delivered, giving the wallet a wrong, inconsistent root.

## Changes

- **Subscription signature**: `dustGenerations(dustAddress, startIndex, endIndex)` becomes `dustGenerations(dustAddress, blockHash, dtimeCutoffHeight)`. The endpoint is `@beta`, so the argument change is acceptable.
- **Block-pinned snapshot**: the resolver loads the ledger state at `blockHash` once and builds every collapsed update from it, so the tree and its hashes reflect the state as of that block (including non-owned mutations). The subscription emits the snapshot and completes (one-shot); the wallet re-subscribes at a newer `blockHash` to advance.
- **Storage `get_ledger_state_at(block_hash)`**: by-hash variant of `get_highest_ledger_state`, returning the block id, protocol version and ledger state key.
- **dtime delta bounded to `(dtimeCutoffHeight, blockHash]`**: the wallet's own generations' `dtime` transitions are issued at the start as a clean delta for the generations set, kept separate from the tree. Bounding the upper end at the snapshot block makes the response deterministic, independent of the current tip. Pass `0` to replay all.
- **Removed** the now-unused `get_dust_generation_dtime_cutoff_block_id` (derived cutoff) and `get_dust_generations_chain_first_free` storage methods.
- **Schema** regenerated via `just generate-indexer-api-schema`.

## Testing

- `just check`, `clippy -D warnings` and `fmt-check` are clean on both `cloud` and `standalone`; tests compile.
- Validated locally against a running indexer with real dust data: block-pinned snapshot, one-shot completion, determinism (byte-identical, including the collapsed-update bytes), both `dtime` bounds, a non-owned `dtime` mutation reflected in the snapshot (acceptance criterion 3), empty / leading / trailing / multi-gap interleaving, and the input-validation errors. The wallet-side root match needs the wallet SDK and is for the wallet team to confirm.
- Before merge: rewrite the QA integration test `dust-generations-subscriptions.test.ts` (still drives the old arguments) and add Rust unit and integration tests.

Closes #1283.

Related: #1267 (per-block dust roots, the authoritative root to match), #1266 (rehash collapsed updates), #980 (the original `@beta` dust wallet-sync endpoints).

## Submission Checklist

- [x] Useful pull request description
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested