### PR TITLE
test: cover per-block dust merkle tree roots

### DIFF
--- a/qa/tests/tests/integration/basic/queries/block-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/block-queries.test.ts
@@ -17,6 +17,7 @@ import log from '@utils/logging/logger';
 import '@utils/logging/test-logging-hooks';
 import { BlockSchema } from '@utils/indexer/graphql/schema';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
+import { isPerBlockDustRootsSupported } from '@utils/indexer/schema-feature-probe';
 import type {
   Block,
   BlockResponse,
@@ -460,6 +461,166 @@ describe('block queries', () => {
       expect(latest.zswapEndIndex).toBeGreaterThanOrEqual(parent.zswapEndIndex);
       expect(latest.dustCommitmentEndIndex).toBeGreaterThanOrEqual(parent.dustCommitmentEndIndex);
       expect(latest.dustGenerationEndIndex).toBeGreaterThanOrEqual(parent.dustGenerationEndIndex);
+    });
+  });
+
+  // Indexers up to 4.3.3 resolve the Block dust root fields at the latest indexed
+  // state (the tip) by design, so per-block assertions only hold on deployments
+  // that include the per-block change. Each test probes the deployed schema and
+  // skips on tip-scoped deployments rather than false-failing there.
+  describe('per-block dust merkle tree roots', () => {
+    /**
+     * Dust roots belong to the queried block, not the tip.
+     *
+     * @given two blocks between which the dust generation tree has grown
+     *        (their dustGenerationEndIndex values differ)
+     * @when both blocks' dust generation Merkle tree roots are read
+     * @then the roots differ — a tree with more leaves cannot share a root
+     *       with its earlier, smaller state
+     *
+     * midnight-indexer#1260
+     */
+    test('should return different dust generation roots for blocks with different tree sizes', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Block', 'Dust', 'MerkleRoot', '#1260'],
+      };
+
+      if (!(await isPerBlockDustRootsSupported())) {
+        ctx.skip?.(true, 'deployed indexer serves tip-scoped dust roots (pre per-block change)');
+        return;
+      }
+
+      const latestResponse = await indexerHttpClient.getLatestBlock();
+      expect(latestResponse).toBeSuccess();
+      const tip = latestResponse.data!.block;
+
+      const earlierResponse = await indexerHttpClient.getBlockByOffset({
+        height: Math.floor(tip.height / 2),
+      });
+      expect(earlierResponse).toBeSuccess();
+      const earlier = earlierResponse.data!.block;
+
+      if (earlier.dustGenerationMerkleTreeRoot === null) {
+        ctx.skip?.(
+          true,
+          `block ${earlier.height} has no stored dust roots — history predates the per-block change`,
+        );
+        return;
+      }
+
+      if (earlier.dustGenerationEndIndex === tip.dustGenerationEndIndex) {
+        ctx.skip?.(
+          true,
+          `generation tree did not grow between block ${earlier.height} and block ${tip.height} ` +
+            `(endIndex ${tip.dustGenerationEndIndex}) — root comparison is vacuous`,
+        );
+        return;
+      }
+
+      log.debug(
+        `Block ${earlier.height} (endIndex=${earlier.dustGenerationEndIndex}) root=${earlier.dustGenerationMerkleTreeRoot} vs ` +
+          `block ${tip.height} (endIndex=${tip.dustGenerationEndIndex}) root=${tip.dustGenerationMerkleTreeRoot}`,
+      );
+
+      expect(tip.dustGenerationMerkleTreeRoot).not.toBeNull();
+      expect(earlier.dustGenerationMerkleTreeRoot).not.toBe(tip.dustGenerationMerkleTreeRoot);
+
+      if (earlier.dustCommitmentEndIndex !== tip.dustCommitmentEndIndex) {
+        expect(tip.dustCommitmentMerkleTreeRoot).not.toBeNull();
+        expect(earlier.dustCommitmentMerkleTreeRoot).not.toBe(tip.dustCommitmentMerkleTreeRoot);
+      }
+    });
+
+    /**
+     * Per-block dust roots are stable: the same block always reports the same roots.
+     *
+     * @given a historical block queried twice by height
+     * @when the dust commitment and generation roots of both responses are compared
+     * @then both queries return identical, non-null roots
+     *
+     * midnight-indexer#1260
+     */
+    test('should return identical dust roots for repeated queries of the same block', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Block', 'Dust', 'MerkleRoot', '#1260'],
+      };
+
+      if (!(await isPerBlockDustRootsSupported())) {
+        ctx.skip?.(true, 'deployed indexer serves tip-scoped dust roots (pre per-block change)');
+        return;
+      }
+
+      const latestResponse = await indexerHttpClient.getLatestBlock();
+      expect(latestResponse).toBeSuccess();
+      const height = Math.floor(latestResponse.data!.block.height / 2);
+
+      const firstResponse = await indexerHttpClient.getBlockByOffset({ height });
+      expect(firstResponse).toBeSuccess();
+      const first = firstResponse.data!.block;
+
+      if (first.dustGenerationMerkleTreeRoot === null) {
+        ctx.skip?.(
+          true,
+          `block ${height} has no stored dust roots — history predates the per-block change`,
+        );
+        return;
+      }
+
+      const secondResponse = await indexerHttpClient.getBlockByOffset({ height });
+      expect(secondResponse).toBeSuccess();
+      const second = secondResponse.data!.block;
+
+      expect(second.dustGenerationMerkleTreeRoot).toBe(first.dustGenerationMerkleTreeRoot);
+      expect(second.dustCommitmentMerkleTreeRoot).toBe(first.dustCommitmentMerkleTreeRoot);
+      expect(first.dustCommitmentMerkleTreeRoot).not.toBeNull();
+    });
+
+    /**
+     * Root and tree size move together: an unchanged tree keeps its root.
+     *
+     * @given the latest block and its parent
+     * @when their dust generation end indexes are equal
+     * @then their dust generation Merkle tree roots are equal as well
+     *       (same leaves, same tree, same root)
+     *
+     * midnight-indexer#1260
+     */
+    test('should return equal dust generation roots for parent and child with equal tree sizes', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = {
+        labels: ['Query', 'Block', 'Dust', 'MerkleRoot', '#1260'],
+      };
+
+      if (!(await isPerBlockDustRootsSupported())) {
+        ctx.skip?.(true, 'deployed indexer serves tip-scoped dust roots (pre per-block change)');
+        return;
+      }
+
+      const latestResponse = await indexerHttpClient.getLatestBlock();
+      expect(latestResponse).toBeSuccess();
+      const latest = latestResponse.data!.block;
+
+      if (latest.height === 0) {
+        ctx.skip?.(true, 'only genesis block available — no parent to compare against');
+        return;
+      }
+
+      const parentResponse = await indexerHttpClient.getBlockByOffset({
+        height: latest.height - 1,
+      });
+      expect(parentResponse).toBeSuccess();
+      const parent = parentResponse.data!.block;
+
+      if (parent.dustGenerationEndIndex !== latest.dustGenerationEndIndex) {
+        ctx.skip?.(
+          true,
+          `generation tree grew between block ${parent.height} and block ${latest.height} — ` +
+            'equal-size comparison is not applicable',
+        );
+        return;
+      }
+
+      expect(latest.dustGenerationMerkleTreeRoot).not.toBeNull();
+      expect(latest.dustGenerationMerkleTreeRoot).toBe(parent.dustGenerationMerkleTreeRoot);
     });
   });
 });

