### PR TITLE
feat(indexer): adopt storage-core gc-v1 with a ledger state retention window

### DIFF
--- a/chain-indexer/config.yaml
+++ b/chain-indexer/config.yaml
@@ -5,6 +5,7 @@ application:
   blocks_buffer: 10
   caught_up_max_distance: 10
   caught_up_leeway: 5
+  gc_bound: "200ms"
 
 infra:
   run_migrations: true

--- a/chain-indexer/config.yaml
+++ b/chain-indexer/config.yaml
@@ -6,6 +6,9 @@ application:
   caught_up_max_distance: 10
   caught_up_leeway: 5
   gc_bound: "200ms"
+  # Recent blocks whose ledger states stay loadable (gc roots). Must comfortably exceed
+  # indexer-api's dust_generations max_snapshot_age.
+  ledger_state_retention: 1000
 
 infra:
   run_migrations: true

--- a/chain-indexer/src/application.rs
+++ b/chain-indexer/src/application.rs
@@ -26,14 +26,19 @@ use async_stream::stream;
 use fastrace::{Span, future::FutureExt, prelude::SpanContext, trace};
 use futures::{Stream, StreamExt, TryStreamExt, future::ok};
 use indexer_common::domain::{
-    BlockIndexed, LedgerVersion, NetworkId, Publisher, UnshieldedUtxoIndexed,
+    BlockIndexed, LedgerVersion, NetworkId, Publisher, SerializedLedgerStateKey,
+    UnshieldedUtxoIndexed,
 };
 use log::{debug, info, warn};
 use parking_lot::RwLock;
 use serde::Deserialize;
 use std::{
-    collections::HashSet, error::Error as StdError, future::ready, pin::pin, sync::Arc,
-    time::Duration,
+    collections::HashSet,
+    error::Error as StdError,
+    future::ready,
+    pin::pin,
+    sync::Arc,
+    time::{Duration, Instant},
 };
 use tokio::{
     select,
@@ -48,6 +53,11 @@ pub struct Config {
     pub blocks_buffer: usize,
     pub caught_up_max_distance: u32,
     pub caught_up_leeway: u32,
+
+    /// Per-block time budget for the storage-core gc-v1 mark-and-sweep pass.
+    /// Set to "0s" to disable garbage collection.
+    #[serde(with = "humantime_serde")]
+    pub gc_bound: Duration,
 }
 
 pub async fn run(
@@ -62,6 +72,7 @@ pub async fn run(
         blocks_buffer,
         caught_up_max_distance,
         caught_up_leeway,
+        gc_bound,
     } = config;
 
     // Get info from highest block.
@@ -92,16 +103,24 @@ pub async fn run(
         contract_action_count,
     );
 
-    // Load/initialize ledger state.
-    let mut ledger_state = match highest_protocol_version_and_ledger_state_key {
-        Some((protocol_version, ledger_state_key)) => {
-            LedgerState::load(&ledger_state_key, protocol_version.ledger_version())
-                .context("load ledger state")?
-        }
+    // Load/initialize ledger state. Track the latest persisted key so the next block's persist()
+    // can be balanced with an unpersist() of the previous one, allowing storage-core's gc-v1 to
+    // reclaim orphan nodes.
+    let (mut ledger_state, mut previous_ledger_state_key) =
+        match highest_protocol_version_and_ledger_state_key {
+            Some((protocol_version, ledger_state_key)) => {
+                let ledger_version = protocol_version.ledger_version();
+                let state = LedgerState::load(&ledger_state_key, ledger_version)
+                    .context("load ledger state")?;
+                (state, Some((ledger_state_key, ledger_version)))
+            }
 
-        None => LedgerState::new(network_id.clone(), LedgerVersion::OLDEST)
-            .context("create ledger state")?,
-    };
+            None => {
+                let state = LedgerState::new(network_id.clone(), LedgerVersion::OLDEST)
+                    .context("create ledger state")?;
+                (state, None)
+            }
+        };
 
     let highest_block_on_node = Arc::new(RwLock::new(None));
 
@@ -150,7 +169,7 @@ pub async fn run(
             let mut parent_block_timestamp = 0;
 
             loop {
-                let next_ledger_state = get_and_index_block(
+                let (next_ledger_state, new_ledger_state_key) = get_and_index_block(
                     caught_up_max_distance,
                     caught_up_leeway,
                     &mut blocks,
@@ -168,6 +187,31 @@ pub async fn run(
                 .await?;
 
                 ledger_state = next_ledger_state;
+
+                // Unpersist the previous ledger state's key (if any) with the version it was
+                // persisted under (they differ at a protocol upgrade boundary). This balances the
+                // prior block's persist() and lets its arena nodes become eligible for gc.
+                if let Some((prev_key, prev_version)) = previous_ledger_state_key
+                    .replace((new_ledger_state_key, ledger_state.ledger_version()))
+                {
+                    LedgerState::unpersist(&prev_key, prev_version)
+                        .context("unpersist previous ledger state")?;
+                }
+
+                // Run a time-bounded mark-and-sweep pass; skip when disabled.
+                if !gc_bound.is_zero() {
+                    let started = Instant::now();
+                    let nodes_culled = LedgerState::gc(gc_bound);
+                    let elapsed = started.elapsed();
+                    metrics.record_gc(elapsed, nodes_culled);
+                    if nodes_culled > 0 {
+                        debug!(
+                            nodes_culled,
+                            elapsed:?;
+                            "gc pass culled orphan arena nodes"
+                        );
+                    }
+                }
             }
         }
     });
@@ -259,14 +303,14 @@ async fn get_and_index_block<E, N>(
     publisher: &impl Publisher,
     metrics: &Metrics,
     node: &N,
-) -> anyhow::Result<LedgerState>
+) -> anyhow::Result<(LedgerState, SerializedLedgerStateKey)>
 where
     E: StdError + Send + Sync + 'static,
     N: Node,
 {
     let block = get_next_block(blocks).await?;
 
-    let ledger_state = index_block(
+    let result = index_block(
         caught_up_max_distance,
         caught_up_leeway,
         block,
@@ -282,7 +326,7 @@ where
     )
     .await?;
 
-    Ok(ledger_state)
+    Ok(result)
 }
 
 #[trace]
@@ -314,7 +358,7 @@ async fn index_block<N>(
     publisher: &impl Publisher,
     metrics: &Metrics,
     node: &N,
-) -> anyhow::Result<LedgerState>
+) -> anyhow::Result<(LedgerState, SerializedLedgerStateKey)>
 where
     N: Node,
 {
@@ -520,7 +564,7 @@ where
         "block indexed"
     );
 
-    Ok(ledger_state)
+    Ok((ledger_state, ledger_state_key))
 }
 
 /// Fetch system parameters from the node and determine if they changed.

--- a/chain-indexer/src/application.rs
+++ b/chain-indexer/src/application.rs
@@ -33,9 +33,10 @@ use log::{debug, info, warn};
 use parking_lot::RwLock;
 use serde::Deserialize;
 use std::{
-    collections::HashSet,
+    collections::{HashSet, VecDeque},
     error::Error as StdError,
     future::ready,
+    num::NonZeroUsize,
     pin::pin,
     sync::Arc,
     time::{Duration, Instant},
@@ -58,6 +59,11 @@ pub struct Config {
     /// Set to "0s" to disable garbage collection.
     #[serde(with = "humantime_serde")]
     pub gc_bound: Duration,
+
+    /// How many recent blocks' ledger state keys stay persisted as gc roots before the oldest
+    /// is unpersisted. Must comfortably exceed indexer-api's block-hash snapshot reads, e.g.
+    /// the dust generations subscription's max_snapshot_age, or those reads hit culled state.
+    pub ledger_state_retention: NonZeroUsize,
 }
 
 pub async fn run(
@@ -73,17 +79,15 @@ pub async fn run(
         caught_up_max_distance,
         caught_up_leeway,
         gc_bound,
+        ledger_state_retention,
     } = config;
 
     // Get info from highest block.
-    let (highest_block_ref, highest_protocol_version_and_ledger_state_key) = match storage
+    let highest_block_ref = storage
         .get_highest_block()
         .await
         .context("get highest block")?
-    {
-        Some((r, v, k)) => (Some(r), Some((v, k))),
-        None => (None, None),
-    };
+        .map(|(block_ref, _, _)| block_ref);
 
     let highest_block_height = highest_block_ref.map(|info| info.height);
     info!(highest_block_height:?; "starting indexing");
@@ -103,24 +107,52 @@ pub async fn run(
         contract_action_count,
     );
 
-    // Load/initialize ledger state. Track the latest persisted key so the next block's persist()
-    // can be balanced with an unpersist() of the previous one, allowing storage-core's gc-v1 to
-    // reclaim orphan nodes.
-    let (mut ledger_state, mut previous_ledger_state_key) =
-        match highest_protocol_version_and_ledger_state_key {
-            Some((protocol_version, ledger_state_key)) => {
-                let ledger_version = protocol_version.ledger_version();
-                let state = LedgerState::load(&ledger_state_key, ledger_version)
-                    .context("load ledger state")?;
-                (state, Some((ledger_state_key, ledger_version)))
-            }
+    // Load/initialize ledger state. Seed the retention window with the newest blocks' keys
+    // (oldest first, each with the ledger version it was persisted under) so a restart keeps
+    // balancing the previous run's persists instead of stranding them as permanent gc roots;
+    // per block, persist() is then balanced by an unpersist() once the key leaves the window,
+    // letting gc-v1 reclaim orphan nodes while recent snapshots stay loadable for indexer-api's
+    // block-hash reads (e.g. the dust generations subscription). Keys whose roots are no
+    // longer persisted are skipped: after a retention increase, older keys have already been
+    // unpersisted, and unpersisting them again would corrupt the root counts.
+    let newest_ledger_state_keys = storage
+        .get_newest_ledger_state_keys(ledger_state_retention)
+        .await
+        .context("get newest ledger state keys")?
+        .into_iter()
+        .map(|(protocol_version, key)| {
+            let ledger_version = protocol_version.ledger_version();
+            LedgerState::root_hash_bytes(&key, ledger_version)
+                .map(|root_hash| (key, ledger_version, root_hash))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .context("get ledger state root hashes")?;
+    let newest_count = newest_ledger_state_keys.len();
+    let persisted_root_hashes = LedgerState::persisted_root_hashes();
+    let mut persisted_ledger_state_keys = newest_ledger_state_keys
+        .into_iter()
+        .filter(|(_, _, root_hash)| persisted_root_hashes.contains(root_hash))
+        .map(|(key, ledger_version, _)| (key, ledger_version))
+        .collect::<VecDeque<_>>();
+    info!(
+        seeded = persisted_ledger_state_keys.len(),
+        skipped_unrooted = newest_count - persisted_ledger_state_keys.len();
+        "seeded ledger state retention window"
+    );
 
-            None => {
-                let state = LedgerState::new(network_id.clone(), LedgerVersion::OLDEST)
-                    .context("create ledger state")?;
-                (state, None)
-            }
-        };
+    let mut ledger_state = match persisted_ledger_state_keys.back() {
+        Some((ledger_state_key, ledger_version)) => {
+            LedgerState::load(ledger_state_key, *ledger_version).context("load ledger state")?
+        }
+
+        None if highest_block_ref.is_some() => bail!(
+            "no persisted ledger state root found within the retention window; the ledger DB \
+             cannot be resumed"
+        ),
+
+        None => LedgerState::new(network_id.clone(), LedgerVersion::OLDEST)
+            .context("create ledger state")?,
+    };
 
     let highest_block_on_node = Arc::new(RwLock::new(None));
 
@@ -188,14 +220,18 @@ pub async fn run(
 
                 ledger_state = next_ledger_state;
 
-                // Unpersist the previous ledger state's key (if any) with the version it was
-                // persisted under (they differ at a protocol upgrade boundary). This balances the
-                // prior block's persist() and lets its arena nodes become eligible for gc.
-                if let Some((prev_key, prev_version)) = previous_ledger_state_key
-                    .replace((new_ledger_state_key, ledger_state.ledger_version()))
-                {
-                    LedgerState::unpersist(&prev_key, prev_version)
-                        .context("unpersist previous ledger state")?;
+                // Keep the newest ledger_state_retention keys persisted and unpersist the
+                // oldest beyond the window, each with the version it was persisted under
+                // (they differ at a protocol upgrade boundary). This makes aged-out states'
+                // arena nodes eligible for gc while recent snapshots stay loadable for
+                // indexer-api's block-hash reads.
+                persisted_ledger_state_keys
+                    .push_back((new_ledger_state_key, ledger_state.ledger_version()));
+                while persisted_ledger_state_keys.len() > ledger_state_retention.get() {
+                    if let Some((key, version)) = persisted_ledger_state_keys.pop_front() {
+                        LedgerState::unpersist(&key, version)
+                            .context("unpersist ledger state beyond retention window")?;
+                    }
                 }
 
                 // Run a time-bounded mark-and-sweep pass; skip when disabled.

--- a/chain-indexer/src/application/metrics.rs
+++ b/chain-indexer/src/application/metrics.rs
@@ -13,7 +13,8 @@
 
 use crate::domain::{Block, ContractAction, Transaction};
 use indexer_common::domain::ContractAttributes;
-use metrics::{Counter, Gauge, counter, gauge};
+use metrics::{Counter, Gauge, Histogram, counter, gauge, histogram};
+use std::time::Duration;
 
 pub struct Metrics {
     block_height: Counter,
@@ -23,6 +24,9 @@ pub struct Metrics {
     contract_deploy_count: Counter,
     contract_call_count: Counter,
     contract_update_count: Counter,
+    gc_run_count: Counter,
+    gc_culled_node_count: Counter,
+    gc_duration_seconds: Histogram,
 }
 
 impl Metrics {
@@ -39,6 +43,9 @@ impl Metrics {
             contract_deploy_count: counter!("indexer_contract_deploy_count"),
             contract_call_count: counter!("indexer_contract_call_count"),
             contract_update_count: counter!("indexer_contract_update_count"),
+            gc_run_count: counter!("indexer_gc_run_count"),
+            gc_culled_node_count: counter!("indexer_gc_culled_node_count"),
+            gc_duration_seconds: histogram!("indexer_gc_duration_seconds"),
         };
 
         if let Some(block_height) = block_height {
@@ -133,5 +140,12 @@ impl Metrics {
                 })
                 .count() as u64,
         );
+    }
+
+    /// Record one storage-core gc-v1 mark-and-sweep pass.
+    pub fn record_gc(&self, duration: Duration, nodes_culled: usize) {
+        self.gc_run_count.increment(1);
+        self.gc_culled_node_count.increment(nodes_culled as u64);
+        self.gc_duration_seconds.record(duration.as_secs_f64());
     }
 }

--- a/chain-indexer/src/domain/ledger_state.rs
+++ b/chain-indexer/src/domain/ledger_state.rs
@@ -64,6 +64,23 @@ impl LedgerState {
             .map(Into::into)
     }
 
+    /// Unpersist a previously-persisted ledger state by its serialized key.
+    /// Balances a prior `persist()` call so storage-core's gc-v1 can reclaim
+    /// the now-unreachable arena nodes on a subsequent `gc()` pass.
+    pub fn unpersist(
+        key: &SerializedLedgerStateKey,
+        ledger_version: LedgerVersion,
+    ) -> Result<(), Error> {
+        indexer_common::domain::ledger::LedgerState::unpersist(key, ledger_version)
+            .map_err(Error::Unpersist)
+    }
+
+    /// Run a time-bounded mark-and-sweep gc on the ledger DB and return the
+    /// number of arena nodes culled.
+    pub fn gc(bound: std::time::Duration) -> usize {
+        indexer_common::domain::ledger::LedgerState::gc(bound)
+    }
+
     /// Apply the given node transactions to this ledger state and return domain transactions.
     #[trace(properties = { "parent_block_hash": "{parent_block_hash}" })]
     pub fn apply_transactions(
@@ -223,6 +240,9 @@ pub enum Error {
 
     #[error(transparent)]
     Translate(indexer_common::domain::ledger::Error),
+
+    #[error(transparent)]
+    Unpersist(indexer_common::domain::ledger::Error),
 
     #[error("cannot apply regular transaction {hash}", hash = stringify_hash(.0))]
     ApplyRegularTransaction(

--- a/chain-indexer/src/domain/ledger_state.rs
+++ b/chain-indexer/src/domain/ledger_state.rs
@@ -19,7 +19,7 @@ use indexer_common::domain::{
     NetworkId, SerializedContractAddress, SerializedLedgerStateKey, TransactionHash,
     ledger::{self, LedgerParameters},
 };
-use std::ops::DerefMut;
+use std::{collections::HashSet, ops::DerefMut};
 use thiserror::Error;
 
 /// New type for ledger state from indexer_common.
@@ -73,6 +73,20 @@ impl LedgerState {
     ) -> Result<(), Error> {
         indexer_common::domain::ledger::LedgerState::unpersist(key, ledger_version)
             .map_err(Error::Unpersist)
+    }
+
+    /// The raw arena hash bytes of a serialized ledger state key, e.g. to check membership in
+    /// [Self::persisted_root_hashes].
+    pub fn root_hash_bytes(
+        key: &SerializedLedgerStateKey,
+        ledger_version: LedgerVersion,
+    ) -> Result<Vec<u8>, indexer_common::domain::ledger::Error> {
+        indexer_common::domain::ledger::LedgerState::root_hash_bytes(key, ledger_version)
+    }
+
+    /// The raw arena hash bytes of all currently persisted gc roots, fetched from the ledger DB.
+    pub fn persisted_root_hashes() -> HashSet<Vec<u8>> {
+        indexer_common::domain::ledger::LedgerState::persisted_root_hashes()
     }
 
     /// Run a time-bounded mark-and-sweep gc on the ledger DB and return the

--- a/chain-indexer/src/domain/storage.rs
+++ b/chain-indexer/src/domain/storage.rs
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 use indexer_common::domain::{ProtocolVersion, SerializedLedgerStateKey};
+use std::num::NonZeroUsize;
 
 use crate::domain::{
     Block, BlockRef, DParameter, DustRegistrationEvent, SystemParametersChange, TermsAndConditions,
@@ -38,6 +39,13 @@ where
     async fn get_highest_block(
         &self,
     ) -> Result<Option<(BlockRef, ProtocolVersion, SerializedLedgerStateKey)>, sqlx::Error>;
+
+    /// Get the protocol versions and ledger state keys of the newest `limit` blocks, ordered
+    /// from oldest to newest.
+    async fn get_newest_ledger_state_keys(
+        &self,
+        limit: NonZeroUsize,
+    ) -> Result<Vec<(ProtocolVersion, SerializedLedgerStateKey)>, sqlx::Error>;
 
     /// Get the number of stored transactions.
     async fn get_transaction_count(&self) -> Result<u64, sqlx::Error>;

--- a/chain-indexer/src/infra/storage.rs
+++ b/chain-indexer/src/infra/storage.rs
@@ -29,6 +29,7 @@ use indoc::indoc;
 use log::debug;
 use serde::{Deserialize, Serialize};
 use sqlx::{QueryBuilder, Type, types::Json};
+use std::num::NonZeroUsize;
 
 #[cfg(feature = "cloud")]
 /// Sqlx transaction for Postgres.
@@ -120,6 +121,34 @@ impl domain::storage::Storage for Storage {
                 Ok((block_ref, protocol_version, key))
             })
             .transpose()
+    }
+
+    #[trace]
+    async fn get_newest_ledger_state_keys(
+        &self,
+        limit: NonZeroUsize,
+    ) -> Result<Vec<(ProtocolVersion, SerializedLedgerStateKey)>, sqlx::Error> {
+        let query = indoc! {"
+            SELECT protocol_version, ledger_state_key
+            FROM blocks
+            ORDER BY height DESC
+            LIMIT $1
+        "};
+
+        let mut keys = sqlx::query_as::<_, (i64, SerializedLedgerStateKey)>(query)
+            .bind(limit.get() as i64)
+            .fetch_all(&*self.pool)
+            .await?
+            .into_iter()
+            .map(|(protocol_version, key)| {
+                let protocol_version = ProtocolVersion::try_from(protocol_version)
+                    .map_err(|error| sqlx::Error::Decode(error.into()))?;
+                Ok((protocol_version, key))
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()?;
+        keys.reverse();
+
+        Ok(keys)
     }
 
     #[trace]

--- a/indexer-api/config.yaml
+++ b/indexer-api/config.yaml
@@ -37,6 +37,9 @@ infra:
         batch_size: 20
       dust_generations:
         batch_size: 20
+        # Snapshots older than this many blocks are rejected; keep well below
+        # chain-indexer's ledger_state_retention.
+        max_snapshot_age: 500
       dust_ledger_events:
         batch_size: 20
       dust_nullifier_transactions:

--- a/indexer-api/src/domain/ledger_state.rs
+++ b/indexer-api/src/domain/ledger_state.rs
@@ -201,6 +201,15 @@ impl LedgerState {
         indexer_common::domain::ledger::LedgerState::load(key, ledger_version).map(Into::into)
     }
 
+    /// Whether the root node of a previously persisted ledger state is still present in the
+    /// ledger DB, i.e. the state is loadable and has not been garbage collected.
+    pub fn root_loadable(
+        key: &SerializedLedgerStateKey,
+        ledger_version: LedgerVersion,
+    ) -> Result<bool, indexer_common::domain::ledger::Error> {
+        indexer_common::domain::ledger::LedgerState::root_loadable(key, ledger_version)
+    }
+
     /// Create a zswap state Merkle tree collapsed update.
     pub fn make_zswap_collapsed_update(
         &self,

--- a/indexer-api/src/domain/storage/ledger_state.rs
+++ b/indexer-api/src/domain/storage/ledger_state.rs
@@ -25,11 +25,12 @@ where
         &self,
     ) -> Result<Option<(ProtocolVersion, SerializedLedgerStateKey)>, sqlx::Error>;
 
-    /// Get the block id, protocol version, and ledger state key at a specific block, by hash.
+    /// Get the block id, height, protocol version, and ledger state key at a specific block,
+    /// by hash.
     async fn get_ledger_state_at(
         &self,
         block_hash: BlockHash,
-    ) -> Result<Option<(u64, ProtocolVersion, SerializedLedgerStateKey)>, sqlx::Error>;
+    ) -> Result<Option<(u64, u32, ProtocolVersion, SerializedLedgerStateKey)>, sqlx::Error>;
 }
 
 #[allow(unused_variables)]
@@ -43,7 +44,7 @@ impl LedgerStateStorage for NoopStorage {
     async fn get_ledger_state_at(
         &self,
         block_hash: BlockHash,
-    ) -> Result<Option<(u64, ProtocolVersion, SerializedLedgerStateKey)>, sqlx::Error> {
+    ) -> Result<Option<(u64, u32, ProtocolVersion, SerializedLedgerStateKey)>, sqlx::Error> {
         unimplemented!()
     }
 }

--- a/indexer-api/src/infra/api.rs
+++ b/indexer-api/src/infra/api.rs
@@ -179,6 +179,16 @@ pub struct ContractActionsSubscriptionConfig {
 #[derive(Debug, Clone, Copy, Deserialize)]
 pub struct DustGenerationsSubscriptionConfig {
     pub batch_size: NonZeroU32,
+
+    /// Maximum age in blocks of the snapshot `block_hash`; older ones are rejected with a
+    /// re-subscribe hint. Must stay well below chain-indexer's ledger_state_retention, which
+    /// bounds how long a block's ledger state remains loadable.
+    #[serde(default = "max_snapshot_age_default")]
+    pub max_snapshot_age: u32,
+}
+
+fn max_snapshot_age_default() -> u32 {
+    500
 }
 
 #[derive(Debug, Clone, Copy, Deserialize)]

--- a/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
+++ b/indexer-api/src/infra/api/v4/subscription/dust_generations.rs
@@ -133,7 +133,9 @@ where
         dtime_cutoff_height: u64,
     ) -> impl Stream<Item = ApiResult<DustGenerationsEvent>> {
         let storage = cx.get_storage::<S>();
-        let batch_size = cx.get_subscription_config().dust_generations.batch_size;
+        let dust_generations_config = cx.get_subscription_config().dust_generations;
+        let batch_size = dust_generations_config.batch_size;
+        let max_snapshot_age = dust_generations_config.max_snapshot_age;
         let network_id = cx.get_network_id();
         let quotas = cx.get_subscription_quotas();
         let per_connection_counter = cx.get_per_connection_counter();
@@ -154,11 +156,40 @@ where
             // Pin the whole snapshot to one block: load the ledger state at `block_hash` so the
             // generation tree (and every collapsed update built from it) reflects the state as of
             // that block. This is what makes the response deterministic and free of tip-drift.
-            let (snapshot_block_id, protocol_version, ledger_state_key) = storage
+            let (snapshot_block_id, snapshot_height, protocol_version, ledger_state_key) = storage
                 .get_ledger_state_at(block_hash)
                 .await
                 .map_err_into_server_error(|| "get ledger state at block")?
                 .some_or_client_error(|| "unknown block hash")?;
+
+            // The chain-indexer only keeps the ledger states of the most recent
+            // ledger_state_retention blocks loadable (older ones are garbage collected), so
+            // reject stale snapshots up front with a re-subscribe hint instead of failing
+            // mid-stream on culled state.
+            let latest_height = storage
+                .get_latest_block()
+                .await
+                .map_err_into_server_error(|| "get latest block")?
+                .map(|block| block.height)
+                .unwrap_or_default();
+            (latest_height.saturating_sub(snapshot_height) <= max_snapshot_age)
+                .then_some(())
+                .some_or_client_error(|| {
+                    "block hash is older than the snapshot freshness window, re-subscribe with \
+                     a more recent block hash"
+                })?;
+
+            // Verify the root node is still in the ledger DB before loading: loading culled
+            // state panics inside storage-core rather than returning an error, so this check is
+            // what turns a gc'd snapshot (possible when max_snapshot_age is misconfigured to
+            // exceed the chain-indexer's ledger_state_retention) into a clean client error.
+            LedgerState::root_loadable(&ledger_state_key, protocol_version.ledger_version())
+                .map_err_into_server_error(|| "check ledger state availability")?
+                .then_some(())
+                .some_or_client_error(|| {
+                    "ledger state for this block is no longer available, re-subscribe with \
+                     a more recent block hash"
+                })?;
 
             let ledger_state =
                 LedgerState::load(&ledger_state_key, protocol_version.ledger_version())

--- a/indexer-api/src/infra/storage/ledger_state.rs
+++ b/indexer-api/src/infra/storage/ledger_state.rs
@@ -40,23 +40,25 @@ impl LedgerStateStorage for Storage {
     async fn get_ledger_state_at(
         &self,
         block_hash: BlockHash,
-    ) -> Result<Option<(u64, ProtocolVersion, SerializedLedgerStateKey)>, sqlx::Error> {
+    ) -> Result<Option<(u64, u32, ProtocolVersion, SerializedLedgerStateKey)>, sqlx::Error> {
         let query = indoc! {"
-            SELECT id, protocol_version, ledger_state_key
+            SELECT id, height, protocol_version, ledger_state_key
             FROM blocks
             WHERE hash = $1
         "};
 
-        sqlx::query_as::<_, (i64, i64, SerializedLedgerStateKey)>(query)
+        sqlx::query_as::<_, (i64, i64, i64, SerializedLedgerStateKey)>(query)
             .bind(block_hash.as_ref())
             .fetch_optional(&*self.pool)
             .await?
-            .map(|(block_id, protocol_version, key)| {
+            .map(|(block_id, height, protocol_version, key)| {
                 let block_id =
                     u64::try_from(block_id).map_err(|error| sqlx::Error::Decode(error.into()))?;
+                let height =
+                    u32::try_from(height).map_err(|error| sqlx::Error::Decode(error.into()))?;
                 let protocol_version = ProtocolVersion::try_from(protocol_version)
                     .map_err(|error| sqlx::Error::Decode(error.into()))?;
-                Ok((block_id, protocol_version, key))
+                Ok((block_id, height, protocol_version, key))
             })
             .transpose()
     }

--- a/indexer-common/Cargo.toml
+++ b/indexer-common/Cargo.toml
@@ -21,7 +21,7 @@ midnight-coin-structure_v2   = { workspace = true }
 midnight-ledger_v8           = { workspace = true }
 midnight-onchain-runtime_v3  = { workspace = true }
 midnight-serialize_v1        = { workspace = true }
-midnight-storage-core_v1     = { workspace = true, features = [ "layout-v2" ] }
+midnight-storage-core_v1     = { workspace = true, features = [ "layout-v2", "gc-v1" ] }
 midnight-transient-crypto_v2 = { workspace = true }
 midnight-zswap_v8            = { workspace = true }
 # ledger v9 rc (base-crypto, serialize and storage-core stay unified across v8

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -83,7 +83,7 @@ use midnight_onchain_runtime_v3::context::BlockContext as BlockContextV3;
 use midnight_onchain_runtime_v4::context::BlockContext as BlockContextV4;
 use midnight_serialize_v1::{Deserializable, tagged_deserialize};
 use midnight_storage_core_v1::{
-    arena::{Sp, TypedArenaKey},
+    arena::{ArenaHash, Sp, TypedArenaKey},
     db::DB,
     storage::default_storage,
 };
@@ -330,6 +330,47 @@ impl LedgerState {
         key: &SerializedLedgerStateKey,
         ledger_version: LedgerVersion,
     ) -> Result<(), Error> {
+        let hash = Self::arena_root_hash(key, ledger_version)?;
+        default_storage::<v1_1::LedgerDb>().with_backend(|b| b.unpersist(&hash));
+
+        Ok(())
+    }
+
+    /// The raw arena hash bytes of a serialized ledger state key, e.g. to check membership in
+    /// [Self::persisted_root_hashes].
+    pub fn root_hash_bytes(
+        key: &SerializedLedgerStateKey,
+        ledger_version: LedgerVersion,
+    ) -> Result<Vec<u8>, Error> {
+        Self::arena_root_hash(key, ledger_version).map(|hash| hash.0.to_vec())
+    }
+
+    /// Whether the root node of a previously persisted ledger state is still present in the
+    /// ledger DB, i.e. the state is loadable and has not been garbage collected. Goes through
+    /// the ledger DB itself, which in standalone mode is separate from the main storage.
+    pub fn root_loadable(
+        key: &SerializedLedgerStateKey,
+        ledger_version: LedgerVersion,
+    ) -> Result<bool, Error> {
+        let hash = Self::arena_root_hash(key, ledger_version)?;
+        Ok(default_storage::<v1_1::LedgerDb>().with_backend(|b| b.get(&hash).is_some()))
+    }
+
+    /// The raw arena hash bytes of all currently persisted gc roots. Fetches the full root set
+    /// from the ledger DB once; bounded by the persisted history (the retention window going
+    /// forward, plus pre-existing roots until they are reclaimed).
+    pub fn persisted_root_hashes() -> HashSet<Vec<u8>> {
+        default_storage::<v1_1::LedgerDb>()
+            .with_backend(|b| b.get_roots())
+            .into_keys()
+            .map(|hash| hash.0.to_vec())
+            .collect()
+    }
+
+    fn arena_root_hash(
+        key: &SerializedLedgerStateKey,
+        ledger_version: LedgerVersion,
+    ) -> Result<ArenaHash<<v1_1::LedgerDb as DB>::Hasher>, Error> {
         match ledger_version {
             LedgerVersion::V8 => {
                 let arena_key = TypedArenaKey::<
@@ -338,10 +379,7 @@ impl LedgerState {
                 >::deserialize(&mut key.as_slice(), 0)
                 .map_err(|error| Error::Deserialize("TypedArenaKeyV8", error))?;
 
-                default_storage::<v1_1::LedgerDb>()
-                    .with_backend(|b| b.unpersist(arena_key.key.hash()));
-
-                Ok(())
+                Ok(arena_key.key.hash().clone())
             }
 
             LedgerVersion::V9 => {
@@ -351,10 +389,7 @@ impl LedgerState {
                 >::deserialize(&mut key.as_slice(), 0)
                 .map_err(|error| Error::Deserialize("TypedArenaKeyV9", error))?;
 
-                default_storage::<v1_1::LedgerDb>()
-                    .with_backend(|b| b.unpersist(arena_key.key.hash()));
-
-                Ok(())
+                Ok(arena_key.key.hash().clone())
             }
         }
     }

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -323,6 +323,49 @@ impl LedgerState {
         }
     }
 
+    /// Unpersist a previously-persisted ledger state by its serialized key, decrementing the
+    /// GC root count on the underlying arena node so it becomes eligible for garbage collection
+    /// on the next `gc()` pass. Each call should balance a prior `persist()` call for the same key.
+    pub fn unpersist(
+        key: &SerializedLedgerStateKey,
+        ledger_version: LedgerVersion,
+    ) -> Result<(), Error> {
+        match ledger_version {
+            LedgerVersion::V8 => {
+                let arena_key = TypedArenaKey::<
+                    LedgerStateV8<v1_1::LedgerDb>,
+                    <v1_1::LedgerDb as DB>::Hasher,
+                >::deserialize(&mut key.as_slice(), 0)
+                .map_err(|error| Error::Deserialize("TypedArenaKeyV8", error))?;
+
+                default_storage::<v1_1::LedgerDb>()
+                    .with_backend(|b| b.unpersist(arena_key.key.hash()));
+
+                Ok(())
+            }
+
+            LedgerVersion::V9 => {
+                let arena_key = TypedArenaKey::<
+                    LedgerStateV9<v1_1::LedgerDb>,
+                    <v1_1::LedgerDb as DB>::Hasher,
+                >::deserialize(&mut key.as_slice(), 0)
+                .map_err(|error| Error::Deserialize("TypedArenaKeyV9", error))?;
+
+                default_storage::<v1_1::LedgerDb>()
+                    .with_backend(|b| b.unpersist(arena_key.key.hash()));
+
+                Ok(())
+            }
+        }
+    }
+
+    /// Run a time-bounded mark-and-sweep garbage collection on the ledger DB.
+    /// Returns the number of nodes culled. The bound is observed best-effort:
+    /// gc() checks the budget between batches and stops when exceeded.
+    pub fn gc(bound: std::time::Duration) -> usize {
+        default_storage::<v1_1::LedgerDb>().with_backend(|b| b.gc(bound))
+    }
+
     /// Apply the given serialized regular transaction to this ledger state and return the
     /// transaction result as well as the created and spent unshielded UTXOs.
     #[trace]

--- a/indexer-common/src/infra/ledger_db/v1_1.rs
+++ b/indexer-common/src/infra/ledger_db/v1_1.rs
@@ -57,6 +57,7 @@ impl LedgerDb {
 
 impl DB for LedgerDb {
     type Hasher = DefaultHasher;
+    type ScanResumeHandle = ArenaHash<DefaultHasher>;
 
     fn get_node(&self, key: &ArenaHash<Self::Hasher>) -> Option<OnDiskObject<Self::Hasher>> {
         block_in_place(|| {
@@ -354,6 +355,53 @@ impl DB for LedgerDb {
             })
         })
     }
+
+    /// Called by storage-core's gc-v1 sweep phase (`gc.rs`): after marking
+    /// reachable nodes, `gc()` scans the DB in batches, culls every scanned
+    /// node not in the mark set, and uses the returned resume handle to pick
+    /// up where a time-bounded pass left off. Not called by indexer code.
+    fn scan(
+        &self,
+        resume_from: Option<Self::ScanResumeHandle>,
+        batch_size: usize,
+    ) -> (
+        Vec<(ArenaHash<Self::Hasher>, OnDiskObject<Self::Hasher>)>,
+        Option<Self::ScanResumeHandle>,
+    ) {
+        block_in_place(|| {
+            Handle::current().block_on(async {
+                let mut query = QueryBuilder::new("SELECT key, object FROM ledger_db_nodes");
+                if let Some(handle) = resume_from.as_ref() {
+                    query.push(" WHERE key > ");
+                    query.push_bind(handle.0.as_slice());
+                }
+                query.push(" ORDER BY key LIMIT ");
+                query.push_bind(batch_size as i64);
+
+                let raw = query
+                    .build_query_as::<(Vec<u8>, Vec<u8>)>()
+                    .fetch_all(&*self.pool)
+                    .await
+                    .unwrap_or_panic("cannot scan ledger_db_nodes");
+
+                let batch = raw
+                    .into_iter()
+                    .map(|(key, object)| {
+                        let key = ArenaHash::<Self::Hasher>::deserialize(&mut key.as_slice(), 0)
+                            .unwrap_or_panic("cannot deserialize key as ArenaHash");
+                        let object =
+                            OnDiskObject::<Self::Hasher>::deserialize(&mut object.as_slice(), 0)
+                                .unwrap_or_panic("cannot deserialize node as OnDiskObject");
+                        (key, object)
+                    })
+                    .collect::<Vec<_>>();
+
+                let next_handle = batch.last().map(|(k, _)| k.clone());
+
+                (batch, next_handle)
+            })
+        })
+    }
 }
 
 impl Default for LedgerDb {
@@ -450,5 +498,142 @@ where
             .execute(&mut **tx)
             .await
             .unwrap_or_panic("cannot set root count");
+    }
+}
+
+#[cfg(all(test, feature = "standalone"))]
+mod sqlite_tests {
+    use crate::infra::{
+        ledger_db::v1_1::LedgerDb,
+        migrations::sqlite::run_for_ledger_db,
+        pool::sqlite::{Config, SqlitePool},
+    };
+    use anyhow::Context;
+    use midnight_storage_core_v1::{DefaultHasher, arena::ArenaHash, db::DB};
+    use std::error::Error as StdError;
+
+    #[tokio::test]
+    async fn scan_empty_db_returns_no_rows_and_no_handle() -> Result<(), Box<dyn StdError>> {
+        let pool = SqlitePool::new(Config::default())
+            .await
+            .context("create sqlite pool")?;
+        run_for_ledger_db(&pool)
+            .await
+            .context("run ledger_db migrations")?;
+
+        let db = LedgerDb::new(pool);
+
+        let (batch, handle) = tokio::task::spawn_blocking(move || {
+            // scan() uses block_in_place internally, which requires being on a
+            // multi-thread runtime; spawn_blocking is a clean way to satisfy that.
+            db.scan(None, 100)
+        })
+        .await
+        .context("await scan")?;
+
+        assert!(batch.is_empty());
+        assert!(handle.is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn scan_with_resume_on_empty_db_still_returns_no_rows() -> Result<(), Box<dyn StdError>> {
+        let pool = SqlitePool::new(Config::default())
+            .await
+            .context("create sqlite pool")?;
+        run_for_ledger_db(&pool)
+            .await
+            .context("run ledger_db migrations")?;
+
+        let db = LedgerDb::new(pool);
+        let fake_resume: ArenaHash<DefaultHasher> = ArenaHash::default();
+
+        let (batch, handle) = tokio::task::spawn_blocking(move || db.scan(Some(fake_resume), 50))
+            .await
+            .context("await scan")?;
+
+        assert!(batch.is_empty());
+        assert!(handle.is_none());
+
+        Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "cloud"))]
+mod postgres_tests {
+    use crate::infra::{
+        ledger_db::v1_1::LedgerDb,
+        migrations::postgres::run as run_migrations,
+        pool::{self, postgres::PostgresPool},
+    };
+    use anyhow::Context;
+    use midnight_storage_core_v1::{DefaultHasher, arena::ArenaHash, db::DB};
+    use sqlx::postgres::PgSslMode;
+    use std::{error::Error as StdError, time::Duration};
+    use testcontainers::{ImageExt, runners::AsyncRunner};
+    use testcontainers_modules::postgres::Postgres;
+
+    async fn setup_pool()
+    -> Result<(testcontainers::ContainerAsync<Postgres>, PostgresPool), Box<dyn StdError>> {
+        let container = Postgres::default()
+            .with_db_name("indexer")
+            .with_user("indexer")
+            .with_password(env!("APP__INFRA__STORAGE__PASSWORD"))
+            .with_tag("17.1-alpine")
+            .start()
+            .await
+            .context("start Postgres container")?;
+        let port = container
+            .get_host_port_ipv4(5432)
+            .await
+            .context("get Postgres port")?;
+
+        let config = pool::postgres::Config {
+            host: "localhost".to_string(),
+            port,
+            dbname: "indexer".to_string(),
+            user: "indexer".to_string(),
+            password: env!("APP__INFRA__STORAGE__PASSWORD").into(),
+            sslmode: PgSslMode::Prefer,
+            max_connections: 10,
+            idle_timeout: Duration::from_secs(60),
+            max_lifetime: Duration::from_secs(5 * 60),
+        };
+        let pool = PostgresPool::new(config).await?;
+        run_migrations(&pool).await.context("run migrations")?;
+
+        Ok((container, pool))
+    }
+
+    #[tokio::test]
+    async fn scan_empty_db_returns_no_rows_and_no_handle() -> Result<(), Box<dyn StdError>> {
+        let (_container, pool) = setup_pool().await?;
+        let db = LedgerDb::new(pool);
+
+        let (batch, handle) = tokio::task::spawn_blocking(move || db.scan(None, 100))
+            .await
+            .context("await scan")?;
+
+        assert!(batch.is_empty());
+        assert!(handle.is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn scan_with_resume_on_empty_db_still_returns_no_rows() -> Result<(), Box<dyn StdError>> {
+        let (_container, pool) = setup_pool().await?;
+        let db = LedgerDb::new(pool);
+        let fake_resume: ArenaHash<DefaultHasher> = ArenaHash::default();
+
+        let (batch, handle) = tokio::task::spawn_blocking(move || db.scan(Some(fake_resume), 50))
+            .await
+            .context("await scan")?;
+
+        assert!(batch.is_empty());
+        assert!(handle.is_none());
+
+        Ok(())
     }
 }

--- a/indexer-standalone/config.yaml
+++ b/indexer-standalone/config.yaml
@@ -5,6 +5,7 @@ application:
   blocks_buffer: 10
   caught_up_max_distance: 10
   caught_up_leeway: 5
+  gc_bound: "200ms"
   active_wallets_query_delay: "500ms"
   active_wallets_ttl: "30m"
   transaction_batch_size: 50

--- a/indexer-standalone/config.yaml
+++ b/indexer-standalone/config.yaml
@@ -6,6 +6,9 @@ application:
   caught_up_max_distance: 10
   caught_up_leeway: 5
   gc_bound: "200ms"
+  # Recent blocks whose ledger states stay loadable (gc roots). Must comfortably exceed
+  # the dust_generations max_snapshot_age.
+  ledger_state_retention: 1000
   active_wallets_query_delay: "500ms"
   active_wallets_ttl: "30m"
   transaction_batch_size: 50

--- a/indexer-standalone/src/config.rs
+++ b/indexer-standalone/src/config.rs
@@ -46,6 +46,8 @@ pub struct ApplicationConfig {
     pub blocks_buffer: usize,
     pub caught_up_max_distance: u32,
     pub caught_up_leeway: u32,
+    #[serde(with = "humantime_serde", default = "gc_bound_default")]
+    pub gc_bound: Duration,
     #[serde(with = "humantime_serde")]
     pub active_wallets_query_delay: Duration,
     #[serde(with = "humantime_serde")]
@@ -53,6 +55,10 @@ pub struct ApplicationConfig {
     pub transaction_batch_size: NonZeroUsize,
     #[serde(default = "concurrency_limit_default")]
     pub concurrency_limit: NonZeroUsize,
+}
+
+fn gc_bound_default() -> Duration {
+    Duration::from_millis(200)
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -79,6 +85,7 @@ impl From<ApplicationConfig> for chain_app::Config {
             blocks_buffer,
             caught_up_max_distance,
             caught_up_leeway,
+            gc_bound,
             ..
         } = config;
 
@@ -87,6 +94,7 @@ impl From<ApplicationConfig> for chain_app::Config {
             blocks_buffer,
             caught_up_max_distance,
             caught_up_leeway,
+            gc_bound,
         }
     }
 }

--- a/indexer-standalone/src/config.rs
+++ b/indexer-standalone/src/config.rs
@@ -48,6 +48,8 @@ pub struct ApplicationConfig {
     pub caught_up_leeway: u32,
     #[serde(with = "humantime_serde", default = "gc_bound_default")]
     pub gc_bound: Duration,
+    #[serde(default = "ledger_state_retention_default")]
+    pub ledger_state_retention: NonZeroUsize,
     #[serde(with = "humantime_serde")]
     pub active_wallets_query_delay: Duration,
     #[serde(with = "humantime_serde")]
@@ -59,6 +61,10 @@ pub struct ApplicationConfig {
 
 fn gc_bound_default() -> Duration {
     Duration::from_millis(200)
+}
+
+fn ledger_state_retention_default() -> NonZeroUsize {
+    NonZeroUsize::new(1000).expect("1000 is not zero")
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -86,6 +92,7 @@ impl From<ApplicationConfig> for chain_app::Config {
             caught_up_max_distance,
             caught_up_leeway,
             gc_bound,
+            ledger_state_retention,
             ..
         } = config;
 
@@ -95,6 +102,7 @@ impl From<ApplicationConfig> for chain_app::Config {
             caught_up_max_distance,
             caught_up_leeway,
             gc_bound,
+            ledger_state_retention,
         }
     }
 }


### PR DESCRIPTION
## Overview

Re-land of #1086 (reverted in #1307), fixed to coexist with the block-hash dust generations sync (#1291): the dust subscription loads the ledger state at a client-chosen block, and with a retention window of 1 that state could already be garbage collected, killing indexer-api with a storage-core panic mid-stream (the e2e failure on main).

Two changes on top of the reapplied #1086:

- **Ledger state retention window** (`ledger_state_retention`, default 1000 blocks): the newest N blocks' state roots stay persisted, and the key ageing out of the window is unpersisted with the ledger version it was persisted under, so gc still culls aged-out state while recent snapshots stay loadable. On startup the window is re-seeded from the newest blocks, skipping keys whose roots are already culled (a retention increase would otherwise double-unpersist them and corrupt the counts), failing fast if an existing chain has no loadable root, and logging seeded/skipped counts.
- **Two guards** in the dust generations subscription, both returning a "re-subscribe with a more recent block hash" client error: a freshness check (`max_snapshot_age`, default 500 blocks, serde-defaulted so existing configs keep working) and a root-presence check before loading, needed because loading culled state panics inside storage-core rather than returning an error. No GraphQL schema change.

The defaults leave 500 blocks of serving runway between the freshness cutoff and gc's horizon; the API value must stay well below the retention, both config files say so. Residual: an emission that outlives the runway still dies as a task panic, so storage-core returning an error instead of panicking on a missing node stays a follow-up on #1047. Cross-process root pinning from indexer-api was considered and rejected, SetRootCount writes absolute per-process counts, so API-side pins would race the chain-indexer's writes — the sound version is also follow-up material on #1047, alongside the backlog reclaim decision on #1300.

## Verification

- Full workspace suite 62/62 (cloud), including the dust e2e that failed on main and the e2e's mid-test chain-indexer restart, which exercises the seeding; GraphQL schema verified unchanged; the 4 scan tests pass (Postgres and SQLite); check/clippy green on both features across all four crates.
- Live stack with gc active: roots track height+1, then pin at retention plus the one-block unpersist flush lag with the trailing root marching at tip−window; culled roots' nodes verifiably deleted; dust serves at the tip and at within-window historical blocks (snapshot pinned, tip-drift-free); culled and stale snapshots get the clean client errors with zero panics; a chain-indexer restart held roots flat (the seeding, where the old behaviour doubled the window); and a retention raise across a restart skipped the already-culled keys (visible in the startup log) and pinned at the new window with zero negative root counts.
- Original #1086 runtime validation (85 gc passes, 65–69 ms per pass, distance 0 throughout) still applies to the gc mechanics.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible) — covered by the existing dust e2e, which regressed on main and passes here
- [x] Key commits have useful messages
- [x] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [x] Reviewer requested
- [x] Update documentation (if relevant) — config.yamls document the new fields and their contract
- [x] No new todos introduced

## Links

Closes #1047

Re-land of #1086 (reverted in #1307). Root-cause pair: #1291. Related: #1300 (backlog reclaim on existing DBs, unchanged by this PR), #1075 (contract_actions roots interaction note stands).
