### PR TITLE
chore: add mn-sre as code owners for indexer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @midnightntwrk/mn-codeowners-indexer
+* @midnightntwrk/mn-codeowners-indexer @midnightntwrk/mn-sre
 /.github/ISSUE_TEMPLATE/ @midnightntwrk/mn-security @midnightntwrk/mn-sre
 /.github/PULL_REQUEST_TEMPLATE/ @midnightntwrk/mn-security @midnightntwrk/mn-sre
 /.github/workflows/scan.yaml @midnightntwrk/mn-security @midnightntwrk/mn-sre


### PR DESCRIPTION
# Overview

Adds `@midnightntwrk/mn-sre` to the catch-all (`*`) entry in `CODEOWNERS` so the
SRE team can approve indexer changes as code owners, alongside
`mn-codeowners-indexer`. Either team's approval satisfies the code-owner
requirement on a matching PR.

## Links

Relates to shieldedtech/shielded-sre#405 (SRE approval coverage for the indexer).
