### PR TITLE
fix for dust timestamp window

### DIFF
--- a/chain-indexer/benches/apply_transaction.rs
+++ b/chain-indexer/benches/apply_transaction.rs
@@ -104,6 +104,7 @@ fn bench_apply_real_tx(c: &mut Criterion) {
                         black_box(parent_block_hash),
                         black_box(block_timestamp),
                         black_box(parent_block_timestamp),
+                        black_box(true),
                     )
                     .expect("apply")
             },
@@ -129,6 +130,7 @@ fn bench_apply_real_tx(c: &mut Criterion) {
                         black_box(parent_block_hash),
                         black_box(block_timestamp),
                         black_box(parent_block_timestamp),
+                        black_box(true),
                     )
                     .expect("apply")
             },

--- a/chain-indexer/benches/ledger_state.rs
+++ b/chain-indexer/benches/ledger_state.rs
@@ -72,6 +72,7 @@ fn bench_apply_transactions_empty(c: &mut Criterion) {
                         black_box(parent_block_hash),
                         black_box(block_timestamp),
                         black_box(parent_block_timestamp),
+                        black_box(true),
                     )
                     .expect("apply_transactions")
             },

--- a/chain-indexer/src/application.rs
+++ b/chain-indexer/src/application.rs
@@ -428,6 +428,9 @@ where
                 block.parent_hash,
                 block.timestamp,
                 *parent_block_timestamp,
+                // Only reproduce the node's mempool-cached first-tx `tblock` bump for non-genesis
+                // blocks; genesis (height 0) transactions never transited the mempool.
+                block.height > 0,
             )
             .context("apply transactions to ledger state")
     };

