### PR TITLE
docs: add architecture and testing guides; expand releasing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,9 @@ Where this is not possible, a copy of the Apache 2.0 or the repository's top-lev
 Process docs under [`docs/`](docs/README.md) for releasing and keeping the
 indexer in step with the node and ledger:
 
+* [Architecture](docs/architecture.md) - data flow, NATS's role, and run modes.
 * [Creating a release](docs/releasing.md) - versioning, changelog, tagging, image publish.
+* [Testing & node consistency](docs/testing.md) - the runtime root-match guard and the test layers.
 * [Upgrading the node version](docs/updating-node-version.md) - `NODE_VERSIONS`, metadata, runtime modules.
 * [Upgrading the ledger](docs/upgrading-ledger.md) - `v8`/`v9` coexistence and the `[patch.crates-io]` pins.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The Midnight Indexer (midnight-indexer) is a set of components designed to optim
 - [Chain Indexer](chain-indexer/README.md): Connects to the Midnight Node, fetches blocks and transactions, and stores indexed data.
 - [Wallet Indexer](wallet-indexer/README.md): Associates connected wallets with relevant transactions, enabling personalized queries and subscriptions.
 - [Indexer API](indexer-api/README.md): Exposes a GraphQL API for queries, mutations, and subscriptions.
+- [SPO Indexer](spo-indexer/README.md): Indexes stake-pool operator data - committee membership, epoch and D-parameter changes, and Cardano stake distribution (via Blockfrost).
 
 ## Features
 
