### PR TITLE
ci(build-indexer-images): split arch into parallel jobs so amd64 publishes without waiting for arm64

### DIFF
--- a/.github/workflows/build-indexer-images.yaml
+++ b/.github/workflows/build-indexer-images.yaml
@@ -22,14 +22,14 @@ concurrency:
 
 jobs:
   build-and-push:
-    name: Build and push
+    name: Build and push (${{ matrix.image.name }}, ${{ matrix.platform.arch }})
     runs-on: ubuntu-latest-16-core-x64
     permissions:
       packages: write
     strategy:
       fail-fast: false
       matrix:
-        include:
+        image:
           - name: chain-indexer
             description: Midnight Chain Indexer
           - name: indexer-api
@@ -40,6 +40,17 @@ jobs:
             description: Midnight Indexer
           - name: spo-indexer
             description: Midnight SPO Indexer
+        # Each (image, arch) is an independent parallel job. amd64 keeps the existing (warm)
+        # buildcache ref and the unsuffixed tag and builds natively, so it publishes without
+        # waiting for arm64. arm64 builds in parallel under QEMU and publishes an -arm64-suffixed
+        # tag, so the slow emulated build never blocks the amd64 image from being pushed.
+        platform:
+          - arch: amd64
+            suffix: ""
+            cache_scope: ""
+          - arch: arm64
+            suffix: "-arm64"
+            cache_scope: "-arm64"
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -73,17 +84,20 @@ jobs:
           DOCKER_METADATA_SHORT_SHA_LENGTH: 8
         with:
           images: |
-            ghcr.io/midnight-ntwrk/${{ matrix.name }}
-            ${{ github.ref_type == 'tag' && format('midnightntwrk/{0}', matrix.name) || '' }}
+            ghcr.io/midnight-ntwrk/${{ matrix.image.name }}
+            ${{ github.ref_type == 'tag' && format('midnightntwrk/{0}', matrix.image.name) || '' }}
+          flavor: |
+            suffix=${{ matrix.platform.suffix }}
           tags: |
             type=semver,pattern={{version}}
             ${{ github.ref_type != 'tag' && format('type=sha,prefix={0}-,format=short', env.VERSION) || '' }}
           labels: |
             org.opencontainers.image.source=https://github.com/midnightntwrk/midnight-indexer/
-            org.opencontainers.image.title=${{ matrix.name }}
-            org.opencontainers.image.description=${{ matrix.description }}
+            org.opencontainers.image.title=${{ matrix.image.name }}
+            org.opencontainers.image.description=${{ matrix.image.description }}
 
       - name: Setup QEMU
+        if: matrix.platform.arch == 'arm64'
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           image: tonistiigi/binfmt:qemu-v8.1.5
@@ -97,20 +111,20 @@ jobs:
           PROFILE: ${{ startsWith(github.ref, 'refs/tags/v') && 'release' || 'dev' }}
         with:
           context: .
-          file: ./${{ matrix.name }}/Dockerfile
+          file: ./${{ matrix.image.name }}/Dockerfile
           push: true
           build-args: |
             PROFILE=${{ env.PROFILE }}
             RUST_VERSION=${{ env.TOOLCHAIN }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/${{ matrix.platform.arch }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: |
-            type=registry,ref=ghcr.io/midnight-ntwrk/${{ matrix.name }}:buildcache
-            type=registry,ref=ghcr.io/midnight-ntwrk/${{ matrix.name }}:buildcache-${{ env.PROFILE }}
+            type=registry,ref=ghcr.io/midnight-ntwrk/${{ matrix.image.name }}:buildcache${{ matrix.platform.cache_scope }}
+            type=registry,ref=ghcr.io/midnight-ntwrk/${{ matrix.image.name }}:buildcache-${{ env.PROFILE }}${{ matrix.platform.cache_scope }}
           cache-to: |
-            type=registry,ref=ghcr.io/midnight-ntwrk/${{ matrix.name }}:buildcache,mode=max
-            type=registry,ref=ghcr.io/midnight-ntwrk/${{ matrix.name }}:buildcache-${{ env.PROFILE }},mode=max
+            type=registry,ref=ghcr.io/midnight-ntwrk/${{ matrix.image.name }}:buildcache${{ matrix.platform.cache_scope }},mode=max
+            type=registry,ref=ghcr.io/midnight-ntwrk/${{ matrix.image.name }}:buildcache-${{ env.PROFILE }}${{ matrix.platform.cache_scope }},mode=max
 
   docker-compose-validation:
     name: Docker Compose Validation


### PR DESCRIPTION
## Summary

Keep arm64 images, but build each architecture as an **independent parallel job** so the **amd64** image builds and publishes on its own timeline instead of waiting for the slow arm64 leg.

Today it's one `docker/build-push-action` step with `platforms: linux/amd64,linux/arm64` on an x86_64 runner + QEMU. The arm64 variant compiles under **QEMU emulation** (Rust ~5–10× slower), and because the job publishes one multi-arch manifest, nothing is pushed until arm64 finishes — plus both legs contend for the runner's CPU/RAM. Result: release builds ~20–40 min gated by arm64.

## Change
Add `platform` as a second matrix axis so each `(image, arch)` is its own parallel job:
- **amd64** — builds natively, keeps the existing (warm) `:buildcache` / `:buildcache-<profile>` refs, publishes the **unsuffixed** tag, and no longer waits on arm64. QEMU step is skipped.
- **arm64** — builds in parallel under QEMU, uses its own `:buildcache-arm64` refs, publishes a **`-arm64`-suffixed** tag.

Net: the deployable amd64 image is available in ~native build time (~7–10 min) regardless of how long arm64 takes.

## Trade-offs (please confirm acceptable)
- The primary `<tag>` becomes a **single-arch amd64** manifest; arm64 is published as `<tag>-arm64` (no combined multi-arch manifest). All deploy targets are amd64 (mainnet EKS nodes are `c7i`, amd64), so deployment is unaffected; arm64 consumers (e.g. local Apple-Silicon dev) pull `-arm64`. If a true multi-arch `<tag>` is required, the alternative is per-arch push-by-digest + a `docker buildx imagetools create` merge job (the merge would re-introduce a wait on arm64 for the *combined* tag, though amd64 could still be published first).
- `docker-compose-validation` (`needs: build-and-push`) still waits for the whole matrix incl. arm64, but it's `continue-on-error` and doesn't gate image publication.

## ⚠️ Validation
I can't run GitHub Actions locally, and `build-indexer-images` only triggers on push-to-main / `v*` tags / `workflow_dispatch` (not `pull_request`), so this PR won't auto-build. `actionlint` will lint it. **Recommend validating via `workflow_dispatch` on this branch before merge** (produces harmless `<version>-<sha>` dev images) to confirm the matrix + `flavor: suffix` behavior. YAML parses clean locally.

Supersedes #1348 (which simply dropped arm64).

AI-assisted (`bot:ai-assisted`).
