### PR TITLE
test: cover contractEvents fieldPrefixes filtering

### DIFF
--- a/qa/tests/tests/integration/basic/queries/contract-event-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/contract-event-queries.test.ts
@@ -496,7 +496,9 @@ describe('contract event queries', () => {
 
       for (const contract of contracts) {
         const address = contract['contract-address'];
-        const unfiltered = await httpClient.getContractEvents({ contractAddress: address });
+        // Explicit limit 500 (the server max) on every fixture-gated query so
+        // membership comparisons are not distorted by the default limit of 100.
+        const unfiltered = await httpClient.getContractEvents({ contractAddress: address }, 500);
         expect(unfiltered).toBeSuccess();
 
         const withField = (unfiltered.data?.contractEvents ?? [])
@@ -508,10 +510,13 @@ describe('contract event queries', () => {
         const { fieldName, value } = withField.fields.find((field) => field.value.length >= 2)!;
 
         for (const prefix of [value.slice(0, 8), value]) {
-          const response = await httpClient.getContractEvents({
-            contractAddress: address,
-            fieldPrefixes: [{ fieldName, prefix }],
-          });
+          const response = await httpClient.getContractEvents(
+            {
+              contractAddress: address,
+              fieldPrefixes: [{ fieldName, prefix }],
+            },
+            500,
+          );
           expect(response).toBeSuccess();
           expect(
             (response.data?.contractEvents ?? []).map((matched) => matched.id),
@@ -522,10 +527,13 @@ describe('contract event queries', () => {
         // Same length and hex alphabet as the matching prefix, last digit flipped.
         const matching = value.slice(0, 8);
         const mutated = matching.slice(0, -1) + (matching.endsWith('0') ? '1' : '0');
-        const excluded = await httpClient.getContractEvents({
-          contractAddress: address,
-          fieldPrefixes: [{ fieldName, prefix: mutated }],
-        });
+        const excluded = await httpClient.getContractEvents(
+          {
+            contractAddress: address,
+            fieldPrefixes: [{ fieldName, prefix: mutated }],
+          },
+          500,
+        );
         expect(excluded).toBeSuccess();
         expect(
           (excluded.data?.contractEvents ?? []).map((matched) => matched.id),
@@ -562,7 +570,10 @@ describe('contract event queries', () => {
 
       for (const contract of contracts) {
         const address = contract['contract-address'];
-        const unfiltered = await httpClient.getContractEvents({ contractAddress: address });
+        // Explicit limit 500 (the server max) on both queries: with the default
+        // limit of 100 the two lists would be truncated independently and the
+        // set comparison could fail against a correct server.
+        const unfiltered = await httpClient.getContractEvents({ contractAddress: address }, 500);
         expect(unfiltered).toBeSuccess();
 
         const expectedIds = (unfiltered.data?.contractEvents ?? [])
@@ -572,10 +583,13 @@ describe('contract event queries', () => {
           .map((event) => event.id)
           .sort((a, b) => a - b);
 
-        const filtered = await httpClient.getContractEvents({
-          contractAddress: address,
-          fieldPrefixes: [{ fieldName: 'nullifier', prefix: '' }],
-        });
+        const filtered = await httpClient.getContractEvents(
+          {
+            contractAddress: address,
+            fieldPrefixes: [{ fieldName: 'nullifier', prefix: '' }],
+          },
+          500,
+        );
         expect(filtered).toBeSuccess();
         const filteredIds = (filtered.data?.contractEvents ?? [])
           .map((event) => event.id)
@@ -612,20 +626,27 @@ describe('contract event queries', () => {
         return ctx.skip?.(true, (error as Error).message);
       }
 
+      let anyFieldSeen = false;
       for (const contract of contracts) {
         const address = contract['contract-address'];
-        const unfiltered = await httpClient.getContractEvents({ contractAddress: address });
+        // Explicit limit 500 (the server max) on both queries so reachability
+        // checks are not distorted by the default limit of 100.
+        const unfiltered = await httpClient.getContractEvents({ contractAddress: address }, 500);
         expect(unfiltered).toBeSuccess();
         const events = unfiltered.data?.contractEvents ?? [];
 
         const fieldNames = new Set(
           events.flatMap((event) => indexedContractFieldsOf(event).map((field) => field.fieldName)),
         );
+        anyFieldSeen ||= fieldNames.size > 0;
         for (const fieldName of fieldNames) {
-          const filtered = await httpClient.getContractEvents({
-            contractAddress: address,
-            fieldPrefixes: [{ fieldName, prefix: '' }],
-          });
+          const filtered = await httpClient.getContractEvents(
+            {
+              contractAddress: address,
+              fieldPrefixes: [{ fieldName, prefix: '' }],
+            },
+            500,
+          );
           expect(filtered).toBeSuccess();
           const filteredIds = (filtered.data?.contractEvents ?? []).map((event) => event.id);
 
@@ -637,6 +658,11 @@ describe('contract event queries', () => {
             }
           }
         }
+      }
+      if (!anyFieldSeen) {
+        // Without at least one indexed field the loop above asserts nothing;
+        // skip explicitly rather than reporting a vacuous pass.
+        return ctx.skip?.(true, 'no event-emitting contract fixture exposes an indexed field');
       }
     });
   });

--- a/qa/tests/tests/integration/basic/queries/contract-event-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/contract-event-queries.test.ts
@@ -345,10 +345,10 @@ describe('contract event queries', () => {
       ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents', 'Negative'] };
       if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
 
-      const validAddress = dataProvider.getNonExistingContractAddress();
+      const contractAddress = dataProvider.getNonExistingContractAddress();
       for (const fieldName of ['bogus', 'domainsep']) {
         const response = await httpClient.getContractEvents({
-          contractAddress: validAddress,
+          contractAddress,
           fieldPrefixes: [{ fieldName, prefix: '' }],
         });
         expect.soft(response, `fieldName "${fieldName}" is not indexable`).toBeError();
@@ -476,8 +476,9 @@ describe('contract event queries', () => {
      * environment; tracked by midnight-indexer#1163.
      *
      * @given a contract that emitted an event carrying an indexed field
-     * @when a contract events query is filtered by the first four bytes of that
-     *       field's value, by the full value, and by a mutated non-matching prefix
+     * @when a contract events query is filtered by a prefix of up to the first
+     *       four bytes of that field's value, by the full value, and by a
+     *       mutated non-matching prefix
      * @then the event is returned for both matching prefixes and absent for the
      *       mutated one
      */

--- a/qa/tests/tests/integration/basic/queries/contract-event-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/contract-event-queries.test.ts
@@ -545,6 +545,89 @@ describe('contract event queries', () => {
     });
 
     /**
+     * Multiple field prefixes combine with AND semantics.
+     *
+     * Skipped until an event-emitting contract fixture is configured for the
+     * environment; tracked by midnight-indexer#1163.
+     *
+     * @given a contract that emitted an event carrying at least two indexed
+     *        fields (e.g. an unshielded event's domainSep and tokenType)
+     * @when a contract events query is filtered by matching prefixes of both
+     *       fields together, and again with one of the two prefixes mutated
+     * @then the event is returned when both prefixes match and absent when
+     *       either prefix does not
+     */
+    test('should combine multiple field prefixes with AND semantics', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      let contracts: EventEmittingContractInfo[];
+      try {
+        contracts = dataProvider.getEventEmittingContracts();
+      } catch (error) {
+        log.warn(error);
+        return ctx.skip?.(true, (error as Error).message);
+      }
+
+      for (const contract of contracts) {
+        const address = contract['contract-address'];
+        const unfiltered = await httpClient.getContractEvents({ contractAddress: address }, 500);
+        expect(unfiltered).toBeSuccess();
+
+        const withTwoFields = (unfiltered.data?.contractEvents ?? [])
+          .map((event) => ({
+            event,
+            fields: indexedContractFieldsOf(event).filter((field) => field.value.length >= 2),
+          }))
+          .find(({ fields }) => fields.length >= 2);
+        if (!withTwoFields) continue;
+
+        const { event } = withTwoFields;
+        const [first, second] = withTwoFields.fields;
+        const firstPrefix = first.value.slice(0, 8);
+        const secondPrefix = second.value.slice(0, 8);
+
+        const both = await httpClient.getContractEvents(
+          {
+            contractAddress: address,
+            fieldPrefixes: [
+              { fieldName: first.fieldName, prefix: firstPrefix },
+              { fieldName: second.fieldName, prefix: secondPrefix },
+            ],
+          },
+          500,
+        );
+        expect(both).toBeSuccess();
+        expect(
+          (both.data?.contractEvents ?? []).map((matched) => matched.id),
+          `event ${event.id} not matched by ${first.fieldName} and ${second.fieldName} together`,
+        ).toContain(event.id);
+
+        // Same length and hex alphabet as the second prefix, last digit flipped:
+        // under OR (or ignored-entry) semantics the still-matching first prefix
+        // would wrongly keep returning the event.
+        const mutated = secondPrefix.slice(0, -1) + (secondPrefix.endsWith('0') ? '1' : '0');
+        const excluded = await httpClient.getContractEvents(
+          {
+            contractAddress: address,
+            fieldPrefixes: [
+              { fieldName: first.fieldName, prefix: firstPrefix },
+              { fieldName: second.fieldName, prefix: mutated },
+            ],
+          },
+          500,
+        );
+        expect(excluded).toBeSuccess();
+        expect(
+          (excluded.data?.contractEvents ?? []).map((matched) => matched.id),
+          `event ${event.id} wrongly matched despite a mutated ${second.fieldName} prefix`,
+        ).not.toContain(event.id);
+        return;
+      }
+      return ctx.skip?.(true, 'no event-emitting contract fixture exposes two indexed fields');
+    });
+
+    /**
      * An empty prefix acts as a has-this-field filter.
      *
      * Skipped until an event-emitting contract fixture is configured for the

--- a/qa/tests/tests/integration/basic/queries/contract-event-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/contract-event-queries.test.ts
@@ -18,7 +18,10 @@ import { env } from 'environment/model';
 import type { TestContext } from 'vitest';
 import '@utils/logging/test-logging-hooks';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
-import { contractEventsSurfacePresent } from '@utils/indexer/contract-events-support';
+import {
+  contractEventsSurfacePresent,
+  indexedContractFieldsOf,
+} from '@utils/indexer/contract-events-support';
 import { ContractEventUnionSchema } from '@utils/indexer/graphql/schema';
 import { CONTRACT_EVENT_TYPES } from '@utils/indexer/indexer-types';
 import dataProvider, { type EventEmittingContractInfo } from '@utils/testdata-provider';
@@ -263,6 +266,36 @@ describe('contract event queries', () => {
       expect(response).toBeSuccess();
       expect(response.data?.contractEvents).toEqual([]);
     });
+
+    /**
+     * A query with valid field prefixes for an idle address is still empty.
+     *
+     * @given a valid-format contract address that has emitted no events
+     * @when a contract events query is issued with a single nullifier field
+     *       prefix, and again with a two-entry field prefix combination
+     * @then each response is successful and the event list is empty
+     */
+    test('should return an empty list when filtered by valid field prefixes', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      const single = await httpClient.getContractEvents({
+        contractAddress: validAddress,
+        fieldPrefixes: [{ fieldName: 'nullifier', prefix: 'aa' }],
+      });
+      expect(single).toBeSuccess();
+      expect(single.data?.contractEvents).toEqual([]);
+
+      const combined = await httpClient.getContractEvents({
+        contractAddress: validAddress,
+        fieldPrefixes: [
+          { fieldName: 'nullifier', prefix: 'aa' },
+          { fieldName: 'tokenType', prefix: '' },
+        ],
+      });
+      expect(combined).toBeSuccess();
+      expect(combined.data?.contractEvents).toEqual([]);
+    });
   });
 
   describe('a contract events query with an invalid filter', () => {
@@ -297,6 +330,48 @@ describe('contract event queries', () => {
         const response = await httpClient.getContractEvents({ contractAddress: malformedAddress });
         expect.soft(response).toBeError();
       }
+    });
+
+    /**
+     * Field prefix filters naming an unknown field are rejected.
+     *
+     * @given a contract events filter with a fieldPrefixes entry whose fieldName
+     *        is not an indexable contract field (a fabricated name, and the real
+     *        field "domainSep" spelled in the wrong case)
+     * @when a contract events query is issued with each filter
+     * @then the indexer responds with an error for each, rather than an empty list
+     */
+    test('should return an error for an unknown field prefix field name', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents', 'Negative'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      const validAddress = dataProvider.getNonExistingContractAddress();
+      for (const fieldName of ['bogus', 'domainsep']) {
+        const response = await httpClient.getContractEvents({
+          contractAddress: validAddress,
+          fieldPrefixes: [{ fieldName, prefix: '' }],
+        });
+        expect.soft(response, `fieldName "${fieldName}" is not indexable`).toBeError();
+      }
+    });
+
+    /**
+     * Field prefix filters whose prefix is not hex are rejected.
+     *
+     * @given a contract events filter with a fieldPrefixes entry on the known
+     *        field "nullifier" whose prefix "zz" is not valid hex
+     * @when a contract events query is issued with that filter
+     * @then the indexer responds with an error
+     */
+    test('should return an error when a field prefix is not hex', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents', 'Negative'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      const response = await httpClient.getContractEvents({
+        contractAddress: dataProvider.getNonExistingContractAddress(),
+        fieldPrefixes: [{ fieldName: 'nullifier', prefix: 'zz' }],
+      });
+      expect(response).toBeError();
     });
   });
 
@@ -390,6 +465,177 @@ describe('contract event queries', () => {
       expect(events.length).toBeGreaterThan(0);
       for (const event of events) {
         expect(TYPE_BY_TYPENAME[event.__typename]).toBe(requestedType);
+      }
+    });
+
+    /**
+     * Prefix filtering matches on prefixes of an indexed field value and
+     * excludes non-matching prefixes.
+     *
+     * Skipped until an event-emitting contract fixture is configured for the
+     * environment; tracked by midnight-indexer#1163.
+     *
+     * @given a contract that emitted an event carrying an indexed field
+     * @when a contract events query is filtered by the first four bytes of that
+     *       field's value, by the full value, and by a mutated non-matching prefix
+     * @then the event is returned for both matching prefixes and absent for the
+     *       mutated one
+     */
+    test('should filter events by a prefix of an indexed field value', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      let contracts: EventEmittingContractInfo[];
+      try {
+        contracts = dataProvider.getEventEmittingContracts();
+      } catch (error) {
+        log.warn(error);
+        return ctx.skip?.(true, (error as Error).message);
+      }
+
+      for (const contract of contracts) {
+        const address = contract['contract-address'];
+        const unfiltered = await httpClient.getContractEvents({ contractAddress: address });
+        expect(unfiltered).toBeSuccess();
+
+        const withField = (unfiltered.data?.contractEvents ?? [])
+          .map((event) => ({ event, fields: indexedContractFieldsOf(event) }))
+          .find(({ fields }) => fields.some((field) => field.value.length >= 2));
+        if (!withField) continue;
+
+        const { event } = withField;
+        const { fieldName, value } = withField.fields.find((field) => field.value.length >= 2)!;
+
+        for (const prefix of [value.slice(0, 8), value]) {
+          const response = await httpClient.getContractEvents({
+            contractAddress: address,
+            fieldPrefixes: [{ fieldName, prefix }],
+          });
+          expect(response).toBeSuccess();
+          expect(
+            (response.data?.contractEvents ?? []).map((matched) => matched.id),
+            `event ${event.id} not matched by ${fieldName} prefix "${prefix}"`,
+          ).toContain(event.id);
+        }
+
+        // Same length and hex alphabet as the matching prefix, last digit flipped.
+        const matching = value.slice(0, 8);
+        const mutated = matching.slice(0, -1) + (matching.endsWith('0') ? '1' : '0');
+        const excluded = await httpClient.getContractEvents({
+          contractAddress: address,
+          fieldPrefixes: [{ fieldName, prefix: mutated }],
+        });
+        expect(excluded).toBeSuccess();
+        expect(
+          (excluded.data?.contractEvents ?? []).map((matched) => matched.id),
+          `event ${event.id} wrongly matched by mutated ${fieldName} prefix "${mutated}"`,
+        ).not.toContain(event.id);
+        return;
+      }
+      return ctx.skip?.(true, 'no event-emitting contract fixture exposes an indexed field');
+    });
+
+    /**
+     * An empty prefix acts as a has-this-field filter.
+     *
+     * Skipped until an event-emitting contract fixture is configured for the
+     * environment; tracked by midnight-indexer#1163.
+     *
+     * @given a contract known to have emitted public contract events
+     * @when a contract events query is filtered by fieldName "nullifier" with an
+     *       empty prefix
+     * @then exactly the nullifier-carrying events (shielded spends and burns) are
+     *       returned; Paused, Unpaused and Misc events never match a field filter
+     */
+    test('should return only events carrying the field for an empty prefix', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      let contracts: EventEmittingContractInfo[];
+      try {
+        contracts = dataProvider.getEventEmittingContracts();
+      } catch (error) {
+        log.warn(error);
+        return ctx.skip?.(true, (error as Error).message);
+      }
+
+      for (const contract of contracts) {
+        const address = contract['contract-address'];
+        const unfiltered = await httpClient.getContractEvents({ contractAddress: address });
+        expect(unfiltered).toBeSuccess();
+
+        const expectedIds = (unfiltered.data?.contractEvents ?? [])
+          .filter((event) =>
+            indexedContractFieldsOf(event).some((field) => field.fieldName === 'nullifier'),
+          )
+          .map((event) => event.id)
+          .sort((a, b) => a - b);
+
+        const filtered = await httpClient.getContractEvents({
+          contractAddress: address,
+          fieldPrefixes: [{ fieldName: 'nullifier', prefix: '' }],
+        });
+        expect(filtered).toBeSuccess();
+        const filteredIds = (filtered.data?.contractEvents ?? [])
+          .map((event) => event.id)
+          .sort((a, b) => a - b);
+
+        expect
+          .soft(filteredIds, `nullifier empty-prefix mismatch for ${address}`)
+          .toEqual(expectedIds);
+      }
+    });
+
+    /**
+     * Every event is reachable through each of its indexed fields.
+     *
+     * Skipped until an event-emitting contract fixture is configured for the
+     * environment; tracked by midnight-indexer#1163.
+     *
+     * @given a contract known to have emitted public contract events
+     * @when for each indexed field name carried by the contract's events a
+     *       contract events query is filtered by that field name with an empty
+     *       prefix
+     * @then every event carrying the field is present in the filtered result,
+     *       pinning the published indexable field names to the stored rows
+     */
+    test('should reach every event through each of its indexed fields', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Query', 'ContractEvents'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      let contracts: EventEmittingContractInfo[];
+      try {
+        contracts = dataProvider.getEventEmittingContracts();
+      } catch (error) {
+        log.warn(error);
+        return ctx.skip?.(true, (error as Error).message);
+      }
+
+      for (const contract of contracts) {
+        const address = contract['contract-address'];
+        const unfiltered = await httpClient.getContractEvents({ contractAddress: address });
+        expect(unfiltered).toBeSuccess();
+        const events = unfiltered.data?.contractEvents ?? [];
+
+        const fieldNames = new Set(
+          events.flatMap((event) => indexedContractFieldsOf(event).map((field) => field.fieldName)),
+        );
+        for (const fieldName of fieldNames) {
+          const filtered = await httpClient.getContractEvents({
+            contractAddress: address,
+            fieldPrefixes: [{ fieldName, prefix: '' }],
+          });
+          expect(filtered).toBeSuccess();
+          const filteredIds = (filtered.data?.contractEvents ?? []).map((event) => event.id);
+
+          for (const event of events) {
+            if (indexedContractFieldsOf(event).some((field) => field.fieldName === fieldName)) {
+              expect
+                .soft(filteredIds, `event ${event.id} not reachable via "${fieldName}"`)
+                .toContain(event.id);
+            }
+          }
+        }
       }
     });
   });

--- a/qa/tests/tests/integration/basic/subscriptions/contract-event-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/contract-event-subscriptions.test.ts
@@ -19,7 +19,10 @@ import type { TestContext } from 'vitest';
 import '@utils/logging/test-logging-hooks';
 import { IndexerWsClient } from '@utils/indexer/websocket-client';
 import { extractSubscriptionErrorMessage } from '@utils/indexer/subscription-error';
-import { contractEventsSurfacePresent } from '@utils/indexer/contract-events-support';
+import {
+  contractEventsSurfacePresent,
+  indexedContractFieldsOf,
+} from '@utils/indexer/contract-events-support';
 import { ContractEventUnionSchema } from '@utils/indexer/graphql/schema';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
 import type { ContractEvent } from '@utils/indexer/indexer-types';
@@ -153,6 +156,61 @@ describe('contract event subscription', () => {
       expect(settled.error).not.toBeNull();
       expect(settled.eventCount).toBe(0);
     }, 20_000);
+
+    /**
+     * An unknown field prefix field name is rejected by the subscription.
+     *
+     * @given a contract events filter with a fieldPrefixes entry whose fieldName
+     *        "bogus" is not an indexable contract field
+     * @when a contract events subscription is opened with that filter
+     * @then the subscription surfaces an error rather than streaming events
+     */
+    test('should return an error for an unknown field prefix field name', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Subscription', 'ContractEvents', 'Negative'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      const settled = await new Promise<{ error: string | null; eventCount: number }>(
+        (resolve, reject) => {
+          let eventCount = 0;
+          const timeout = setTimeout(() => {
+            subscription.unsubscribe();
+            // Validation errors are immediate; a 10s silence is a real problem,
+            // so fail loudly rather than resolving `error: null` and tripping
+            // the assertion with a misleading value.
+            reject(
+              new Error(
+                'Timed out after 10s waiting for the unknown-field-name subscription to error',
+              ),
+            );
+          }, 10_000);
+
+          const subscription = wsClient.subscribeToContractEvents(
+            {
+              next: () => {
+                eventCount++;
+              },
+              error: (error) => {
+                clearTimeout(timeout);
+                subscription.unsubscribe();
+                resolve({ error: extractSubscriptionErrorMessage(error), eventCount });
+              },
+              complete: () => {
+                clearTimeout(timeout);
+                resolve({ error: null, eventCount });
+              },
+            },
+            {
+              contractAddress: dataProvider.getNonExistingContractAddress(),
+              fieldPrefixes: [{ fieldName: 'bogus', prefix: '' }],
+            },
+            0,
+          );
+        },
+      );
+
+      expect(settled.error).not.toBeNull();
+      expect(settled.eventCount).toBe(0);
+    }, 20_000);
   });
 
   describe('a contract events subscription for a contract with emitted events', () => {
@@ -236,6 +294,102 @@ describe('contract event subscription', () => {
           `Contract event schema validation failed: ${JSON.stringify(parsed.error, null, 2)}`,
         ).toBe(true);
         expect(event.contractAddress).toBe(contractAddress);
+      }
+    }, 30_000);
+
+    /**
+     * A field-prefix-filtered subscription streams only events carrying the field.
+     *
+     * Skipped until an event-emitting contract fixture is configured for the
+     * environment (see testdata-provider.getEventEmittingContracts); the
+     * emit-bearing toolchain path is tracked by midnight-indexer#1163.
+     *
+     * @given a contract that emitted an event carrying an indexed field
+     * @when a contract events subscription bounded by the latest block is opened
+     *       filtered by that field name with an empty prefix
+     * @then the stream completes via the toBlock terminator having delivered at
+     *       least one event, each carrying the filtered field
+     */
+    test('should stream only events carrying the filtered field', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Subscription', 'ContractEvents'] };
+      if (!surfacePresent) return ctx.skip?.(true, 'contract events surface not present');
+
+      let contracts: EventEmittingContractInfo[];
+      try {
+        contracts = dataProvider.getEventEmittingContracts();
+      } catch (error) {
+        log.warn(error);
+        return ctx.skip?.(true, (error as Error).message);
+      }
+
+      // Pick, via the query surface, a fixture contract and a field name one of
+      // its events actually carries, so the subscription is expected to stream.
+      let contractAddress: string | undefined;
+      let fieldName: string | undefined;
+      for (const contract of contracts) {
+        const response = await httpClient.getContractEvents({
+          contractAddress: contract['contract-address'],
+        });
+        expect(response).toBeSuccess();
+        const fields = (response.data?.contractEvents ?? []).flatMap(indexedContractFieldsOf);
+        if (fields.length > 0) {
+          contractAddress = contract['contract-address'];
+          fieldName = fields[0].fieldName;
+          break;
+        }
+      }
+      if (!contractAddress || !fieldName) {
+        return ctx.skip?.(true, 'no event-emitting contract fixture exposes an indexed field');
+      }
+
+      const blockResponse = await httpClient.getLatestBlock();
+      expect(blockResponse).toBeSuccess();
+      const toBlock = blockResponse.data!.block.height;
+
+      const received: ContractEvent[] = [];
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          subscription.unsubscribe();
+          reject(
+            new Error(
+              `Timed out after 20s waiting for the ${fieldName}-filtered stream to complete`,
+            ),
+          );
+        }, 20_000);
+
+        const subscription = wsClient.subscribeToContractEvents(
+          {
+            next: (payload) => {
+              const event = payload.data?.contractEvents;
+              if (event) received.push(event);
+            },
+            error: (error) => {
+              clearTimeout(timeout);
+              subscription.unsubscribe();
+              reject(new Error(`Subscription error: ${JSON.stringify(error)}`));
+            },
+            complete: () => {
+              clearTimeout(timeout);
+              resolve();
+            },
+          },
+          {
+            contractAddress,
+            fieldPrefixes: [{ fieldName, prefix: '' }],
+            fromBlock: 0,
+            toBlock,
+          },
+          0,
+        );
+      });
+
+      expect(received.length).toBeGreaterThan(0);
+      for (const event of received) {
+        expect(event.contractAddress).toBe(contractAddress);
+        expect(
+          indexedContractFieldsOf(event).map((field) => field.fieldName),
+          `streamed event ${event.id} does not carry "${fieldName}"`,
+        ).toContain(fieldName);
       }
     }, 30_000);
   });

