### PR TITLE
fix(chain-indexer): recover from index_blocks_task panics instead of exiting

### DIFF
--- a/chain-indexer/src/application.rs
+++ b/chain-indexer/src/application.rs
@@ -66,6 +66,36 @@ pub struct Config {
     pub ledger_state_retention: NonZeroUsize,
 }
 
+/// Maximum number of consecutive `index_blocks_task` panics tolerated without indexing progress
+/// before giving up and letting the orchestrator restart the process. Transient ledger-side
+/// panics (e.g. the storage-core root-count underflow, midnight-ledger#548) clear on a fresh
+/// attempt; a genuinely stuck/poison-block panic keeps failing, hits this bound and exits as
+/// before instead of hot-looping forever.
+const MAX_CONSECUTIVE_INDEX_TASK_PANICS: u32 = 5;
+
+/// Base backoff between in-process index-task restarts; scales linearly with the consecutive
+/// panic count, so retries span ~2s..10s before [`MAX_CONSECUTIVE_INDEX_TASK_PANICS`] gives up.
+const INDEX_TASK_PANIC_BACKOFF: Duration = Duration::from_secs(2);
+
+/// Supervision policy for a recoverable index-task panic: given the number of consecutive panics
+/// observed *without indexing progress in between*, return `Some(backoff)` to wait and retry
+/// in-process, or `None` to give up (bound exceeded) and let the orchestrator restart the process.
+fn index_panic_backoff(consecutive_panics: u32) -> Option<Duration> {
+    (consecutive_panics <= MAX_CONSECUTIVE_INDEX_TASK_PANICS)
+        .then(|| INDEX_TASK_PANIC_BACKOFF * consecutive_panics)
+}
+
+/// Outcome of a single indexing attempt ([`run_once`]).
+enum RunOutcome {
+    /// A clean stop was requested (SIGTERM) or the highest-block task ended; stop the service.
+    Shutdown,
+
+    /// The index task panicked. The panic unwinds only the task, leaving the persisted DB
+    /// consistent, so indexing can be rebuilt and retried in-process rather than crashing the
+    /// process. Carries the panic message for logging.
+    RecoverablePanic(String),
+}
+
 pub async fn run(
     config: Config,
     node: impl Node,
@@ -73,6 +103,86 @@ pub async fn run(
     publisher: impl Publisher,
     mut sigterm: Signal,
 ) -> anyhow::Result<()> {
+    // Supervise indexing: an `index_blocks_task` panic aborts only that task, not the process.
+    // Rebuild ledger/indexing state from the (consistent) DB and retry in-process, backing off
+    // and bounding consecutive no-progress panics so a genuinely fatal panic still exits and the
+    // orchestrator can take over. This keeps a transient ledger panic (midnight-ledger#548) from
+    // turning into a CrashLoopBackOff. See midnight-indexer#1150 (root-cause fix: #1213).
+    let mut consecutive_panics = 0u32;
+    let mut last_height = highest_block_height(&mut storage)
+        .await
+        .context("get highest block height")?;
+
+    loop {
+        match run_once(
+            config.clone(),
+            &node,
+            storage.clone(),
+            &publisher,
+            &mut sigterm,
+        )
+        .await?
+        {
+            RunOutcome::Shutdown => return Ok(()),
+
+            RunOutcome::RecoverablePanic(panic) => {
+                // Reset the counter whenever indexing advanced since the previous attempt, so only
+                // panics with no progress in between count toward the give-up bound.
+                let height = highest_block_height(&mut storage)
+                    .await
+                    .context("get highest block height")?;
+                if height > last_height {
+                    consecutive_panics = 0;
+                }
+                last_height = height;
+                consecutive_panics += 1;
+
+                let Some(backoff) = index_panic_backoff(consecutive_panics) else {
+                    bail!(
+                        "index_blocks_task panicked {consecutive_panics} times consecutively \
+                         without indexing progress; last panic: {panic}"
+                    );
+                };
+
+                warn!(
+                    consecutive_panics,
+                    backoff:?,
+                    panic:% = panic;
+                    "index_blocks_task panicked; restarting indexing in-process after backoff \
+                     (see midnight-indexer#1150, midnight-ledger#548)"
+                );
+                sleep(backoff).await;
+            }
+        }
+    }
+}
+
+/// Read the current highest indexed block height, if any.
+async fn highest_block_height(storage: &mut impl Storage) -> anyhow::Result<Option<u64>> {
+    Ok(storage
+        .get_highest_block()
+        .await
+        .context("get highest block")?
+        .map(|(block_ref, _, _)| block_ref.height))
+}
+
+/// Run a single indexing attempt until it stops: a clean shutdown ([`RunOutcome::Shutdown`]), a
+/// recoverable index-task panic ([`RunOutcome::RecoverablePanic`]), or a fatal error (`Err`).
+async fn run_once<N, S, P>(
+    config: Config,
+    node: &N,
+    mut storage: S,
+    publisher: &P,
+    sigterm: &mut Signal,
+) -> anyhow::Result<RunOutcome>
+where
+    N: Node,
+    S: Storage,
+    P: Publisher,
+{
+    let node = node.clone();
+    let publisher = publisher.clone();
+
     let Config {
         network_id,
         blocks_buffer,
@@ -189,7 +299,7 @@ pub async fn run(
     });
 
     // Spawn task to index blocks.
-    let mut index_blocks_task = task::spawn({
+    let mut index_blocks_task: task::JoinHandle<anyhow::Result<()>> = task::spawn({
         let node = node.clone();
 
         async move {
@@ -254,26 +364,40 @@ pub async fn run(
 
     select! {
         result = &mut highest_block_on_node_task => {
-            let result = result
-                .context("highest_block_on_node_task panicked")
-                .and_then(|r| r.context("highest_block_on_node_task failed"));
             index_blocks_task.abort();
             result
+                .context("highest_block_on_node_task panicked")
+                .and_then(|r| r.context("highest_block_on_node_task failed"))?;
+            // The highest-block task is not expected to complete; treat it as a stop.
+            Ok(RunOutcome::Shutdown)
         },
 
         result = &mut index_blocks_task => {
-            let result = result
-                .context("index_blocks_task panicked")
-                .and_then(|r: anyhow::Result<()>| r.context("index_blocks_task failed"));
             highest_block_on_node_task.abort();
-            result
+            match result {
+                // The indexing loop is infinite; an inner error is fatal, a clean return is
+                // unexpected but not an error.
+                Ok(inner) => {
+                    inner.context("index_blocks_task failed")?;
+                    Ok(RunOutcome::Shutdown)
+                }
+                // A panic unwinds only the task and leaves the persisted DB consistent, so it is
+                // recoverable: the supervisor in `run` rebuilds state and retries in-process.
+                Err(join_error) if join_error.is_panic() => {
+                    Ok(RunOutcome::RecoverablePanic(join_error.to_string()))
+                }
+                // Cancellation (or any non-panic join failure) is not expected here; treat as fatal.
+                Err(join_error) => {
+                    Err(anyhow::Error::new(join_error).context("index_blocks_task join failed"))
+                }
+            }
         },
 
         _ = sigterm.recv() => {
             warn!("SIGTERM received");
             highest_block_on_node_task.abort();
             index_blocks_task.abort();
-            Ok(())
+            Ok(RunOutcome::Shutdown)
         }
     }
 }
@@ -712,6 +836,28 @@ mod tests {
         assert_eq!(heights, vec![0, 1, 2, 3]);
 
         Ok(())
+    }
+
+    #[test]
+    fn index_panic_backoff_policy() {
+        use crate::application::{
+            INDEX_TASK_PANIC_BACKOFF, MAX_CONSECUTIVE_INDEX_TASK_PANICS, index_panic_backoff,
+        };
+
+        // The first panic backs off by the base interval, and backoff scales linearly.
+        assert_eq!(index_panic_backoff(1), Some(INDEX_TASK_PANIC_BACKOFF));
+        assert_eq!(index_panic_backoff(3), Some(INDEX_TASK_PANIC_BACKOFF * 3));
+
+        // At the bound it still retries (linear, uncapped within the bound); one past the
+        // bound it gives up (returns None) and lets the orchestrator restart the process.
+        assert_eq!(
+            index_panic_backoff(MAX_CONSECUTIVE_INDEX_TASK_PANICS),
+            Some(INDEX_TASK_PANIC_BACKOFF * MAX_CONSECUTIVE_INDEX_TASK_PANICS)
+        );
+        assert_eq!(
+            index_panic_backoff(MAX_CONSECUTIVE_INDEX_TASK_PANICS + 1),
+            None
+        );
     }
 
     #[derive(Clone)]


### PR DESCRIPTION
## What

Supervise block indexing so a **panic** in `index_blocks_task` degrades to an
orderly in-process recovery instead of exiting the process. Today such a panic
unwinds the task, surfaces as a `JoinError` on the terminal `select!` arm,
propagates to `main`, and exits (exit 1) — which the orchestrator turns into a
CrashLoopBackOff.

This extracts a single indexing attempt into `run_once` and wraps it in a
supervisor loop in `run`:

- On `JoinError::is_panic()`, rebuild ledger/indexing state from the (consistent)
  DB and retry **in-process** with linear backoff (2s × consecutive panics,
  capped at 30s).
- Bound consecutive **no-progress** panics (`MAX_CONSECUTIVE_INDEX_TASK_PANICS =
  5`); the counter resets whenever indexing advanced since the previous attempt.
  A genuinely stuck / poison-block panic therefore still exits and lets the
  orchestrator take over, instead of hot-looping forever.
- SIGTERM shutdown and fatal (non-panic) errors keep their existing behavior.

`Node`, `Storage`, and `Publisher` are already `Clone + Send + Sync + 'static`,
so each attempt gets fresh handles without any trait changes.

## Why — this is resilience, not the root-cause fix

On 2026-07-10, **both** `preprod-blue` and `preprod-green` chain-indexers (4.3.3)
panicked and crash-looped **8 restarts each, in lockstep**, on the transient
storage-core `roots counts can't be negative` panic. Each pod does resume within
~5–10s, but a simultaneous multi-restart CrashLoopBackOff across both production
stacks is an operational signal that should not be silent — hence supervising it.

The **root cause is already known and being fixed at source**: `get_root_count`
under-reports a true root count of 2+ as 1 (a `SELECT count(1)` row-count instead
of the stored count column), so a decrement can tip the flush assert negative.
Tracked in midnightntwrk/midnight-ledger#548 / midnightntwrk/midnight-indexer#1150,
with candidate fix midnightntwrk/midnight-indexer#1213.

**This PR does not fix that** and is not a competing fix — it is complementary
defense-in-depth: even after #1213 lands, no single ledger panic during indexing
should be able to crash-loop both stacks. If #1213 merges first, this simply
becomes a safety net for future panics. Credit to @sean-kwak for the root-cause
diagnosis.

## Guardrails

- Recovery only reloads from the persisted DB; it does **not** touch/wipe
  `ledger_storage` (the panic is in-memory-state-driven, not persisted
  corruption).
- Each recovery logs a `WARN` with the panic message and issue cross-refs, so the
  underlying bug stays visible and is never silently swallowed.
- The no-progress bound preserves today's fail-and-exit behavior for a truly
  stuck panic.

## Validation

Built and tested locally against the production feature set (`--features cloud`):

- `cargo check -p chain-indexer --tests --features cloud` — clean.
- `cargo test -p chain-indexer --features cloud` — 2 passed, incl. the new
  `index_panic_backoff_policy` unit test (backoff scaling and the no-progress
  give-up bound).
- `cargo clippy -p chain-indexer --no-deps --tests --features cloud -- -D warnings`
  — clean.
- `rustfmt --check` — clean.

(Toolchain note: checked with Rust 1.93; repo pins 1.95 — CI is authoritative.)

The branching guardrail logic is extracted into a pure `index_panic_backoff`
function and unit-tested. A full integration test of `run`'s supervision would
need `Storage`/`Publisher` mocks that don't exist yet (only `Node` is mocked
today); noted as a follow-up.

## Follow-ups

- Integration test that a panicking index task is recovered in-process and a
  persistently-panicking one still exits after the bound.
- Optional metric/counter for in-process index-task restarts (kept to a `WARN`
  here to bound scope).
