### PR TITLE
chore: add mn-qa as code owner for qa/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,5 @@
 * @midnightntwrk/mn-codeowners-indexer @midnightntwrk/mn-sre
+/qa/ @midnightntwrk/mn-qa @midnightntwrk/mn-codeowners-indexer
 /.github/ISSUE_TEMPLATE/ @midnightntwrk/mn-security @midnightntwrk/mn-sre
 /.github/PULL_REQUEST_TEMPLATE/ @midnightntwrk/mn-security @midnightntwrk/mn-sre
 /.github/workflows/scan.yaml @midnightntwrk/mn-security @midnightntwrk/mn-sre


### PR DESCRIPTION
## Scope

Add a `/qa/` rule to CODEOWNERS so the QA team (`@midnightntwrk/mn-qa`) can approve changes under `qa/`, alongside `@midnightntwrk/mn-codeowners-indexer`.

## Why

The QA team owns and maintains the `qa/` area (test suites, scripts, tooling) but currently cannot satisfy the code-owner review gate for its own changes — the root `*` rule routes everything to `mn-codeowners-indexer`/`mn-sre`.

Since CODEOWNERS applies only the **last matching pattern** per file (no inheritance from `*`), `mn-codeowners-indexer` is re-listed explicitly on the new line to keep its approval rights for `qa/` paths.