--- a/chain-indexer/src/domain/ledger_state.rs
+++ b/chain-indexer/src/domain/ledger_state.rs
@@ -22,6 +22,12 @@ use indexer_common::domain::{
 use std::{collections::HashSet, ops::DerefMut};
 use thiserror::Error;
 
+/// Amount, in milliseconds, by which the first regular transaction's dust-validity `tblock` is
+/// bumped ahead of block time. The node validates mempool transactions against a `tblock` bumped
+/// `slot_duration_secs + skipped_slots_margin` (one slot each, two slots by default) ahead of block
+/// time. Midnight slots are 6s, so the default bump is two slots. Block timestamps are milliseconds.
+const MEMPOOL_TBLOCK_BUMP_MILLIS: u64 = 2 * 6_000;
+
 /// New type for ledger state from indexer_common.
 #[derive(Debug, Clone, From, Deref)]
 pub struct LedgerState(pub indexer_common::domain::ledger::LedgerState);
@@ -104,15 +110,33 @@ impl LedgerState {
         block_timestamp: u64,
         parent_block_timestamp: u64,
     ) -> Result<(Vec<Transaction>, LedgerParameters), Error> {
+        // The node validates a mempool transaction's dust validity window against a `tblock` bumped
+        // two slots ahead of block time, then caches the well-formed result keyed on (tx_hash,
+        // ledger_state_key). At block inclusion only the first regular transaction still matches
+        // that key, so the node reuses the cached (bumped) validity result and skips re-checking it
+        // against the real block time; later transactions get a fresh check against block time.
+        // Reproduce that by bumping only the first regular transaction's well-formed `tblock`.
+        // `apply` always runs against the real block time, so the resulting state matches the node.
+        let mut first_regular_transaction = true;
         let transactions = transactions
             .into_iter()
             .map(|transaction| match transaction {
-                node::Transaction::Regular(transaction) => self.apply_regular_transaction(
-                    transaction,
-                    parent_block_hash,
-                    block_timestamp,
-                    parent_block_timestamp,
-                ),
+                node::Transaction::Regular(transaction) => {
+                    let well_formed_timestamp = if first_regular_transaction {
+                        block_timestamp + MEMPOOL_TBLOCK_BUMP_MILLIS
+                    } else {
+                        block_timestamp
+                    };
+                    first_regular_transaction = false;
+
+                    self.apply_regular_transaction(
+                        transaction,
+                        parent_block_hash,
+                        block_timestamp,
+                        parent_block_timestamp,
+                        well_formed_timestamp,
+                    )
+                }
 
                 node::Transaction::System(transaction) => {
                     self.apply_system_transaction(transaction, block_timestamp)
@@ -134,7 +158,8 @@ impl LedgerState {
 
     #[trace(properties = {
         "parent_block_hash": "{parent_block_hash}",
-        "block_timestamp": "{block_timestamp}"
+        "block_timestamp": "{block_timestamp}",
+        "well_formed_timestamp": "{well_formed_timestamp}"
     })]
     fn apply_regular_transaction(
         &mut self,
@@ -142,6 +167,7 @@ impl LedgerState {
         parent_block_hash: BlockHash,
         block_timestamp: u64,
         parent_block_timestamp: u64,
+        well_formed_timestamp: u64,
     ) -> Result<Transaction, Error> {
         let mut transaction = RegularTransaction::from(transaction);
 
@@ -163,6 +189,7 @@ impl LedgerState {
                 parent_block_hash,
                 block_timestamp,
                 parent_block_timestamp,
+                well_formed_timestamp,
             )
             .map_err(|error| Error::ApplyRegularTransaction(Some(transaction.hash), error))?;
 

--- a/chain-indexer/src/domain/ledger_state.rs
+++ b/chain-indexer/src/domain/ledger_state.rs
@@ -102,6 +102,13 @@ impl LedgerState {
     }
 
     /// Apply the given node transactions to this ledger state and return domain transactions.
+    ///
+    /// `bump_first_regular_tblock` selects whether the node's mempool-cached validity result is
+    /// reproduced for the first regular transaction (see below). It must be `false` for the genesis
+    /// block (height 0): the transactions embedded in genesis never transited the mempool, so the
+    /// node never cached a bumped result for them and validated them against the real block time.
+    /// Bumping them would push the well-formed `tblock` past a bootstrap transaction's intent TTL
+    /// and wrongly reject it.
     #[trace(properties = { "parent_block_hash": "{parent_block_hash}" })]
     pub fn apply_transactions(
         &mut self,
@@ -109,6 +116,7 @@ impl LedgerState {
         parent_block_hash: BlockHash,
         block_timestamp: u64,
         parent_block_timestamp: u64,
+        bump_first_regular_tblock: bool,
     ) -> Result<(Vec<Transaction>, LedgerParameters), Error> {
         // The node validates a mempool transaction's dust validity window against a `tblock` bumped
         // two slots ahead of block time, then caches the well-formed result keyed on (tx_hash,
@@ -122,7 +130,9 @@ impl LedgerState {
             .into_iter()
             .map(|transaction| match transaction {
                 node::Transaction::Regular(transaction) => {
-                    let well_formed_timestamp = if first_regular_transaction {
+                    let well_formed_timestamp = if first_regular_transaction
+                        && bump_first_regular_tblock
+                    {
                         block_timestamp + MEMPOOL_TBLOCK_BUMP_MILLIS
                     } else {
                         block_timestamp

--- a/chain-indexer/src/domain/ledger_state.rs
+++ b/chain-indexer/src/domain/ledger_state.rs
@@ -130,13 +130,12 @@ impl LedgerState {
             .into_iter()
             .map(|transaction| match transaction {
                 node::Transaction::Regular(transaction) => {
-                    let well_formed_timestamp = if first_regular_transaction
-                        && bump_first_regular_tblock
-                    {
-                        block_timestamp + MEMPOOL_TBLOCK_BUMP_MILLIS
-                    } else {
-                        block_timestamp
-                    };
+                    let well_formed_timestamp =
+                        if first_regular_transaction && bump_first_regular_tblock {
+                            block_timestamp + MEMPOOL_TBLOCK_BUMP_MILLIS
+                        } else {
+                            block_timestamp
+                        };
                     first_regular_transaction = false;
 
                     self.apply_regular_transaction(

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -446,6 +446,14 @@ impl LedgerState {
 
     /// Apply the given serialized regular transaction to this ledger state and return the
     /// transaction result as well as the created and spent unshielded UTXOs.
+    ///
+    /// `block_timestamp` drives the block context passed to `apply`, and thus the timestamps the
+    /// ledger writes into its state (e.g. dust generation `dtime`), so it must always be the real
+    /// block time. `well_formed_timestamp` is the `tblock` used only for the dust-validity-window
+    /// check in `well_formed`; it normally equals `block_timestamp` but is bumped ahead for the
+    /// first regular transaction in a block to reproduce the node's cached mempool validity result
+    /// (see `chain-indexer`'s `apply_transactions`). Bumping it only affects whether the check
+    /// passes, not the resulting state, since `well_formed` merely validates.
     #[trace]
     pub fn apply_regular_transaction(
         &mut self,
@@ -453,6 +461,7 @@ impl LedgerState {
         parent_block_hash: ByteArray<32>,
         block_timestamp: u64,
         parent_block_timestamp: u64,
+        well_formed_timestamp: u64,
     ) -> Result<ApplyRegularTransactionOutcome, Error> {
         match self {
             Self::V8 {
@@ -481,7 +490,11 @@ impl LedgerState {
                     .fees(&ledger_state.parameters, true)
                     .map_err(|error| Error::TransactionCost(error.into()))?;
                 let verified_ledger_transaction = transaction
-                    .well_formed(&cx.ref_state, *STRICTNESS_V8, cx.block_context.tblock)
+                    .well_formed(
+                        &cx.ref_state,
+                        *STRICTNESS_V8,
+                        timestamp(well_formed_timestamp),
+                    )
                     .map_err(|error| Error::MalformedTransaction(error.into()))?;
                 let (ledger_state, transaction_result) =
                     ledger_state.apply(&verified_ledger_transaction, &cx);
@@ -573,7 +586,11 @@ impl LedgerState {
                         .into_atomic_units(SPECKS_PER_DUST_V9)
                 };
                 let verified_ledger_transaction = transaction
-                    .well_formed(&cx.ref_state, *STRICTNESS_V9, cx.block_context.tblock)
+                    .well_formed(
+                        &cx.ref_state,
+                        *STRICTNESS_V9,
+                        timestamp(well_formed_timestamp),
+                    )
                     .map_err(|error| Error::MalformedTransaction(error.into()))?;
                 let (ledger_state, transaction_result) =
                     ledger_state.apply(&verified_ledger_transaction, &cx);


### PR DESCRIPTION
Fix for stuck indexer in preview.

Root cause is node mempool behavior. When a transaction enters the mempool, the node runs the ledger well_formed check against a tblock bumped two slots ahead of block time (slot_duration_secs + skipped_slots_margin, ~12s on 6s slots) and caches the result keyed on (tx_hash, ledger_state_key). At block inclusion, only the first regular transaction still matches that cache key (the ledger-state key moves on after each apply), so the node reuses the cached, bumped validity result and skips re-checking it against the real block time. Later transactions get a fresh check against block time.

The indexer re-derives well_formed for every transaction using the real block time. So a first-in-block transaction whose dust ctime sits a few seconds ahead of block time — inside that 2-slot mempool window — passes on the node but is wrongly rejected by the indexer, which then stops.

Fix

Reproduce the node's mempool behavior for the first regular transaction of each block: run the dust-validity well_formed check against a tblock bumped two slots ahead (MEMPOOL_TBLOCK_BUMP_MILLIS = 2 * 6_000).

Evidence of fix on preview blue:
```
{"timestamp":"2026-07-24T15:01:25.375519+00:00","level":"INFO","target":"chain_indexer::application","file":"chain-indexer/src/application.rs","line":93,"message":"starting indexing","kvs":{"highest_block_height":"Some(113101)"}}
```