--- a/qa/tests/utils/indexer/contract-events-support.ts
+++ b/qa/tests/utils/indexer/contract-events-support.ts
@@ -16,6 +16,7 @@
 import log from '@utils/logging/logger';
 import { env } from 'environment/model';
 import { retry } from '@utils/retry-helper';
+import type { AddressOrContract, ContractEvent } from './indexer-types';
 
 /**
  * Probes whether the deployed indexer exposes the public contract-events surface
@@ -56,4 +57,68 @@ export async function contractEventsSurfacePresent(): Promise<boolean> {
     },
     { maxRetries: 2, delayMs: 1000, retryLabel: 'contract events surface probe' },
   );
+}
+
+/** An indexed contract-event field paired with its hex value as returned by the API. */
+export interface IndexedContractField {
+  fieldName: string;
+  value: string;
+}
+
+/** Hex value of whichever side of an `AddressOrContract` union is populated. */
+function addressValue(address: AddressOrContract): string {
+  return address.userAddress ?? address.contractAddress ?? '';
+}
+
+/**
+ * The MIP-0002 indexed fields a contract event contributes to the
+ * `contract_event_indexed_fields` sidecar (#1159), as `{fieldName, value}`
+ * pairs usable in a `fieldPrefixes` filter. Mirrors the indexer's
+ * `LedgerEvent::indexable_contract_fields` per-variant sets: `sender` /
+ * `recipient` resolve to the populated side of the address union (the sidecar
+ * stores the flat address bytes regardless of kind), a `ShieldedReceiveEvent`
+ * without ciphertext indexes no `ciphertext`, and Paused / Unpaused / Misc
+ * events index nothing.
+ */
+export function indexedContractFieldsOf(event: ContractEvent): IndexedContractField[] {
+  switch (event.__typename) {
+    case 'ShieldedSpendEvent':
+      return [{ fieldName: 'nullifier', value: event.nullifier }];
+    case 'ShieldedReceiveEvent':
+      return [
+        { fieldName: 'commitment', value: event.commitment },
+        ...(event.ciphertext ? [{ fieldName: 'ciphertext', value: event.ciphertext }] : []),
+      ];
+    case 'ShieldedMintEvent':
+      return [
+        { fieldName: 'commitment', value: event.commitment },
+        { fieldName: 'domainSep', value: event.domainSep },
+      ];
+    case 'ShieldedBurnEvent':
+      return [{ fieldName: 'nullifier', value: event.nullifier }];
+    case 'UnshieldedSpendEvent':
+      return [
+        { fieldName: 'sender', value: addressValue(event.sender) },
+        { fieldName: 'domainSep', value: event.domainSep },
+        { fieldName: 'tokenType', value: event.tokenType },
+      ];
+    case 'UnshieldedReceiveEvent':
+      return [
+        { fieldName: 'recipient', value: addressValue(event.recipient) },
+        { fieldName: 'domainSep', value: event.domainSep },
+        { fieldName: 'tokenType', value: event.tokenType },
+      ];
+    case 'UnshieldedMintEvent':
+      return [
+        { fieldName: 'domainSep', value: event.domainSep },
+        { fieldName: 'tokenType', value: event.tokenType },
+      ];
+    case 'UnshieldedBurnEvent':
+      return [
+        { fieldName: 'sender', value: addressValue(event.sender) },
+        { fieldName: 'tokenType', value: event.tokenType },
+      ];
+    default:
+      return [];
+  }
 }