--- a/qa/tests/utils/indexer/schema-feature-probe.ts
+++ b/qa/tests/utils/indexer/schema-feature-probe.ts
@@ -1,0 +1,69 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { env } from 'environment/model';
+
+const BLOCK_FIELD_DESCRIPTIONS_QUERY = `{
+  __type(name: "Block") {
+    fields {
+      name
+      description
+    }
+  }
+}`;
+
+interface IntrospectedField {
+  name: string;
+  description: string | null;
+}
+
+/**
+ * Introspects the deployed schema and returns the description of a `Block` field,
+ * or null when the field does not exist.
+ *
+ * Uses native fetch (pattern of http-compression-probe) because the typed
+ * IndexerHttpClient methods are bound to domain queries, not introspection.
+ */
+export async function fetchBlockFieldDescription(fieldName: string): Promise<string | null> {
+  const apiVersion = process.env.INDEXER_API_VERSION?.trim() || 'v4';
+  const url = `${env.getIndexerHttpBaseURL()}/api/${apiVersion}/graphql`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: BLOCK_FIELD_DESCRIPTIONS_QUERY }),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  const body = (await response.json()) as {
+    data?: { __type?: { fields?: IntrospectedField[] } };
+  };
+  const field = body.data?.__type?.fields?.find((f) => f.name === fieldName);
+  return field?.description ?? null;
+}
+
+/**
+ * Whether the deployed indexer serves per-block dust Merkle tree roots.
+ *
+ * Up to and including 4.3.3 the `Block.dust*MerkleTreeRoot` fields are documented
+ * (and resolved) "at the latest indexed state" — the tip's roots for every block.
+ * Since the per-block change the deployed schema documents them "at this block".
+ * The description is the only observable version marker: field name and type are
+ * identical on both sides.
+ */
+export async function isPerBlockDustRootsSupported(): Promise<boolean> {
+  const description = await fetchBlockFieldDescription('dustGenerationMerkleTreeRoot');
+  return description !== null && description.includes('at this block');
+}


### PR DESCRIPTION
## Scope

Adds regression coverage on the `Block` query surface for per-block dust Merkle tree roots (#1267):

- blocks with different dust generation tree sizes report different roots (the tip-scoping defect made them identical for every block);
- repeated queries of the same block return identical, non-null roots;
- a parent and child block with equal generation end indexes share the same root.

Adds `utils/indexer/schema-feature-probe.ts`, a small introspection helper that reads the deployed `Block.dustGenerationMerkleTreeRoot` field description — the only observable marker distinguishing per-block deployments ("at this block") from tip-scoped ones ("at the latest indexed state", up to 4.3.3, where that behaviour is by design). The tests skip with an explicit reason on tip-scoped deployments and on blocks whose stored roots predate the change, instead of false-failing.

## Why

#1267 changed `Block.dustCommitmentMerkleTreeRoot` / `dustGenerationMerkleTreeRoot` from tip-resolved values to roots computed and stored per block during indexing, but shipped without regression coverage. The defect ("the hash the wallet had a step before appears in the next block query") was reported from wallet integration and was not caught by any automated test.

## Validation

- `TARGET_ENV=stagenet` and `TARGET_ENV=devnet`: all three tests pass (block-queries file fully green, 23/23).
- `TARGET_ENV=qanet` (4.3.3, tip-scoped by design): all three skip with the probe's reason; rest of the file unaffected.
- `yarn lint`, `yarn audit`, `yarn format` clean.

Relates to #1260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)