### PR TITLE
test: run QA smoke+integration on main merge

### DIFF
--- a/.github/workflows/qa-integration-tests-base-workflow.yml
+++ b/.github/workflows/qa-integration-tests-base-workflow.yml
@@ -39,6 +39,11 @@ on:
         required: true
         description: Indexer tag
         default: latest
+      node_toolkit_tag:
+        type: string
+        required: false
+        description: Node toolkit tag (leave empty for the startup script default)
+        default: ""
   workflow_call:
     inputs:
       target_env:
@@ -65,6 +70,11 @@ on:
         description: Indexer tag
         required: false
         default: latest
+      node_toolkit_tag:
+        type: string
+        description: Node toolkit tag (leave empty for the startup script default)
+        required: false
+        default: ""
     secrets:
       MIDNIGHTCI_PACKAGES_READ:
         required: true
@@ -127,6 +137,7 @@ jobs:
         env:
           NODE_TAG: ${{ inputs.node_tag }}
           INDEXER_TAG: ${{ inputs.indexer_tag }}
+          NODE_TOOLKIT_TAG: ${{ inputs.node_toolkit_tag }}
           APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
           APP__INFRA__STORAGE__PASSWORD: ${{ secrets.APP__INFRA__STORAGE__PASSWORD }}
           APP__INFRA__PUB_SUB__PASSWORD: ${{ secrets.APP__INFRA__PUB_SUB__PASSWORD }}

