### PR TITLE
refactor: review fixes for the public contract events surface

### DIFF
--- a/chain-indexer/src/infra/storage.rs
+++ b/chain-indexer/src/infra/storage.rs
@@ -775,7 +775,7 @@ async fn save_ledger_events(
                     ledger_event
                         .contract_address
                         .as_ref()
-                        .map(|a| a.as_ref().to_vec()),
+                        .map(|address| address.as_ref()),
                 )
                 .push_bind(
                     correlated_action_id
@@ -788,11 +788,11 @@ async fn save_ledger_events(
     // SQLite + Postgres both return RETURNING rows in the order the rows
     // were inserted (the multi-row INSERT is one statement so row order is
     // deterministic), so we can zip ids back onto ledger_events by index.
-    let inserted_ids: Vec<(i64,)> = qb.build_query_as::<(i64,)>().fetch_all(&mut **tx).await?;
+    let inserted_ids = qb.build_query_as::<(i64,)>().fetch_all(&mut **tx).await?;
 
     if inserted_ids.len() != ledger_events.len() {
         return Err(sqlx::Error::Protocol(format!(
-            "save_ledger_events: expected {} RETURNING ids but got {}",
+            "save_ledger_events: expected {} RETURNING ids, was {}",
             ledger_events.len(),
             inserted_ids.len()
         )));
@@ -816,13 +816,13 @@ async fn save_contract_event_indexed_fields<I: IntoIterator<Item = i64>>(
     ids: I,
     tx: &mut SqlxTransaction,
 ) -> Result<(), sqlx::Error> {
-    let pairs: Vec<(i64, Vec<(&'static str, indexer_common::domain::ByteVec)>)> = ledger_events
+    let pairs = ledger_events
         .iter()
         .zip(ids)
-        .filter(|(e, _)| matches!(e.grouping, LedgerEventGrouping::Contract))
-        .map(|(e, id)| (id, e.indexable_contract_fields()))
+        .filter(|(ledger_event, _)| matches!(ledger_event.grouping, LedgerEventGrouping::Contract))
+        .map(|(ledger_event, id)| (id, ledger_event.indexable_contract_fields()))
         .filter(|(_, fields)| !fields.is_empty())
-        .collect();
+        .collect::<Vec<_>>();
 
     if pairs.is_empty() {
         return Ok(());
@@ -840,11 +840,9 @@ async fn save_contract_event_indexed_fields<I: IntoIterator<Item = i64>>(
     qb.push_values(
         pairs
             .iter()
-            .flat_map(|(id, fields)| fields.iter().map(move |f| (*id, f))),
+            .flat_map(|(id, fields)| fields.iter().map(move |field| (*id, field))),
         |mut q, (id, (name, value))| {
-            q.push_bind(id)
-                .push_bind(*name)
-                .push_bind(value.as_ref().to_vec());
+            q.push_bind(id).push_bind(*name).push_bind(value.as_ref());
         },
     );
     qb.build().execute(&mut **tx).await?;

--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -6,20 +6,31 @@ Exactly one of `userAddress` or `contractAddress` is non-null; the `kind`
 discriminator says which.
 """
 type AddressOrContract @beta {
+	"""
+	Which of the two address fields is populated.
+	"""
 	kind: AddressOrContractKind!
 	"""
-	Bech32m-encoded user address; populated when kind = USER.
-	Hex-encoded here at the wire level; clients re-encode if needed.
+	The hex-encoded user address; populated when kind is USER.
 	"""
 	userAddress: HexEncoded
 	"""
-	Hex-encoded contract address; populated when kind = CONTRACT.
+	The hex-encoded contract address; populated when kind is CONTRACT.
 	"""
 	contractAddress: HexEncoded
 }
 
+"""
+Discriminator for `AddressOrContract`.
+"""
 enum AddressOrContractKind {
+	"""
+	The address is a user (zswap coin public key) address.
+	"""
 	USER
+	"""
+	The address is a contract address.
+	"""
 	CONTRACT
 }
 
@@ -178,8 +189,9 @@ type Contract @beta {
 	"""
 	maintenanceAuthority: ContractMaintenanceAuthority! @beta
 	"""
-	Recent contract actions for this contract, newest first, optionally filtered by type. Use
-	the `contractActions` subscription to enumerate all actions.
+	Recent contract actions for this contract, newest first, optionally filtered by type;
+	`limit` defaults to 100 and is capped at 500. Use the `contractActions` subscription to
+	enumerate all actions.
 	"""
 	actions(limit: Int, type: ContractActionType): [ContractAction!]! @beta
 }
@@ -270,8 +282,7 @@ type ContractCall implements ContractAction {
 	Contract events emitted by this contract call.
 	
 	Only `ContractCall` exposes this field — `ContractDeploy` and
-	`ContractUpdate` don't execute circuits with the `log()` expression.
-	Per Andrzej's 12 May design call (#feat-public-events).
+	`ContractUpdate` don't execute circuits with the `emit` expression.
 	
 	Events are attributed to a call by matching contract address and entry
 	point within the transaction; if several calls in one transaction share
@@ -322,57 +333,87 @@ interface ContractEvent {
 }
 
 """
-Filter for contract events queries and subscriptions. Block-range bounds
-live here so the same shape works for both (per Andrzej 21 May review).
+Filter for contract events queries and subscriptions; block-range bounds live here so the
+same shape works for both.
 """
 input ContractEventFilter {
 	"""
-	Required: the contract address to filter events for.
+	The hex-encoded contract address to filter events for.
 	"""
 	contractAddress: HexEncoded!
 	"""
-	Optional: filter to a subset of contract event types. Indexer translates
-	to `variant = ANY(...)` against the indexed variant column.
+	Event types to narrow to; must be non-empty when given.
 	"""
 	types: [ContractEventType!]
 	"""
-	Optional: prefix-match on indexed fields of the event. Standard events only.
+	Prefix matches on indexed event fields, combined with AND semantics; standard events
+	only.
 	"""
 	fieldPrefixes: [FieldPrefixFilter!]
 	"""
-	Optional: lower bound on the block height an event was emitted in. On
-	subscription, acts as a starting cursor (alternative to `id`).
+	Lower bound on the block height an event was emitted in; on subscription this acts as
+	a starting cursor alongside `id`.
 	"""
 	fromBlock: Int
 	"""
-	Optional: upper bound on the block height an event was emitted in. On
-	subscription, terminates the stream once the chain reaches this block.
+	Upper bound on the block height an event was emitted in; on subscription, the stream
+	completes once the chain has reached this block.
 	"""
 	toBlock: Int
 	"""
-	Optional: hex-encoded transaction hash; narrows to events emitted from
-	transactions with this hash ("I just submitted tx X, give me its
-	events").
+	The hex-encoded transaction hash to narrow to events emitted by that transaction.
 	"""
 	transactionHash: HexEncoded
 }
 
 """
 Closed enum of contract event types the indexer surfaces. Used in filter
-input only, response discrimination is via `__typename`. Mirrors the
-11 variants of `LogEventType` (onchain-vm/src/ops.rs, ledger-9 alpha).
+input only, response discrimination is via `__typename`.
 """
 enum ContractEventType {
+	"""
+	A contract spends a shielded coin.
+	"""
 	SHIELDED_SPEND
+	"""
+	A contract or user receives a shielded coin.
+	"""
 	SHIELDED_RECEIVE
+	"""
+	A contract mints a shielded coin.
+	"""
 	SHIELDED_MINT
+	"""
+	A contract burns a shielded coin.
+	"""
 	SHIELDED_BURN
+	"""
+	A contract spends an unshielded coin.
+	"""
 	UNSHIELDED_SPEND
+	"""
+	A contract or user receives an unshielded coin.
+	"""
 	UNSHIELDED_RECEIVE
+	"""
+	A contract mints an unshielded coin.
+	"""
 	UNSHIELDED_MINT
+	"""
+	A contract burns an unshielded coin.
+	"""
 	UNSHIELDED_BURN
+	"""
+	A contract is paused.
+	"""
 	PAUSED
+	"""
+	A contract is unpaused.
+	"""
 	UNPAUSED
+	"""
+	A custom event emitted by a contract.
+	"""
 	MISC
 }
 
@@ -819,20 +860,17 @@ type EpochPerf {
 }
 
 """
-Prefix filter on an indexed field of a standard event. Indexer resolves
-`fieldName` for all standard events from the variant; no descriptor needed.
-Not supported on Misc events.
+Prefix filter on an indexed field of a standard event; not supported on Misc events.
 """
 input FieldPrefixFilter {
 	"""
-	Field name (e.g. `nullifier`, `commitment`, `sender`). Must match an
-	indexed field of the filtered event type.
+	The indexed field name; one of `nullifier`, `commitment`, `ciphertext`, `domainSep`,
+	`tokenType`, `sender` or `recipient`.
 	"""
 	fieldName: String!
 	"""
-	Hex-encoded prefix bytes. Empty string matches all values; otherwise
-	the indexer returns events whose field value starts with this prefix,
-	client filters to exact match if needed.
+	The hex-encoded field value prefix. An empty string matches all values; otherwise
+	events whose field value starts with this prefix are returned.
 	"""
 	prefix: HexEncoded!
 }
@@ -870,20 +908,41 @@ type MerkleTreeCollapsedUpdate {
 }
 
 type MiscContractEvent implements ContractEvent @beta {
+	"""
+	The ID of this contract event.
+	"""
 	id: Int!
+	"""
+	The hex-encoded serialized event payload.
+	"""
 	raw: HexEncoded!
+	"""
+	The maximum ID of all contract events.
+	"""
 	maxId: Int!
+	"""
+	The protocol version.
+	"""
 	protocolVersion: Int!
+	"""
+	The event schema version, as declared by the emitting contract's compiler.
+	"""
 	version: Int!
+	"""
+	The hex-encoded address of the emitting contract.
+	"""
 	contractAddress: HexEncoded!
+	"""
+	The ID of the transaction this event was emitted from.
+	"""
 	transactionId: Int!
 	"""
-	Hex-encoded contract-defined event name (Compact Bytes<32>).
+	The hex-encoded contract-defined event name (32 bytes).
 	"""
 	name: HexEncoded!
 	"""
-	Hex-encoded opaque payload (Compact Bytes<256>); consumer brings
-	descriptor to decode.
+	The hex-encoded opaque event payload, up to 256 bytes; consumers decode it with their
+	contract's descriptor.
 	"""
 	payload: HexEncoded!
 	"""
@@ -923,12 +982,33 @@ type ParamChange implements DustLedgerEvent {
 }
 
 type PausedEvent implements ContractEvent @beta {
+	"""
+	The ID of this contract event.
+	"""
 	id: Int!
+	"""
+	The hex-encoded serialized event payload.
+	"""
 	raw: HexEncoded!
+	"""
+	The maximum ID of all contract events.
+	"""
 	maxId: Int!
+	"""
+	The protocol version.
+	"""
 	protocolVersion: Int!
+	"""
+	The event schema version, as declared by the emitting contract's compiler.
+	"""
 	version: Int!
+	"""
+	The hex-encoded address of the emitting contract.
+	"""
 	contractAddress: HexEncoded!
+	"""
+	The ID of the transaction this event was emitted from.
+	"""
 	transactionId: Int!
 	"""
 	The transaction this event was emitted from.
@@ -998,7 +1078,8 @@ type Query {
 	"""
 	dustGenerationMerkleTreeUpdate(startIndex: Int!, endIndex: Int!): MerkleTreeCollapsedUpdate! @beta
 	"""
-	Find contract events matching the filter, with optional pagination.
+	Find contract events matching the filter, ordered by ID; `limit` defaults to 100 and is
+	capped at 500, `offset` defaults to 0.
 	
 	Block-range bounds (`fromBlock`, `toBlock`) live on `ContractEventFilter`
 	for symmetry with the subscription. `limit`/`offset` are top-level args.
@@ -1254,19 +1335,40 @@ type Segment {
 }
 
 type ShieldedBurnEvent implements ContractEvent @beta {
+	"""
+	The ID of this contract event.
+	"""
 	id: Int!
+	"""
+	The hex-encoded serialized event payload.
+	"""
 	raw: HexEncoded!
+	"""
+	The maximum ID of all contract events.
+	"""
 	maxId: Int!
+	"""
+	The protocol version.
+	"""
 	protocolVersion: Int!
+	"""
+	The event schema version, as declared by the emitting contract's compiler.
+	"""
 	version: Int!
+	"""
+	The hex-encoded address of the emitting contract.
+	"""
 	contractAddress: HexEncoded!
+	"""
+	The ID of the transaction this event was emitted from.
+	"""
 	transactionId: Int!
 	"""
-	Indexed.
+	The hex-encoded nullifier; filterable via `fieldPrefixes`.
 	"""
 	nullifier: HexEncoded!
 	"""
-	Optional, hidden in some shielded burns (`Maybe<Uint<128>>`).
+	The optional amount as a decimal string; hidden in some shielded burns.
 	"""
 	amount: String
 	"""
@@ -1276,23 +1378,44 @@ type ShieldedBurnEvent implements ContractEvent @beta {
 }
 
 type ShieldedMintEvent implements ContractEvent @beta {
+	"""
+	The ID of this contract event.
+	"""
 	id: Int!
+	"""
+	The hex-encoded serialized event payload.
+	"""
 	raw: HexEncoded!
+	"""
+	The maximum ID of all contract events.
+	"""
 	maxId: Int!
+	"""
+	The protocol version.
+	"""
 	protocolVersion: Int!
+	"""
+	The event schema version, as declared by the emitting contract's compiler.
+	"""
 	version: Int!
+	"""
+	The hex-encoded address of the emitting contract.
+	"""
 	contractAddress: HexEncoded!
+	"""
+	The ID of the transaction this event was emitted from.
+	"""
 	transactionId: Int!
 	"""
-	Indexed.
+	The hex-encoded commitment; filterable via `fieldPrefixes`.
 	"""
 	commitment: HexEncoded!
 	"""
-	Indexed (per Andrzej, useful for token-type queries).
+	The hex-encoded domain separator; filterable via `fieldPrefixes`.
 	"""
 	domainSep: HexEncoded!
 	"""
-	Optional, hidden in some shielded mints (`Maybe<Uint<128>>`).
+	The optional amount as a decimal string; hidden in some shielded mints.
 	"""
 	amount: String
 	"""
@@ -1332,27 +1455,46 @@ type ShieldedNullifierTransaction {
 }
 
 type ShieldedReceiveEvent implements ContractEvent @beta {
+	"""
+	The ID of this contract event.
+	"""
 	id: Int!
+	"""
+	The hex-encoded serialized event payload.
+	"""
 	raw: HexEncoded!
+	"""
+	The maximum ID of all contract events.
+	"""
 	maxId: Int!
+	"""
+	The protocol version.
+	"""
 	protocolVersion: Int!
+	"""
+	The event schema version, as declared by the emitting contract's compiler.
+	"""
 	version: Int!
+	"""
+	The hex-encoded address of the emitting contract.
+	"""
 	contractAddress: HexEncoded!
+	"""
+	The ID of the transaction this event was emitted from.
+	"""
 	transactionId: Int!
 	"""
-	Indexed.
+	The hex-encoded commitment; filterable via `fieldPrefixes`.
 	"""
 	commitment: HexEncoded!
 	"""
-	Indexed. Optional ciphertext for shielded coin receipt
-	(`Maybe<Bytes<512>>`). Hex-encoded, up to 512 bytes.
+	The hex-encoded optional ciphertext of the shielded coin receipt, up to 512 bytes;
+	filterable via `fieldPrefixes`.
 	"""
 	ciphertext: HexEncoded
 	"""
-	Set when received by a contract; null for user recipients
-	(`Maybe<ContractAddress>`). Renamed from `contractAddress` in the CoIP
-	to avoid collision with the top-level emitting `contractAddress`
-	inherited from the ContractEvent interface.
+	The hex-encoded receiving contract address; set when received by a contract, null for
+	user recipients. Named to avoid collision with the emitting `contractAddress`.
 	"""
 	receivingContractAddress: HexEncoded
 	"""
@@ -1362,15 +1504,36 @@ type ShieldedReceiveEvent implements ContractEvent @beta {
 }
 
 type ShieldedSpendEvent implements ContractEvent @beta {
+	"""
+	The ID of this contract event.
+	"""
 	id: Int!
+	"""
+	The hex-encoded serialized event payload.
+	"""
 	raw: HexEncoded!
+	"""
+	The maximum ID of all contract events.
+	"""
 	maxId: Int!
+	"""
+	The protocol version.
+	"""
 	protocolVersion: Int!
+	"""
+	The event schema version, as declared by the emitting contract's compiler.
+	"""
 	version: Int!
+	"""
+	The hex-encoded address of the emitting contract.
+	"""
 	contractAddress: HexEncoded!
+	"""
+	The ID of the transaction this event was emitted from.
+	"""
 	transactionId: Int!
 	"""
-	Indexed.
+	The hex-encoded nullifier; filterable via `fieldPrefixes`.
 	"""
 	nullifier: HexEncoded!
 	"""
@@ -1532,8 +1695,9 @@ type Subscription {
 	"""
 	contractActions(address: HexEncoded!, offset: BlockOffset): ContractAction!
 	"""
-	Subscribe to contract events matching the given filter, returning
-	events in monotonic `id` order.
+	Subscribe to contract events matching the given filter, starting at the given event ID
+	(inclusive) and returning events in monotonic ID order; completes once the chain has
+	reached `filter.toBlock` if that is set.
 	"""
 	contractEvents(filter: ContractEventFilter!, id: Int): ContractEvent! @beta
 	"""
@@ -1744,12 +1908,33 @@ enum TransactionResultStatus {
 scalar Unit
 
 type UnpausedEvent implements ContractEvent @beta {
+	"""
+	The ID of this contract event.
+	"""
 	id: Int!
+	"""
+	The hex-encoded serialized event payload.
+	"""
 	raw: HexEncoded!
+	"""
+	The maximum ID of all contract events.
+	"""
 	maxId: Int!
+	"""
+	The protocol version.
+	"""
 	protocolVersion: Int!
+	"""
+	The event schema version, as declared by the emitting contract's compiler.
+	"""
 	version: Int!
+	"""
+	The hex-encoded address of the emitting contract.
+	"""
 	contractAddress: HexEncoded!
+	"""
+	The ID of the transaction this event was emitted from.
+	"""
 	transactionId: Int!
 	"""
 	The transaction this event was emitted from.
@@ -1760,21 +1945,45 @@ type UnpausedEvent implements ContractEvent @beta {
 scalar UnshieldedAddress
 
 type UnshieldedBurnEvent implements ContractEvent @beta {
+	"""
+	The ID of this contract event.
+	"""
 	id: Int!
+	"""
+	The hex-encoded serialized event payload.
+	"""
 	raw: HexEncoded!
+	"""
+	The maximum ID of all contract events.
+	"""
 	maxId: Int!
+	"""
+	The protocol version.
+	"""
 	protocolVersion: Int!
+	"""
+	The event schema version, as declared by the emitting contract's compiler.
+	"""
 	version: Int!
+	"""
+	The hex-encoded address of the emitting contract.
+	"""
 	contractAddress: HexEncoded!
+	"""
+	The ID of the transaction this event was emitted from.
+	"""
 	transactionId: Int!
 	"""
-	Indexed.
+	The spending user or contract address; filterable via `fieldPrefixes`.
 	"""
 	sender: AddressOrContract!
 	"""
-	Indexed; matches existing unshielded_utxos.token_type index.
+	The hex-encoded token type; filterable via `fieldPrefixes`.
 	"""
 	tokenType: HexEncoded!
+	"""
+	The amount as a decimal string.
+	"""
 	amount: String!
 	"""
 	The transaction this event was emitted from.
@@ -1783,21 +1992,45 @@ type UnshieldedBurnEvent implements ContractEvent @beta {
 }
 
 type UnshieldedMintEvent implements ContractEvent @beta {
+	"""
+	The ID of this contract event.
+	"""
 	id: Int!
+	"""
+	The hex-encoded serialized event payload.
+	"""
 	raw: HexEncoded!
+	"""
+	The maximum ID of all contract events.
+	"""
 	maxId: Int!
+	"""
+	The protocol version.
+	"""
 	protocolVersion: Int!
+	"""
+	The event schema version, as declared by the emitting contract's compiler.
+	"""
 	version: Int!
+	"""
+	The hex-encoded address of the emitting contract.
+	"""
 	contractAddress: HexEncoded!
+	"""
+	The ID of the transaction this event was emitted from.
+	"""
 	transactionId: Int!
 	"""
-	Indexed.
+	The hex-encoded domain separator; filterable via `fieldPrefixes`.
 	"""
 	domainSep: HexEncoded!
 	"""
-	Indexed; matches existing unshielded_utxos.token_type index.
+	The hex-encoded token type; filterable via `fieldPrefixes`.
 	"""
 	tokenType: HexEncoded!
+	"""
+	The amount as a decimal string.
+	"""
 	amount: String!
 	"""
 	The transaction this event was emitted from.
@@ -1806,25 +2039,49 @@ type UnshieldedMintEvent implements ContractEvent @beta {
 }
 
 type UnshieldedReceiveEvent implements ContractEvent @beta {
+	"""
+	The ID of this contract event.
+	"""
 	id: Int!
+	"""
+	The hex-encoded serialized event payload.
+	"""
 	raw: HexEncoded!
+	"""
+	The maximum ID of all contract events.
+	"""
 	maxId: Int!
+	"""
+	The protocol version.
+	"""
 	protocolVersion: Int!
+	"""
+	The event schema version, as declared by the emitting contract's compiler.
+	"""
 	version: Int!
+	"""
+	The hex-encoded address of the emitting contract.
+	"""
 	contractAddress: HexEncoded!
+	"""
+	The ID of the transaction this event was emitted from.
+	"""
 	transactionId: Int!
 	"""
-	Indexed.
+	The receiving user or contract address; filterable via `fieldPrefixes`.
 	"""
 	recipient: AddressOrContract!
 	"""
-	Indexed.
+	The hex-encoded domain separator; filterable via `fieldPrefixes`.
 	"""
 	domainSep: HexEncoded!
 	"""
-	Indexed; matches existing unshielded_utxos.token_type index.
+	The hex-encoded token type; filterable via `fieldPrefixes`.
 	"""
 	tokenType: HexEncoded!
+	"""
+	The amount as a decimal string.
+	"""
 	amount: String!
 	"""
 	The transaction this event was emitted from.
@@ -1833,25 +2090,49 @@ type UnshieldedReceiveEvent implements ContractEvent @beta {
 }
 
 type UnshieldedSpendEvent implements ContractEvent @beta {
+	"""
+	The ID of this contract event.
+	"""
 	id: Int!
+	"""
+	The hex-encoded serialized event payload.
+	"""
 	raw: HexEncoded!
+	"""
+	The maximum ID of all contract events.
+	"""
 	maxId: Int!
+	"""
+	The protocol version.
+	"""
 	protocolVersion: Int!
+	"""
+	The event schema version, as declared by the emitting contract's compiler.
+	"""
 	version: Int!
+	"""
+	The hex-encoded address of the emitting contract.
+	"""
 	contractAddress: HexEncoded!
+	"""
+	The ID of the transaction this event was emitted from.
+	"""
 	transactionId: Int!
 	"""
-	Indexed.
+	The spending user or contract address; filterable via `fieldPrefixes`.
 	"""
 	sender: AddressOrContract!
 	"""
-	Indexed.
+	The hex-encoded domain separator; filterable via `fieldPrefixes`.
 	"""
 	domainSep: HexEncoded!
 	"""
-	Indexed; matches existing unshielded_utxos.token_type index.
+	The hex-encoded token type; filterable via `fieldPrefixes`.
 	"""
 	tokenType: HexEncoded!
+	"""
+	The amount as a decimal string.
+	"""
 	amount: String!
 	"""
 	The transaction this event was emitted from.

--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -91,8 +91,9 @@ type Block {
 	The zswap commitment tree filtered to the given contract address, resolved from this
 	block's ledger state; null if the contract does not exist at this block. Hex-encoded.
 	For building transactions, compose with `ledgerParameters` and `contract { state }` in
-	one request, anchored to the same block; use the latest block, older trees age out of
-	the ledger's root window.
+	one request, anchored to the same block; use the latest block: older trees age out of
+	the ledger's root window, and blocks beyond the chain-indexer's ledger state retention
+	window no longer have a loadable ledger state and yield an error.
 	"""
 	contractZswapState(address: HexEncoded!): HexEncoded @beta
 }

--- a/indexer-api/src/domain/storage/contract_action.rs
+++ b/indexer-api/src/domain/storage/contract_action.rs
@@ -58,6 +58,14 @@ where
         hash: BlockHash,
     ) -> Result<Option<ContractAction>, sqlx::Error>;
 
+    /// Whether any contract action exists for the given address as of (in any block at or before)
+    /// the block with the given hash.
+    async fn contract_action_exists_by_address_as_of_block_hash(
+        &self,
+        address: &SerializedContractAddress,
+        hash: BlockHash,
+    ) -> Result<bool, sqlx::Error>;
+
     /// Get the contract action giving the address's state as of (the latest action in any block at
     /// or before) the given block height.
     async fn get_contract_action_by_address_as_of_block_height(
@@ -170,6 +178,14 @@ impl ContractActionStorage for NoopStorage {
         address: &SerializedContractAddress,
         hash: BlockHash,
     ) -> Result<Option<ContractAction>, sqlx::Error> {
+        unimplemented!()
+    }
+
+    async fn contract_action_exists_by_address_as_of_block_hash(
+        &self,
+        address: &SerializedContractAddress,
+        hash: BlockHash,
+    ) -> Result<bool, sqlx::Error> {
         unimplemented!()
     }
 

--- a/indexer-api/src/domain/storage/contract_event.rs
+++ b/indexer-api/src/domain/storage/contract_event.rs
@@ -13,32 +13,42 @@
 
 use crate::domain::{ContractEventRow, storage::NoopStorage};
 use futures::{Stream, stream};
+use indexer_common::domain::{ByteVec, SerializedContractAddress, TransactionHash};
 use std::num::NonZeroU32;
 
-/// Filter that the chain-indexer storage layer accepts for both query and
-/// subscription paths. Mirrors the GraphQL `ContractEventFilter` input.
+/// Filter accepted by the indexer-api storage layer for both the contract events query and
+/// subscription paths.
 #[derive(Debug, Clone)]
 pub struct ContractEventFilter {
-    /// Required: the emitting contract address.
-    pub contract_address: Vec<u8>,
-    /// Optional: filter by event variant name (per `LEDGER_EVENT_VARIANT`).
-    /// Empty/None means no type filter; non-empty narrows to those variants.
-    pub variants: Option<Vec<&'static str>>,
-    /// Optional: prefix-match on indexed-field rows in `contract_event_indexed_fields`.
-    /// AND semantics across multiple entries.
+    /// The emitting contract address.
+    pub contract_address: SerializedContractAddress,
+
+    /// Event variant names (per `LEDGER_EVENT_VARIANT`) to narrow to; empty means no type
+    /// filter.
+    pub variants: Vec<&'static str>,
+
+    /// Prefix matches on indexed-field rows in `contract_event_indexed_fields`, combined with
+    /// AND semantics.
     pub field_prefixes: Vec<FieldPrefix>,
-    /// Optional: lower bound on block height.
+
+    /// Optional lower bound on block height.
     pub from_block: Option<u32>,
-    /// Optional: upper bound on block height.
+
+    /// Optional upper bound on block height.
     pub to_block: Option<u32>,
-    /// Optional: narrow to events emitted from transactions with this hash.
-    pub transaction_hash: Option<Vec<u8>>,
+
+    /// Optional transaction hash to narrow to events emitted by that transaction.
+    pub transaction_hash: Option<TransactionHash>,
 }
 
+/// A prefix match on one indexed event field.
 #[derive(Debug, Clone)]
 pub struct FieldPrefix {
+    /// The indexed field name.
     pub field_name: String,
-    pub prefix: Vec<u8>,
+
+    /// The field value prefix to match.
+    pub prefix: ByteVec,
 }
 
 #[trait_variant::make(Send)]
@@ -46,32 +56,27 @@ pub trait ContractEventStorage
 where
     Self: Clone + Send + Sync + 'static,
 {
-    /// Paginated query: returns contract events matching the filter, with an
-    /// optional limit/offset window for pagination. Ordered by `id` ascending.
+    /// Get the contract events matching the filter, ordered by ID, windowed by the given limit
+    /// and offset.
     async fn get_contract_events(
         &self,
-        filter: ContractEventFilter,
-        limit: Option<u32>,
-        offset: Option<u32>,
+        filter: &ContractEventFilter,
+        limit: u32,
+        offset: u32,
     ) -> Result<Vec<ContractEventRow>, sqlx::Error>;
 
-    /// Streaming subscription: returns contract events matching the filter,
-    /// starting at the given event `id` (inclusive). On `filter.to_block`, the
-    /// stream stops once the chain has advanced past that block — see
-    /// `dust_nullifier_transactions` / `shielded_nullifier_transactions`
-    /// bounded-subscription pattern.
-    async fn get_contract_events_after_id(
+    /// Get a stream of contract events matching the filter, starting at the given event ID
+    /// (inclusive), ordered by ID.
+    async fn get_contract_events_from_id(
         &self,
-        filter: ContractEventFilter,
-        after_id: u64,
+        filter: &ContractEventFilter,
+        id: u64,
         batch_size: NonZeroU32,
     ) -> impl Stream<Item = Result<ContractEventRow, sqlx::Error>> + Send;
 
-    /// Batched lookup keyed on `contract_action_id` for the
-    /// `ContractCall.contractEvents` nested field DataLoader (#1162).
-    /// Returns `(contract_action_id, ContractEventRow)` pairs covering every
-    /// requested key; pre-#1162 (no contract_action_id column populated) this
-    /// returns an empty Vec.
+    /// Batched lookup keyed on `contract_action_id` for the `ContractCall.contractEvents`
+    /// nested field DataLoader (#1162). Returns `(contract_action_id, ContractEventRow)` pairs
+    /// covering every requested key; rows without a populated `contract_action_id` are omitted.
     async fn get_contract_events_by_contract_action_ids(
         &self,
         ids: &[u64],
@@ -82,17 +87,17 @@ where
 impl ContractEventStorage for NoopStorage {
     async fn get_contract_events(
         &self,
-        filter: ContractEventFilter,
-        limit: Option<u32>,
-        offset: Option<u32>,
+        filter: &ContractEventFilter,
+        limit: u32,
+        offset: u32,
     ) -> Result<Vec<ContractEventRow>, sqlx::Error> {
         Ok(vec![])
     }
 
-    async fn get_contract_events_after_id(
+    async fn get_contract_events_from_id(
         &self,
-        filter: ContractEventFilter,
-        after_id: u64,
+        filter: &ContractEventFilter,
+        id: u64,
         batch_size: NonZeroU32,
     ) -> impl Stream<Item = Result<ContractEventRow, sqlx::Error>> + Send {
         stream::empty()

--- a/indexer-api/src/infra/api/v4/block.rs
+++ b/indexer-api/src/infra/api/v4/block.rs
@@ -148,8 +148,9 @@ where
     /// The zswap commitment tree filtered to the given contract address, resolved from this
     /// block's ledger state; null if the contract does not exist at this block. Hex-encoded.
     /// For building transactions, compose with `ledgerParameters` and `contract { state }` in
-    /// one request, anchored to the same block; use the latest block, older trees age out of
-    /// the ledger's root window.
+    /// one request, anchored to the same block; use the latest block: older trees age out of
+    /// the ledger's root window, and blocks beyond the chain-indexer's ledger state retention
+    /// window no longer have a loadable ledger state and yield an error.
     #[graphql(directive = beta::apply())]
     async fn contract_zswap_state(
         &self,
@@ -177,11 +178,22 @@ where
             return Ok(None);
         }
 
-        let (_, protocol_version, ledger_state_key) = storage
+        let (_, _, protocol_version, ledger_state_key) = storage
             .get_ledger_state_at(self.raw_hash)
             .await
             .map_err_into_server_error(|| format!("get ledger state at block {}", self.hash))?
             .some_or_server_error(|| format!("no ledger state for block {}", self.hash))?;
+
+        // Verify the root node is still in the ledger DB before loading: loading culled state
+        // panics inside storage-core rather than returning an error, so this check is what
+        // turns a block beyond the chain-indexer's ledger_state_retention into a clean client
+        // error.
+        domain::LedgerState::root_loadable(&ledger_state_key, protocol_version.ledger_version())
+            .map_err_into_server_error(|| "check ledger state availability")?
+            .then_some(())
+            .some_or_client_error(
+                || "ledger state for this block is no longer available, query a more recent block",
+            )?;
 
         let ledger_state =
             domain::LedgerState::load(&ledger_state_key, protocol_version.ledger_version())

--- a/indexer-api/src/infra/api/v4/block.rs
+++ b/indexer-api/src/infra/api/v4/block.rs
@@ -164,16 +164,15 @@ where
             .map_err_into_client_error(|| "invalid address")?;
 
         // Null when the contract does not exist as of this block.
-        if storage
-            .get_contract_action_by_address_as_of_block_hash(address, self.raw_hash)
+        if !storage
+            .contract_action_exists_by_address_as_of_block_hash(address, self.raw_hash)
             .await
             .map_err_into_server_error(|| {
                 format!(
-                    "get contract action for address {address} as of block {}",
+                    "check contract existence for address {address} as of block {}",
                     self.hash
                 )
             })?
-            .is_none()
         {
             return Ok(None);
         }

--- a/indexer-api/src/infra/api/v4/contract.rs
+++ b/indexer-api/src/infra/api/v4/contract.rs
@@ -32,7 +32,10 @@ use indexer_common::domain::{
 use std::marker::PhantomData;
 
 /// Default number of recent actions returned by `Contract.actions` when no `limit` is given.
-const DEFAULT_ACTIONS_LIMIT: u32 = 100;
+const DEFAULT_ACTIONS_LIMIT: i32 = 100;
+
+/// Maximum number of recent actions returned by `Contract.actions`.
+const MAX_ACTIONS_LIMIT: i32 = 500;
 
 /// A contract, identified by address, resolved as of a given block (or the latest state if no
 /// offset is given). The topmost contract concept; its actions are a sub-query.
@@ -111,8 +114,9 @@ where
         Ok(authority.into())
     }
 
-    /// Recent contract actions for this contract, newest first, optionally filtered by type. Use
-    /// the `contractActions` subscription to enumerate all actions.
+    /// Recent contract actions for this contract, newest first, optionally filtered by type;
+    /// `limit` defaults to 100 and is capped at 500. Use the `contractActions` subscription to
+    /// enumerate all actions.
     #[graphql(directive = beta::apply())]
     async fn actions(
         &self,
@@ -123,8 +127,8 @@ where
         let storage = cx.get_storage::<S>();
 
         let limit = limit
-            .map(|limit| limit.max(0) as u32)
-            .unwrap_or(DEFAULT_ACTIONS_LIMIT);
+            .unwrap_or(DEFAULT_ACTIONS_LIMIT)
+            .clamp(1, MAX_ACTIONS_LIMIT) as u32;
         let variant = r#type.map(ContractActionType::variant_name);
 
         let actions = storage

--- a/indexer-api/src/infra/api/v4/contract_action.rs
+++ b/indexer-api/src/infra/api/v4/contract_action.rs
@@ -243,8 +243,7 @@ where
     /// Contract events emitted by this contract call.
     ///
     /// Only `ContractCall` exposes this field — `ContractDeploy` and
-    /// `ContractUpdate` don't execute circuits with the `log()` expression.
-    /// Per Andrzej's 12 May design call (#feat-public-events).
+    /// `ContractUpdate` don't execute circuits with the `emit` expression.
     ///
     /// Events are attributed to a call by matching contract address and entry
     /// point within the transaction; if several calls in one transaction share

--- a/indexer-api/src/infra/api/v4/contract_event.rs
+++ b/indexer-api/src/infra/api/v4/contract_event.rs
@@ -11,14 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! GraphQL types for the `contractEvents` query and subscription surface
-//! (public contract events, MIP-107 / CoIP-442).
+//! GraphQL types for the `contractEvents` query and subscription surface (#1161, public
+//! contract events per MIP-0002 / CoIP-442).
 //!
-//! `ContractEvent` is the polymorphic interface; concrete types per
-//! `LogEventType` variant (`ShieldedSpendEvent`, `MiscContractEvent`, etc.)
-//! implement it. Clients discriminate via `__typename`. See
-//! `docs/interactions/event-epic/8may-2026/contract-events-graphql-draft-v0.7.graphql`
-//! for the canonical reference shape.
+//! `ContractEvent` is the polymorphic interface; concrete types per `LogEventType` variant
+//! (`ShieldedSpendEvent`, `MiscContractEvent`, etc.) implement it. Clients discriminate via
+//! `__typename`.
 
 use crate::{
     domain::{
@@ -33,15 +31,16 @@ use crate::{
     infra::api::{
         ApiResult,
         v4::{
-            HexEncodable, HexEncoded, contract_action::get_transaction_by_id, directives::beta,
-            transaction::Transaction,
+            HexDecodeError, HexEncodable, HexEncoded, contract_action::get_transaction_by_id,
+            directives::beta, transaction::Transaction,
         },
     },
 };
 use async_graphql::{ComplexObject, Context, Enum, InputObject, Interface, SimpleObject};
 use derive_more::Debug;
 use indexer_common::domain::{
-    AddressOrContract as DomainAddressOrContract, ByteVec, LedgerEventAttributes,
+    AddressOrContract as DomainAddressOrContract, ByteVec, INDEXABLE_CONTRACT_FIELD_NAMES,
+    LedgerEventAttributes, SerializedContractAddress, TransactionHash,
 };
 use std::marker::PhantomData;
 use thiserror::Error;
@@ -54,17 +53,23 @@ use thiserror::Error;
 #[derive(Debug, Clone, SimpleObject)]
 #[graphql(directive = beta::apply())]
 pub struct AddressOrContract {
+    /// Which of the two address fields is populated.
     pub kind: AddressOrContractKind,
-    /// Bech32m-encoded user address; populated when kind = USER.
-    /// Hex-encoded here at the wire level; clients re-encode if needed.
+
+    /// The hex-encoded user address; populated when kind is USER.
     pub user_address: Option<HexEncoded>,
-    /// Hex-encoded contract address; populated when kind = CONTRACT.
+
+    /// The hex-encoded contract address; populated when kind is CONTRACT.
     pub contract_address: Option<HexEncoded>,
 }
 
+/// Discriminator for `AddressOrContract`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Enum)]
 pub enum AddressOrContractKind {
+    /// The address is a user (zswap coin public key) address.
     User,
+
+    /// The address is a contract address.
     Contract,
 }
 
@@ -86,57 +91,78 @@ impl From<DomainAddressOrContract> for AddressOrContract {
 }
 
 /// Closed enum of contract event types the indexer surfaces. Used in filter
-/// input only, response discrimination is via `__typename`. Mirrors the
-/// 11 variants of `LogEventType` (onchain-vm/src/ops.rs, ledger-9 alpha).
+/// input only, response discrimination is via `__typename`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Enum)]
 pub enum ContractEventType {
+    /// A contract spends a shielded coin.
     ShieldedSpend,
+
+    /// A contract or user receives a shielded coin.
     ShieldedReceive,
+
+    /// A contract mints a shielded coin.
     ShieldedMint,
+
+    /// A contract burns a shielded coin.
     ShieldedBurn,
+
+    /// A contract spends an unshielded coin.
     UnshieldedSpend,
+
+    /// A contract or user receives an unshielded coin.
     UnshieldedReceive,
+
+    /// A contract mints an unshielded coin.
     UnshieldedMint,
+
+    /// A contract burns an unshielded coin.
     UnshieldedBurn,
+
+    /// A contract is paused.
     Paused,
+
+    /// A contract is unpaused.
     Unpaused,
+
+    /// A custom event emitted by a contract.
     Misc,
 }
 
-/// Prefix filter on an indexed field of a standard event. Indexer resolves
-/// `fieldName` for all standard events from the variant; no descriptor needed.
-/// Not supported on Misc events.
+/// Prefix filter on an indexed field of a standard event; not supported on Misc events.
 #[derive(Debug, Clone, InputObject)]
 pub struct FieldPrefixFilter {
-    /// Field name (e.g. `nullifier`, `commitment`, `sender`). Must match an
-    /// indexed field of the filtered event type.
+    /// The indexed field name; one of `nullifier`, `commitment`, `ciphertext`, `domainSep`,
+    /// `tokenType`, `sender` or `recipient`.
     pub field_name: String,
-    /// Hex-encoded prefix bytes. Empty string matches all values; otherwise
-    /// the indexer returns events whose field value starts with this prefix,
-    /// client filters to exact match if needed.
+
+    /// The hex-encoded field value prefix. An empty string matches all values; otherwise
+    /// events whose field value starts with this prefix are returned.
     pub prefix: HexEncoded,
 }
 
-/// Filter for contract events queries and subscriptions. Block-range bounds
-/// live here so the same shape works for both (per Andrzej 21 May review).
+/// Filter for contract events queries and subscriptions; block-range bounds live here so the
+/// same shape works for both.
 #[derive(Debug, Clone, InputObject)]
 pub struct ContractEventFilter {
-    /// Required: the contract address to filter events for.
+    /// The hex-encoded contract address to filter events for.
     pub contract_address: HexEncoded,
-    /// Optional: filter to a subset of contract event types. Indexer translates
-    /// to `variant = ANY(...)` against the indexed variant column.
+
+    /// Event types to narrow to; must be non-empty when given.
     pub types: Option<Vec<ContractEventType>>,
-    /// Optional: prefix-match on indexed fields of the event. Standard events only.
+
+    /// Prefix matches on indexed event fields, combined with AND semantics; standard events
+    /// only.
     pub field_prefixes: Option<Vec<FieldPrefixFilter>>,
-    /// Optional: lower bound on the block height an event was emitted in. On
-    /// subscription, acts as a starting cursor (alternative to `id`).
+
+    /// Lower bound on the block height an event was emitted in; on subscription this acts as
+    /// a starting cursor alongside `id`.
     pub from_block: Option<u32>,
-    /// Optional: upper bound on the block height an event was emitted in. On
-    /// subscription, terminates the stream once the chain reaches this block.
+
+    /// Upper bound on the block height an event was emitted in; on subscription, the stream
+    /// completes once the chain has reached this block.
     pub to_block: Option<u32>,
-    /// Optional: hex-encoded transaction hash; narrows to events emitted from
-    /// transactions with this hash ("I just submitted tx X, give me its
-    /// events").
+
+    /// The hex-encoded transaction hash to narrow to events emitted by that transaction.
     pub transaction_hash: Option<HexEncoded>,
 }
 
@@ -205,14 +231,27 @@ pub struct ShieldedSpendEvent<S>
 where
     S: Storage,
 {
+    /// The ID of this contract event.
     pub id: u64,
+
+    /// The hex-encoded serialized event payload.
     pub raw: HexEncoded,
+
+    /// The maximum ID of all contract events.
     pub max_id: u64,
+
+    /// The protocol version.
     pub protocol_version: u32,
+
+    /// The event schema version, as declared by the emitting contract's compiler.
     pub version: u32,
+
+    /// The hex-encoded address of the emitting contract.
     pub contract_address: HexEncoded,
+
+    /// The ID of the transaction this event was emitted from.
     pub transaction_id: u64,
-    /// Indexed.
+    /// The hex-encoded nullifier; filterable via `fieldPrefixes`.
     pub nullifier: HexEncoded,
     #[graphql(skip)]
     _s: PhantomData<S>,
@@ -235,22 +274,34 @@ pub struct ShieldedReceiveEvent<S>
 where
     S: Storage,
 {
+    /// The ID of this contract event.
     pub id: u64,
+
+    /// The hex-encoded serialized event payload.
     pub raw: HexEncoded,
+
+    /// The maximum ID of all contract events.
     pub max_id: u64,
+
+    /// The protocol version.
     pub protocol_version: u32,
+
+    /// The event schema version, as declared by the emitting contract's compiler.
     pub version: u32,
+
+    /// The hex-encoded address of the emitting contract.
     pub contract_address: HexEncoded,
+
+    /// The ID of the transaction this event was emitted from.
     pub transaction_id: u64,
-    /// Indexed.
+    /// The hex-encoded commitment; filterable via `fieldPrefixes`.
     pub commitment: HexEncoded,
-    /// Indexed. Optional ciphertext for shielded coin receipt
-    /// (`Maybe<Bytes<512>>`). Hex-encoded, up to 512 bytes.
+    /// The hex-encoded optional ciphertext of the shielded coin receipt, up to 512 bytes;
+    /// filterable via `fieldPrefixes`.
     pub ciphertext: Option<HexEncoded>,
-    /// Set when received by a contract; null for user recipients
-    /// (`Maybe<ContractAddress>`). Renamed from `contractAddress` in the CoIP
-    /// to avoid collision with the top-level emitting `contractAddress`
-    /// inherited from the ContractEvent interface.
+
+    /// The hex-encoded receiving contract address; set when received by a contract, null for
+    /// user recipients. Named to avoid collision with the emitting `contractAddress`.
     pub receiving_contract_address: Option<HexEncoded>,
     #[graphql(skip)]
     _s: PhantomData<S>,
@@ -273,18 +324,32 @@ pub struct ShieldedMintEvent<S>
 where
     S: Storage,
 {
+    /// The ID of this contract event.
     pub id: u64,
+
+    /// The hex-encoded serialized event payload.
     pub raw: HexEncoded,
+
+    /// The maximum ID of all contract events.
     pub max_id: u64,
+
+    /// The protocol version.
     pub protocol_version: u32,
+
+    /// The event schema version, as declared by the emitting contract's compiler.
     pub version: u32,
+
+    /// The hex-encoded address of the emitting contract.
     pub contract_address: HexEncoded,
+
+    /// The ID of the transaction this event was emitted from.
     pub transaction_id: u64,
-    /// Indexed.
+    /// The hex-encoded commitment; filterable via `fieldPrefixes`.
     pub commitment: HexEncoded,
-    /// Indexed (per Andrzej, useful for token-type queries).
+    /// The hex-encoded domain separator; filterable via `fieldPrefixes`.
     pub domain_sep: HexEncoded,
-    /// Optional, hidden in some shielded mints (`Maybe<Uint<128>>`).
+
+    /// The optional amount as a decimal string; hidden in some shielded mints.
     pub amount: Option<String>,
     #[graphql(skip)]
     _s: PhantomData<S>,
@@ -307,16 +372,29 @@ pub struct ShieldedBurnEvent<S>
 where
     S: Storage,
 {
+    /// The ID of this contract event.
     pub id: u64,
+
+    /// The hex-encoded serialized event payload.
     pub raw: HexEncoded,
+
+    /// The maximum ID of all contract events.
     pub max_id: u64,
+
+    /// The protocol version.
     pub protocol_version: u32,
+
+    /// The event schema version, as declared by the emitting contract's compiler.
     pub version: u32,
+
+    /// The hex-encoded address of the emitting contract.
     pub contract_address: HexEncoded,
+
+    /// The ID of the transaction this event was emitted from.
     pub transaction_id: u64,
-    /// Indexed.
+    /// The hex-encoded nullifier; filterable via `fieldPrefixes`.
     pub nullifier: HexEncoded,
-    /// Optional, hidden in some shielded burns (`Maybe<Uint<128>>`).
+    /// The optional amount as a decimal string; hidden in some shielded burns.
     pub amount: Option<String>,
     #[graphql(skip)]
     _s: PhantomData<S>,
@@ -344,19 +422,36 @@ pub struct UnshieldedSpendEvent<S>
 where
     S: Storage,
 {
+    /// The ID of this contract event.
     pub id: u64,
+
+    /// The hex-encoded serialized event payload.
     pub raw: HexEncoded,
+
+    /// The maximum ID of all contract events.
     pub max_id: u64,
+
+    /// The protocol version.
     pub protocol_version: u32,
+
+    /// The event schema version, as declared by the emitting contract's compiler.
     pub version: u32,
+
+    /// The hex-encoded address of the emitting contract.
     pub contract_address: HexEncoded,
+
+    /// The ID of the transaction this event was emitted from.
     pub transaction_id: u64,
-    /// Indexed.
+    /// The spending user or contract address; filterable via `fieldPrefixes`.
     pub sender: AddressOrContract,
-    /// Indexed.
+
+    /// The hex-encoded domain separator; filterable via `fieldPrefixes`.
     pub domain_sep: HexEncoded,
-    /// Indexed; matches existing unshielded_utxos.token_type index.
+
+    /// The hex-encoded token type; filterable via `fieldPrefixes`.
     pub token_type: HexEncoded,
+
+    /// The amount as a decimal string.
     pub amount: String,
     #[graphql(skip)]
     _s: PhantomData<S>,
@@ -379,19 +474,36 @@ pub struct UnshieldedReceiveEvent<S>
 where
     S: Storage,
 {
+    /// The ID of this contract event.
     pub id: u64,
+
+    /// The hex-encoded serialized event payload.
     pub raw: HexEncoded,
+
+    /// The maximum ID of all contract events.
     pub max_id: u64,
+
+    /// The protocol version.
     pub protocol_version: u32,
+
+    /// The event schema version, as declared by the emitting contract's compiler.
     pub version: u32,
+
+    /// The hex-encoded address of the emitting contract.
     pub contract_address: HexEncoded,
+
+    /// The ID of the transaction this event was emitted from.
     pub transaction_id: u64,
-    /// Indexed.
+    /// The receiving user or contract address; filterable via `fieldPrefixes`.
     pub recipient: AddressOrContract,
-    /// Indexed.
+
+    /// The hex-encoded domain separator; filterable via `fieldPrefixes`.
     pub domain_sep: HexEncoded,
-    /// Indexed; matches existing unshielded_utxos.token_type index.
+
+    /// The hex-encoded token type; filterable via `fieldPrefixes`.
     pub token_type: HexEncoded,
+
+    /// The amount as a decimal string.
     pub amount: String,
     #[graphql(skip)]
     _s: PhantomData<S>,
@@ -414,17 +526,33 @@ pub struct UnshieldedMintEvent<S>
 where
     S: Storage,
 {
+    /// The ID of this contract event.
     pub id: u64,
+
+    /// The hex-encoded serialized event payload.
     pub raw: HexEncoded,
+
+    /// The maximum ID of all contract events.
     pub max_id: u64,
+
+    /// The protocol version.
     pub protocol_version: u32,
+
+    /// The event schema version, as declared by the emitting contract's compiler.
     pub version: u32,
+
+    /// The hex-encoded address of the emitting contract.
     pub contract_address: HexEncoded,
+
+    /// The ID of the transaction this event was emitted from.
     pub transaction_id: u64,
-    /// Indexed.
+    /// The hex-encoded domain separator; filterable via `fieldPrefixes`.
     pub domain_sep: HexEncoded,
-    /// Indexed; matches existing unshielded_utxos.token_type index.
+
+    /// The hex-encoded token type; filterable via `fieldPrefixes`.
     pub token_type: HexEncoded,
+
+    /// The amount as a decimal string.
     pub amount: String,
     #[graphql(skip)]
     _s: PhantomData<S>,
@@ -447,17 +575,33 @@ pub struct UnshieldedBurnEvent<S>
 where
     S: Storage,
 {
+    /// The ID of this contract event.
     pub id: u64,
+
+    /// The hex-encoded serialized event payload.
     pub raw: HexEncoded,
+
+    /// The maximum ID of all contract events.
     pub max_id: u64,
+
+    /// The protocol version.
     pub protocol_version: u32,
+
+    /// The event schema version, as declared by the emitting contract's compiler.
     pub version: u32,
+
+    /// The hex-encoded address of the emitting contract.
     pub contract_address: HexEncoded,
+
+    /// The ID of the transaction this event was emitted from.
     pub transaction_id: u64,
-    /// Indexed.
+    /// The spending user or contract address; filterable via `fieldPrefixes`.
     pub sender: AddressOrContract,
-    /// Indexed; matches existing unshielded_utxos.token_type index.
+
+    /// The hex-encoded token type; filterable via `fieldPrefixes`.
     pub token_type: HexEncoded,
+
+    /// The amount as a decimal string.
     pub amount: String,
     #[graphql(skip)]
     _s: PhantomData<S>,
@@ -484,12 +628,25 @@ pub struct PausedEvent<S>
 where
     S: Storage,
 {
+    /// The ID of this contract event.
     pub id: u64,
+
+    /// The hex-encoded serialized event payload.
     pub raw: HexEncoded,
+
+    /// The maximum ID of all contract events.
     pub max_id: u64,
+
+    /// The protocol version.
     pub protocol_version: u32,
+
+    /// The event schema version, as declared by the emitting contract's compiler.
     pub version: u32,
+
+    /// The hex-encoded address of the emitting contract.
     pub contract_address: HexEncoded,
+
+    /// The ID of the transaction this event was emitted from.
     pub transaction_id: u64,
     #[graphql(skip)]
     _s: PhantomData<S>,
@@ -512,12 +669,25 @@ pub struct UnpausedEvent<S>
 where
     S: Storage,
 {
+    /// The ID of this contract event.
     pub id: u64,
+
+    /// The hex-encoded serialized event payload.
     pub raw: HexEncoded,
+
+    /// The maximum ID of all contract events.
     pub max_id: u64,
+
+    /// The protocol version.
     pub protocol_version: u32,
+
+    /// The event schema version, as declared by the emitting contract's compiler.
     pub version: u32,
+
+    /// The hex-encoded address of the emitting contract.
     pub contract_address: HexEncoded,
+
+    /// The ID of the transaction this event was emitted from.
     pub transaction_id: u64,
     #[graphql(skip)]
     _s: PhantomData<S>,
@@ -544,17 +714,31 @@ pub struct MiscContractEvent<S>
 where
     S: Storage,
 {
+    /// The ID of this contract event.
     pub id: u64,
+
+    /// The hex-encoded serialized event payload.
     pub raw: HexEncoded,
+
+    /// The maximum ID of all contract events.
     pub max_id: u64,
+
+    /// The protocol version.
     pub protocol_version: u32,
+
+    /// The event schema version, as declared by the emitting contract's compiler.
     pub version: u32,
+
+    /// The hex-encoded address of the emitting contract.
     pub contract_address: HexEncoded,
+
+    /// The ID of the transaction this event was emitted from.
     pub transaction_id: u64,
-    /// Hex-encoded contract-defined event name (Compact Bytes<32>).
+    /// The hex-encoded contract-defined event name (32 bytes).
     pub name: HexEncoded,
-    /// Hex-encoded opaque payload (Compact Bytes<256>); consumer brings
-    /// descriptor to decode.
+
+    /// The hex-encoded opaque event payload, up to 256 bytes; consumers decode it with their
+    /// contract's descriptor.
     pub payload: HexEncoded,
     #[graphql(skip)]
     _s: PhantomData<S>,
@@ -582,9 +766,8 @@ where
     type Error = Box<UnexpectedContractEvent>;
 
     fn try_from(row: ContractEventRow) -> Result<Self, Self::Error> {
-        use LedgerEventAttributes::*;
         match &row.attributes {
-            ContractShieldedSpend {
+            LedgerEventAttributes::ContractShieldedSpend {
                 version, nullifier, ..
             } => {
                 let base = Base::from_row(&row, *version);
@@ -601,7 +784,7 @@ where
                 }))
             }
 
-            ContractShieldedReceive {
+            LedgerEventAttributes::ContractShieldedReceive {
                 version,
                 commitment,
                 ciphertext,
@@ -626,7 +809,7 @@ where
                 }))
             }
 
-            ContractShieldedMint {
+            LedgerEventAttributes::ContractShieldedMint {
                 version,
                 commitment,
                 domain_sep,
@@ -649,7 +832,7 @@ where
                 }))
             }
 
-            ContractShieldedBurn {
+            LedgerEventAttributes::ContractShieldedBurn {
                 version,
                 nullifier,
                 amount,
@@ -670,7 +853,7 @@ where
                 }))
             }
 
-            ContractUnshieldedSpend {
+            LedgerEventAttributes::ContractUnshieldedSpend {
                 version,
                 sender,
                 domain_sep,
@@ -695,7 +878,7 @@ where
                 }))
             }
 
-            ContractUnshieldedReceive {
+            LedgerEventAttributes::ContractUnshieldedReceive {
                 version,
                 recipient,
                 domain_sep,
@@ -720,7 +903,7 @@ where
                 }))
             }
 
-            ContractUnshieldedMint {
+            LedgerEventAttributes::ContractUnshieldedMint {
                 version,
                 domain_sep,
                 token_type,
@@ -743,7 +926,7 @@ where
                 }))
             }
 
-            ContractUnshieldedBurn {
+            LedgerEventAttributes::ContractUnshieldedBurn {
                 version,
                 sender,
                 token_type,
@@ -766,7 +949,7 @@ where
                 }))
             }
 
-            ContractPaused { version, .. } => {
+            LedgerEventAttributes::ContractPaused { version, .. } => {
                 let base = Base::from_row(&row, *version);
                 Ok(ContractEvent::Paused(PausedEvent {
                     id: base.id,
@@ -780,7 +963,7 @@ where
                 }))
             }
 
-            ContractUnpaused { version, .. } => {
+            LedgerEventAttributes::ContractUnpaused { version, .. } => {
                 let base = Base::from_row(&row, *version);
                 Ok(ContractEvent::Unpaused(UnpausedEvent {
                     id: base.id,
@@ -794,7 +977,7 @@ where
                 }))
             }
 
-            ContractMisc {
+            LedgerEventAttributes::ContractMisc {
                 version,
                 name,
                 payload,
@@ -829,51 +1012,73 @@ pub struct UnexpectedContractEvent(LedgerEventAttributes);
 // ============================================================================
 
 impl ContractEventFilter {
-    /// Convert into the domain filter shape consumed by the storage layer.
-    /// Validates that `contract_address` is non-empty and hex-decodable.
+    /// Convert into the domain filter shape consumed by the storage layer, validating the
+    /// user-supplied fields.
     pub fn into_domain(self) -> Result<DomainContractEventFilter, ContractEventFilterError> {
-        let contract_address: ByteVec = self
+        let contract_address = self
             .contract_address
-            .hex_decode()
-            .map_err(|e| ContractEventFilterError::InvalidContractAddress(e.to_string()))?;
+            .hex_decode::<SerializedContractAddress>()
+            .map_err(ContractEventFilterError::InvalidContractAddress)?;
         if contract_address.as_ref().is_empty() {
             return Err(ContractEventFilterError::EmptyContractAddress);
         }
 
-        let variants = self.types.map(|ts| {
-            ts.into_iter()
-                .map(contract_event_type_variant_name)
-                .collect::<Vec<_>>()
-        });
-
-        let field_prefixes = match self.field_prefixes {
-            None => Vec::new(),
-            Some(fps) => {
-                fps.into_iter()
-                    .map(|fp| {
-                        let prefix: ByteVec = fp.prefix.hex_decode().map_err(|e| {
-                            ContractEventFilterError::InvalidFieldPrefix(e.to_string())
-                        })?;
-                        Ok(DomainFieldPrefix {
-                            field_name: fp.field_name,
-                            prefix: prefix.as_ref().to_vec(),
-                        })
-                    })
-                    .collect::<Result<Vec<_>, _>>()?
+        let variants = match self.types {
+            Some(types) if types.is_empty() => {
+                return Err(ContractEventFilterError::EmptyTypes);
             }
+
+            Some(types) => types
+                .into_iter()
+                .map(ContractEventType::variant_name)
+                .collect(),
+
+            None => Vec::new(),
         };
+
+        let field_prefixes = self
+            .field_prefixes
+            .unwrap_or_default()
+            .into_iter()
+            .map(|field_prefix| {
+                if !INDEXABLE_CONTRACT_FIELD_NAMES.contains(&field_prefix.field_name.as_str()) {
+                    return Err(ContractEventFilterError::UnknownFieldName(
+                        field_prefix.field_name,
+                    ));
+                }
+
+                let prefix = field_prefix
+                    .prefix
+                    .hex_decode::<ByteVec>()
+                    .map_err(ContractEventFilterError::InvalidFieldPrefix)?;
+
+                Ok(DomainFieldPrefix {
+                    field_name: field_prefix.field_name,
+                    prefix,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if let (Some(from_block), Some(to_block)) = (self.from_block, self.to_block)
+            && from_block > to_block
+        {
+            return Err(ContractEventFilterError::InvalidBlockRange {
+                from_block,
+                to_block,
+            });
+        }
 
         let transaction_hash = self
             .transaction_hash
-            .map(|hash| {
-                hash.hex_decode::<ByteVec>()
-                    .map(|hash| hash.as_ref().to_vec())
-                    .map_err(|e| ContractEventFilterError::InvalidTransactionHash(e.to_string()))
+            .map(|transaction_hash| {
+                transaction_hash
+                    .hex_decode::<TransactionHash>()
+                    .map_err(ContractEventFilterError::InvalidTransactionHash)
             })
             .transpose()?;
 
         Ok(DomainContractEventFilter {
-            contract_address: contract_address.as_ref().to_vec(),
+            contract_address,
             variants,
             field_prefixes,
             from_block: self.from_block,
@@ -883,35 +1088,47 @@ impl ContractEventFilter {
     }
 }
 
-fn contract_event_type_variant_name(t: ContractEventType) -> &'static str {
-    match t {
-        ContractEventType::ShieldedSpend => "ShieldedSpend",
-        ContractEventType::ShieldedReceive => "ShieldedReceive",
-        ContractEventType::ShieldedMint => "ShieldedMint",
-        ContractEventType::ShieldedBurn => "ShieldedBurn",
-        ContractEventType::UnshieldedSpend => "UnshieldedSpend",
-        ContractEventType::UnshieldedReceive => "UnshieldedReceive",
-        ContractEventType::UnshieldedMint => "UnshieldedMint",
-        ContractEventType::UnshieldedBurn => "UnshieldedBurn",
-        ContractEventType::Paused => "Paused",
-        ContractEventType::Unpaused => "Unpaused",
-        ContractEventType::Misc => "Misc",
+impl ContractEventType {
+    /// The `LEDGER_EVENT_VARIANT` value matching this type.
+    fn variant_name(self) -> &'static str {
+        match self {
+            Self::ShieldedSpend => "ShieldedSpend",
+            Self::ShieldedReceive => "ShieldedReceive",
+            Self::ShieldedMint => "ShieldedMint",
+            Self::ShieldedBurn => "ShieldedBurn",
+            Self::UnshieldedSpend => "UnshieldedSpend",
+            Self::UnshieldedReceive => "UnshieldedReceive",
+            Self::UnshieldedMint => "UnshieldedMint",
+            Self::UnshieldedBurn => "UnshieldedBurn",
+            Self::Paused => "Paused",
+            Self::Unpaused => "Unpaused",
+            Self::Misc => "Misc",
+        }
     }
 }
 
 #[derive(Debug, Error)]
 pub enum ContractEventFilterError {
-    #[error("invalid contractAddress: {0}")]
-    InvalidContractAddress(String),
+    #[error("invalid contractAddress")]
+    InvalidContractAddress(#[source] HexDecodeError),
 
-    #[error("contractAddress is required and must be non-empty")]
+    #[error("contractAddress must be non-empty")]
     EmptyContractAddress,
 
-    #[error("invalid fieldPrefix.prefix: {0}")]
-    InvalidFieldPrefix(String),
+    #[error("types must not be empty")]
+    EmptyTypes,
 
-    #[error("invalid transactionHash: {0}")]
-    InvalidTransactionHash(String),
+    #[error("unknown fieldPrefixes.fieldName {0}")]
+    UnknownFieldName(String),
+
+    #[error("invalid fieldPrefixes.prefix")]
+    InvalidFieldPrefix(#[source] HexDecodeError),
+
+    #[error("fromBlock {from_block} must not exceed toBlock {to_block}")]
+    InvalidBlockRange { from_block: u32, to_block: u32 },
+
+    #[error("invalid transactionHash")]
+    InvalidTransactionHash(#[source] HexDecodeError),
 }
 
 #[cfg(test)]
@@ -998,15 +1215,12 @@ mod tests {
     #[test]
     fn contract_event_type_variant_name_is_stable() {
         assert_eq!(
-            contract_event_type_variant_name(ContractEventType::ShieldedSpend),
+            ContractEventType::ShieldedSpend.variant_name(),
             "ShieldedSpend"
         );
+        assert_eq!(ContractEventType::Misc.variant_name(), "Misc");
         assert_eq!(
-            contract_event_type_variant_name(ContractEventType::Misc),
-            "Misc"
-        );
-        assert_eq!(
-            contract_event_type_variant_name(ContractEventType::UnshieldedReceive),
+            ContractEventType::UnshieldedReceive.variant_name(),
             "UnshieldedReceive"
         );
     }
@@ -1044,11 +1258,8 @@ mod tests {
         let domain = filter.into_domain().expect("valid");
         assert_eq!(domain.from_block, Some(100));
         assert_eq!(domain.to_block, Some(200));
-        assert_eq!(
-            domain.variants.as_deref(),
-            Some(&["ShieldedSpend", "Misc"][..])
-        );
-        assert_eq!(domain.contract_address.len(), 32);
+        assert_eq!(domain.variants, vec!["ShieldedSpend", "Misc"]);
+        assert_eq!(domain.contract_address.as_ref().len(), 32);
         assert_eq!(domain.transaction_hash, None);
     }
 
@@ -1063,7 +1274,81 @@ mod tests {
             transaction_hash: Some(HexEncoded::try_from("cd".repeat(32)).expect("valid hex")),
         };
         let domain = filter.into_domain().expect("valid");
-        assert_eq!(domain.transaction_hash, Some(vec![0xcd; 32]));
+        assert_eq!(
+            domain.transaction_hash,
+            Some(TransactionHash::from([0xcd; 32]))
+        );
+    }
+
+    #[test]
+    fn filter_into_domain_rejects_empty_types() {
+        let filter = ContractEventFilter {
+            contract_address: HexEncoded::try_from("ab".repeat(32)).expect("valid hex"),
+            types: Some(vec![]),
+            field_prefixes: None,
+            from_block: None,
+            to_block: None,
+            transaction_hash: None,
+        };
+        let err = filter.into_domain().expect_err("should reject");
+        assert!(matches!(err, ContractEventFilterError::EmptyTypes));
+    }
+
+    #[test]
+    fn filter_into_domain_rejects_unknown_field_name() {
+        let filter = ContractEventFilter {
+            contract_address: HexEncoded::try_from("ab".repeat(32)).expect("valid hex"),
+            types: None,
+            field_prefixes: Some(vec![FieldPrefixFilter {
+                field_name: "token_type".to_owned(),
+                prefix: HexEncoded::try_from("ab".to_owned()).expect("valid hex"),
+            }]),
+            from_block: None,
+            to_block: None,
+            transaction_hash: None,
+        };
+        let err = filter.into_domain().expect_err("should reject");
+        assert!(matches!(
+            err,
+            ContractEventFilterError::UnknownFieldName(name) if name == "token_type"
+        ));
+    }
+
+    #[test]
+    fn filter_into_domain_rejects_inverted_block_range() {
+        let filter = ContractEventFilter {
+            contract_address: HexEncoded::try_from("ab".repeat(32)).expect("valid hex"),
+            types: None,
+            field_prefixes: None,
+            from_block: Some(200),
+            to_block: Some(100),
+            transaction_hash: None,
+        };
+        let err = filter.into_domain().expect_err("should reject");
+        assert!(matches!(
+            err,
+            ContractEventFilterError::InvalidBlockRange {
+                from_block: 200,
+                to_block: 100,
+            }
+        ));
+    }
+
+    #[test]
+    fn filter_into_domain_rejects_wrong_length_transaction_hash() {
+        let filter = ContractEventFilter {
+            contract_address: HexEncoded::try_from("ab".repeat(32)).expect("valid hex"),
+            types: None,
+            field_prefixes: None,
+            from_block: None,
+            to_block: None,
+            transaction_hash: Some(HexEncoded::try_from("cd".repeat(3)).expect("valid hex")),
+        };
+        let err = filter.into_domain().expect_err("should reject");
+        assert!(matches!(
+            err,
+            ContractEventFilterError::InvalidTransactionHash(_)
+        ));
     }
 }
 

--- a/indexer-api/src/infra/api/v4/query.rs
+++ b/indexer-api/src/infra/api/v4/query.rs
@@ -20,7 +20,7 @@ use crate::{
             block::{Block, BlockOffset},
             contract::Contract,
             contract_action::{ContractAction, ContractActionOffset},
-            contract_event::{ContractEvent, ContractEventFilter as GraphQLContractEventFilter},
+            contract_event::{ContractEvent, ContractEventFilter},
             directives::beta,
             dust::DustGenerationStatus,
             dust_generations::DustGenerations,
@@ -420,7 +420,8 @@ where
             .map(MerkleTreeCollapsedUpdate::from)
     }
 
-    /// Find contract events matching the filter, with optional pagination.
+    /// Find contract events matching the filter, ordered by ID; `limit` defaults to 100 and is
+    /// capped at 500, `offset` defaults to 0.
     ///
     /// Block-range bounds (`fromBlock`, `toBlock`) live on `ContractEventFilter`
     /// for symmetry with the subscription. `limit`/`offset` are top-level args.
@@ -429,21 +430,21 @@ where
     async fn contract_events(
         &self,
         cx: &Context<'_>,
-        filter: GraphQLContractEventFilter,
+        filter: ContractEventFilter,
         limit: Option<i32>,
         offset: Option<i32>,
     ) -> ApiResult<Vec<ContractEvent<S>>> {
         let storage = cx.get_storage::<S>();
 
-        let domain_filter = filter
+        let filter = filter
             .into_domain()
-            .map_err(|e| ApiError::client("invalid ContractEventFilter", e))?;
+            .map_err(|error| ApiError::client("invalid contract event filter", error))?;
 
-        let limit = limit.map(|l| l.max(0) as u32);
-        let offset = offset.map(|o| o.max(0) as u32);
+        let limit = limit.unwrap_or(100).clamp(1, 500) as u32;
+        let offset = offset.unwrap_or(0).max(0) as u32;
 
         let rows = storage
-            .get_contract_events(domain_filter, limit, offset)
+            .get_contract_events(&filter, limit, offset)
             .await
             .map_err_into_server_error(|| "get contract events")?;
 

--- a/indexer-api/src/infra/api/v4/subscription/contract_event.rs
+++ b/indexer-api/src/infra/api/v4/subscription/contract_event.rs
@@ -13,21 +13,21 @@
 
 //! Subscription resolver for `contractEvents` (ticket #1161).
 //!
-//! Starting cursor: either the `id` argument (resume from a previous event)
-//! OR `filter.fromBlock` (start from the first event in that block); if both
-//! are set, indexer uses the LATER cursor. Pattern follows `dustLedgerEvents`
-//! / `zswapLedgerEvents` for the id-cursor path.
+//! Starting cursor: either the `id` argument (resume from a previous event) or
+//! `filter.fromBlock` (start from the first event in that block); if both are set, the
+//! effective cursor is the later of the two. Pattern follows `dustLedgerEvents` /
+//! `zswapLedgerEvents` for the id-cursor path.
 //!
-//! `filter.toBlock`, if set, terminates the stream once the chain reaches
-//! that block, matching the bounded-subscription pattern used by
-//! `dust_nullifier_transactions` / `shielded_nullifier_transactions`.
+//! `filter.toBlock`, if set, completes the stream once the chain has reached that block,
+//! matching the bounded-subscription pattern of `dust_nullifier_transactions` /
+//! `shielded_nullifier_transactions`.
 
 use crate::{
     domain::{ContractEventRow, storage::Storage},
     infra::api::{
         ApiError, ApiResult, ContextExt, ResultExt,
         v4::{
-            contract_event::{ContractEvent, ContractEventFilter as GraphQLContractEventFilter},
+            contract_event::{ContractEvent, ContractEventFilter},
             directives::beta,
         },
     },
@@ -60,76 +60,77 @@ where
     S: Storage,
     B: Subscriber,
 {
-    /// Subscribe to contract events matching the given filter, returning
-    /// events in monotonic `id` order.
+    /// Subscribe to contract events matching the given filter, starting at the given event ID
+    /// (inclusive) and returning events in monotonic ID order; completes once the chain has
+    /// reached `filter.toBlock` if that is set.
     #[graphql(directive = beta::apply())]
     async fn contract_events<'a>(
         &self,
         cx: &'a Context<'a>,
-        filter: GraphQLContractEventFilter,
+        filter: ContractEventFilter,
         id: Option<u64>,
-    ) -> impl Stream<Item = ApiResult<ContractEvent<S>>> {
+    ) -> Result<impl Stream<Item = ApiResult<ContractEvent<S>>> + use<'a, S, B>, ApiError> {
+        let filter = filter
+            .into_domain()
+            .map_err(|error| ApiError::client("invalid contract event filter", error))?;
+
+        let id = id.unwrap_or(0);
+        // Event IDs are i64 in the database; reject IDs beyond that range up front instead of
+        // letting the SQL bind wrap negative and replay the full history.
+        i64::try_from(id).map_err_into_client_error(|| "id out of range")?;
+
+        let quota_guard = cx
+            .get_subscription_quotas()
+            .try_acquire(cx.get_per_connection_counter(), None)
+            .map_err_into_client_error(|| "subscription limit exceeded")?;
+
         let storage = cx.get_storage::<S>();
         let subscriber = cx.get_subscriber::<B>();
         let batch_size = cx.get_subscription_config().contract_events.batch_size;
-        let quotas = cx.get_subscription_quotas();
-        let per_connection_counter = cx.get_per_connection_counter();
         let block_indexed_stream = subscriber.subscribe::<BlockIndexed>();
 
-        try_stream! {
-            let _quota_guard = quotas
-                .try_acquire(per_connection_counter, None)
-                .map_err_into_client_error(|| "subscription limit exceeded")?;
+        // Bounded subscription: when `filter.toBlock` is set, evaluate the terminator BEFORE
+        // each drain — the drain's DB snapshot then covers everything the check saw, so events
+        // committed between snapshot and check cannot be lost — and complete after the final
+        // drain.
+        let to_block = filter.to_block;
 
-            let domain_filter = filter
-                .into_domain()
-                .map_err(|e| ApiError::client("invalid ContractEventFilter", e))?;
+        let contract_events = try_stream! {
+            let _hold = quota_guard;
+            let mut id = id;
 
-            // Starting cursor: explicit `id` arg only. `filter.fromBlock` is
-            // applied via the storage layer's WHERE clause (`blocks.height >=
-            // from_block`), so we don't need to translate it to an id here.
-            // If both are set, the WHERE clause + id cursor combine — the
-            // effective cursor is "id >= id_arg AND blocks.height >=
-            // from_block", which is exactly the "later of the two" semantics
-            // requested in v0.7.
-            let mut id = id.unwrap_or(0);
-
-            // Bounded-subscription terminator: if filter.toBlock is set, we
-            // stop once the chain's latest block height crosses it. The check
-            // happens after each backfill drain and each live-tail tick.
-            let to_block = domain_filter.to_block;
-
+            // Stream existing contract events.
+            let last_round = reached_to_block(storage, to_block).await?;
             debug!(id; "streaming existing contract events");
-            let rows = storage
-                .get_contract_events_after_id(domain_filter.clone(), id, batch_size)
-                .await;
+            let rows = storage.get_contract_events_from_id(&filter, id, batch_size).await;
             let mut rows = pin!(rows);
             while let Some(row) = get_next_row(&mut rows)
                 .await
                 .map_err_into_server_error(|| format!("get next contract event at id {id}"))?
             {
-                id = row.id + 1;
+                let event_id = row.id;
+                id = event_id + 1;
                 yield ContractEvent::try_from(row).map_err_into_server_error(|| {
-                    format!("unexpected contract event row at id {id}")
+                    format!("unexpected contract event row at id {event_id}")
                 })?;
             }
-
-            if reached_to_block(storage, to_block).await? {
-                debug!(to_block:?; "contractEvents subscription terminated at toBlock");
+            if last_round {
+                debug!(to_block:?; "contractEvents subscription completed at toBlock");
                 return;
             }
 
+            // Stream live contract events.
             debug!(id; "streaming live contract events");
             let mut block_indexed_stream = pin!(block_indexed_stream);
-            while block_indexed_stream
+            while let Some(BlockIndexed { height, .. }) = block_indexed_stream
                 .try_next()
                 .await
                 .map_err_into_server_error(|| "get next BlockIndexed event")?
-                .is_some()
             {
-                let rows = storage
-                    .get_contract_events_after_id(domain_filter.clone(), id, batch_size)
-                    .await;
+                let last_round =
+                    to_block.is_some_and(|to_block| height >= u64::from(to_block));
+
+                let rows = storage.get_contract_events_from_id(&filter, id, batch_size).await;
                 let mut rows = pin!(rows);
                 while let Some(row) = get_next_row(&mut rows)
                     .await
@@ -137,20 +138,23 @@ where
                         format!("get next contract event at id {id}")
                     })?
                 {
-                    id = row.id + 1;
+                    let event_id = row.id;
+                    id = event_id + 1;
                     yield ContractEvent::try_from(row).map_err_into_server_error(|| {
-                        format!("unexpected contract event row at id {id}")
+                        format!("unexpected contract event row at id {event_id}")
                     })?;
                 }
 
-                if reached_to_block(storage, to_block).await? {
-                    debug!(to_block:?; "contractEvents subscription terminated at toBlock");
+                if last_round {
+                    debug!(to_block:?; "contractEvents subscription completed at toBlock");
                     return;
                 }
             }
 
-            warn!("contract-events stream: BlockIndexed channel ended unexpectedly");
-        }
+            warn!("stream of BlockIndexed events completed unexpectedly");
+        };
+
+        Ok(contract_events)
     }
 }
 
@@ -165,13 +169,17 @@ async fn get_next_row<E>(
         .await
 }
 
+/// Whether the chain has already reached `to_block`; used before the initial drain so the
+/// bounded subscription can complete after it.
 async fn reached_to_block<S: Storage>(storage: &S, to_block: Option<u32>) -> ApiResult<bool> {
     let Some(to_block) = to_block else {
         return Ok(false);
     };
+
     let latest = storage
         .get_latest_block()
         .await
         .map_err_into_server_error(|| "get latest block to evaluate toBlock terminator")?;
-    Ok(latest.map(|b| b.height >= to_block).unwrap_or(false))
+
+    Ok(latest.is_some_and(|block| block.height >= to_block))
 }

--- a/indexer-api/src/infra/api/v4/subscription/contract_event.rs
+++ b/indexer-api/src/infra/api/v4/subscription/contract_event.rs
@@ -173,7 +173,5 @@ async fn reached_to_block<S: Storage>(storage: &S, to_block: Option<u32>) -> Api
         .get_latest_block()
         .await
         .map_err_into_server_error(|| "get latest block to evaluate toBlock terminator")?;
-    Ok(latest
-        .map(|b| b.height as u64 >= to_block as u64)
-        .unwrap_or(false))
+    Ok(latest.map(|b| b.height >= to_block).unwrap_or(false))
 }

--- a/indexer-api/src/infra/storage/contract_action.rs
+++ b/indexer-api/src/infra/storage/contract_action.rs
@@ -178,6 +178,32 @@ impl ContractActionStorage for Storage {
             .await
     }
 
+    #[trace(properties = { "address": "{address}", "hash": "{hash}" })]
+    async fn contract_action_exists_by_address_as_of_block_hash(
+        &self,
+        address: &SerializedContractAddress,
+        hash: BlockHash,
+    ) -> Result<bool, sqlx::Error> {
+        // Existence-only variant of the "as of" lookup above: avoids fetching the state and
+        // zswap state blobs when only presence matters.
+        let query = indoc! {"
+            SELECT 1
+            FROM contract_actions
+            INNER JOIN transactions ON transactions.id = transaction_id
+            INNER JOIN blocks ON blocks.id = transactions.block_id
+            WHERE address = $1
+            AND blocks.height <= (SELECT height FROM blocks WHERE hash = $2)
+            LIMIT 1
+        "};
+
+        sqlx::query(query)
+            .bind(address.as_ref())
+            .bind(hash.as_ref())
+            .fetch_optional(&*self.pool)
+            .await
+            .map(|row| row.is_some())
+    }
+
     #[trace(properties = { "address": "{address}", "block_height": "{block_height}" })]
     async fn get_contract_action_by_address_as_of_block_height(
         &self,

--- a/indexer-api/src/infra/storage/contract_event.rs
+++ b/indexer-api/src/infra/storage/contract_event.rs
@@ -11,10 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Storage impl for the `contractEvents` query and subscription surface
-//! (ticket #1161). Pattern follows `get_ledger_events` in `ledger_events.rs`
-//! but joins through `blocks` for block-range filtering and through
-//! `contract_event_indexed_fields` for prefix lookup.
+//! Storage impl for the `contractEvents` query and subscription surface (#1161). Pattern
+//! follows `get_ledger_events` in `ledger_events.rs` but joins through `blocks` for
+//! block-range filtering and through `contract_event_indexed_fields` for prefix lookup.
 
 use crate::{
     domain::{
@@ -27,50 +26,57 @@ use async_stream::try_stream;
 use fastrace::trace;
 use futures::Stream;
 use indexer_common::stream::flatten_chunks;
+use indoc::indoc;
 use std::num::NonZeroU32;
+
+#[cfg(feature = "cloud")]
+type Db = sqlx::Postgres;
+#[cfg(feature = "standalone")]
+type Db = sqlx::Sqlite;
 
 impl ContractEventStorage for Storage {
     #[trace(properties = {
-        "limit": "{limit:?}",
-        "offset": "{offset:?}"
+        "limit": "{limit}",
+        "offset": "{offset}"
     })]
     async fn get_contract_events(
         &self,
-        filter: ContractEventFilter,
-        limit: Option<u32>,
-        offset: Option<u32>,
+        filter: &ContractEventFilter,
+        limit: u32,
+        offset: u32,
     ) -> Result<Vec<ContractEventRow>, sqlx::Error> {
-        let mut qb = base_query_builder(&filter);
-        qb.push(" ORDER BY le.id ASC ");
-        if let Some(l) = limit {
-            qb.push(" LIMIT ").push_bind(l as i64);
-        }
-        if let Some(o) = offset {
-            qb.push(" OFFSET ").push_bind(o as i64);
-        }
-        qb.build_query_as::<ContractEventRow>()
+        let mut query_builder = base_query_builder(filter);
+        query_builder
+            .push(" ORDER BY ledger_events.id LIMIT ")
+            .push_bind(limit as i64)
+            .push(" OFFSET ")
+            .push_bind(offset as i64);
+
+        query_builder
+            .build_query_as::<ContractEventRow>()
             .fetch_all(&*self.pool)
             .await
     }
 
-    async fn get_contract_events_after_id(
+    async fn get_contract_events_from_id(
         &self,
-        filter: ContractEventFilter,
-        mut after_id: u64,
+        filter: &ContractEventFilter,
+        mut id: u64,
         batch_size: NonZeroU32,
     ) -> impl Stream<Item = Result<ContractEventRow, sqlx::Error>> + Send {
         let chunks = try_stream! {
             loop {
-                let rows = self
-                    .fetch_contract_events_chunk(&filter, after_id, batch_size)
-                    .await?;
+                let rows = self.get_contract_events_chunk(filter, id, batch_size).await?;
+
                 match rows.last() {
-                    Some(last) => after_id = last.id + 1,
+                    Some(last) => id = last.id + 1,
                     None => break,
                 }
+
                 yield rows;
             }
         };
+
         flatten_chunks(chunks)
     }
 
@@ -83,195 +89,176 @@ impl ContractEventStorage for Storage {
             return Ok(vec![]);
         }
 
-        let mut qb = ids_query_builder();
-        let mut separated = qb.separated(", ");
-        for id in ids {
-            separated.push_bind(*id as i64);
-        }
-        qb.push(") ORDER BY le.id ASC");
+        #[cfg(feature = "cloud")]
+        let rows = {
+            let query = indoc! {"
+                SELECT
+                    ledger_events.id,
+                    ledger_events.contract_address,
+                    ledger_events.transaction_id,
+                    ledger_events.contract_action_id,
+                    ledger_events.raw,
+                    ledger_events.attributes,
+                    (SELECT MAX(id) FROM ledger_events WHERE grouping = 'Contract') AS max_id,
+                    transactions.protocol_version
+                FROM ledger_events
+                INNER JOIN transactions ON transactions.id = ledger_events.transaction_id
+                WHERE ledger_events.grouping = 'Contract'
+                AND ledger_events.contract_action_id = ANY($1)
+                ORDER BY ledger_events.id
+            "};
 
-        let rows: Vec<ContractEventRow> = qb
-            .build_query_as::<ContractEventRow>()
-            .fetch_all(&*self.pool)
-            .await?;
+            let ids = ids.iter().map(|id| *id as i64).collect::<Vec<_>>();
+
+            sqlx::query_as::<_, ContractEventRow>(query)
+                .bind(ids)
+                .fetch_all(&*self.pool)
+                .await?
+        };
+
+        #[cfg(feature = "standalone")]
+        let rows = {
+            let mut query_builder = sqlx::QueryBuilder::<Db>::new(indoc! {"
+                SELECT
+                    ledger_events.id,
+                    ledger_events.contract_address,
+                    ledger_events.transaction_id,
+                    ledger_events.contract_action_id,
+                    ledger_events.raw,
+                    ledger_events.attributes,
+                    (SELECT MAX(id) FROM ledger_events WHERE grouping = 'Contract') AS max_id,
+                    transactions.protocol_version
+                FROM ledger_events
+                INNER JOIN transactions ON transactions.id = ledger_events.transaction_id
+                WHERE ledger_events.grouping = 'Contract'
+                AND ledger_events.contract_action_id IN (
+            "});
+
+            let mut separated = query_builder.separated(", ");
+            for id in ids {
+                separated.push_bind(*id as i64);
+            }
+            query_builder.push(") ORDER BY ledger_events.id");
+
+            query_builder
+                .build_query_as::<ContractEventRow>()
+                .fetch_all(&*self.pool)
+                .await?
+        };
 
         Ok(rows
             .into_iter()
-            .filter_map(|r| r.contract_action_id.map(|key| (key, r)))
+            .filter_map(|row| row.contract_action_id.map(|key| (key, row)))
             .collect())
     }
 }
 
-#[cfg(feature = "cloud")]
-fn ids_query_builder<'a>() -> sqlx::QueryBuilder<'a, sqlx::Postgres> {
-    sqlx::QueryBuilder::<sqlx::Postgres>::new(indoc::indoc! {"
-        SELECT
-            le.id,
-            le.contract_address,
-            le.transaction_id,
-            le.contract_action_id,
-            le.raw,
-            le.attributes,
-            (SELECT MAX(id) FROM ledger_events WHERE grouping = 'Contract') AS max_id,
-            transactions.protocol_version
-        FROM ledger_events le
-        INNER JOIN transactions ON transactions.id = le.transaction_id
-        WHERE le.grouping = 'Contract'
-        AND le.contract_action_id IN (
-    "})
-}
-
-#[cfg(feature = "standalone")]
-fn ids_query_builder<'a>() -> sqlx::QueryBuilder<'a, sqlx::Sqlite> {
-    sqlx::QueryBuilder::<sqlx::Sqlite>::new(indoc::indoc! {"
-        SELECT
-            le.id,
-            le.contract_address,
-            le.transaction_id,
-            le.contract_action_id,
-            le.raw,
-            le.attributes,
-            (SELECT MAX(id) FROM ledger_events WHERE grouping = 'Contract') AS max_id,
-            transactions.protocol_version
-        FROM ledger_events le
-        INNER JOIN transactions ON transactions.id = le.transaction_id
-        WHERE le.grouping = 'Contract'
-        AND le.contract_action_id IN (
-    "})
-}
-
 impl Storage {
-    async fn fetch_contract_events_chunk(
+    #[trace(properties = {
+        "id": "{id}",
+        "batch_size": "{batch_size}"
+    })]
+    async fn get_contract_events_chunk(
         &self,
         filter: &ContractEventFilter,
-        after_id: u64,
+        id: u64,
         batch_size: NonZeroU32,
     ) -> Result<Vec<ContractEventRow>, sqlx::Error> {
-        let mut qb = base_query_builder(filter);
-        qb.push(" AND le.id >= ").push_bind(after_id as i64);
-        qb.push(" ORDER BY le.id ASC LIMIT ")
+        let mut query_builder = base_query_builder(filter);
+        query_builder
+            .push(" AND ledger_events.id >= ")
+            .push_bind(id as i64)
+            .push(" ORDER BY ledger_events.id LIMIT ")
             .push_bind(batch_size.get() as i64);
-        qb.build_query_as::<ContractEventRow>()
+
+        query_builder
+            .build_query_as::<ContractEventRow>()
             .fetch_all(&*self.pool)
             .await
     }
 }
 
-/// Shared SELECT + WHERE construction for both query and subscription paths.
-/// Caller appends ORDER/LIMIT/OFFSET as appropriate.
-#[cfg(feature = "cloud")]
-fn base_query_builder<'a>(
-    filter: &'a ContractEventFilter,
-) -> sqlx::QueryBuilder<'a, sqlx::Postgres> {
-    use sqlx::QueryBuilder;
-    let mut qb = QueryBuilder::<sqlx::Postgres>::new(indoc::indoc! {"
+/// Shared SELECT + WHERE construction for both the query and subscription paths; the caller
+/// appends ORDER/LIMIT/OFFSET as appropriate.
+fn base_query_builder<'a>(filter: &'a ContractEventFilter) -> sqlx::QueryBuilder<'a, Db> {
+    let mut query_builder = sqlx::QueryBuilder::<Db>::new(indoc! {"
         SELECT
-            le.id,
-            le.contract_address,
-            le.transaction_id,
-            le.contract_action_id,
-            le.raw,
-            le.attributes,
+            ledger_events.id,
+            ledger_events.contract_address,
+            ledger_events.transaction_id,
+            ledger_events.contract_action_id,
+            ledger_events.raw,
+            ledger_events.attributes,
             (SELECT MAX(id) FROM ledger_events WHERE grouping = 'Contract') AS max_id,
             transactions.protocol_version
-        FROM ledger_events le
-        INNER JOIN transactions ON transactions.id = le.transaction_id
+        FROM ledger_events
+        INNER JOIN transactions ON transactions.id = ledger_events.transaction_id
         INNER JOIN blocks ON blocks.id = transactions.block_id
-        WHERE le.grouping = 'Contract'
+        WHERE ledger_events.grouping = 'Contract'
     "});
-    qb.push(" AND le.contract_address = ")
-        .push_bind(filter.contract_address.clone());
 
-    if let Some(variants) = &filter.variants
-        && !variants.is_empty()
-    {
-        qb.push(" AND le.variant::text = ANY(")
-            .push_bind(variants.iter().map(|v| v.to_string()).collect::<Vec<_>>())
+    query_builder
+        .push(" AND ledger_events.contract_address = ")
+        .push_bind(filter.contract_address.as_ref());
+
+    if !filter.variants.is_empty() {
+        // The variant column is a Postgres enum (cast to text to compare) and a SQLite TEXT.
+        #[cfg(feature = "cloud")]
+        query_builder
+            .push(" AND ledger_events.variant::text = ANY(")
+            .push_bind(&filter.variants)
+            .push(") ");
+
+        #[cfg(feature = "standalone")]
+        {
+            query_builder.push(" AND ledger_events.variant IN (");
+            let mut separated = query_builder.separated(", ");
+            for variant in &filter.variants {
+                separated.push_bind(*variant);
+            }
+            query_builder.push(") ");
+        }
+    }
+
+    if let Some(from_block) = filter.from_block {
+        query_builder
+            .push(" AND blocks.height >= ")
+            .push_bind(from_block as i64);
+    }
+    if let Some(to_block) = filter.to_block {
+        query_builder
+            .push(" AND blocks.height <= ")
+            .push_bind(to_block as i64);
+    }
+    if let Some(transaction_hash) = &filter.transaction_hash {
+        query_builder
+            .push(" AND transactions.hash = ")
+            .push_bind(transaction_hash.as_ref());
+    }
+
+    for (index, field_prefix) in filter.field_prefixes.iter().enumerate() {
+        let alias = format!("cef{index}");
+        query_builder
+            .push(format!(
+                " AND EXISTS (SELECT 1 FROM contract_event_indexed_fields {alias} "
+            ))
+            .push(format!(
+                "WHERE {alias}.ledger_event_id = ledger_events.id AND {alias}.field_name = "
+            ))
+            .push_bind(&field_prefix.field_name)
+            .push(format!(" AND substr({alias}.field_value, 1, "));
+
+        // Postgres substr takes an int4 length; SQLite an integer.
+        #[cfg(feature = "cloud")]
+        query_builder.push_bind(field_prefix.prefix.len() as i32);
+        #[cfg(feature = "standalone")]
+        query_builder.push_bind(field_prefix.prefix.len() as i64);
+
+        query_builder
+            .push(") = ")
+            .push_bind(field_prefix.prefix.as_ref())
             .push(") ");
     }
 
-    if let Some(from) = filter.from_block {
-        qb.push(" AND blocks.height >= ").push_bind(from as i64);
-    }
-    if let Some(to) = filter.to_block {
-        qb.push(" AND blocks.height <= ").push_bind(to as i64);
-    }
-    if let Some(hash) = &filter.transaction_hash {
-        qb.push(" AND transactions.hash = ").push_bind(hash.clone());
-    }
-
-    for (i, fp) in filter.field_prefixes.iter().enumerate() {
-        let alias = format!("cef{i}");
-        qb.push(format!(
-            " AND EXISTS (SELECT 1 FROM contract_event_indexed_fields {alias} \
-             WHERE {alias}.ledger_event_id = le.id AND {alias}.field_name = "
-        ))
-        .push_bind(fp.field_name.clone())
-        .push(format!(" AND substr({alias}.field_value, 1, "))
-        .push_bind(fp.prefix.len() as i32)
-        .push(") = ")
-        .push_bind(fp.prefix.clone())
-        .push(") ");
-    }
-
-    qb
-}
-
-#[cfg(feature = "standalone")]
-fn base_query_builder<'a>(filter: &'a ContractEventFilter) -> sqlx::QueryBuilder<'a, sqlx::Sqlite> {
-    use sqlx::QueryBuilder;
-    let mut qb = QueryBuilder::<sqlx::Sqlite>::new(indoc::indoc! {"
-        SELECT
-            le.id,
-            le.contract_address,
-            le.transaction_id,
-            le.contract_action_id,
-            le.raw,
-            le.attributes,
-            (SELECT MAX(id) FROM ledger_events WHERE grouping = 'Contract') AS max_id,
-            transactions.protocol_version
-        FROM ledger_events le
-        INNER JOIN transactions ON transactions.id = le.transaction_id
-        INNER JOIN blocks ON blocks.id = transactions.block_id
-        WHERE le.grouping = 'Contract'
-    "});
-    qb.push(" AND le.contract_address = ")
-        .push_bind(filter.contract_address.clone());
-
-    if let Some(variants) = &filter.variants
-        && !variants.is_empty()
-    {
-        qb.push(" AND le.variant IN (");
-        let mut sep = qb.separated(", ");
-        for v in variants {
-            sep.push_bind(v.to_string());
-        }
-        qb.push(") ");
-    }
-
-    if let Some(from) = filter.from_block {
-        qb.push(" AND blocks.height >= ").push_bind(from as i64);
-    }
-    if let Some(to) = filter.to_block {
-        qb.push(" AND blocks.height <= ").push_bind(to as i64);
-    }
-    if let Some(hash) = &filter.transaction_hash {
-        qb.push(" AND transactions.hash = ").push_bind(hash.clone());
-    }
-
-    for (i, fp) in filter.field_prefixes.iter().enumerate() {
-        let alias = format!("cef{i}");
-        qb.push(format!(
-            " AND EXISTS (SELECT 1 FROM contract_event_indexed_fields {alias} \
-             WHERE {alias}.ledger_event_id = le.id AND {alias}.field_name = "
-        ))
-        .push_bind(fp.field_name.clone())
-        .push(format!(" AND substr({alias}.field_value, 1, "))
-        .push_bind(fp.prefix.len() as i64)
-        .push(") = ")
-        .push_bind(fp.prefix.clone())
-        .push(") ");
-    }
-
-    qb
+    query_builder
 }

--- a/indexer-common/src/domain.rs
+++ b/indexer-common/src/domain.rs
@@ -274,7 +274,7 @@ pub struct LedgerEvent {
     /// (`LedgerEventGrouping::Contract`); `None` for zswap/dust events. Mapped
     /// onto the indexed `ledger_events.contract_address` column for fast
     /// filtering on the `contractEvents` query/subscription surface.
-    pub contract_address: Option<ByteVec>,
+    pub contract_address: Option<SerializedContractAddress>,
 }
 
 impl LedgerEvent {
@@ -376,25 +376,12 @@ impl LedgerEvent {
     /// callers that already know the id (e.g. future upstream attribution).
     pub fn contract_event(
         raw: SerializedLedgerEvent,
-        contract_address: ByteVec,
+        contract_address: SerializedContractAddress,
         contract_action_id: Option<u64>,
         attributes: LedgerEventAttributes,
     ) -> Self {
         debug_assert!(
-            matches!(
-                attributes,
-                LedgerEventAttributes::ContractShieldedSpend { .. }
-                    | LedgerEventAttributes::ContractShieldedReceive { .. }
-                    | LedgerEventAttributes::ContractShieldedMint { .. }
-                    | LedgerEventAttributes::ContractShieldedBurn { .. }
-                    | LedgerEventAttributes::ContractUnshieldedSpend { .. }
-                    | LedgerEventAttributes::ContractUnshieldedReceive { .. }
-                    | LedgerEventAttributes::ContractUnshieldedMint { .. }
-                    | LedgerEventAttributes::ContractUnshieldedBurn { .. }
-                    | LedgerEventAttributes::ContractPaused { .. }
-                    | LedgerEventAttributes::ContractUnpaused { .. }
-                    | LedgerEventAttributes::ContractMisc { .. }
-            ),
+            attributes.contract_entry_point().is_some(),
             "contract_event() called with non-contract attributes"
         );
         Self {
@@ -412,23 +399,24 @@ impl LedgerEvent {
     /// non-contract events and for `Paused`/`Unpaused`/`Misc` (no indexable
     /// fields per the design).
     pub fn indexable_contract_fields(&self) -> Vec<(&'static str, ByteVec)> {
-        use LedgerEventAttributes::*;
         match &self.attributes {
-            ContractShieldedSpend { nullifier, .. } => {
+            LedgerEventAttributes::ContractShieldedSpend { nullifier, .. } => {
                 vec![("nullifier", nullifier.clone())]
             }
-            ContractShieldedReceive {
+
+            LedgerEventAttributes::ContractShieldedReceive {
                 commitment,
                 ciphertext,
                 ..
             } => {
-                let mut out = vec![("commitment", commitment.clone())];
-                if let Some(c) = ciphertext {
-                    out.push(("ciphertext", c.clone()));
+                let mut fields = vec![("commitment", commitment.clone())];
+                if let Some(ciphertext) = ciphertext {
+                    fields.push(("ciphertext", ciphertext.clone()));
                 }
-                out
+                fields
             }
-            ContractShieldedMint {
+
+            LedgerEventAttributes::ContractShieldedMint {
                 commitment,
                 domain_sep,
                 ..
@@ -436,30 +424,34 @@ impl LedgerEvent {
                 ("commitment", commitment.clone()),
                 ("domainSep", domain_sep.clone()),
             ],
-            ContractShieldedBurn { nullifier, .. } => {
+
+            LedgerEventAttributes::ContractShieldedBurn { nullifier, .. } => {
                 vec![("nullifier", nullifier.clone())]
             }
-            ContractUnshieldedSpend {
+
+            LedgerEventAttributes::ContractUnshieldedSpend {
                 sender,
                 domain_sep,
                 token_type,
                 ..
             } => vec![
-                ("sender", sender.as_bytes()),
+                ("sender", sender.to_bytes()),
                 ("domainSep", domain_sep.clone()),
                 ("tokenType", token_type.clone()),
             ],
-            ContractUnshieldedReceive {
+
+            LedgerEventAttributes::ContractUnshieldedReceive {
                 recipient,
                 domain_sep,
                 token_type,
                 ..
             } => vec![
-                ("recipient", recipient.as_bytes()),
+                ("recipient", recipient.to_bytes()),
                 ("domainSep", domain_sep.clone()),
                 ("tokenType", token_type.clone()),
             ],
-            ContractUnshieldedMint {
+
+            LedgerEventAttributes::ContractUnshieldedMint {
                 domain_sep,
                 token_type,
                 ..
@@ -467,33 +459,47 @@ impl LedgerEvent {
                 ("domainSep", domain_sep.clone()),
                 ("tokenType", token_type.clone()),
             ],
-            ContractUnshieldedBurn {
+
+            LedgerEventAttributes::ContractUnshieldedBurn {
                 sender, token_type, ..
             } => vec![
-                ("sender", sender.as_bytes()),
+                ("sender", sender.to_bytes()),
                 ("tokenType", token_type.clone()),
             ],
-            ContractPaused { .. }
-            | ContractUnpaused { .. }
-            | ContractMisc { .. }
-            | ZswapInput { .. }
-            | ZswapOutput
-            | ParamChange
-            | DustInitialUtxo { .. }
-            | DustGenerationDtimeUpdate { .. }
-            | DustSpendProcessed { .. } => vec![],
+
+            LedgerEventAttributes::ContractPaused { .. }
+            | LedgerEventAttributes::ContractUnpaused { .. }
+            | LedgerEventAttributes::ContractMisc { .. }
+            | LedgerEventAttributes::ZswapInput { .. }
+            | LedgerEventAttributes::ZswapOutput
+            | LedgerEventAttributes::ParamChange
+            | LedgerEventAttributes::DustInitialUtxo { .. }
+            | LedgerEventAttributes::DustGenerationDtimeUpdate { .. }
+            | LedgerEventAttributes::DustSpendProcessed { .. } => vec![],
         }
     }
 }
+
+/// Every field name `LedgerEvent::indexable_contract_fields` can emit; the closed set of valid
+/// `fieldName` values for the contract events field-prefix filter.
+pub const INDEXABLE_CONTRACT_FIELD_NAMES: [&str; 7] = [
+    "nullifier",
+    "commitment",
+    "ciphertext",
+    "domainSep",
+    "tokenType",
+    "sender",
+    "recipient",
+];
 
 impl AddressOrContract {
     /// Flat byte representation for sidecar storage (32 bytes). Indexer
     /// filters by the raw bytes regardless of whether the address is a user
     /// or contract; the `kind` discriminator is in the JSONB payload only.
-    pub fn as_bytes(&self) -> ByteVec {
+    fn to_bytes(&self) -> ByteVec {
         match self {
-            AddressOrContract::User(b) => b.clone(),
-            AddressOrContract::Contract(b) => b.clone(),
+            Self::User(bytes) => bytes.clone(),
+            Self::Contract(bytes) => bytes.clone(),
         }
     }
 }
@@ -503,26 +509,25 @@ impl LedgerEventAttributes {
     /// for zswap and dust events. Used by the chain-indexer to correlate
     /// contract events with the emitting `ContractCall` (ticket #1162).
     pub fn contract_entry_point(&self) -> Option<&ByteVec> {
-        use LedgerEventAttributes::*;
         match self {
-            ContractShieldedSpend { entry_point, .. }
-            | ContractShieldedReceive { entry_point, .. }
-            | ContractShieldedMint { entry_point, .. }
-            | ContractShieldedBurn { entry_point, .. }
-            | ContractUnshieldedSpend { entry_point, .. }
-            | ContractUnshieldedReceive { entry_point, .. }
-            | ContractUnshieldedMint { entry_point, .. }
-            | ContractUnshieldedBurn { entry_point, .. }
-            | ContractPaused { entry_point, .. }
-            | ContractUnpaused { entry_point, .. }
-            | ContractMisc { entry_point, .. } => Some(entry_point),
+            Self::ContractShieldedSpend { entry_point, .. }
+            | Self::ContractShieldedReceive { entry_point, .. }
+            | Self::ContractShieldedMint { entry_point, .. }
+            | Self::ContractShieldedBurn { entry_point, .. }
+            | Self::ContractUnshieldedSpend { entry_point, .. }
+            | Self::ContractUnshieldedReceive { entry_point, .. }
+            | Self::ContractUnshieldedMint { entry_point, .. }
+            | Self::ContractUnshieldedBurn { entry_point, .. }
+            | Self::ContractPaused { entry_point, .. }
+            | Self::ContractUnpaused { entry_point, .. }
+            | Self::ContractMisc { entry_point, .. } => Some(entry_point),
 
-            ZswapInput { .. }
-            | ZswapOutput
-            | ParamChange
-            | DustInitialUtxo { .. }
-            | DustGenerationDtimeUpdate { .. }
-            | DustSpendProcessed { .. } => None,
+            Self::ZswapInput { .. }
+            | Self::ZswapOutput
+            | Self::ParamChange
+            | Self::DustInitialUtxo { .. }
+            | Self::DustGenerationDtimeUpdate { .. }
+            | Self::DustSpendProcessed { .. } => None,
         }
     }
 }
@@ -889,11 +894,34 @@ mod contract_event_tests {
     }
 
     #[test]
-    fn address_or_contract_as_bytes_returns_inner() {
+    fn address_or_contract_to_bytes_returns_inner() {
         let user = AddressOrContract::User(bv(&[0xab; 32]));
         let contract = AddressOrContract::Contract(bv(&[0xcd; 32]));
-        assert_eq!(user.as_bytes().as_ref(), &[0xab; 32]);
-        assert_eq!(contract.as_bytes().as_ref(), &[0xcd; 32]);
+        assert_eq!(user.to_bytes().as_ref(), &[0xab; 32]);
+        assert_eq!(contract.to_bytes().as_ref(), &[0xcd; 32]);
+    }
+
+    #[test]
+    fn indexable_contract_field_names_cover_every_emitted_field() {
+        let all_attrs = [
+            shielded_spend_attrs(),
+            shielded_receive_attrs(),
+            shielded_mint_attrs(),
+            shielded_burn_attrs(),
+            unshielded_spend_attrs(),
+            unshielded_receive_attrs(),
+            unshielded_mint_attrs(),
+            unshielded_burn_attrs(),
+            paused_attrs(),
+            unpaused_attrs(),
+            misc_attrs(),
+        ];
+        for attrs in all_attrs {
+            let event = LedgerEvent::contract_event(bv(b"raw"), bv(&[0x01; 32]), None, attrs);
+            for (name, _) in event.indexable_contract_fields() {
+                assert!(INDEXABLE_CONTRACT_FIELD_NAMES.contains(&name));
+            }
+        }
     }
 
     #[test]

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -111,7 +111,7 @@ const OUTPUT_INDEX_ZERO: u32 = 0;
 /// (32) + `amount` (16) = 145; Burn has no `domain_sep`, so `65 + 32 + 16 = 113`. `UnshieldedMint`
 /// has a `domain_sep` in place of the address (`32 + 32 + 16 = 80`).
 const SHIELDED_SPEND_SIZE: usize = 32;
-const SHIELDED_RECEIVE_SIZE: usize = 578; // 32 + (1 + 32) + (1 + 512).
+const SHIELDED_RECEIVE_SIZE: usize = 578; // 32 + (1 + 512) + (1 + 32).
 const SHIELDED_MINT_SIZE: usize = 81; // 32 + 32 + (1 + 16).
 const SHIELDED_BURN_SIZE: usize = 49; // 32 + (1 + 16).
 const UNSHIELDED_SPEND_SIZE: usize = 145; // (1 + 32 + 32) + 32 + 32 + 16.
@@ -1561,9 +1561,10 @@ where
     // stripping. Set so that an emission whose only-trailing-zero stripping
     // is the final value field still decodes correctly, while an emission
     // with a missing (truncated) leading field falls back. Crucial for the
-    // UnshieldedSpend / UnshieldedReceive spec/Compact divergence: spec is
-    // 113 bytes, Compact issue-377 is 81 bytes; min 97 (=113-16, only the
-    // u128 amount fully stripped) rejects 81-byte emissions cleanly.
+    // UnshieldedSpend / UnshieldedReceive layouts: the spec size is 145
+    // bytes; min 129 (= 145 - 16, only the u128 amount fully stripped)
+    // rejects superseded shorter layouts (e.g. the pre-domainSep 113-byte
+    // emissions) cleanly.
     match item.event_type {
         LogEventType::ShieldedSpend => {
             // nullifier is a 32-byte hash; require all 32 bytes.
@@ -1805,9 +1806,9 @@ where
 /// - multi-atom `AlignedValue` (Compact's `serialize<T, n>` produces a single atom for the flat
 ///   byte payload)
 /// - atom longer than `max` (oversize — wrong event type or unexpected layout)
-/// - atom shorter than `min` (undersize — likely a different event-struct layout, e.g. spec/Compact
-///   divergence on UnshieldedSpend/Receive where Compact issue-377 emits 81 bytes vs the spec's
-///   113-byte layout)
+/// - atom shorter than `min` (undersize — likely a different event-struct layout, e.g. a
+///   superseded pre-domainSep UnshieldedSpend/Receive emission shorter than the spec's 145-byte
+///   layout)
 ///
 /// `min` is the per-event minimum atom-byte length after maximum trailing-zero
 /// stripping of the last variable-width field. `max` is the canonical full


### PR DESCRIPTION
## Summary

Pre-merge review pass over feat-public-contract-events ahead of the #1185 merge to main: a full sweep of the ~5,300-line diff against main for correctness bugs, style-guide conventions and reviewer preferences. One commit per concern:

- 656f4eb0 fix: the last main merge (a41221e3) silently broke the branch. Main's #1308 changed `get_ledger_state_at` to also return the block id and height, and made ledger states older than the retention window unloadable, where loading culled state panics inside storage-core. `contractZswapState` now destructures the new tuple and verifies `root_loadable` before loading, so a request for an aged-out block is a clean client error (same idiom as the dust generations subscription); field docs and schema updated.
- 5d429356 fix: the bounded `contractEvents` subscription could complete without delivering events committed between its drain snapshot and the toBlock check, losing them permanently (realistic during chain-indexer catch-up). The terminator is now evaluated before each drain, so the drain snapshot covers everything the check saw, and the live loop reads the height off the `BlockIndexed` message it already consumes instead of re-querying the latest block row per tick. Filter and `id` validation moved to subscription setup so bad input fails the subscription rather than arriving as the first stream item, and ids beyond the i64 range are rejected instead of wrapping negative in the SQL bind and replaying the full history.
- 59ba6f40 fix: filter input validation and list caps. Unknown `fieldPrefixes.fieldName` values (checked against the closed indexable set, now published from indexer-common as `INDEXABLE_CONTRACT_FIELD_NAMES` with a coherence test), empty `types` lists, inverted block ranges and wrong-length transaction hashes are client errors now instead of silently empty results; the filter errors carry typed sources. `contractEvents` defaults `limit` to 100 and caps it at 500 like the sibling queries (previously an omitted limit fetched the contract's entire event history in one request), and `Contract.actions` gets the same 500 cap. Storage side: the domain filter uses the existing domain type aliases and is passed by reference, the duplicated Postgres/SQLite query builders are collapsed into one with feature-gated divergences only, the DataLoader query uses a plain `ANY($1)` bind per the transactions precedent, and the `contractZswapState` existence pre-check runs a dedicated `SELECT 1` instead of fetching the state and zswap state blobs to discard them. Public schema descriptions are completed for every event type and filter field, and internal review references are removed from the generated schema.
- 34b89bed / ea443669 refactor: redundant casts in the toBlock check, stale decoder comments (they still described the superseded 113-byte Unshielded layout and the pre-reorder ShieldedReceive field order), and borrowed binds in the event persistence path per the adjacent precedent.

Two review calls to confirm, not covered by the epic design docs (one-line changes if preferred otherwise): the 100 default / 500 cap on `contractEvents.limit` (numbers follow the established query.rs convention), and `types: []` as a client error rather than match-all.

Found but deliberately not changed here: the new `ledger_events` indexes don't serve the subscription's cursor query shape (a composite `(contract_address, id)` would) — left untouched because editing the migration files changes their sqlx checksums and would force resets on the environments already running them; candidate follow-up ticket. `transactionId` stays on the event types because the QA suite (#1289) asserts it.

## Testing

- `cargo check --tests` and `cargo clippy -D warnings` on both cloud and standalone: green.
- `cargo nextest` for indexer-common and indexer-api: 105/105, including new tests locking each validation behavior (unknown field name, empty types, inverted range, wrong-length hash, variant-name stability, field-name const coherence).
- Schema regenerated; the deltas are documentation strings and the two documented limit defaults — no type or field shape changes, `@beta` unchanged everywhere.
- Every line these commits replace is feature-branch code (git-blame audited); no pre-existing main-side code is modified.
- The local full `just all-all` run was cut short; CI on this PR is the authoritative full-suite run.

## Links

- Feature PR to main: #1185
- QA coverage already on main, gating on this surface: #1289
- Retention rework this adapts to: #1308
- Tickets: #1161 (events query/subscription), #1275 (contract query), #1304 (contractZswapState)
