### PR TITLE
fix(indexer-api): re-emit bridgeBalance after claims, single-query bridgeDeposits

### DIFF
--- a/chain-indexer/src/application.rs
+++ b/chain-indexer/src/application.rs
@@ -591,7 +591,7 @@ where
     for event in &block.bridge_pallet_events {
         publisher
             .publish(&BridgeEventIndexed {
-                block_id: block.height,
+                block_height: block.height,
                 event: event.clone(),
             })
             .await

--- a/chain-indexer/src/domain/block.rs
+++ b/chain-indexer/src/domain/block.rs
@@ -32,9 +32,9 @@ pub struct Block {
     // TODO: Remove Option once support for Node < 0.22 is dropped!
     pub ledger_state_root: Option<ByteVec>,
     pub dust_registration_events: Vec<DustRegistrationEvent>,
-    /// c2m-bridge pallet events (5 variants, see indexer-common::domain::bridge).
-    /// Populated once the runtime metadata for `c-to-m-subminimal-transfers-accumulation`
-    /// branch is regenerated; until then, always empty.
+    /// c2m-bridge pallet events (5 variants, see indexer-common::domain::bridge), decoded from
+    /// the node 2.0+ runtime (`infra/subxt_node/runtimes/v2_0_0.rs`); always empty for earlier
+    /// runtimes, where the pallet does not exist.
     pub bridge_pallet_events: Vec<BridgePalletEvent>,
 
     // These fields are set after applying all transactions of this block to the ledger state.

--- a/chain-indexer/src/infra/storage.rs
+++ b/chain-indexer/src/infra/storage.rs
@@ -1128,12 +1128,8 @@ async fn save_system_parameters_change(
 }
 
 /// Save a bridge claim parsed from a regular `ClaimRewardsTransaction` with
-/// `ClaimKind::CardanoBridge`.
-///
-/// Currently called only when the chain-indexer detects a CardanoBridge claim during
-/// regular-transaction parsing; that detection path is TODO until the wallet-side claim flow
-/// stabilises (see ticket #940).
-#[allow(dead_code)]
+/// `ClaimKind::CardanoBridge`, as populated on the transaction by the indexer-common apply path
+/// and persisted from `save_regular_transaction`.
 #[trace(properties = { "transaction_id": "{transaction_id}" })]
 async fn save_bridge_claim(
     transaction_id: i64,

--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -1422,7 +1422,9 @@ type Subscription {
 	bridgePoolUpdates: BridgePoolUpdate! @beta
 	"""
 	Subscribe to a recipient's bridge balance. Emits the current balance on subscribe and
-	re-emits whenever a relevant bridge event indexes.
+	re-emits whenever a bridge event for the recipient indexes or the recipient's unshielded
+	UTXOs change (a claim emits no bridge pallet event, but it creates unshielded UTXOs for
+	the recipient).
 	"""
 	bridgeBalance(address: HexEncoded!): BridgeBalance! @beta
 	"""

--- a/indexer-api/src/domain/storage/bridge.rs
+++ b/indexer-api/src/domain/storage/bridge.rs
@@ -17,10 +17,11 @@ use crate::domain::{
 };
 use indexer_common::domain::{UnshieldedAddress, bridge::BridgePalletEventVariant};
 
-/// Filters for `get_bridge_events`. All fields combined with AND.
+/// Filters for `get_bridge_events`. All fields combined with AND; empty `variants` matches all
+/// variants.
 #[derive(Debug, Default, Clone)]
 pub struct BridgeEventFilter {
-    pub variant: Option<BridgePalletEventVariant>,
+    pub variants: Vec<BridgePalletEventVariant>,
     pub recipient: Option<UnshieldedAddress>,
     pub block_height_from: Option<u64>,
     pub block_height_to: Option<u64>,

--- a/indexer-api/src/infra/api/v4/query.rs
+++ b/indexer-api/src/infra/api/v4/query.rs
@@ -811,7 +811,7 @@ where
             .map_err_into_client_error(|| "invalid recipient address")?;
 
         let filter = BridgeEventFilter {
-            variant: variant.map(Into::into),
+            variants: variant.map(Into::into).into_iter().collect(),
             recipient,
             block_height_from,
             block_height_to,
@@ -883,36 +883,23 @@ where
             .hex_decode::<UnshieldedAddress>()
             .map_err_into_client_error(|| "invalid recipient address")?;
 
-        let user_filter = BridgeEventFilter {
-            variant: Some(BridgeEventVariant::UserTransfer.into()),
+        let mut variants = vec![BridgeEventVariant::UserTransfer.into()];
+        if include_unapproved.unwrap_or(false) {
+            variants.push(BridgeEventVariant::UnapprovedTransfer.into());
+        }
+        let filter = BridgeEventFilter {
+            variants,
             recipient: Some(recipient),
             ..Default::default()
         };
-        let mut events = storage
+        let events = storage
             .get_bridge_events(
-                &user_filter,
+                &filter,
                 offset.unwrap_or(0),
                 limit.unwrap_or(100).min(1_000),
             )
             .await
-            .map_err_into_server_error(|| "get bridge deposits (user)")?;
-
-        if include_unapproved.unwrap_or(false) {
-            let unapproved_filter = BridgeEventFilter {
-                variant: Some(BridgeEventVariant::UnapprovedTransfer.into()),
-                recipient: Some(recipient),
-                ..Default::default()
-            };
-            let mut unapproved = storage
-                .get_bridge_events(
-                    &unapproved_filter,
-                    offset.unwrap_or(0),
-                    limit.unwrap_or(100).min(1_000),
-                )
-                .await
-                .map_err_into_server_error(|| "get bridge deposits (unapproved)")?;
-            events.append(&mut unapproved);
-        }
+            .map_err_into_server_error(|| "get bridge deposits")?;
 
         Ok(events.into_iter().map(Into::into).collect())
     }

--- a/indexer-api/src/infra/api/v4/subscription/bridge_events.rs
+++ b/indexer-api/src/infra/api/v4/subscription/bridge_events.rs
@@ -119,7 +119,7 @@ where
 
             loop {
                 let filter = BridgeEventFilter {
-                    variant: variant_pallet,
+                    variants: variant_pallet.into_iter().collect(),
                     recipient,
                     block_height_from: None,
                     block_height_to: None,
@@ -156,7 +156,7 @@ where
                 .map_err_into_server_error(|| "subscribe BridgeEventIndexed")?
             {
                 let filter = BridgeEventFilter {
-                    variant: variant_pallet,
+                    variants: variant_pallet.into_iter().collect(),
                     recipient,
                     block_height_from: None,
                     block_height_to: None,

--- a/indexer-api/src/infra/api/v4/subscription/bridge_events.rs
+++ b/indexer-api/src/infra/api/v4/subscription/bridge_events.rs
@@ -30,7 +30,7 @@ use async_stream::try_stream;
 use futures::{Stream, TryStreamExt, stream};
 use indexer_common::domain::{
     BridgeEventIndexed, Subscriber, UnshieldedAddress, UnshieldedUtxoIndexed,
-    bridge::{BridgePalletEvent, BridgePalletEventVariant},
+    bridge::BridgePalletEvent,
 };
 use std::{future::ready, marker::PhantomData, pin::pin};
 
@@ -46,10 +46,10 @@ pub struct BridgePoolUpdate {
 }
 
 /// Synthesise a `domain_bridge::BridgeEvent` from a pub-sub message so the subscription can emit
-/// the same `BridgeEvent` interface used elsewhere. The `id`/`block_height`/`transaction_id`
-/// fields are zero-valued when sourced from pub-sub since the message carries the pallet-event
-/// payload but not the persisted-row identifiers; consumers needing them should read from the
-/// live tail of `bridgeEvents` instead.
+/// the same `BridgeEvent` interface used elsewhere. The `id` and `transaction_id` fields are
+/// zero-valued/absent when sourced from pub-sub since the message carries the pallet-event
+/// payload and block height but not the persisted-row identifiers; consumers needing them should
+/// read from the live tail of `bridgeEvents` instead.
 fn synthesise_event(msg: BridgeEventIndexed) -> domain_bridge::BridgeEvent {
     let variant = msg.event.variant();
     let mc_tx_hash = msg.event.mc_tx_hash().cloned();
@@ -60,10 +60,9 @@ fn synthesise_event(msg: BridgeEventIndexed) -> domain_bridge::BridgeEvent {
         BridgePalletEvent::SubminimalFlushTransfer { count, .. } => Some(count),
         _ => None,
     };
-    let _ = BridgePalletEventVariant::UserTransfer;
     domain_bridge::BridgeEvent {
         id: 0,
-        block_height: msg.block_id,
+        block_height: msg.block_height,
         transaction_id: None,
         variant,
         mc_tx_hash,

--- a/indexer-api/src/infra/api/v4/subscription/bridge_events.rs
+++ b/indexer-api/src/infra/api/v4/subscription/bridge_events.rs
@@ -27,9 +27,9 @@ use crate::{
 };
 use async_graphql::{Context, SimpleObject, Subscription};
 use async_stream::try_stream;
-use futures::{Stream, TryStreamExt};
+use futures::{Stream, TryStreamExt, stream};
 use indexer_common::domain::{
-    BridgeEventIndexed, Subscriber, UnshieldedAddress,
+    BridgeEventIndexed, Subscriber, UnshieldedAddress, UnshieldedUtxoIndexed,
     bridge::{BridgePalletEvent, BridgePalletEventVariant},
 };
 use std::{future::ready, marker::PhantomData, pin::pin};
@@ -224,7 +224,9 @@ where
     }
 
     /// Subscribe to a recipient's bridge balance. Emits the current balance on subscribe and
-    /// re-emits whenever a relevant bridge event indexes.
+    /// re-emits whenever a bridge event for the recipient indexes or the recipient's unshielded
+    /// UTXOs change (a claim emits no bridge pallet event, but it creates unshielded UTXOs for
+    /// the recipient).
     #[graphql(directive = beta::apply())]
     async fn bridge_balance<'a>(
         &self,
@@ -261,8 +263,11 @@ where
             };
             yield BridgeBalance::from(initial);
 
-            // Re-emit on each relevant pub-sub event.
-            let live = subscriber
+            // Re-emit on each relevant pub-sub event. Bridge pallet events cover the deposit
+            // side; a claim is a regular `ClaimRewards` transaction that emits no pallet event,
+            // so also wake on unshielded UTXO activity for the address (a claim creates
+            // unshielded UTXOs for the recipient).
+            let deposits = subscriber
                 .subscribe::<BridgeEventIndexed>()
                 .try_filter(move |evt| {
                     let matches = evt
@@ -271,10 +276,16 @@ where
                         .map(|r| r.as_bytes() == address.as_ref())
                         .unwrap_or(false);
                     ready(matches)
-                });
+                })
+                .map_ok(|_| ());
+            let claims = subscriber
+                .subscribe::<UnshieldedUtxoIndexed>()
+                .try_filter(move |utxo| ready(utxo.address == address))
+                .map_ok(|_| ());
+            let live = stream::select(deposits, claims);
             let mut live = pin!(live);
             while let Some(_msg) = live.try_next().await
-                .map_err_into_server_error(|| "subscribe BridgeEventIndexed")?
+                .map_err_into_server_error(|| "subscribe bridge balance updates")?
             {
                 let mut updated = storage
                     .get_bridge_balance(address)

--- a/indexer-api/src/infra/storage/bridge.rs
+++ b/indexer-api/src/infra/storage/bridge.rs
@@ -94,9 +94,14 @@ fn push_filter<'a>(builder: &mut QueryBuilder<'a, Db>, filter: &'a BridgeEventFi
         }
     };
 
-    if let Some(variant) = filter.variant {
+    if !filter.variants.is_empty() {
         push_clause(builder, &mut started);
-        builder.push("bpe.variant = ").push_bind(variant);
+        builder.push("bpe.variant IN (");
+        let mut variants = builder.separated(", ");
+        for variant in filter.variants.iter().copied() {
+            variants.push_bind(variant);
+        }
+        builder.push(")");
     }
     if let Some(recipient) = &filter.recipient {
         push_clause(builder, &mut started);
@@ -195,7 +200,7 @@ impl BridgeStorage for Storage {
         limit: u64,
     ) -> Result<Vec<BridgeEvent>, sqlx::Error> {
         let filter = BridgeEventFilter {
-            variant: Some(BridgePalletEventVariant::ReserveTransfer),
+            variants: vec![BridgePalletEventVariant::ReserveTransfer],
             block_height_from,
             block_height_to,
             ..Default::default()

--- a/indexer-common/migrations/sqlite/007_bridge_events.sql
+++ b/indexer-common/migrations/sqlite/007_bridge_events.sql
@@ -1,6 +1,6 @@
 -- Cardano-to-Midnight bridge events (PM-15404).
 --
--- See the matching postgres/004_bridge_events.sql for full context. SQLite
+-- See the matching postgres/005_bridge_events.sql for full context. SQLite
 -- has no ENUM type, so `variant` is a TEXT column with a CHECK constraint;
 -- partial indexes use `WHERE` clauses.
 

--- a/indexer-common/src/domain/pub_sub.rs
+++ b/indexer-common/src/domain/pub_sub.rs
@@ -66,7 +66,7 @@ message!(UnshieldedUtxoIndexed);
 /// Emitted when a c2m-bridge pallet event (any of the 5 variants) is indexed.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BridgeEventIndexed {
-    pub block_id: u64,
+    pub block_height: u64,
     pub event: BridgePalletEvent,
 }
 message!(BridgeEventIndexed);


### PR DESCRIPTION
## Description

My review fixes for the bridge epic, from a pre-review pass over #1102. Targets `feat/bridge-pallet-events` (not main) so they land before the PR goes ready for review.

**fix: re-emit bridgeBalance subscription after claims (df710fc1)**

The subscription's live loop only woke on `BridgeEventIndexed`, but a claim is a regular `ClaimRewards` transaction that emits no bridge pallet event, so a subscribed wallet kept seeing the stale pre-claim balance until an unrelated later deposit. The loop now also wakes on `UnshieldedUtxoIndexed` for the recipient, since a claim creates unshielded UTXOs for the claiming address. Schema description regenerated to match.

**fix: fetch bridgeDeposits with a single ordered query (878731bf)**

With `includeUnapproved: true` the resolver ran two queries (UserTransfer, then UnapprovedTransfer) with the same offset and limit applied to each and concatenated the results, so a page could hold up to twice the limit, ordered by variant instead of id, with per-variant page boundaries. `BridgeEventFilter` now takes a `variants` list (empty = all variants) rendered as `variant IN (...)`, and the resolver issues one query ordered by id.

**chore: naming and stale docs (c0654f24)**

- `BridgeEventIndexed.block_id` renamed to `block_height`, which is what it actually carried; the old name invited joining it against `blocks.id`.
- Corrected the `block.rs` comment claiming bridge events are never populated; decode is fully wired for node 2.0+ runtimes.
- Dropped the stale `#[allow(dead_code)]` and TODO paragraph from `save_bridge_claim`, which is live on the regular-transaction save path.
- Removed a leftover no-op statement in the bridge events subscription and pointed the sqlite migration header at `postgres/005` after the renumbering.

**Verification**

`just check` and `just lint` pass for both `cloud` and `standalone`; the committed GraphQL schema matches the regenerated one (the `just test` schema gate).

Remaining findings from the same review pass (ledger-state cache reuse in bridgeBalance, hot-path bridge-claim attach, pool-summary aggregation, batched event inserts, backfill-vs-subscribe window) are deliberately not in this PR and will be captured as follow-up tickets rather than block #1102.