--- a/.github/workflows/qa-tests-main-merge.yml
+++ b/.github/workflows/qa-tests-main-merge.yml
@@ -1,0 +1,108 @@
+name: Indexer QA Tests - main merge
+
+# Runs the QA smoke + integration suites against an undeployed (local
+# docker compose) environment using the indexer images built by
+# build-indexer-images for the same commit.
+#
+# This is chained via workflow_run instead of being a job inside
+# build-indexer-images because GitHub Actions does not support
+# continue-on-error on jobs that call reusable workflows: running in a
+# separate workflow keeps QA failures from ever failing the image build
+# pipeline (the QA run is informational/optional by construction).
+
+permissions:
+  contents: read
+
+on:
+  workflow_run:
+    workflows:
+      - build-indexer-images
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      node_tag:
+        type: string
+        description: Node tag (leave empty to use the last line of NODE_VERSIONS)
+        required: false
+        default: ""
+      indexer_tag:
+        type: string
+        description: Indexer tag (leave empty to derive <cargo-version>-<sha8> from the checked-out commit)
+        required: false
+        default: ""
+
+jobs:
+  derive-tags:
+    name: Derive image tags
+    # For workflow_run: only after a successful image build for a push to
+    # main (tag builds are excluded; they have their own release flow).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'main')
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.tags.outputs.ref }}
+      node_tag: ${{ steps.tags.outputs.node_tag }}
+      indexer_tag: ${{ steps.tags.outputs.indexer_tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Derive tags
+        id: tags
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          NODE_TAG_INPUT: ${{ inputs.node_tag }}
+          INDEXER_TAG_INPUT: ${{ inputs.indexer_tag }}
+        run: |
+          echo "ref=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+          # Indexer tag: what build-indexer-images pushed for this commit.
+          # docker/metadata-action tags main-branch builds as
+          # <cargo-version>-<sha> with DOCKER_METADATA_SHORT_SHA_LENGTH=8,
+          # i.e. the first 8 characters of the commit SHA.
+          if [ -n "$INDEXER_TAG_INPUT" ]; then
+            indexer_tag="$INDEXER_TAG_INPUT"
+            echo "Using indexer tag from workflow dispatch: $indexer_tag"
+          else
+            version=$(grep '^version.*=' Cargo.toml | sed -E 's/version.*=.*"(.*)"/\1/')
+            indexer_tag="${version}-${HEAD_SHA:0:8}"
+            echo "Derived indexer tag: $indexer_tag"
+          fi
+          echo "indexer_tag=$indexer_tag" >> "$GITHUB_OUTPUT"
+
+          # Node tag: pinned in the NODE_VERSIONS file (last line), same
+          # source as the docker-compose-validation job in
+          # build-indexer-images.
+          if [ -n "$NODE_TAG_INPUT" ]; then
+            node_tag="$NODE_TAG_INPUT"
+            echo "Using node tag from workflow dispatch: $node_tag"
+          else
+            node_tag=$(tail -n 1 NODE_VERSIONS)
+            echo "Using node tag from NODE_VERSIONS: $node_tag"
+          fi
+          echo "node_tag=$node_tag" >> "$GITHUB_OUTPUT"
+
+  qa-tests:
+    name: Indexer QA Tests on undeployed
+    needs: derive-tags
+    uses: ./.github/workflows/qa-integration-tests-base-workflow.yml
+    with:
+      target_env: undeployed
+      ref: ${{ needs.derive-tags.outputs.ref }}
+      publish_to_xray: false
+      node_tag: ${{ needs.derive-tags.outputs.node_tag }}
+      indexer_tag: ${{ needs.derive-tags.outputs.indexer_tag }}
+    secrets:
+      MIDNIGHTCI_PACKAGES_READ: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
+      APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
+      APP__INFRA__STORAGE__PASSWORD: ${{ secrets.APP__INFRA__STORAGE__PASSWORD }}
+      APP__INFRA__PUB_SUB__PASSWORD: ${{ secrets.APP__INFRA__PUB_SUB__PASSWORD }}
+      APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD: ${{ secrets.APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD }}
+      XRAY_CLIENT_ID: ${{ secrets.XRAY_CLIENT_ID }}
+      XRAY_CLIENT_SECRET: ${{ secrets.XRAY_CLIENT_SECRET }}

--- a/.github/workflows/qa-tests-main-merge.yml
+++ b/.github/workflows/qa-tests-main-merge.yml
@@ -31,6 +31,11 @@ on:
         description: Indexer tag (leave empty to derive <cargo-version>-<sha8> from the checked-out commit)
         required: false
         default: ""
+      node_toolkit_tag:
+        type: string
+        description: Node toolkit tag (leave empty to pair with the node tag)
+        required: false
+        default: ""
 
 jobs:
   derive-tags:
@@ -47,6 +52,7 @@ jobs:
       ref: ${{ steps.tags.outputs.ref }}
       node_tag: ${{ steps.tags.outputs.node_tag }}
       indexer_tag: ${{ steps.tags.outputs.indexer_tag }}
+      node_toolkit_tag: ${{ steps.tags.outputs.node_toolkit_tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -59,6 +65,7 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
           NODE_TAG_INPUT: ${{ inputs.node_tag }}
           INDEXER_TAG_INPUT: ${{ inputs.indexer_tag }}
+          NODE_TOOLKIT_TAG_INPUT: ${{ inputs.node_toolkit_tag }}
         run: |
           echo "ref=$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
@@ -88,6 +95,19 @@ jobs:
           fi
           echo "node_tag=$node_tag" >> "$GITHUB_OUTPUT"
 
+          # Node toolkit tag: paired 1:1 with the node tag — the toolkit
+          # publishes a matching tag for every node release, and running
+          # a node with its own toolkit version keeps the test data
+          # generation consistent with the node under test.
+          if [ -n "$NODE_TOOLKIT_TAG_INPUT" ]; then
+            node_toolkit_tag="$NODE_TOOLKIT_TAG_INPUT"
+            echo "Using node toolkit tag from workflow dispatch: $node_toolkit_tag"
+          else
+            node_toolkit_tag="$node_tag"
+            echo "Pairing node toolkit tag with node tag: $node_toolkit_tag"
+          fi
+          echo "node_toolkit_tag=$node_toolkit_tag" >> "$GITHUB_OUTPUT"
+
   qa-tests:
     name: Indexer QA Tests on undeployed
     needs: derive-tags
@@ -98,6 +118,7 @@ jobs:
       publish_to_xray: false
       node_tag: ${{ needs.derive-tags.outputs.node_tag }}
       indexer_tag: ${{ needs.derive-tags.outputs.indexer_tag }}
+      node_toolkit_tag: ${{ needs.derive-tags.outputs.node_toolkit_tag }}
     secrets:
       MIDNIGHTCI_PACKAGES_READ: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
       APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}


### PR DESCRIPTION
## Scope

Adds a `qa-tests-main-merge.yml` workflow that runs the QA **smoke + integration** suites against `TARGET_ENV=undeployed` using the indexer images built for each commit merged into `main`.

- Triggered via `workflow_run` on successful `build-indexer-images` completion (push to `main` only; tag builds excluded). GitHub Actions does not support `continue-on-error` on jobs calling reusable workflows ([discussion](https://github.com/orgs/community/discussions/77915)), so a separate chained workflow is what keeps the QA run **optional**: it can never fail the image build pipeline.
- `indexer_tag` is derived exactly as `docker/metadata-action` tags main-branch builds (`<cargo-version>-<first 8 chars of commit SHA>`), so the run provably targets the images just pushed for that commit.
- `node_tag` comes from the last line of `NODE_VERSIONS` (same source as the `docker-compose-validation` job).
- `node_toolkit_tag` is paired 1:1 with the node tag (the toolkit publishes a matching tag for every node release), replacing the moving `latest-main` default with a reproducible pin. This required a new optional `node_toolkit_tag` input on `qa-integration-tests-base-workflow.yml`, forwarded as `NODE_TOOLKIT_TAG` to the undeployed startup script — empty keeps the script's default, so existing callers are unaffected.
- A `workflow_dispatch` trigger with tag-override inputs is included for manual runs and pre-merge testing (as a `workflow_run` workflow, it only auto-triggers from `main` after this merges).
- Test execution reuses `qa-integration-tests-base-workflow.yml`, pinned to the built commit via `ref`.

## Why

Merges to `main` currently build and push images with only a docker-compose syntax/startup validation; the QA suites against `undeployed` only run on manual dispatch. This surfaces functional regressions at merge time without blocking the build pipeline.

## Validation

- `actionlint` passes on both changed workflow files.
- Toolkit tags matching every pinned node version (`0.22.0`, `1.0.0`, `2.0.0-rc.3`) verified present on Docker Hub.
- End-to-end trigger is exercisable only from `main` (workflow_run limitation); the dispatch path is available for verification after merge.

Closes #1359

🤖 Generated with [Claude Code](https://claude.com/claude-code)