### PR TITLE
test: add compile-check script and fix tsc errors

### DIFF
--- a/qa/tests/package.json
+++ b/qa/tests/package.json
@@ -6,6 +6,7 @@
     "lint": "eslint '**/*.{js,jsx,ts,tsx}'",
     "lint:fix": "eslint '**/*.{js,jsx,ts,tsx}' --fix",
     "audit": "bun audit --audit-level=high",
+    "compile-check": "tsc --noEmit",
     "test": "vitest run --project smoke --project e2e --project integration",
     "test:e2e": "vitest run --project e2e",
     "test:smoke": "vitest run --project smoke",

--- a/qa/tests/tsconfig.json
+++ b/qa/tests/tsconfig.json
@@ -2,10 +2,11 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
+    "skipLibCheck": true,
     "strict": true,
     "baseUrl": ".",
     "paths": {

--- a/qa/tests/types/vitest.d.ts
+++ b/qa/tests/types/vitest.d.ts
@@ -19,13 +19,15 @@ declare module 'vitest' {
     toBeSuccess(message?: string): void;
   }
 
-  interface TestContext {
-    skip?: (condition: boolean, reason?: string) => void;
-    task?: {
-      meta: {
-        done?: boolean;
-        custom?: Record<string, unknown>;
-      };
-    };
+  // Custom fields we attach via `ctx.task.meta` in tests. Augment TaskMeta
+  // (the type of Test.meta) rather than redefining TestContext, so vitest's
+  // own TestContext members (skip, task, signal, …) are preserved.
+  interface TaskMeta {
+    done?: boolean;
+    custom?: Record<string, unknown>;
   }
 }
+
+// This file must be a module for `declare module 'vitest'` to *augment*
+// (merge with) vitest's types rather than shadow them.
+export {};

--- a/qa/tests/utils/indexer/websocket-client.ts
+++ b/qa/tests/utils/indexer/websocket-client.ts
@@ -101,8 +101,8 @@ export type ContractEventSubscriptionResponse = GraphQLResponse<{
  * Handlers used to respond to incoming GraphQL subscription messages.
  */
 export interface SubscriptionHandlers<T> {
-  /** Called when a new payload is received */
-  next: (value: T) => void;
+  /** Called when a new payload is received (optional: the client invokes it as `next?.()`) */
+  next?: (value: T) => void;
 
   /** Called when an error is received */
   error?: (err: Error | GraphQLError) => void;


### PR DESCRIPTION
## Scope

Add a `compile-check` script (`tsc --noEmit`) to `qa/tests` and fix the pre-existing type errors it surfaces, taking the suite from 81 type errors to a clean type-check.

## Why

`tsc` was not run for `qa/tests` (vitest transpiles via esbuild and does not type-check), so type regressions could land unnoticed. A dedicated type-check script makes them catchable, and the accompanying fixes make the baseline clean so the check can be relied on.

## Changes

- **`package.json`** — add `compile-check` → `tsc --noEmit`.
- **`tsconfig.json`** — `moduleResolution: "Bundler"` (correct for this Vite/Vitest project; resolves packages that ship `exports` maps) and `skipLibCheck: true` (do not type-check third-party declaration files).
- **`types/vitest.d.ts`** — make the file a module (`export {}`) so `declare module 'vitest'` augments vitest's types instead of shadowing them, and augment `TaskMeta` (the type of `Test.meta`) rather than redefining `TestContext`. This restores vitest's own `skip`/`task` members and clears the widespread `ctx.skip()` errors.
- **`utils/indexer/websocket-client.ts`** — mark `SubscriptionHandlers.next` optional to match the client, which invokes it as `next?.()`.

## Validation

- `bun run compile-check` → 0 errors (was 81).
- `bun run lint` → clean.
- `bun run format:check` → clean.
