### PR TITLE
test: decompress zstd fetch responses in probe

### DIFF
--- a/qa/tests/README.md
+++ b/qa/tests/README.md
@@ -47,7 +47,7 @@ See [Test Framework Organization](#-test-framework-organization) for the differe
 
 ## 📦 Prerequisites
 
-- **Node.js**: v22 or higher (vitest runs under Node; Bun is the package manager/launcher)
+- **Node.js**: v22 or higher (vitest runs under Node; Bun is the package manager/launcher). The HTTP compression probe's `zstd` decompression path additionally requires Node >= 22.15.0 (where `node:zlib.zstdDecompressSync` was added); the gzip/brotli/identity paths work on any v22.
 - **Bun**: v1.3.x
 - **Midnight Indexer**: 3.x and above
 - **Docker**: latest stable (required for local/undeployed runs)

--- a/qa/tests/utils/indexer/http-compression-probe.ts
+++ b/qa/tests/utils/indexer/http-compression-probe.ts
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { zstdDecompressSync } from 'node:zlib';
-
 import { env } from 'environment/model';
 
 export interface CompressionProbeResult {
@@ -58,6 +56,12 @@ const INTROSPECTION_QUERY = `{
  * So for zstd we read the raw bytes and decompress them ourselves (see below).
  * The Content-Encoding header is preserved in `response.headers` regardless and
  * reflects what the server actually sent.
+ *
+ * Note on the zstd runtime requirement: `zstdDecompressSync` was only added to
+ * `node:zlib` in Node 22.15.0. We import it lazily, inside the zstd branch, so
+ * the gzip / brotli / identity probes keep working on earlier Node 22.x
+ * releases — only the zstd decompression path needs Node >= 22.15.0 (see the
+ * prerequisites note in qa/tests/README.md).
  *
  * Note on identity responses: undici unconditionally appends its own
  * `Accept-Encoding` (gzip, deflate, br) to every outgoing request. To test
@@ -103,7 +107,21 @@ export async function probeGraphQLCompression(
     buffer[1] === 0xb5 &&
     buffer[2] === 0x2f &&
     buffer[3] === 0xfd;
-  const data = JSON.parse((isRawZstd ? zstdDecompressSync(buffer) : buffer).toString('utf8'));
+
+  let payload = buffer;
+  if (isRawZstd) {
+    // Import lazily so the module still loads on Node 22.x < 22.15, where
+    // `zstdDecompressSync` does not exist — only this branch needs it.
+    const { zstdDecompressSync } = await import('node:zlib');
+    if (typeof zstdDecompressSync !== 'function') {
+      throw new Error(
+        'Received a zstd-compressed response but node:zlib.zstdDecompressSync ' +
+          'is unavailable; Node >= 22.15.0 is required to decompress zstd.',
+      );
+    }
+    payload = zstdDecompressSync(buffer);
+  }
+  const data = JSON.parse(payload.toString('utf8'));
 
   return {
     status: response.status,

--- a/qa/tests/utils/indexer/http-compression-probe.ts
+++ b/qa/tests/utils/indexer/http-compression-probe.ts
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { zstdDecompressSync } from 'node:zlib';
+
 import { env } from 'environment/model';
 
 export interface CompressionProbeResult {
@@ -48,11 +50,14 @@ const INTROSPECTION_QUERY = `{
  * remain accessible — graphql-request parses and discards them before
  * surfacing the response to callers.
  *
- * Note on Node.js fetch (undici): undici automatically decompresses the
- * response body when Content-Encoding is present, so `response.json()` works
- * transparently regardless of the encoding. The Content-Encoding header is
- * still preserved in `response.headers` and reflects what the server actually
- * sent.
+ * Note on fetch decompression: gzip, deflate and brotli are decompressed
+ * transparently by both Node (undici) and Bun. `zstd`, however, is NOT
+ * auto-decompressed by Node's fetch on the versions we run on — undici only
+ * gained zstd support in v7.11 (Node >= 24.4.0), and the entire Node 22.x /
+ * 23.x line ships undici 6.x/early-7.x without it (Bun does decompress zstd).
+ * So for zstd we read the raw bytes and decompress them ourselves (see below).
+ * The Content-Encoding header is preserved in `response.headers` regardless and
+ * reflects what the server actually sent.
  *
  * Note on identity responses: undici unconditionally appends its own
  * `Accept-Encoding` (gzip, deflate, br) to every outgoing request. To test
@@ -81,11 +86,28 @@ export async function probeGraphQLCompression(
     signal: AbortSignal.timeout(30_000),
   });
 
-  const data = await response.json();
+  const contentEncoding = response.headers.get('content-encoding');
+
+  // Node's fetch (undici < 7.11, i.e. all Node 22.x/23.x) does NOT
+  // auto-decompress `Content-Encoding: zstd`, so `response.json()` would try to
+  // parse raw zstd bytes and throw. Read the body as bytes and decompress zstd
+  // ourselves, but only when the server actually sent zstd AND the payload
+  // still carries the zstd magic number (0x28 B5 2F FD). The magic-number guard
+  // makes this a no-op on runtimes that already decompressed (Bun, Node >=
+  // 24.4.0), so the gzip / brotli / identity paths are unaffected.
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const isRawZstd =
+    contentEncoding === 'zstd' &&
+    buffer.length >= 4 &&
+    buffer[0] === 0x28 &&
+    buffer[1] === 0xb5 &&
+    buffer[2] === 0x2f &&
+    buffer[3] === 0xfd;
+  const data = JSON.parse((isRawZstd ? zstdDecompressSync(buffer) : buffer).toString('utf8'));
 
   return {
     status: response.status,
-    contentEncoding: response.headers.get('content-encoding'),
+    contentEncoding,
     data,
   };
 }


### PR DESCRIPTION
## What

The `Accept-Encoding: zstd` case of `graphql-http-compression.test.ts` fails with `SyntaxError: Unexpected token '(', "(<binary>"... is not valid JSON`. The probe uses `fetch` + `response.json()` and assumed the runtime auto-decompresses the body per `Content-Encoding`.

**Node's `fetch` does not auto-decompress `zstd`** on the versions we run: undici only gained zstd support in **v7.11 (Node ≥ 24.4.0)**, and the **entire Node 22.x / 23.x line** ships undici 6.x/early-7.x without it. CI's `qa-integration-tests` workflow pins `node-version: 22.x` (currently v22.23.1), so this test is **red** whenever it runs against an indexer serving zstd. gzip / brotli / identity were unaffected (those are decompressed transparently). Bun also decompresses zstd fine.

This fix reads the body as bytes and decompresses `zstd` ourselves, guarded by the zstd magic number (`0x28 B5 2F FD`) so it's a **no-op** on runtimes that already decompressed (Bun, Node ≥ 24.4.0) — gzip/br/identity paths are untouched. Also corrects the JSDoc that wrongly claimed undici decompresses every encoding.

## Not a bun-migration regression

Independent of the yarn→bun switch: the test runs under Node either way (vitest workers run on Node), and Node 22.x is what fails. It would fail identically on the old yarn/Node path.

## Verification

Local server serving each `Content-Encoding`, exercising the exact committed decode logic — all four encodings (identity/gzip/br/zstd) parse correctly on:
- **Node v22.16.0** (fails without this change)
- **Node v22.23.1** (what CI's `22.x` resolves to today)
- **Node v24.18.0** (native zstd — confirms the magic-number guard is a correct no-op)
- **Bun 1.3.14**

Also confirmed in-situ earlier: the `zstd` case passes against a live undeployed indexer stack with this logic. `lint` and `format:check` pass.

Ref: undici zstd support — https://github.com/nodejs/undici/pull/4238

🤖 Generated with [Claude Code](https://claude.com/claude-code)
