### PR TITLE
feat: let's try removing netrc

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,1 +1,0 @@
-net.git-fetch-with-cli = true

--- a/.github/workflows/ci-cloud.yaml
+++ b/.github/workflows/ci-cloud.yaml
@@ -70,7 +70,7 @@ jobs:
           echo "toolchain=$toolchain" | tee -a "$GITHUB_OUTPUT"
 
   check:
-    runs-on: ubuntu-latest-8-core-x64
+    runs-on: ubuntu-latest
     needs: [changes, toolchain]
     if: needs.changes.outputs.non_qa == 'true'
     steps:
@@ -125,7 +125,7 @@ jobs:
           just feature=cloud fmt-check
 
   lint:
-    runs-on: ubuntu-latest-8-core-x64
+    runs-on: ubuntu-latest
     needs: [changes, toolchain]
     if: needs.changes.outputs.non_qa == 'true'
     steps:
@@ -198,7 +198,7 @@ jobs:
           just feature=cloud test
 
   doc:
-    runs-on: ubuntu-latest-8-core-x64
+    runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.non_qa == 'true'
     steps:

--- a/.github/workflows/ci-standalone.yaml
+++ b/.github/workflows/ci-standalone.yaml
@@ -70,7 +70,7 @@ jobs:
           echo "toolchain=$toolchain" | tee -a "$GITHUB_OUTPUT"
 
   check:
-    runs-on: ubuntu-latest-8-core-x64
+    runs-on: ubuntu-latest
     needs: [changes, toolchain]
     if: needs.changes.outputs.non_qa == 'true'
     steps:
@@ -125,7 +125,7 @@ jobs:
           just feature=standalone fmt-check
 
   lint:
-    runs-on: ubuntu-latest-8-core-x64
+    runs-on: ubuntu-latest
     needs: [changes, toolchain]
     if: needs.changes.outputs.non_qa == 'true'
     steps:
@@ -155,7 +155,7 @@ jobs:
           just feature=standalone lint
 
   test:
-    runs-on: ubuntu-latest-8-core-x64
+    runs-on: ubuntu-latest
     needs: [changes, toolchain]
     if: needs.changes.outputs.non_qa == 'true'
     timeout-minutes: 15
@@ -198,7 +198,7 @@ jobs:
           just feature=standalone test
 
   doc:
-    runs-on: ubuntu-latest-8-core-x64
+    runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.non_qa == 'true'
     steps:

--- a/.github/workflows/rust-security-scan.yaml
+++ b/.github/workflows/rust-security-scan.yaml
@@ -8,7 +8,6 @@ name: rust-security-scan
 # Fork PR behavior:
 # - cargo-deny runs successfully (no secrets needed)
 # - SARIF uploads to GitHub Security (no secrets needed)
-# - netrc is skipped (requires secrets)
 #
 # This is acceptable because fork PRs still get security scanning via cargo-deny.
 
@@ -34,15 +33,6 @@ jobs:
         uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2.79.2
         with:
           tool: cargo-deny
-
-      # Skip for fork PRs (no secrets available)
-      - name: Add github.com credentials to netrc
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: extractions/netrc@c3879108aae6b4ed5c4eb60854ae04f06d2f2f68 # v3.0.0
-        with:
-          machine: github.com
-          username: MidnightCI
-          password: ${{ secrets.MIDNIGHTCI_REPO }}
 
       - name: Run cargo-deny (produce SARIF for Security tab)
         # `-f sarif` always exits 0 since findings are encoded in the SARIF, not the exit code.

--- a/README.md
+++ b/README.md
@@ -233,14 +233,6 @@ Create a classic PAT with:
 - `read:packages`
 - `read:org`
 
-#### ~/.netrc Setup
-
-```bash
-machine github.com
-login <YOUR_GITHUB_ID>
-password <YOUR_GITHUB_PAT>
-```
-
 #### Docker Authentication
 
 ```bash

--- a/qa/tests/README.md
+++ b/qa/tests/README.md
@@ -91,21 +91,13 @@ You need access to private Midnight repos and the GHCR container registry (steps
 
 Create a **classic** PAT with scopes: `repo` (all), `read:packages`, `read:org`.
 
-#### Step 4 — [~/.netrc Setup](../../README.md#netrc-setup)
-
-```
-machine github.com
-login <YOUR_GITHUB_ID>
-password <YOUR_GITHUB_PAT>
-```
-
-#### Step 5 — [Docker Authentication](../../README.md#docker-authentication)
+#### Step 4 — [Docker Authentication](../../README.md#docker-authentication)
 
 ```bash
 echo $GITHUB_TOKEN | docker login ghcr.io -u <YOUR_GITHUB_ID> --password-stdin
 ```
 
-#### Step 6 — [GPG Setup (Signed Git Commits)](../../README.md#gpg-setup-signed-git-commits)
+#### Step 5 — [GPG Setup (Signed Git Commits)](../../README.md#gpg-setup-signed-git-commits)
 
 Generate an ed25519 key and configure Git to sign commits/tags (`commit.gpgsign = true`); add `export GPG_TTY=$(tty)` to your shell config so the passphrase prompt works.
 


### PR DESCRIPTION
Do we still need this? CI says... GREEN

Also points more of the runners to using the free runners as the CI was slowed down by having to wait on a queue of jobs trying to use the 8 core runners. Now at least they all start when the PR starts. Longest is 6 min so that's not too shabby.