@@ -75,7 +76,7 @@ To run the Midnight Indexer Docker images are provided under the [`midnightntwrk
 
 ### Standalone Mode
 
-The standalone Indexer combines the Chain Indexer, Indexer API and Wallet Indexer components in a single executable alongside an in-process SQLite database. Therefore the only Docker image to be run is [`indexer-standalone`](https://hub.docker.com/r/midnightntwrk/indexer-standalone).
+The standalone Indexer combines the Chain Indexer, Indexer API, Wallet Indexer and SPO Indexer components in a single executable alongside an in-process SQLite database. Therefore the only Docker image to be run is [`indexer-standalone`](https://hub.docker.com/r/midnightntwrk/indexer-standalone).
 
 By default it connects to a local Midnight Node at `ws://localhost:9944` and exposes its GraphQL API at `0.0.0.0:8088`. All configuration has defaults except for the secret used to encrypt stored sensitive data which must be provided via the `APP__INFRA__SECRET` environment variable as valid hex-encoded 32 bytes.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,13 @@
 # Indexer Docs
 
-Maintainer and contributor guides. For architecture and local setup see the
-top-level [`README.md`](../README.md) and [`CLAUDE.md`](../CLAUDE.md).
+Maintainer and contributor guides. For local setup see the top-level
+[`README.md`](../README.md) and [`CLAUDE.md`](../CLAUDE.md).
+
+## Architecture & testing
+
+- [Architecture](./architecture.md) - the data flow, NATS's role, and run modes.
+- [Testing & node consistency](./testing.md) - the runtime root-match guard and the
+  test layers.
 
 ## Releasing & version upgrades
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,7 @@ node ──subxt──▶ chain-indexer ──writes──▶ DB ◀─reads/wri
   `keep_wallet_active` heartbeat. A newly connected wallet is picked up by wallet-indexer **polling
   the active wallet set**, not via a connect event; subscriptions then stream that wallet's
   relevant transactions.
-- **spo-indexer** (cloud) indexes stake-pool data via Blockfrost.
+- **spo-indexer** indexes stake-pool data via Blockfrost.
 
 ## NATS is a signal bus, not a data bus
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,58 @@
+# Architecture
+
+How the pieces fit together and talk. For *what each component is* see the
+[top-level README](../README.md#components) and the per-component READMEs; this is the data flow
+and the parts that aren't obvious from the component list.
+
+## Data flow
+
+```
+node ──subxt──▶ chain-indexer ──writes──▶ DB ◀─reads/writes─▶ indexer-api ──GraphQL──▶ clients / wallets
+                     │                    ▲
+                     └──event (IDs)──▶ NATS ──▶ wallet-indexer ──writes relevant txs──┘
+```
+
+- **chain-indexer** is the **single writer**. It subscribes to the node over subxt (a
+  finalized-block subscription), applies each block to its **own** `LedgerState` - recomputing and
+  [guarding the merkle roots](./testing.md) - and writes blocks, transactions and ledger state to
+  the DB. Only one may run per environment (two would race the DB). It publishes small indexing
+  events (`BlockIndexed`, `UnshieldedUtxoIndexed`).
+- **wallet-indexer** does the per-wallet work **asynchronously in the background** - the
+  least-obvious component. It subscribes to `BlockIndexed` (the new-data signal) and polls the
+  active wallet set (`active_wallet_ids`), trial-decrypts each new transaction against each active
+  wallet's viewing key, materialises the relevant transactions into the DB, and emits
+  `WalletIndexed`.
+- **indexer-api** serves GraphQL queries and subscriptions (reads) **and owns the wallet-lifecycle
+  writes** - it is read-heavy, not read-only. `connect` upserts the wallet into the `wallets` table
+  (the encrypted viewing key, a fresh `session_id`, and the scan start index) and returns the
+  session ID; `disconnect` nulls the session; and the shielded subscription periodically writes a
+  `keep_wallet_active` heartbeat. A newly connected wallet is picked up by wallet-indexer **polling
+  the active wallet set**, not via a connect event; subscriptions then stream that wallet's
+  relevant transactions.
+- **spo-indexer** (cloud) indexes stake-pool data via Blockfrost.
+
+## NATS is a signal bus, not a data bus
+
+NATS carries **small event messages - IDs only** (block ID, transaction ID, wallet); the data
+itself stays in the DB. So the queue stays light regardless of chain size. Ledger state used to
+live in NATS and was **moved to the DB** (more reliable across abrupt restarts) - NATS remains for
+messaging only.
+
+Deployed clusters run a **NATS quorum of 3** and typically **2 wallet-indexer** replicas for
+redundancy, alongside the single chain-indexer and the HPA'd indexer-api.
+
+## Run modes
+
+- **cloud** - the four services (chain-indexer, indexer-api, wallet-indexer, spo-indexer) +
+  PostgreSQL + NATS, as separate images. This is what runs in Kubernetes.
+- **standalone** - one `indexer-standalone` binary with SQLite and an **in-memory** pub/sub in
+  place of NATS. For local dev / single-operator use.
+
+The messaging seam is `indexer-common`'s `pub_sub` (NATS for cloud, in-memory channels for
+standalone); the SQL migrations also live in `indexer-common/migrations`.
+
+## See also
+
+- [Testing & node consistency](./testing.md) - the runtime root-match guard.
+- Per-component detail: [chain-indexer](../chain-indexer/README.md),
+  [wallet-indexer](../wallet-indexer/README.md), [indexer-api](../indexer-api/README.md).

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -33,18 +33,33 @@ Review the prepended section before committing.
    `CHANGELOG.md` - copy the last `chore(release)` PR as the template. Review,
    merge.
 
-2. **Tag** the merge commit and push:
+2. **Tag** the merge commit with an **annotated, GPG-signed** tag and push (releases are
+   signed; a lightweight `git tag vX.Y.Z` is not enough):
 
    ```bash
-   git tag vX.Y.Z && git push origin vX.Y.Z
+   git tag -s -a vX.Y.Z -m "Release X.Y.Z"   # on the merge commit
+   git verify-tag vX.Y.Z                       # confirm the signature
+   git push origin vX.Y.Z
    ```
+
+   Confirm the tag sits on the merge commit that is the remote branch tip before pushing.
 
 3. **Images publish automatically.** A `v*` tag triggers
    `.github/workflows/build-indexer-images.yaml`, which builds every component
    (`chain-indexer`, `wallet-indexer`, `indexer-api`, `spo-indexer`,
    `indexer-standalone`) with the `release` profile and pushes semver-tagged
    images to `ghcr.io/midnight-ntwrk/<component>` (always) and
-   `docker.io/midnightntwrk/<component>` (tag builds only).
+   `docker.io/midnightntwrk/<component>` (tag builds only). The same workflow also runs on
+   **main pushes** and **manual dispatch**, tagging those images `<cargo-version>-<short-sha>`
+   with the `dev` profile (GHCR only) - a pre-merge or feature image is identifiable by its
+   `-<sha>` suffix.
+
+## Scheduling & sign-off
+
+There is no fixed cadence - releases are on-demand and gated: **QA signs off the release
+candidate** and the **maintainers make the release call**, with prod / mainnet timing gated by the
+wider release schedule. Feature-integration (pre-alpha) images are cut whenever a meaningful chunk
+lands on the integration branch.
 
 ## Maintenance branches
 
@@ -53,7 +68,10 @@ runs on them as on `main`.
 
 ## Pre-release / dev tags
 
-In-flight builds use non-semver tags encoding the ledger/node RCs they were
+**Release candidates** `vX.Y.Z-rc.N` are cut on a `chore/release-X-Y-Z` branch and shipped to QA
+ahead of the final `vX.Y.Z`; they build with the `release` profile like a real release.
+
+Feature-integration builds use non-semver tags encoding the ledger/node RCs they were
 built against:
 
 ```text
@@ -67,5 +85,6 @@ These never reach Docker Hub - only semver-pattern tag builds get the
 
 ## See also
 
+- [Testing & node consistency](./testing.md)
 - [Upgrading the node version](./updating-node-version.md)
 - [Upgrading the ledger](./upgrading-ledger.md)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,76 @@
+# Testing & Node Consistency
+
+How the indexer is kept consistent with the node, and what the test layers cover.
+
+## The guarantee is a runtime guard, not a test
+
+The hard guarantee lives in the chain-indexer, not in a suite. For every block the
+chain-indexer applies the node's transactions to its **own** `LedgerState`, recomputes the
+merkle roots, and **`bail!`s (halts indexing) on any mismatch** rather than persisting a
+divergent state - `chain-indexer/src/application.rs` (~404-420):
+
+- **Zswap merkle tree root - every block.** `ledger_state.zswap_merkle_tree_root()` is
+  compared to the node's per-block root; mismatch → `bail!`. This is the check that works
+  against every node version.
+- **Full ledger-state root - every block the node supplies one.** When `block.ledger_state_root`
+  is present (Node ≥ 0.22) the recomputed `ledger_state.root()` is compared to it; mismatch →
+  `bail!`. At genesis the state root additionally disambiguates a pre- vs post-block-0 genesis.
+  (A `TODO` retires the zswap-only path once Node < 0.22 support is dropped.)
+
+So the model is **fail loud, don't drift**: if the indexer ever computes a root the node
+disagrees with, it stops. There is no after-the-fact `assert!(indexer_root == node_root)`
+anywhere - the guard is the source of truth.
+
+Per-block **dust roots** are computed, stored and served but not cross-checked against the node
+(there is no node dust-root RPC); they are covered transitively by the deterministic re-apply
+that the zswap/state-root match guards each block.
+
+## How CI exercises the guard
+
+`indexer-tests/tests/native_e2e.rs` (run by `just test`, on every PR via `ci-cloud.yaml` /
+`ci-standalone.yaml`):
+
+- Starts a **real `midnightntwrk/midnight-node` container** (version = last line of
+  `NODE_VERSIONS`, currently `2.0.0-rc.3`) whose chain DB is **pre-seeded from fixed data in
+  `.node/<version>/`** (bind-mounted, `CFG_PRESET=dev`) so it replays a known, deterministic
+  chain, plus postgres + nats via testcontainers, and runs the **actual** chain-indexer /
+  wallet-indexer / indexer-api binaries (cloud) or `indexer-standalone` + SQLite (standalone).
+  It SIGTERMs and restarts chain-indexer once to exercise reconnect.
+- `indexer-tests/src/e2e.rs` then runs the assertions. It **collects the blocks subscription
+  (heights 0..=32) as the source of truth**, validating structural invariants as it goes: heights
+  increment by one, parent-hash linkage, transactions reference their block and share its protocol
+  version, segment results match the transaction status, fees parse, a contract call shares its
+  deploy's address, unshielded balances have a valid token type + amount, and zswap/dust ledger
+  events are present. It then asserts **every query and every other subscription returns
+  byte-identical JSON to that collected data** (`to_json_value()` equality, across all offsets plus
+  the unknown/error cases). It also round-trips a wallet through **connect → wallet-indexer → the
+  shielded-transactions subscription** (expecting the two relevant test-wallet txs with no index
+  gaps), and exercises the input guards (invalid viewing key, unknown/short session id, invalid
+  index ranges, nullifier-prefix validation).
+- There is **no explicit node-root assertion** - but if the indexer's roots disagreed with the
+  real node container the chain-indexer would `bail!`, `/ready` would never reach 200, and the
+  e2e would fail. That is how the guard is covered in CI.
+
+`indexer-tests/src/main.rs` (the `e2e` bin) can point the same suite at a **deployed** indexer
+(`--host/--port/--network-id`), but no workflow wires it up - it is a manual tool.
+
+## The QA TypeScript suite (`qa/tests/`)
+
+- **smoke** - `/ready`, schema introspection, schema-change / deprecation detection.
+- **integration** - GraphQL correctness via zod schemas + internal consistency.
+- **e2e** (`tests/e2e/`) - the closest to node-matching: submits real shielded / unshielded txs
+  and a contract deploy/call through the **Midnight Node Toolkit**, then asserts the indexer
+  reports them over GraphQL (source of truth = what the toolkit pushed to the node). Env config
+  in `qa/tests/environment/model.ts`.
+
+## Against deployed environments
+
+- CI runs against an **ephemeral fresh node**, never a deployed env.
+- Scheduled monitors (`.github/workflows/qa-test-*`, business hours) hit
+  `indexer.<env>.midnight.network` for devnet / qanet / preprod / preview and run
+  block-subscription + ledger-event streaming tests - they validate the **API** (streaming
+  continuity, shape), **not** an indexer-vs-node root diff.
+
+## See also
+
+- [Creating a release](./releasing.md)


### PR DESCRIPTION
Builds on #1287 (base is `giles-contributing-docs`), so it merges into that branch. Adds two maintainer docs that round out the process set and fills the gaps in `releasing.md`.

## New
- `docs/architecture.md` - data flow, NATS as an IDs-only signal bus, the event-driven wallet-indexer, run modes (the how-it-works narrative the README's component list lacks).
- `docs/testing.md` - the runtime root-match consistency guard (verified against `chain-indexer/src/application.rs`), the e2e / CI / QA layers, and the honest gaps.

## releasing.md
- Corrected the tag step to **annotated + GPG-signed** on the merge commit (releases are signed; a lightweight `git tag vX.Y.Z` isn't enough).
- Added RC tags (`vX.Y.Z-rc.N`), a Scheduling & sign-off section, and the build-workflow's main-push / manual-dispatch trigger.

Indexed in `docs/README.md` and `CONTRIBUTING.md`. Claims verified against the repo (migrations `002_*`/`003_*`, the scheduled `qa-test-*` workflows, the `qa/tests` tiers, the e2e `.node`/`CFG_PRESET` seeding, and that release tags are signed).

A deployment runbook was written too but kept out of this PR - it references internal kubectl contexts, private repos and reset ops, so it's shared internally rather than in the public repo.