### PR TITLE
chore(release): prepare for 4.4.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.4.0] - 2026-07-22
+## [4.4.0-rc.1] - 2026-07-22
 
 ### 🚀 Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "chain-indexer"
-version = "4.4.0"
+version = "4.4.0-rc.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-api"
-version = "4.4.0"
+version = "4.4.0-rc.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3477,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-standalone"
-version = "4.4.0"
+version = "4.4.0-rc.1"
 dependencies = [
  "anyhow",
  "byte-unit-serde",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-tests"
-version = "4.4.0"
+version = "4.4.0-rc.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -7516,7 +7516,7 @@ dependencies = [
 
 [[package]]
 name = "spo-indexer"
-version = "4.4.0"
+version = "4.4.0-rc.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -9060,7 +9060,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-indexer"
-version = "4.4.0"
+version = "4.4.0-rc.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version       = "4.4.0"
+version       = "4.4.0-rc.1"
 edition       = "2024"
 license       = "Apache-2.0"
 readme        = "README.md"


### PR DESCRIPTION
Prepares the 4.4.0 release candidate: bumps the workspace version and lockfile to 4.4.0-rc.1 and updates the generated changelog.