### PR TITLE
ci(build-indexer-images): build linux/amd64 only, drop QEMU arm64 emulation

### DIFF
--- a/.github/workflows/build-indexer-images.yaml
+++ b/.github/workflows/build-indexer-images.yaml
@@ -83,11 +83,6 @@ jobs:
             org.opencontainers.image.title=${{ matrix.name }}
             org.opencontainers.image.description=${{ matrix.description }}
 
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-        with:
-          image: tonistiigi/binfmt:qemu-v8.1.5
-
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
@@ -102,7 +97,7 @@ jobs:
           build-args: |
             PROFILE=${{ env.PROFILE }}
             RUST_VERSION=${{ env.TOOLCHAIN }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: |


### PR DESCRIPTION
## Summary

Build the indexer images for **`linux/amd64` only** and drop the QEMU setup step.

The job built `linux/amd64,linux/arm64` on an x86_64 runner (`ubuntu-latest-16-core-x64`) with `setup-qemu-action`, so the **arm64** variant compiled under **QEMU emulation** — Rust compiles ~5–10× slower emulated. The multi-arch manifest can't publish until the slow arm64 leg finishes, and both variants build concurrently on the same runner and contend for CPU/RAM, so arm64 dominates wall-clock. Observed release builds ran ~20–40 min; the amd64 leg alone is ~7–10 min.

**arm64 images are unused by any deployment target** — the indexer runs on amd64 EKS nodes (mainnet verified: `c7i.2xlarge`, `architecture: amd64`; pods scheduled on amd64). Dropping arm64 removes the QEMU long-pole and the resource contention.

## Changes
- `platforms: linux/amd64,linux/arm64` → `platforms: linux/amd64`
- Remove the now-unnecessary `Setup QEMU` (`setup-qemu-action`) step (only needed for cross-arch emulation).

## Expected impact
Release image builds drop from ~20–40 min to roughly native amd64 build time (~7–10 min). No change to the published amd64 image or its cache lines (cargo-chef + registry buildcache unchanged).

## Testing
- `actionlint` (repo CI on workflow changes) will validate the workflow.
- Deployment arch verified: `kubectl get nodes -o …architecture` on `stl-euw1-mainnet-1` → all `amd64`.

## Notes / trade-off
This makes the images **single-arch amd64**. If anyone consumes arm64 images (e.g. running the indexer container locally on an Apple-Silicon Mac), they'd need to build locally or re-enable a native arm64 build. If multi-arch is wanted later without the QEMU penalty, the follow-up is a per-arch native-runner matrix + `docker manifest` merge (kept out of scope here).

AI-assisted (`bot:ai-assisted`).
