### PR TITLE
feat(chain-indexer): derive block author from BABE pre-runtime digests

### DIFF
--- a/chain-indexer/src/infra/subxt_node.rs
+++ b/chain-indexer/src/infra/subxt_node.rs
@@ -670,11 +670,10 @@ where
     author_from_digest_logs(&header.digest.logs, authorities, content_node_version)
 }
 
-/// Determine the block author from the pre-runtime digest logs: Aura carries the slot (the
-/// author is the slot modulo the authority-set length), BABE carries the authority index
-/// explicitly in all of its pre-digest variants. Should a header carry both digests (the
-/// planned Aura→BABE transition window), Aura wins until the authoritative rule is defined
-/// node-side (see #1313).
+/// Determine the block author from the pre-runtime digest logs, taking the first log with a
+/// recognized consensus engine that yields an author, in digest order (mirroring polkadot-js
+/// `extractAuthor`): Aura carries the slot (the author is the slot modulo the authority-set
+/// length), BABE carries the authority index explicitly in all of its pre-digest variants.
 fn author_from_digest_logs(
     logs: &[DigestItem],
     authorities: &[[u8; 32]],
@@ -684,30 +683,35 @@ fn author_from_digest_logs(
         return Ok(None);
     }
 
-    let pre_runtime_digest = |engine_id: ConsensusEngineId| {
-        logs.iter().find_map(move |log| match log {
-            DigestItem::PreRuntime(id, inner) if *id == engine_id => Some(inner.as_slice()),
+    for log in logs {
+        let DigestItem::PreRuntime(engine_id, pre_digest) = log else {
+            continue;
+        };
+
+        let author = match *engine_id {
+            AURA_ENGINE_ID => {
+                let slot = runtimes::decode_slot(pre_digest, content_node_version)?;
+                let index = slot % authorities.len() as u64;
+                authorities.get(index as usize).copied().map(Into::into)
+            }
+
+            BABE_ENGINE_ID => {
+                let index = decode_babe_authority_index(pre_digest)?;
+                // An out-of-range index means the cached authority set does not match the
+                // block's epoch; report an unknown author instead of failing block processing.
+                usize::try_from(index)
+                    .ok()
+                    .and_then(|index| authorities.get(index))
+                    .copied()
+                    .map(Into::into)
+            }
+
             _ => None,
-        })
-    };
+        };
 
-    if let Some(slot) = pre_runtime_digest(AURA_ENGINE_ID) {
-        let slot = runtimes::decode_slot(slot, content_node_version)?;
-        let index = slot % authorities.len() as u64;
-        let author = authorities.get(index as usize).copied().map(Into::into);
-        return Ok(author);
-    }
-
-    if let Some(pre_digest) = pre_runtime_digest(BABE_ENGINE_ID) {
-        let index = decode_babe_authority_index(pre_digest)?;
-        // An out-of-range index means the cached authority set does not match the block's
-        // epoch; report an unknown author instead of failing block processing.
-        let author = usize::try_from(index)
-            .ok()
-            .and_then(|index| authorities.get(index))
-            .copied()
-            .map(Into::into);
-        return Ok(author);
+        if author.is_some() {
+            return Ok(author);
+        }
     }
 
     Ok(None)
@@ -846,9 +850,29 @@ mod tests {
     }
 
     #[test]
-    fn aura_wins_over_babe_during_transition() {
+    fn first_pre_runtime_digest_in_digest_order_wins() {
         let logs = vec![
             DigestItem::PreRuntime(BABE_ENGINE_ID, babe_pre_digest(2, 2)),
+            DigestItem::PreRuntime(AURA_ENGINE_ID, 4u64.encode()),
+        ];
+        let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0)
+            .expect("author can be determined");
+        assert_eq!(author, Some([3; 32].into()));
+
+        let logs = vec![
+            DigestItem::PreRuntime(AURA_ENGINE_ID, 4u64.encode()),
+            DigestItem::PreRuntime(BABE_ENGINE_ID, babe_pre_digest(2, 2)),
+        ];
+        let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0)
+            .expect("author can be determined");
+        assert_eq!(author, Some([2; 32].into()));
+    }
+
+    #[test]
+    fn unrecognized_engine_and_authorless_digest_are_skipped() {
+        let logs = vec![
+            DigestItem::PreRuntime(*b"test", vec![0xaa]),
+            DigestItem::PreRuntime(BABE_ENGINE_ID, babe_pre_digest(2, 7)),
             DigestItem::PreRuntime(AURA_ENGINE_ID, 4u64.encode()),
         ];
 

--- a/chain-indexer/src/infra/subxt_node.rs
+++ b/chain-indexer/src/infra/subxt_node.rs
@@ -38,6 +38,7 @@ use indexer_common::{
     error::BoxError,
 };
 use log::{debug, info, warn};
+use parity_scale_codec::Decode;
 use serde::Deserialize;
 use std::{future::ready, time::Duration};
 use subxt::{
@@ -59,6 +60,7 @@ type OnlineClientAtBlock = subxt::client::OnlineClientAtBlock<SubstrateConfig>;
 type SubxtBlock = subxt::client::Block<SubstrateConfig>;
 
 const AURA_ENGINE_ID: ConsensusEngineId = [b'a', b'u', b'r', b'a'];
+const BABE_ENGINE_ID: ConsensusEngineId = [b'B', b'A', b'B', b'E'];
 const CATCH_UP_LOG_INTERVAL: u64 = 1_000;
 
 /// One GRANDPA session worth of blocks. Blocks within this distance of the finalized tip are
@@ -602,6 +604,9 @@ pub enum SubxtNodeError {
     #[error("cannot decode authorities")]
     DecodeAuthorities(#[source] Box<subxt::error::StorageValueError>),
 
+    #[error("invalid BABE pre-runtime digest variant tag {0}")]
+    InvalidBabePreDigestTag(u8),
+
     #[error("cannot fetch genesis cNight registrations")]
     FetchGenesisCnightRegistrations(#[source] Box<subxt::error::StorageError>),
 
@@ -662,26 +667,63 @@ fn extract_block_author<H>(
 where
     H: Hash,
 {
+    author_from_digest_logs(&header.digest.logs, authorities, content_node_version)
+}
+
+/// Determine the block author from the pre-runtime digest logs: Aura carries the slot (the
+/// author is the slot modulo the authority-set length), BABE carries the authority index
+/// explicitly in all of its pre-digest variants. Should a header carry both digests (the
+/// planned Aura→BABE transition window), Aura wins until the authoritative rule is defined
+/// node-side (see #1313).
+fn author_from_digest_logs(
+    logs: &[DigestItem],
+    authorities: &[[u8; 32]],
+    content_node_version: NodeVersion,
+) -> Result<Option<BlockAuthor>, SubxtNodeError> {
     if authorities.is_empty() {
         return Ok(None);
     }
 
-    let block_author = header
-        .digest
-        .logs
-        .iter()
-        .find_map(|log| match log {
-            DigestItem::PreRuntime(AURA_ENGINE_ID, inner) => Some(inner.as_slice()),
+    let pre_runtime_digest = |engine_id: ConsensusEngineId| {
+        logs.iter().find_map(move |log| match log {
+            DigestItem::PreRuntime(id, inner) if *id == engine_id => Some(inner.as_slice()),
             _ => None,
         })
-        .map(|slot| runtimes::decode_slot(slot, content_node_version))
-        .transpose()?
-        .and_then(|slot| {
-            let index = slot % authorities.len() as u64;
-            authorities.get(index as usize).copied().map(Into::into)
-        });
+    };
 
-    Ok(block_author)
+    if let Some(slot) = pre_runtime_digest(AURA_ENGINE_ID) {
+        let slot = runtimes::decode_slot(slot, content_node_version)?;
+        let index = slot % authorities.len() as u64;
+        let author = authorities.get(index as usize).copied().map(Into::into);
+        return Ok(author);
+    }
+
+    if let Some(pre_digest) = pre_runtime_digest(BABE_ENGINE_ID) {
+        let index = decode_babe_authority_index(pre_digest)?;
+        // An out-of-range index means the cached authority set does not match the block's
+        // epoch; report an unknown author instead of failing block processing.
+        let author = usize::try_from(index)
+            .ok()
+            .and_then(|index| authorities.get(index))
+            .copied()
+            .map(Into::into);
+        return Ok(author);
+    }
+
+    Ok(None)
+}
+
+/// Extract the authority index from a BABE pre-runtime digest. All `PreDigest` variants
+/// (`Primary` = 1, `SecondaryPlain` = 2, `SecondaryVRF` = 3, see `sp_consensus_babe::digests`)
+/// lead with the SCALE-encoded `authority_index: u32` right after the variant tag, so only that
+/// prefix is decoded and the remainder (slot, VRF signature) is ignored.
+fn decode_babe_authority_index(mut pre_digest: &[u8]) -> Result<u32, SubxtNodeError> {
+    let tag = u8::decode(&mut pre_digest)?;
+    if !(1..=3).contains(&tag) {
+        return Err(SubxtNodeError::InvalidBabePreDigestTag(tag));
+    }
+
+    Ok(u32::decode(&mut pre_digest)?)
 }
 
 async fn make_transaction(
@@ -760,4 +802,116 @@ async fn block_header(
         .block_header()
         .await
         .map_err(|error| SubxtNodeError::GetBlockHeader(error.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parity_scale_codec::Encode;
+
+    const AUTHORITIES: [[u8; 32]; 3] = [[1; 32], [2; 32], [3; 32]];
+
+    /// A BABE pre-digest prefix: variant tag, then the SCALE-encoded authority index, then
+    /// trailing payload (slot, VRF signature) which must be ignored.
+    fn babe_pre_digest(tag: u8, authority_index: u32) -> Vec<u8> {
+        let mut pre_digest = vec![tag];
+        pre_digest.extend(authority_index.encode());
+        pre_digest.extend([0xff; 8]);
+        pre_digest
+    }
+
+    #[test]
+    fn author_from_aura_digest() {
+        let logs = vec![DigestItem::PreRuntime(AURA_ENGINE_ID, 4u64.encode())];
+
+        let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0)
+            .expect("author can be determined");
+
+        assert_eq!(author, Some([2; 32].into()));
+    }
+
+    #[test]
+    fn author_from_babe_digest_for_all_variants() {
+        for tag in 1..=3 {
+            let logs = vec![DigestItem::PreRuntime(
+                BABE_ENGINE_ID,
+                babe_pre_digest(tag, 2),
+            )];
+
+            let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0)
+                .expect("author can be determined");
+
+            assert_eq!(author, Some([3; 32].into()));
+        }
+    }
+
+    #[test]
+    fn aura_wins_over_babe_during_transition() {
+        let logs = vec![
+            DigestItem::PreRuntime(BABE_ENGINE_ID, babe_pre_digest(2, 2)),
+            DigestItem::PreRuntime(AURA_ENGINE_ID, 4u64.encode()),
+        ];
+
+        let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0)
+            .expect("author can be determined");
+
+        assert_eq!(author, Some([2; 32].into()));
+    }
+
+    #[test]
+    fn babe_out_of_range_authority_index_yields_no_author() {
+        let logs = vec![DigestItem::PreRuntime(
+            BABE_ENGINE_ID,
+            babe_pre_digest(2, 7),
+        )];
+
+        let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0)
+            .expect("out-of-range index is not an error");
+
+        assert_eq!(author, None);
+    }
+
+    #[test]
+    fn invalid_babe_pre_digest_tag_is_an_error() {
+        for tag in [0, 4] {
+            let logs = vec![DigestItem::PreRuntime(
+                BABE_ENGINE_ID,
+                babe_pre_digest(tag, 2),
+            )];
+
+            let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0);
+
+            assert!(matches!(
+                author,
+                Err(SubxtNodeError::InvalidBabePreDigestTag(t)) if t == tag
+            ));
+        }
+    }
+
+    #[test]
+    fn truncated_babe_pre_digest_is_an_error() {
+        let logs = vec![DigestItem::PreRuntime(BABE_ENGINE_ID, vec![1, 0xaa])];
+
+        let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0);
+
+        assert!(matches!(author, Err(SubxtNodeError::ScaleDecode(_))));
+    }
+
+    #[test]
+    fn no_pre_runtime_digest_yields_no_author() {
+        let author = author_from_digest_logs(&[], &AUTHORITIES, NodeVersion::V2_0)
+            .expect("no digest is not an error");
+
+        assert_eq!(author, None);
+    }
+
+    #[test]
+    fn empty_authorities_yield_no_author() {
+        let logs = vec![DigestItem::PreRuntime(AURA_ENGINE_ID, 4u64.encode())];
+
+        let author = author_from_digest_logs(&logs, &[], NodeVersion::V2_0)
+            .expect("empty authorities are not an error");
+
+        assert_eq!(author, None);
+    }
 }


### PR DESCRIPTION
Part of #1313 (do not auto-close, the ticket keeps the remaining work).

Implements the unblocked kernel of the Aura→BABE migration: era-aware block-author derivation. The digest scan now branches by pre-runtime engine id:

- `aura` (unchanged): decode the slot per runtime version, author = slot modulo authority-set length. Kept permanently, any sync from genesis re-derives authors for all historical blocks.
- `BABE` (new): read `authority_index` directly from the pre-digest. All `PreDigest` variants (Primary = 1, SecondaryPlain = 2, SecondaryVRF = 3) lead with the SCALE-encoded `authority_index: u32` after the variant tag, so only that prefix is decoded, no VRF logic indexer-side. An out-of-range index reports an unknown author rather than failing block processing (a mismatched cached authority set should not halt indexing).

Design choices, aligned with the #1313 discussion:

~- If a header carries both digests (the planned transition window), Aura wins, preserving today's behaviour until the node team defines the authoritative rule (node-side dependency in #1313).~
- No per-block node round-trip added: derivation stays pure header maths against the per-session cached authority set.
- The digest scan is factored into `author_from_digest_logs` over `&[DigestItem]` so it is unit-testable without header construction; `extract_block_author` keeps its signature and call site.

Dormant-safe: no midnight-node runtime emits BABE digests today, so behaviour on current chains is unchanged (the aura path is byte-for-byte the same logic). The BABE path activates only when BABE headers appear.

Out of scope, still tracked in #1313 (blocked on node-side artifacts):
- New per-runtime module for the BABE runtime (needs its metadata) including `fetch_authorities` reading BABE epoch authorities (note: pallet_babe stores `Vec<(AuthorityId, weight)>` pairs, map to keys).
- `NewSession` event source swap when node #1802 lands (metadata regen) https://github.com/midnightntwrk/midnight-indexer/pull/1333.
- SPO committee surface (`auraPubkeyHex`, `expectedSlots`, `SLOT_DURATION`) pending the committee API shape under BABE.
- The transition-epoch precedence rule, revisit the Aura-wins default once defined.

Testing: 8 new unit tests covering aura derivation, all three BABE variants, aura-over-babe precedence, out-of-range index, invalid tag, truncated pre-digest, no-digest and empty-authorities cases. `cargo check`/`clippy` clean on cloud and standalone, full chain-indexer suite passes. Note for reviewers: the BABE pre-digest layout (tags 1..=3, leading authority_index) matches sp_consensus_babe::digests and the polkadot-js author extraction; it should be re-confirmed against the actual midnight-node BABE runtime when it exists, the tests encode the assumption so a mismatch will surface there.
