### PR TITLE
chore(test): use ledger v9 token types in the v9 balances test

### DIFF
--- a/indexer-common/src/domain/ledger/contract_state.rs
+++ b/indexer-common/src/domain/ledger/contract_state.rs
@@ -139,6 +139,9 @@ mod tests {
     };
     use midnight_base_crypto_v1::hash::HashOutput;
     use midnight_coin_structure_v2::coin::{TokenType as MidnightTokenType, UnshieldedTokenType};
+    use midnight_coin_structure_v3::coin::{
+        TokenType as MidnightTokenTypeV9, UnshieldedTokenType as UnshieldedTokenTypeV9,
+    };
     use midnight_onchain_runtime_v3::state::ContractState as ContractStateV3;
     use midnight_onchain_runtime_v4::state::ContractState as ContractStateV4;
     use midnight_storage_core_v1::DefaultDB;
@@ -168,7 +171,7 @@ mod tests {
     fn test_balances_v9() {
         let mut contract_state = ContractStateV4::<DefaultDB>::default();
         contract_state.balance = contract_state.balance.insert(
-            MidnightTokenType::Unshielded(UnshieldedTokenType(HashOutput(TOKEN_TYPE.0))),
+            MidnightTokenTypeV9::Unshielded(UnshieldedTokenTypeV9(HashOutput(TOKEN_TYPE.0))),
             AMOUNT,
         );
         let contract_state = contract_state


### PR DESCRIPTION
## Summary
[TEST CODE CHANGE]: main currently fails to compile the `indexer-common` lib-test target:
  
  `test_balances_v9` (indexer-common/src/domain/ledger/contract_state.rs) constructs the balance key from `midnight-coin-structure` **v2** (crates.io 2.0.1, the ledger-8 family), but `ContractStateV4`'s balance map is keyed by
  **v3** (git `coin-structure-3.0.0-rc.1`, the ledger-9 family). The two versions coexist in the dependency graph by design (v8 + v9 support); the families must not mix, hence the E0308 "multiple different versions of crate 
  `midnight_coin_structure`".
  
  This landed via #1246 as a semantic merge (the PR was green on its own base; red combined with main's current dependency state) and first surfaced on #1297's CI, since PR builds use the merge ref.
  
  ## Change
  
  Import the v3 aliases in the test module and use them in `test_balances_v9` — mirroring the same test as it already exists on the `feat/l9a1-n2a1-bridge-and-public-events-with-unshielded-balance-fix` epic branch, so main and
  the epic stay convergent.