### PR TITLE
test(indexer): block-hash dust generations sync coverage (#1283)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3406,6 +3406,8 @@ dependencies = [
  "serde_json",
  "sqlx",
  "stream-cancel",
+ "testcontainers",
+ "testcontainers-modules",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/indexer-api/Cargo.toml
+++ b/indexer-api/Cargo.toml
@@ -53,6 +53,10 @@ tower-http         = { workspace = true, features = [ "compression-br", "compres
 trait-variant      = { workspace = true }
 uuid               = { workspace = true, features = [ "v7" ] }
 
+[dev-dependencies]
+testcontainers         = { workspace = true }
+testcontainers-modules = { workspace = true, features = [ "postgres" ] }
+
 [features]
 cloud      = [ "indexer-common/cloud" ]
 standalone = [ "indexer-common/standalone" ]

--- a/indexer-api/src/infra/storage.rs
+++ b/indexer-api/src/infra/storage.rs
@@ -24,6 +24,9 @@ mod transaction;
 mod unshielded;
 mod wallet;
 
+#[cfg(all(test, feature = "cloud"))]
+mod block_hash_dust_sync_tests;
+
 use crate::domain;
 use chacha20poly1305::ChaCha20Poly1305;
 

--- a/indexer-api/src/infra/storage/block_hash_dust_sync_tests.rs
+++ b/indexer-api/src/infra/storage/block_hash_dust_sync_tests.rs
@@ -1,0 +1,440 @@
+// This file is part of midnight-indexer.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Storage-layer integration tests for the block-hash dust generations sync
+//! (issue #1283). These exercise the three storage methods the re-scoped
+//! `dustGenerations` subscription is built on, against a real PostgreSQL
+//! instance seeded with hand-crafted fixtures (no node required):
+//!
+//! * [`LedgerStateStorage::get_ledger_state_at`] — the by-block-hash
+//!   ledger-state lookup that pins the whole snapshot to one block.
+//! * [`DustGenerationsStorage::get_dust_generation_entries`] — the wallet's
+//!   owned generation entries within a generation-tree index range.
+//! * [`DustGenerationsStorage::get_dust_generation_dtime_updates`] — the
+//!   owned-entry dtime delta, bounded to `(cutoff_block_id, upper_block_id]`;
+//!   this bounding is the storage foundation of the subscription's
+//!   determinism guarantee (issue #1283 acceptance criterion #2).
+//!
+//! These do NOT verify the cryptographic root match against
+//! `dustGenerationMerkleTreeRoot` (acceptance criterion #1) — that needs a
+//! real ledger state and belongs in an e2e test with dust-generating
+//! fixtures. See the investigation notes on #1283.
+//!
+//! NOTE: cloud (PostgreSQL) only. The `get_dust_generation_dtime_updates`
+//! query has a separate SQLite implementation (`json_extract`/`unhex`/`iif`
+//! instead of `->>`/`decode`/`regexp_replace`), so a standalone mirror of the
+//! dtime tests is still required to close the "cloud + standalone" task item.
+
+use crate::{
+    domain::storage::{dust_generations::DustGenerationsStorage, ledger_state::LedgerStateStorage},
+    infra::storage::Storage,
+};
+use futures::TryStreamExt;
+use indexer_common::{
+    cipher::make_cipher,
+    domain::{
+        ByteArray, ByteVec, LedgerEventAttributes, ProtocolVersion, dust::DustGenerationInfo,
+    },
+    infra::{
+        migrations,
+        pool::postgres::{Config, PostgresPool},
+    },
+};
+use secrecy::SecretString;
+use sqlx::postgres::PgSslMode;
+use std::{error::Error as StdError, num::NonZeroU32, time::Duration};
+use testcontainers::{ImageExt, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres;
+
+const PROTOCOL_VERSION: i64 = 2_000_000; // ProtocolVersion::V2_0
+const BATCH: NonZeroU32 = NonZeroU32::new(16).unwrap();
+
+/// Spin up PostgreSQL, run migrations, and return the container (kept alive by
+/// the caller), the raw pool for seeding fixtures, and the [`Storage`] under
+/// test.
+async fn setup() -> Result<
+    (
+        testcontainers::ContainerAsync<Postgres>,
+        PostgresPool,
+        Storage,
+    ),
+    Box<dyn StdError>,
+> {
+    let container = Postgres::default()
+        .with_db_name("indexer")
+        .with_user("indexer")
+        .with_password(env!("APP__INFRA__STORAGE__PASSWORD"))
+        .with_tag("17.1-alpine")
+        .start()
+        .await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+
+    let config = Config {
+        host: "localhost".to_string(),
+        port,
+        dbname: "indexer".to_string(),
+        user: "indexer".to_string(),
+        password: env!("APP__INFRA__STORAGE__PASSWORD").into(),
+        sslmode: PgSslMode::Prefer,
+        max_connections: 10,
+        idle_timeout: Duration::from_secs(60),
+        max_lifetime: Duration::from_secs(5 * 60),
+    };
+    let pool = PostgresPool::new(config).await?;
+    migrations::postgres::run(&pool).await?;
+
+    // 64 hex chars = 32 bytes; the cipher is unused by the methods under test
+    // but is required to construct `Storage`.
+    let secret: SecretString = "00".repeat(32).into();
+    let storage = Storage::new(make_cipher(secret)?, pool.clone());
+
+    Ok((container, pool, storage))
+}
+
+/// Insert a block and return its internal id.
+async fn insert_block(
+    pool: &PostgresPool,
+    height: i64,
+    hash: &[u8],
+    ledger_state_key: &[u8],
+) -> Result<i64, Box<dyn StdError>> {
+    let (id,): (i64,) = sqlx::query_as(
+        "INSERT INTO blocks (
+             hash, height, protocol_version, parent_hash, timestamp,
+             zswap_merkle_tree_root, ledger_parameters, ledger_state_key
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         RETURNING id",
+    )
+    .bind(hash)
+    .bind(height)
+    .bind(PROTOCOL_VERSION)
+    .bind(&b"parent"[..])
+    .bind(1_700_000_000_i64 + height)
+    .bind(&b"zswap-root"[..])
+    .bind(&b"params"[..])
+    .bind(ledger_state_key)
+    .fetch_one(&**pool)
+    .await?;
+    Ok(id)
+}
+
+/// Insert a regular transaction into a block and return its internal id.
+async fn insert_transaction(
+    pool: &PostgresPool,
+    block_id: i64,
+    hash: &[u8],
+) -> Result<i64, Box<dyn StdError>> {
+    let (id,): (i64,) = sqlx::query_as(
+        "INSERT INTO transactions (block_id, variant, hash, protocol_version, raw)
+         VALUES ($1, 'Regular'::TRANSACTION_VARIANT, $2, $3, $4)
+         RETURNING id",
+    )
+    .bind(block_id)
+    .bind(hash)
+    .bind(PROTOCOL_VERSION)
+    .bind(&b"raw"[..])
+    .fetch_one(&**pool)
+    .await?;
+    Ok(id)
+}
+
+/// Insert a dust generation info row (an owned generation entry).
+#[allow(clippy::too_many_arguments)]
+async fn insert_generation_info(
+    pool: &PostgresPool,
+    owner: &[u8],
+    night_utxo_hash: &[u8],
+    value: u128,
+    generation_index: Option<i64>,
+    dtime: Option<i64>,
+    transaction_id: i64,
+) -> Result<(), Box<dyn StdError>> {
+    sqlx::query(
+        "INSERT INTO dust_generation_info (
+             night_utxo_hash, value, owner, nonce, ctime, merkle_index,
+             dtime, transaction_id, generation_index, backing_night, initial_value
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+    )
+    .bind(night_utxo_hash)
+    .bind(&value.to_be_bytes()[..])
+    .bind(owner)
+    .bind(&[9u8; 32][..])
+    .bind(100_i64)
+    // Give commitment index a distinct-ish value from generation index.
+    .bind(generation_index.map(|i| i + 1000).unwrap_or(0))
+    .bind(dtime)
+    .bind(transaction_id)
+    .bind(generation_index)
+    .bind(&[7u8; 32][..]) // backing_night
+    .bind(&value.to_be_bytes()[..]) // initial_value
+    .execute(&**pool)
+    .await?;
+    Ok(())
+}
+
+/// Insert a `DustGenerationDtimeUpdate` ledger event whose embedded
+/// `night_utxo_hash` matches an existing `dust_generation_info` row (the join
+/// key), with the given `dtime` and `tree_insertion_path` surfaced verbatim.
+async fn insert_dtime_event(
+    pool: &PostgresPool,
+    transaction_id: i64,
+    night_utxo_hash: [u8; 32],
+    dtime: u64,
+    tree_insertion_path: &[u8],
+) -> Result<(), Box<dyn StdError>> {
+    let attributes = LedgerEventAttributes::DustGenerationDtimeUpdate {
+        generation_info: DustGenerationInfo {
+            night_utxo_hash: ByteArray(night_utxo_hash),
+            value: 1_000,
+            owner: ByteVec(vec![0xff; 32]),
+            nonce: ByteArray([0u8; 32]),
+            ctime: 100,
+            dtime,
+        },
+        generation_index: 0, // ignored by the query; index comes from dgi
+        tree_insertion_path: ByteVec(tree_insertion_path.to_vec()),
+    };
+    let attributes = serde_json::to_string(&attributes)?;
+
+    sqlx::query(
+        "INSERT INTO ledger_events (transaction_id, variant, grouping, raw, attributes)
+         VALUES (
+             $1,
+             'DustGenerationDtimeUpdate'::LEDGER_EVENT_VARIANT,
+             'Dust'::LEDGER_EVENT_GROUPING,
+             $2,
+             $3::jsonb
+         )",
+    )
+    .bind(transaction_id)
+    .bind(&b""[..])
+    .bind(attributes)
+    .execute(&**pool)
+    .await?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// get_ledger_state_at
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_ledger_state_at_returns_the_row_for_a_known_hash() -> Result<(), Box<dyn StdError>> {
+    let (_container, pool, storage) = setup().await?;
+
+    let hash_a = [0xa1u8; 32];
+    let hash_b = [0xb2u8; 32];
+    let key_a = b"ledger-state-key-a";
+    let block_a = insert_block(&pool, 1, &hash_a, key_a).await?;
+    insert_block(&pool, 2, &hash_b, b"ledger-state-key-b").await?;
+
+    let result = storage.get_ledger_state_at(ByteArray(hash_a)).await?;
+
+    let (block_id, height, protocol_version, ledger_state_key) =
+        result.expect("known block hash resolves to a row");
+    assert_eq!(block_id, block_a as u64);
+    assert_eq!(height, 1);
+    assert_eq!(protocol_version, ProtocolVersion::V2_0(2_000_000));
+    assert_eq!(ledger_state_key.0, key_a);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_ledger_state_at_returns_none_for_an_unknown_hash() -> Result<(), Box<dyn StdError>> {
+    let (_container, pool, storage) = setup().await?;
+    insert_block(&pool, 1, &[0xa1u8; 32], b"key").await?;
+
+    // This drives the "unknown block hash" client error in the resolver.
+    let result = storage.get_ledger_state_at(ByteArray([0xffu8; 32])).await?;
+    assert!(result.is_none(), "unknown block hash must resolve to None");
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// get_dust_generation_entries
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_dust_generation_entries_orders_filters_and_skips_legacy_rows()
+-> Result<(), Box<dyn StdError>> {
+    let (_container, pool, storage) = setup().await?;
+
+    let owner_a = [1u8; 32];
+    let owner_b = [2u8; 32];
+    let block = insert_block(&pool, 1, &[0x01u8; 32], b"key").await?;
+    let tx = insert_transaction(&pool, block, &[0x11u8; 32]).await?;
+
+    // Owner A at generation indices 0, 2, 5 (deliberately out of insert order).
+    insert_generation_info(&pool, &owner_a, &[10u8; 32], 100, Some(5), None, tx).await?;
+    insert_generation_info(&pool, &owner_a, &[11u8; 32], 100, Some(0), None, tx).await?;
+    insert_generation_info(&pool, &owner_a, &[12u8; 32], 100, Some(2), None, tx).await?;
+    // Owner B — must be excluded.
+    insert_generation_info(&pool, &owner_b, &[20u8; 32], 100, Some(1), None, tx).await?;
+    // Legacy row for owner A with NULL generation_index — must be skipped.
+    insert_generation_info(&pool, &owner_a, &[13u8; 32], 100, None, None, tx).await?;
+
+    let entries: Vec<_> = storage
+        .get_dust_generation_entries(&owner_a, 0, 5, BATCH)
+        .await
+        .try_collect()
+        .await?;
+
+    let indices: Vec<u64> = entries.iter().map(|e| e.generation_mt_index).collect();
+    assert_eq!(
+        indices,
+        vec![0, 2, 5],
+        "owner A entries, ordered, legacy skipped"
+    );
+    assert!(entries.iter().all(|e| e.owner.0 == owner_a));
+
+    // Sub-range [2, 4] selects only index 2.
+    let sub: Vec<_> = storage
+        .get_dust_generation_entries(&owner_a, 2, 4, BATCH)
+        .await
+        .try_collect()
+        .await?;
+    assert_eq!(
+        sub.iter()
+            .map(|e| e.generation_mt_index)
+            .collect::<Vec<_>>(),
+        vec![2]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_dust_generation_entries_paginates_across_batches() -> Result<(), Box<dyn StdError>> {
+    let (_container, pool, storage) = setup().await?;
+
+    let owner = [1u8; 32];
+    let block = insert_block(&pool, 1, &[0x01u8; 32], b"key").await?;
+    let tx = insert_transaction(&pool, block, &[0x11u8; 32]).await?;
+    for i in 0..5i64 {
+        insert_generation_info(&pool, &owner, &[i as u8; 32], 100, Some(i), None, tx).await?;
+    }
+
+    // Batch size 2 forces the internal loop to page three times.
+    let batch = NonZeroU32::new(2).unwrap();
+    let entries: Vec<_> = storage
+        .get_dust_generation_entries(&owner, 0, 4, batch)
+        .await
+        .try_collect()
+        .await?;
+    assert_eq!(
+        entries
+            .iter()
+            .map(|e| e.generation_mt_index)
+            .collect::<Vec<_>>(),
+        vec![0, 1, 2, 3, 4],
+        "all entries returned in order across batch boundaries"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// get_dust_generation_dtime_updates
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_dust_generation_dtime_updates_bounds_by_cutoff_and_upper_block()
+-> Result<(), Box<dyn StdError>> {
+    let (_container, pool, storage) = setup().await?;
+
+    let owner = [1u8; 32];
+    // Three blocks, each with one dtime update for owner A.
+    let mut block_ids = Vec::new();
+    for h in 1..=3i64 {
+        let block = insert_block(&pool, h, &[h as u8; 32], b"key").await?;
+        let tx = insert_transaction(&pool, block, &[(0x10 + h) as u8; 32]).await?;
+        let night = [(0x30 + h) as u8; 32];
+        // dgi row is the join target and supplies generation_index + owner.
+        insert_generation_info(&pool, &owner, &night, 100, Some(h - 1), Some(h * 1000), tx).await?;
+        insert_dtime_event(&pool, tx, night, (h * 1000) as u64, &[0xaa, h as u8]).await?;
+        block_ids.push(block);
+    }
+
+    // Bound to (block 1, block 2]: only block 2's update survives.
+    let updates: Vec<_> = storage
+        .get_dust_generation_dtime_updates(
+            &owner,
+            block_ids[0] as u64,
+            block_ids[1] as u64,
+            0,
+            BATCH,
+        )
+        .await
+        .try_collect()
+        .await?;
+
+    assert_eq!(updates.len(), 1, "exactly one update in (block 1, block 2]");
+    assert_eq!(updates[0].generation_mt_index, 1);
+    assert_eq!(
+        updates[0].new_dtime, 2000,
+        "dtime recovered from attributes"
+    );
+    assert_eq!(
+        updates[0].tree_insertion_path.0,
+        vec![0xaa, 2],
+        "tree_insertion_path recovered from attributes"
+    );
+
+    // cutoff 0, upper = block 3 → all three, ordered by ledger event id.
+    let all: Vec<_> = storage
+        .get_dust_generation_dtime_updates(&owner, 0, block_ids[2] as u64, 0, BATCH)
+        .await
+        .try_collect()
+        .await?;
+    assert_eq!(
+        all.iter()
+            .map(|u| u.generation_mt_index)
+            .collect::<Vec<_>>(),
+        vec![0, 1, 2]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_dust_generation_dtime_updates_filters_by_owner() -> Result<(), Box<dyn StdError>> {
+    let (_container, pool, storage) = setup().await?;
+
+    let owner_a = [1u8; 32];
+    let owner_b = [2u8; 32];
+    let block = insert_block(&pool, 1, &[0x01u8; 32], b"key").await?;
+    let tx = insert_transaction(&pool, block, &[0x11u8; 32]).await?;
+
+    let night_a = [0x30u8; 32];
+    let night_b = [0x31u8; 32];
+    insert_generation_info(&pool, &owner_a, &night_a, 100, Some(0), Some(1000), tx).await?;
+    insert_generation_info(&pool, &owner_b, &night_b, 100, Some(1), Some(2000), tx).await?;
+    insert_dtime_event(&pool, tx, night_a, 1000, &[0xaa]).await?;
+    insert_dtime_event(&pool, tx, night_b, 2000, &[0xbb]).await?;
+
+    let updates: Vec<_> = storage
+        .get_dust_generation_dtime_updates(&owner_a, 0, block as u64, 0, BATCH)
+        .await
+        .try_collect()
+        .await?;
+
+    assert_eq!(updates.len(), 1, "only owner A's dtime update is returned");
+    assert_eq!(updates[0].owner.0, owner_a);
+    assert_eq!(updates[0].new_dtime, 1000);
+
+    Ok(())
+}

--- a/indexer-api/src/infra/storage/block_hash_dust_sync_tests.rs
+++ b/indexer-api/src/infra/storage/block_hash_dust_sync_tests.rs
@@ -25,10 +25,10 @@
 //!   this bounding is the storage foundation of the subscription's
 //!   determinism guarantee (issue #1283 acceptance criterion #2).
 //!
-//! These do NOT verify the cryptographic root match against
-//! `dustGenerationMerkleTreeRoot` (acceptance criterion #1) — that needs a
-//! real ledger state and belongs in an e2e test with dust-generating
-//! fixtures. See the investigation notes on #1283.
+//! The cryptographic root match against `dustGenerationMerkleTreeRoot`
+//! (acceptance criterion #1) is covered separately — by the unit test in
+//! `indexer-common` (`dust_generation_root_from_collapsed_update_matches_tree_root`)
+//! and end-to-end in `indexer-tests`.
 //!
 //! NOTE: cloud (PostgreSQL) only. The `get_dust_generation_dtime_updates`
 //! query has a separate SQLite implementation (`json_extract`/`unhex`/`iif`
@@ -231,35 +231,27 @@ async fn insert_dtime_event(
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn get_ledger_state_at_returns_the_row_for_a_known_hash() -> Result<(), Box<dyn StdError>> {
+async fn get_ledger_state_at_resolves_by_hash() -> Result<(), Box<dyn StdError>> {
     let (_container, pool, storage) = setup().await?;
 
     let hash_a = [0xa1u8; 32];
-    let hash_b = [0xb2u8; 32];
     let key_a = b"ledger-state-key-a";
     let block_a = insert_block(&pool, 1, &hash_a, key_a).await?;
-    insert_block(&pool, 2, &hash_b, b"ledger-state-key-b").await?;
+    insert_block(&pool, 2, &[0xb2u8; 32], b"ledger-state-key-b").await?;
 
-    let result = storage.get_ledger_state_at(ByteArray(hash_a)).await?;
-
-    let (block_id, height, protocol_version, ledger_state_key) =
-        result.expect("known block hash resolves to a row");
+    // Known hash resolves to that block's row.
+    let (block_id, height, protocol_version, ledger_state_key) = storage
+        .get_ledger_state_at(ByteArray(hash_a))
+        .await?
+        .expect("known block hash resolves to a row");
     assert_eq!(block_id, block_a as u64);
     assert_eq!(height, 1);
     assert_eq!(protocol_version, ProtocolVersion::V2_0(2_000_000));
     assert_eq!(ledger_state_key.0, key_a);
 
-    Ok(())
-}
-
-#[tokio::test]
-async fn get_ledger_state_at_returns_none_for_an_unknown_hash() -> Result<(), Box<dyn StdError>> {
-    let (_container, pool, storage) = setup().await?;
-    insert_block(&pool, 1, &[0xa1u8; 32], b"key").await?;
-
-    // This drives the "unknown block hash" client error in the resolver.
-    let result = storage.get_ledger_state_at(ByteArray([0xffu8; 32])).await?;
-    assert!(result.is_none(), "unknown block hash must resolve to None");
+    // Unknown hash resolves to None (drives the resolver's "unknown block hash" client error).
+    let unknown = storage.get_ledger_state_at(ByteArray([0xffu8; 32])).await?;
+    assert!(unknown.is_none(), "unknown block hash must resolve to None");
 
     Ok(())
 }
@@ -278,17 +270,20 @@ async fn get_dust_generation_entries_orders_filters_and_skips_legacy_rows()
     let block = insert_block(&pool, 1, &[0x01u8; 32], b"key").await?;
     let tx = insert_transaction(&pool, block, &[0x11u8; 32]).await?;
 
-    // Owner A at generation indices 0, 2, 5 (deliberately out of insert order).
+    // Owner A at generation indices 0, 2, 5, 7 (deliberately out of insert order).
     insert_generation_info(&pool, &owner_a, &[10u8; 32], 100, Some(5), None, tx).await?;
     insert_generation_info(&pool, &owner_a, &[11u8; 32], 100, Some(0), None, tx).await?;
     insert_generation_info(&pool, &owner_a, &[12u8; 32], 100, Some(2), None, tx).await?;
+    insert_generation_info(&pool, &owner_a, &[14u8; 32], 100, Some(7), None, tx).await?;
     // Owner B — must be excluded.
     insert_generation_info(&pool, &owner_b, &[20u8; 32], 100, Some(1), None, tx).await?;
     // Legacy row for owner A with NULL generation_index — must be skipped.
     insert_generation_info(&pool, &owner_a, &[13u8; 32], 100, None, None, tx).await?;
 
+    // Batch size 2 forces the internal cursor loop to page multiple times.
+    let batch = NonZeroU32::new(2).unwrap();
     let entries: Vec<_> = storage
-        .get_dust_generation_entries(&owner_a, 0, 5, BATCH)
+        .get_dust_generation_entries(&owner_a, 0, 7, batch)
         .await
         .try_collect()
         .await?;
@@ -296,14 +291,14 @@ async fn get_dust_generation_entries_orders_filters_and_skips_legacy_rows()
     let indices: Vec<u64> = entries.iter().map(|e| e.generation_mt_index).collect();
     assert_eq!(
         indices,
-        vec![0, 2, 5],
-        "owner A entries, ordered, legacy skipped"
+        vec![0, 2, 5, 7],
+        "owner A entries, ordered across batch boundaries, B excluded, legacy skipped"
     );
     assert!(entries.iter().all(|e| e.owner.0 == owner_a));
 
     // Sub-range [2, 4] selects only index 2.
     let sub: Vec<_> = storage
-        .get_dust_generation_entries(&owner_a, 2, 4, BATCH)
+        .get_dust_generation_entries(&owner_a, 2, 4, batch)
         .await
         .try_collect()
         .await?;
@@ -312,36 +307,6 @@ async fn get_dust_generation_entries_orders_filters_and_skips_legacy_rows()
             .map(|e| e.generation_mt_index)
             .collect::<Vec<_>>(),
         vec![2]
-    );
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn get_dust_generation_entries_paginates_across_batches() -> Result<(), Box<dyn StdError>> {
-    let (_container, pool, storage) = setup().await?;
-
-    let owner = [1u8; 32];
-    let block = insert_block(&pool, 1, &[0x01u8; 32], b"key").await?;
-    let tx = insert_transaction(&pool, block, &[0x11u8; 32]).await?;
-    for i in 0..5i64 {
-        insert_generation_info(&pool, &owner, &[i as u8; 32], 100, Some(i), None, tx).await?;
-    }
-
-    // Batch size 2 forces the internal loop to page three times.
-    let batch = NonZeroU32::new(2).unwrap();
-    let entries: Vec<_> = storage
-        .get_dust_generation_entries(&owner, 0, 4, batch)
-        .await
-        .try_collect()
-        .await?;
-    assert_eq!(
-        entries
-            .iter()
-            .map(|e| e.generation_mt_index)
-            .collect::<Vec<_>>(),
-        vec![0, 1, 2, 3, 4],
-        "all entries returned in order across batch boundaries"
     );
 
     Ok(())
@@ -357,7 +322,8 @@ async fn get_dust_generation_dtime_updates_bounds_by_cutoff_and_upper_block()
     let (_container, pool, storage) = setup().await?;
 
     let owner = [1u8; 32];
-    // Three blocks, each with one dtime update for owner A.
+    let other_owner = [2u8; 32];
+    // Three blocks, each with one dtime update for `owner`.
     let mut block_ids = Vec::new();
     for h in 1..=3i64 {
         let block = insert_block(&pool, h, &[h as u8; 32], b"key").await?;
@@ -368,8 +334,22 @@ async fn get_dust_generation_dtime_updates_bounds_by_cutoff_and_upper_block()
         insert_dtime_event(&pool, tx, night, (h * 1000) as u64, &[0xaa, h as u8]).await?;
         block_ids.push(block);
     }
+    // A different owner's update in block 2 — must never be returned for `owner`.
+    let other_night = [0x99u8; 32];
+    let tx2 = insert_transaction(&pool, block_ids[1], &[0x22u8; 32]).await?;
+    insert_generation_info(
+        &pool,
+        &other_owner,
+        &other_night,
+        100,
+        Some(9),
+        Some(2000),
+        tx2,
+    )
+    .await?;
+    insert_dtime_event(&pool, tx2, other_night, 2000, &[0xbb]).await?;
 
-    // Bound to (block 1, block 2]: only block 2's update survives.
+    // Bound to (block 1, block 2]: only block 2's own update survives (other owner excluded).
     let updates: Vec<_> = storage
         .get_dust_generation_dtime_updates(
             &owner,
@@ -382,7 +362,12 @@ async fn get_dust_generation_dtime_updates_bounds_by_cutoff_and_upper_block()
         .try_collect()
         .await?;
 
-    assert_eq!(updates.len(), 1, "exactly one update in (block 1, block 2]");
+    assert_eq!(
+        updates.len(),
+        1,
+        "exactly one owned update in (block 1, block 2]"
+    );
+    assert_eq!(updates[0].owner.0, owner);
     assert_eq!(updates[0].generation_mt_index, 1);
     assert_eq!(
         updates[0].new_dtime, 2000,
@@ -394,7 +379,7 @@ async fn get_dust_generation_dtime_updates_bounds_by_cutoff_and_upper_block()
         "tree_insertion_path recovered from attributes"
     );
 
-    // cutoff 0, upper = block 3 → all three, ordered by ledger event id.
+    // cutoff 0, upper = block 3 → all three owned updates, ordered by ledger event id.
     let all: Vec<_> = storage
         .get_dust_generation_dtime_updates(&owner, 0, block_ids[2] as u64, 0, BATCH)
         .await
@@ -404,37 +389,9 @@ async fn get_dust_generation_dtime_updates_bounds_by_cutoff_and_upper_block()
         all.iter()
             .map(|u| u.generation_mt_index)
             .collect::<Vec<_>>(),
-        vec![0, 1, 2]
+        vec![0, 1, 2],
+        "only the owner's updates, no other-owner leakage"
     );
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn get_dust_generation_dtime_updates_filters_by_owner() -> Result<(), Box<dyn StdError>> {
-    let (_container, pool, storage) = setup().await?;
-
-    let owner_a = [1u8; 32];
-    let owner_b = [2u8; 32];
-    let block = insert_block(&pool, 1, &[0x01u8; 32], b"key").await?;
-    let tx = insert_transaction(&pool, block, &[0x11u8; 32]).await?;
-
-    let night_a = [0x30u8; 32];
-    let night_b = [0x31u8; 32];
-    insert_generation_info(&pool, &owner_a, &night_a, 100, Some(0), Some(1000), tx).await?;
-    insert_generation_info(&pool, &owner_b, &night_b, 100, Some(1), Some(2000), tx).await?;
-    insert_dtime_event(&pool, tx, night_a, 1000, &[0xaa]).await?;
-    insert_dtime_event(&pool, tx, night_b, 2000, &[0xbb]).await?;
-
-    let updates: Vec<_> = storage
-        .get_dust_generation_dtime_updates(&owner_a, 0, block as u64, 0, BATCH)
-        .await
-        .try_collect()
-        .await?;
-
-    assert_eq!(updates.len(), 1, "only owner A's dtime update is returned");
-    assert_eq!(updates[0].owner.0, owner_a);
-    assert_eq!(updates[0].new_dtime, 1000);
 
     Ok(())
 }

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -88,10 +88,10 @@ use midnight_storage_core_v1::{
     storage::default_storage,
 };
 use midnight_transient_crypto_v2::merkle_tree::{
-    MerkleTreeCollapsedUpdate, MerkleTreeDigest, TreeInsertionPath,
+    MerkleTree as MerkleTreeV8, MerkleTreeCollapsedUpdate, MerkleTreeDigest, TreeInsertionPath,
 };
 use midnight_transient_crypto_v3::merkle_tree::{
-    MerkleTreeCollapsedUpdate as MerkleTreeCollapsedUpdateV9,
+    MerkleTree as MerkleTreeV9, MerkleTreeCollapsedUpdate as MerkleTreeCollapsedUpdateV9,
     MerkleTreeDigest as MerkleTreeDigestV9, TreeInsertionPath as TreeInsertionPathV9,
 };
 use midnight_zswap_v8::ledger::State as ZswapStateV8;
@@ -747,6 +747,52 @@ impl LedgerState {
                 .expect("dust generation merkle tree root should exist")
                 .serialize()
                 .map_err(|error| Error::Serialize("DustGenerationMerkleTreeRoot", error)),
+        }
+    }
+
+    /// Reconstruct the dust generation Merkle tree root from a collapsed update that covers the
+    /// whole tree (`[0, first_free - 1]`), as a wallet does: apply the update to a blank tree,
+    /// rehash, and take the root. The result is serialized identically to
+    /// [`LedgerState::dust_generation_merkle_tree_root`], so a wallet rebuilding its tree from the
+    /// block-hash dust generations sync (#1283) can assert it matches the authoritative block root.
+    ///
+    /// `collapsed_update` is the tagged-serialized `MerkleTreeCollapsedUpdate` served on the
+    /// `dustGenerations` subscription. The aux type is irrelevant to the root, so a unit-aux tree
+    /// is used for reconstruction.
+    pub fn dust_generation_root_from_collapsed_update(
+        collapsed_update: &[u8],
+        ledger_version: LedgerVersion,
+    ) -> Result<ByteVec, Error> {
+        // Matches midnight-ledger's `DUST_GENERATION_TREE_DEPTH`.
+        const DUST_GENERATION_TREE_DEPTH: u8 = 32;
+
+        match ledger_version {
+            LedgerVersion::V8 => {
+                let update =
+                    tagged_deserialize::<MerkleTreeCollapsedUpdate>(&mut &*collapsed_update)
+                        .map_err(|error| Error::Deserialize("MerkleTreeCollapsedUpdate", error))?;
+                MerkleTreeV8::<()>::blank(DUST_GENERATION_TREE_DEPTH)
+                    .apply_collapsed_update(&update)
+                    .map_err(|error| Error::InvalidUpdate(error.into()))?
+                    .rehash()
+                    .root()
+                    .expect("dust generation merkle tree root should exist")
+                    .serialize()
+                    .map_err(|error| Error::Serialize("DustGenerationMerkleTreeRoot", error))
+            }
+            LedgerVersion::V9 => {
+                let update =
+                    tagged_deserialize::<MerkleTreeCollapsedUpdateV9>(&mut &*collapsed_update)
+                        .map_err(|error| Error::Deserialize("MerkleTreeCollapsedUpdate", error))?;
+                MerkleTreeV9::<()>::blank(DUST_GENERATION_TREE_DEPTH)
+                    .apply_collapsed_update(&update)
+                    .map_err(|error| Error::InvalidUpdate(error.into()))?
+                    .rehash()
+                    .root()
+                    .expect("dust generation merkle tree root should exist")
+                    .serialize()
+                    .map_err(|error| Error::Serialize("DustGenerationMerkleTreeRoot", error))
+            }
         }
     }
 
@@ -2043,5 +2089,54 @@ mod tests {
         assert_eq!(normalized.block_usage, half);
         assert_eq!(normalized.bytes_written, half);
         assert_eq!(normalized.bytes_churned, half);
+    }
+
+    /// Issue #1283, acceptance criterion #1: a wallet that applies the full collapsed update the
+    /// `dustGenerations` subscription serves rebuilds a generation tree whose root matches the
+    /// authoritative block root. This exercises the exact production primitives — the collapsed
+    /// update is built like [`LedgerState::dust_generations_collapsed_update`] and the expected
+    /// root like [`LedgerState::dust_generation_merkle_tree_root`] — so no chain is needed.
+    #[test]
+    fn dust_generation_root_from_collapsed_update_matches_tree_root() {
+        use crate::domain::ledger::{SerializableExt, TaggedSerializableExt};
+        use midnight_base_crypto_v1::hash::HashOutput;
+        use midnight_transient_crypto_v3::merkle_tree::{MerkleTree, MerkleTreeCollapsedUpdate};
+
+        // Matches midnight-ledger's DUST_GENERATION_TREE_DEPTH.
+        const DEPTH: u8 = 32;
+
+        for leaf_count in [1u64, 3, 8] {
+            let tree = (0..leaf_count).fold(MerkleTree::<()>::blank(DEPTH), |tree, i| {
+                tree.try_update_hash(i, HashOutput([(i + 1) as u8; 32]), ())
+                    .expect("insert leaf")
+            });
+            let last_index = leaf_count - 1;
+
+            // Authoritative root, exactly as `dust_generation_merkle_tree_root` computes it.
+            let expected_root = tree
+                .rehash()
+                .root()
+                .expect("root exists")
+                .serialize()
+                .expect("serialize root");
+
+            // The full collapsed update, exactly as `dust_generations_collapsed_update` produces it.
+            let collapsed_update = MerkleTreeCollapsedUpdate::new(&tree.rehash(), 0, last_index)
+                .expect("build collapsed update")
+                .tagged_serialize()
+                .expect("serialize collapsed update");
+
+            // Wallet-side reconstruction from that single update.
+            let reconstructed = LedgerState::dust_generation_root_from_collapsed_update(
+                &collapsed_update,
+                LedgerVersion::V9,
+            )
+            .expect("reconstruct root");
+
+            assert_eq!(
+                reconstructed, expected_root,
+                "reconstructed root must match the tree root for {leaf_count} leaves"
+            );
+        }
     }
 }

--- a/indexer-tests/e2e.graphql
+++ b/indexer-tests/e2e.graphql
@@ -182,11 +182,6 @@ query BlockQuery($block_offset: BlockOffset) {
 query BlockDustRootQuery($block_offset: BlockOffset) {
     block(offset: $block_offset) {
         hash
-        height
-        protocolVersion
-        parent {
-            hash
-        }
         dustGenerationMerkleTreeRoot
     }
 }

--- a/indexer-tests/e2e.graphql
+++ b/indexer-tests/e2e.graphql
@@ -179,6 +179,18 @@ query BlockQuery($block_offset: BlockOffset) {
     }
 }
 
+query BlockDustRootQuery($block_offset: BlockOffset) {
+    block(offset: $block_offset) {
+        hash
+        height
+        protocolVersion
+        parent {
+            hash
+        }
+        dustGenerationMerkleTreeRoot
+    }
+}
+
 query TransactionsQuery($transaction_offset: TransactionOffset!) {
     transactions(offset: $transaction_offset) {
         hash

--- a/indexer-tests/e2e.graphql
+++ b/indexer-tests/e2e.graphql
@@ -764,9 +764,22 @@ subscription DustGenerationsSubscription(
         __typename
         ... on DustGenerationsItem {
             generationMtIndex
+            owner
+            collapsedMerkleTree {
+                startIndex
+                endIndex
+                update
+                protocolVersion
+            }
         }
         ... on DustGenerationsProgress {
             highestIndex
+            collapsedMerkleTree {
+                startIndex
+                endIndex
+                update
+                protocolVersion
+            }
         }
         ... on DustGenerationDtimeUpdateItem {
             generationMtIndex

--- a/indexer-tests/src/e2e.rs
+++ b/indexer-tests/src/e2e.rs
@@ -1074,8 +1074,8 @@ async fn test_dust_ledger_events_subscription(
 /// all-zero dust address (owns no generations), so the stream is a single
 /// `DustGenerationsProgress` whose final `collapsedMerkleTree` covers the whole
 /// generation tree at the pinned block, making the response a pure function of
-/// the block. Asserts determinism at a fixed block, per-block pinning, that the
-/// tree rebuilt from the served collapsed update matches the block's
+/// the block. Asserts determinism at a fixed block (acceptance criterion #2),
+/// that the tree rebuilt from the served collapsed update matches the block's
 /// `dustGenerationMerkleTreeRoot` (acceptance criterion #1), and rejection of an
 /// unknown block hash.
 async fn test_dust_generations_subscription(
@@ -1086,8 +1086,7 @@ async fn test_dust_generations_subscription(
     let network_id: NetworkId = "undeployed".try_into().unwrap();
     let dust_address = encode_address([0u8; 32], AddressType::Dust, &network_id);
 
-    // Pin to the tip (fresh, ledger state loadable); its parent is a second,
-    // distinct pinned block for the per-block-pinning check.
+    // Pin to the tip: fresh (well within max_snapshot_age) and its ledger state is loadable.
     let latest = send_query::<BlockDustRootQuery>(
         api_client,
         api_url,
@@ -1097,12 +1096,6 @@ async fn test_dust_generations_subscription(
     .block
     .expect("there is a latest block");
     let latest_hash = latest.hash.to_owned();
-    let parent_hash = latest
-        .parent
-        .as_ref()
-        .expect("the tip has a parent")
-        .hash
-        .to_owned();
 
     // Collect the snapshot. For the all-zero address there are no owned entries
     // or dtime updates, so the resolver emits exactly one event (the final
@@ -1160,10 +1153,6 @@ async fn test_dust_generations_subscription(
         Some("DustGenerationsProgress"),
         "snapshot completes with a DustGenerationsProgress event, got: {first:?}"
     );
-    let latest_highest = first
-        .get("highestIndex")
-        .and_then(|v| v.as_i64())
-        .expect("progress carries highestIndex");
 
     // Root match (acceptance criterion #1): rebuild the generation tree from the
     // full collapsed update the snapshot served and assert its root equals the
@@ -1198,18 +1187,7 @@ async fn test_dust_generations_subscription(
         "tree rebuilt from the collapsed update must match the block's dust generation root"
     );
 
-    // Per-block pinning: the parent snapshot cannot be ahead of the tip's.
-    let parent = snapshot(ws_api_url, DustAddress(dust_address.clone()), parent_hash).await?;
-    let parent_highest = parent
-        .get("highestIndex")
-        .and_then(|v| v.as_i64())
-        .expect("parent progress carries highestIndex");
-    assert!(
-        parent_highest <= latest_highest,
-        "generation tree grows monotonically by block: parent {parent_highest} > tip \
-         {latest_highest}"
-    );
-
+    // An unknown but well-formed block hash is rejected as a client error.
     let unknown = snapshot(
         ws_api_url,
         DustAddress(dust_address),

--- a/indexer-tests/src/e2e.rs
+++ b/indexer-tests/src/e2e.rs
@@ -147,7 +147,7 @@ pub async fn run(network_id: NetworkId, host: &str, port: u16, secure: bool) -> 
     test_dust_ledger_events_subscription(&indexer_data, &ws_api_url)
         .await
         .context("test dust ledger events subscription")?;
-    test_dust_generations_subscription(&indexer_data, &ws_api_url)
+    test_dust_generations_subscription(&api_client, &api_url, &ws_api_url)
         .await
         .context("test dust generations subscription")?;
     test_shielded_nullifier_transactions_subscription(&ws_api_url)
@@ -1068,51 +1068,119 @@ async fn test_dust_ledger_events_subscription(
     Ok(())
 }
 
-/// Test the dustGenerations subscription with a fresh dust address. Uses
-/// `start_index > end_index` so the resolver's `cursor > end_index` check
-/// fires on first pass (cursor starts at start_index, no entries to advance
-/// it), yielding a single final `DustGenerationsProgress` event and closing.
-/// Verifies wire-format compatibility for all three union variants and the
-/// completion-event shape on the empty case.
+/// Test the re-scoped `dustGenerations` subscription (issue #1283): a
+/// consistent, tip-independent snapshot pinned to `blockHash`. Uses the
+/// all-zero dust address (owns no generations), so the stream is a single
+/// `DustGenerationsProgress` whose final `collapsedMerkleTree` covers the whole
+/// generation tree at the pinned block, making the response a pure function of
+/// the block. Asserts determinism at a fixed block, per-block pinning, and
+/// rejection of an unknown block hash.
 async fn test_dust_generations_subscription(
-    indexer_data: &IndexerData,
+    api_client: &Client,
+    api_url: &str,
     ws_api_url: &str,
 ) -> anyhow::Result<()> {
     let network_id: NetworkId = "undeployed".try_into().unwrap();
-    let dust_address = DustAddress(encode_address([0u8; 32], AddressType::Dust, &network_id));
-    let block_hash = indexer_data
-        .blocks
-        .last()
-        .expect("there is at least one indexed block")
+    let dust_address = encode_address([0u8; 32], AddressType::Dust, &network_id);
+
+    // Pin to the tip (fresh, ledger state loadable); its parent is a second,
+    // distinct pinned block for the per-block-pinning check.
+    let latest = send_query::<BlockQuery>(
+        api_client,
+        api_url,
+        block_query::Variables { block_offset: None },
+    )
+    .await?
+    .block
+    .expect("there is a latest block");
+    let latest_hash = latest.hash.to_owned();
+    let parent_hash = latest
+        .parent
+        .as_ref()
+        .expect("the tip has a parent")
         .hash
         .to_owned();
-    let variables = dust_generations_subscription::Variables {
-        dust_address,
-        block_hash,
-        dtime_cutoff_height: 0,
-    };
-    let events = graphql_ws_client::subscribe::<DustGenerationsSubscription>(ws_api_url, variables)
-        .await
-        .context("subscribe to dust generations")?
-        .map_ok(|data| data.dust_generations.to_json_value())
-        .take(1)
-        .take_until(sleep(Duration::from_secs(5)))
-        .try_collect::<Vec<_>>()
-        .await
-        .context("collect dust generations events from subscription")?;
 
+    // Collect the snapshot. For the all-zero address there are no owned entries
+    // or dtime updates, so the resolver emits exactly one event (the final
+    // `DustGenerationsProgress`); `take(1)` grabs it and drops the connection.
+    // We cannot collect to `Complete` because this WS client does not terminate
+    // the stream on the server's completion message. The timeout only guards
+    // against a hang (e.g. a block whose ledger state never loads).
+    async fn snapshot(
+        ws_api_url: &str,
+        dust_address: DustAddress,
+        block_hash: HexEncoded,
+    ) -> anyhow::Result<serde_json::Value> {
+        let variables = dust_generations_subscription::Variables {
+            dust_address,
+            block_hash,
+            dtime_cutoff_height: 0,
+        };
+        let stream =
+            graphql_ws_client::subscribe::<DustGenerationsSubscription>(ws_api_url, variables)
+                .await
+                .context("subscribe to dust generations")?
+                .map_ok(|data| data.dust_generations.to_json_value())
+                .take(1);
+        let events = tokio::time::timeout(Duration::from_secs(10), stream.try_collect::<Vec<_>>())
+            .await
+            .context("dust generations subscription did not complete in time")?
+            .context("collect dust generations events from subscription")?;
+        events
+            .into_iter()
+            .next()
+            .context("dust generations subscription yielded no event")
+    }
+
+    // Determinism (acceptance criterion #2): two reads at the same block,
+    // including the collapsed-tree `update` blob, must be identical.
+    let first = snapshot(
+        ws_api_url,
+        DustAddress(dust_address.clone()),
+        latest_hash.clone(),
+    )
+    .await?;
+    let second = snapshot(
+        ws_api_url,
+        DustAddress(dust_address.clone()),
+        latest_hash.clone(),
+    )
+    .await?;
     assert_eq!(
-        events.len(),
-        1,
-        "expected exactly one DustGenerationsProgress event"
+        first, second,
+        "dustGenerations at a fixed block must be deterministic"
     );
 
-    let event = &events[0];
     assert_eq!(
-        event.get("__typename").and_then(|v| v.as_str()),
+        first.get("__typename").and_then(|v| v.as_str()),
         Some("DustGenerationsProgress"),
-        "expected DustGenerationsProgress for an address with no owned generations, got: {event:?}"
+        "snapshot completes with a DustGenerationsProgress event, got: {first:?}"
     );
+    let latest_highest = first
+        .get("highestIndex")
+        .and_then(|v| v.as_i64())
+        .expect("progress carries highestIndex");
+
+    // Per-block pinning: the parent snapshot cannot be ahead of the tip's.
+    let parent = snapshot(ws_api_url, DustAddress(dust_address.clone()), parent_hash).await?;
+    let parent_highest = parent
+        .get("highestIndex")
+        .and_then(|v| v.as_i64())
+        .expect("parent progress carries highestIndex");
+    assert!(
+        parent_highest <= latest_highest,
+        "generation tree grows monotonically by block: parent {parent_highest} > tip \
+         {latest_highest}"
+    );
+
+    let unknown = snapshot(
+        ws_api_url,
+        DustAddress(dust_address),
+        [42u8; 32].hex_encode(),
+    )
+    .await;
+    assert!(unknown.is_err(), "an unknown block hash must be rejected");
 
     Ok(())
 }

--- a/indexer-tests/src/e2e.rs
+++ b/indexer-tests/src/e2e.rs
@@ -15,14 +15,15 @@
 
 use crate::{
     e2e::graphql::{
-        BlockQuery, BlockSubscription, ConnectMutation, ContractActionQuery,
+        BlockDustRootQuery, BlockQuery, BlockSubscription, ConnectMutation, ContractActionQuery,
         ContractActionSubscription, DParameterHistoryQuery, DisconnectMutation,
         DustCommitmentMerkleTreeUpdateQuery, DustGenerationMerkleTreeUpdateQuery,
         DustGenerationStatusQuery, DustGenerationsQuery, DustGenerationsSubscription,
         DustLedgerEventsSubscription, DustNullifierTransactionsSubscription,
         ShieldedNullifierTransactionsSubscription, ShieldedTransactionsSubscription,
         TermsAndConditionsHistoryQuery, TransactionsQuery, UnshieldedTransactionsSubscription,
-        ZswapLedgerEventsSubscription, ZswapMerkleTreeCollapsedUpdateQuery, block_query,
+        ZswapLedgerEventsSubscription, ZswapMerkleTreeCollapsedUpdateQuery, block_dust_root_query,
+        block_query,
         block_subscription::{
             self, BlockSubscriptionBlocks, BlockSubscriptionBlocksTransactions,
             BlockSubscriptionBlocksTransactionsContractActions,
@@ -51,7 +52,7 @@ use indexer_api::infra::api::v4::{
     AddressType, HexEncodable, HexEncoded, dust::DustAddress, encode_address,
     viewing_key::ViewingKey,
 };
-use indexer_common::domain::NetworkId;
+use indexer_common::domain::{ByteVec, LedgerVersion, NetworkId, ledger::LedgerState};
 use itertools::Itertools;
 use reqwest::Client;
 use serde::Serialize;
@@ -1073,8 +1074,10 @@ async fn test_dust_ledger_events_subscription(
 /// all-zero dust address (owns no generations), so the stream is a single
 /// `DustGenerationsProgress` whose final `collapsedMerkleTree` covers the whole
 /// generation tree at the pinned block, making the response a pure function of
-/// the block. Asserts determinism at a fixed block, per-block pinning, and
-/// rejection of an unknown block hash.
+/// the block. Asserts determinism at a fixed block, per-block pinning, that the
+/// tree rebuilt from the served collapsed update matches the block's
+/// `dustGenerationMerkleTreeRoot` (acceptance criterion #1), and rejection of an
+/// unknown block hash.
 async fn test_dust_generations_subscription(
     api_client: &Client,
     api_url: &str,
@@ -1085,10 +1088,10 @@ async fn test_dust_generations_subscription(
 
     // Pin to the tip (fresh, ledger state loadable); its parent is a second,
     // distinct pinned block for the per-block-pinning check.
-    let latest = send_query::<BlockQuery>(
+    let latest = send_query::<BlockDustRootQuery>(
         api_client,
         api_url,
-        block_query::Variables { block_offset: None },
+        block_dust_root_query::Variables { block_offset: None },
     )
     .await?
     .block
@@ -1161,6 +1164,39 @@ async fn test_dust_generations_subscription(
         .get("highestIndex")
         .and_then(|v| v.as_i64())
         .expect("progress carries highestIndex");
+
+    // Root match (acceptance criterion #1): rebuild the generation tree from the
+    // full collapsed update the snapshot served and assert its root equals the
+    // block's authoritative `dustGenerationMerkleTreeRoot`. The dev chain seeds
+    // dust generations at genesis, so the tip's tree is non-empty and the final
+    // progress carries a collapsed update.
+    let update: HexEncoded = serde_json::from_value(
+        first
+            .get("collapsedMerkleTree")
+            .and_then(|c| c.get("update"))
+            .cloned()
+            .expect("non-empty generation tree carries a collapsed update"),
+    )
+    .expect("collapsed update is a HexEncoded string");
+    let update_bytes = update
+        .hex_decode::<ByteVec>()
+        .expect("hex-decode collapsed update");
+    // The e2e node runs protocol V2_0 (ledger V9).
+    let rebuilt_root = LedgerState::dust_generation_root_from_collapsed_update(
+        update_bytes.as_ref(),
+        LedgerVersion::V9,
+    )
+    .expect("rebuild dust generation root");
+    let block_root = latest
+        .dust_generation_merkle_tree_root
+        .as_ref()
+        .expect("tip block carries a dust generation merkle tree root")
+        .hex_decode::<ByteVec>()
+        .expect("hex-decode block root");
+    assert_eq!(
+        rebuilt_root, block_root,
+        "tree rebuilt from the collapsed update must match the block's dust generation root"
+    );
 
     // Per-block pinning: the parent snapshot cannot be ahead of the tip's.
     let parent = snapshot(ws_api_url, DustAddress(dust_address.clone()), parent_hash).await?;
@@ -1433,6 +1469,14 @@ mod graphql {
         response_derives = "Debug, Clone, Serialize"
     )]
     pub struct BlockQuery;
+
+    #[derive(GraphQLQuery)]
+    #[graphql(
+        schema_path = "../indexer-api/graphql/schema-v4.graphql",
+        query_path = "./e2e.graphql",
+        response_derives = "Debug, Clone, Serialize"
+    )]
+    pub struct BlockDustRootQuery;
 
     #[derive(GraphQLQuery)]
     #[graphql(


### PR DESCRIPTION
## Summary

Adds test coverage for the block-hash `dustGenerations` sync (feature shipped in #1291, closes the test gap on #1283). The feature merged with only an empty-case e2e test that exercised none of the acceptance criteria; this PR covers all three ACs across the storage layer, a chain-free unit test, and end-to-end.

## What's covered

**Storage integration tests** (`indexer-api/src/infra/storage/block_hash_dust_sync_tests.rs`, cloud/Postgres via testcontainers — first storage-level tests in `indexer-api`):
- `get_ledger_state_at` — by-hash lookup (known → row, unknown → `None`, which drives the resolver's "unknown block hash" client error).
- `get_dust_generation_entries` — ordering, index-range + owner filtering, legacy `NULL generation_index` skip, and cursor pagination (`batch_size=2`).
- `get_dust_generation_dtime_updates` — the `(cutoff, upper]` block bounding (the determinism foundation), owner filtering with no other-owner leakage, and `dtime`/`tree_insertion_path` recovery from the JSONB attributes.

**Root match — AC#1** (`indexer-common`):
- New `LedgerState::dust_generation_root_from_collapsed_update(update, ledger_version)`: the wallet-side rebuild (blank tree + `apply_collapsed_update` + `rehash().root()`), serialized identically to `dust_generation_merkle_tree_root`. V8 + V9.
- Chain-free unit test: build a tree, produce the full collapsed update and expected root via the same ledger primitives the resolver uses, reconstruct, assert equal (across several leaf counts).

**E2E** (`indexer-tests`):
- Determinism — **AC#2**: two subscriptions at the same block yield byte-identical responses (including the serialized collapsed-tree `update` blob).
- Root match — **AC#1**: rebuild the root from the zero-address snapshot's collapsed update and assert it equals the tip block's `dustGenerationMerkleTreeRoot` (via new `BlockDustRootQuery`).
- Unknown block hash → client error.

Key insight for AC#1: no owned dust address is needed — the zero-address snapshot's final `collapsedMerkleTree` covers the whole generation tree `[0, first_free-1]`, so applying it to a blank tree rebuilds the full root.

## Verification

- Storage tests: pass (cloud).
- `indexer-common` unit test: pass.
- Full `native_e2e`: pass on **cloud** and **standalone**.
- fmt + clippy clean on all changed crates.

## Not included

A standalone/SQLite mirror of the storage-layer `dtime` tests (the SQLite query uses `json_extract`/`unhex`/`iif` vs Postgres `->>`/`decode`/`regexp_replace`). The e2e already exercises the standalone path end-to-end; only the SQL-level dtime test with seeded rows is Postgres-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)