### PR DESCRIPTION
## Scope

QA coverage for the `fieldPrefixes` element of `ContractEventFilter` (query + subscription) — the externally observable surface of the `contract_event_indexed_fields` sidecar storage delivered in #1185 (refs #1159).

## Why

The sidecar's filter surface had schema-introspection checks only — no behavioural coverage. In particular, nothing would detect a regression in filter validation, prefix matching, or the documented AND combination semantics of multi-entry filters.

## What's added

- `indexedContractFieldsOf` extractor in `contract-events-support.ts` mapping each event type to its MIP-0002 indexed `{fieldName, value}` pairs (mirrors `LedgerEvent::indexable_contract_fields`).
- Query tests: unknown / case-mismatched field name and non-hex prefix rejected as errors; valid single and AND-combined prefixes on an idle address return an empty list; fixture-gated behavioural cases — prefix/full-value matching with mutated-prefix exclusion, empty-prefix (has-field) semantics, reachability of every event through each of its indexed fields, and AND-semantics discrimination (matching + mutated pair must exclude).
- Subscription tests: unknown field name rejected on registration; field-filtered stream delivers only field-carrying events and completes at `toBlock`.

Fixture-gated cases skip cleanly where `contract-events.jsonc` has no emitting contracts (undeployed today) and self-activate once the #1163 toolkit lands — no code change needed.

## Validation

Undeployed (indexer 4.4.0-rc.1 / node 2.0.0-rc.3): integration 154 pass / 0 fail / 90 skip (baseline 150/0/85 — delta is exactly the new tests: +4 passes, +5 gated skips); smoke unchanged 26/0/1. Lint, audit, format, `tsc --noEmit` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)