### PR TITLE
test: cover per-session subscription rate limit

### DIFF
--- a/qa/tests/package.json
+++ b/qa/tests/package.json
@@ -22,6 +22,10 @@
     "clean": "bun run clean:logs && bun run clean:reports && bun run clean:modules",
     "prepare": "cd ../.. && husky qa/tests/.husky"
   },
+  "overrides": {
+    "brace-expansion": "^5.0.8",
+    "minimatch": "^10.2.5"
+  },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": [
       "eslint --fix",

--- a/qa/tests/package.json
+++ b/qa/tests/package.json
@@ -22,10 +22,6 @@
     "clean": "bun run clean:logs && bun run clean:reports && bun run clean:modules",
     "prepare": "cd ../.. && husky qa/tests/.husky"
   },
-  "overrides": {
-    "brace-expansion": "^5.0.8",
-    "minimatch": "^10.2.5"
-  },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": [
       "eslint --fix",

--- a/qa/tests/tests/integration/basic/subscriptions/subscription-quotas.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/subscription-quotas.test.ts
@@ -13,16 +13,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { randomBytes } from 'crypto';
 import type { TestContext } from 'vitest';
 import '@utils/logging/test-logging-hooks';
 import { IndexerWsClient } from '@utils/indexer/websocket-client';
 import { BLOCKS_SUBSCRIPTION_FROM_LATEST_BLOCK } from '@utils/indexer/graphql/subscriptions';
+import { ToolkitWrapper } from '@utils/toolkit/toolkit-wrapper';
 
-// Shipped default from the indexer-api `infra.api.quota` configuration.
+// Shipped defaults from the indexer-api `infra.api.quota` configuration.
 const PER_CONNECTION_CAP = 20;
+const PER_SESSION_RATE_LIMIT = 10;
 
+// The rate-limit token bucket refills continuously at the per-minute limit spread
+// across 60 seconds — one token every 6 seconds at the default of 10 per minute.
+const TOKEN_REFILL_WAIT_MS = 8_000;
+// A live shielded subscription re-polls progress within its 30s base interval ±20% jitter.
+const PROGRESS_AFTER_REJECTION_TIMEOUT_MS = 60_000;
 const REGISTRATION_WAIT_MS = 1_000;
 const RESPONSE_TIMEOUT_MS = 5_000;
+const TOOLKIT_STARTUP_TIMEOUT = 60_000;
 const WS_OPEN = 1;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -156,5 +165,225 @@ describe('subscription quotas', () => {
 
       cleanups.forEach((fn) => fn());
     }, 30_000);
+  });
+
+  describe('per-session subscription creation rate limit', () => {
+    let toolkit: ToolkitWrapper;
+
+    beforeAll(async () => {
+      toolkit = new ToolkitWrapper({});
+      await toolkit.start();
+    }, TOOLKIT_STARTUP_TIMEOUT);
+
+    afterAll(async () => {
+      await toolkit.stop();
+    });
+
+    // The rate limit is enforced before wallet resolution, so a session for a
+    // random (empty) wallet is sufficient — no on-chain data is needed.
+    const openRandomWalletSession = async (): Promise<string> => {
+      const viewingKey = await toolkit.showViewingKey(randomBytes(32).toString('hex'));
+      return client.openWalletSession(viewingKey);
+    };
+
+    // Starts `count` shielded subscriptions for the session in rapid succession,
+    // collecting unexpected rejections instead of throwing so callers can assert on them.
+    const openShieldedSubscriptions = (sessionId: string, count: number) => {
+      const errors: Error[] = [];
+      const cleanups: Array<() => void> = [];
+      for (let i = 0; i < count; i++) {
+        const cleanup = client.subscribeToShieldedTransactionEvents(
+          {
+            next: () => {
+              /* drain quietly */
+            },
+            error: (err) => {
+              errors.push(err as Error);
+            },
+          },
+          sessionId,
+        );
+        cleanups.push(cleanup);
+      }
+      return { errors, cleanups };
+    };
+
+    // Attempts one more shielded subscription creation for the session. Resolves with
+    // 'accepted' once its first progress event arrives, the rejection Error if the
+    // creation is refused, or 'no response' if neither happens in time.
+    const attemptShieldedSubscription = (
+      sessionId: string,
+    ): Promise<Error | 'accepted' | 'no response'> => {
+      return new Promise((resolve) => {
+        const timeout = setTimeout(() => resolve('no response'), RESPONSE_TIMEOUT_MS);
+        const cleanup = client.subscribeToShieldedTransactionEvents(
+          {
+            next: () => {
+              clearTimeout(timeout);
+              cleanup();
+              resolve('accepted');
+            },
+            error: (err) => {
+              clearTimeout(timeout);
+              resolve(err as Error);
+            },
+          },
+          sessionId,
+        );
+      });
+    };
+
+    /**
+     * The indexer enforces a per-session subscription creation rate limit via a
+     * token bucket, default 10 creations per minute (configurable via
+     * `infra.api.quota.max_session_subscriptions_per_minute`). The 11th shielded
+     * subscription creation for the same session within the same minute must be
+     * rejected with a client error, while the WebSocket connection stays open.
+     *
+     * @given a wallet session opened with a valid viewing key
+     * @when 10 shielded subscriptions for that session are created in rapid succession
+     * @and an 11th creation is attempted within the same minute
+     * @then the 11th creation is rejected with a client error mentioning the limit
+     * @and the WebSocket connection stays open
+     */
+    test('should reject shielded subscription creations beyond the per-session rate limit', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Subscription', 'Quota', 'Wallet', 'Negative'] };
+
+      const sessionId = await openRandomWalletSession();
+
+      // The burst plus the registration wait stays well under the 6s single-token
+      // refill period, so no token refills before the extra attempt.
+      const { errors, cleanups } = openShieldedSubscriptions(sessionId, PER_SESSION_RATE_LIMIT);
+      await sleep(REGISTRATION_WAIT_MS);
+      expect(
+        errors,
+        `The first ${PER_SESSION_RATE_LIMIT} subscription creations should all be accepted, got: ${errors.map((e) => e.message).join('; ')}`,
+      ).toHaveLength(0);
+
+      const outcome = await attemptShieldedSubscription(sessionId);
+
+      expect(
+        outcome,
+        `Expected creation ${PER_SESSION_RATE_LIMIT + 1} within the same minute to be rejected, got: ${String(outcome)}`,
+      ).toBeInstanceOf(Error);
+      expect((outcome as Error).message.toLowerCase()).toContain('subscription limit exceeded');
+      expect(
+        client.getState(),
+        `WebSocket connection should stay open after a rate-limited creation, got ${IndexerWsClient.getStateName(client.getState())}`,
+      ).toBe(WS_OPEN);
+
+      cleanups.forEach((fn) => fn());
+    }, 60_000);
+
+    /**
+     * The rate-limit token bucket refills continuously at the per-minute limit
+     * spread across 60 seconds — one token every 6 seconds at the default of 10
+     * per minute. After the session's allowance is exhausted, waiting longer than
+     * one refill period must allow a new subscription creation to succeed, so a
+     * throttled wallet is never permanently locked out.
+     *
+     * @given a wallet session whose subscription creation allowance is exhausted
+     * @when a new shielded subscription is created after an 8s wait, longer than the 6s single-token refill period
+     * @then the new subscription is accepted
+     */
+    test('should allow a new shielded subscription after the rate limit refills', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Subscription', 'Quota', 'Wallet'] };
+
+      const sessionId = await openRandomWalletSession();
+
+      const { errors, cleanups } = openShieldedSubscriptions(sessionId, PER_SESSION_RATE_LIMIT);
+      await sleep(REGISTRATION_WAIT_MS);
+      expect(
+        errors,
+        `The first ${PER_SESSION_RATE_LIMIT} subscription creations should all be accepted, got: ${errors.map((e) => e.message).join('; ')}`,
+      ).toHaveLength(0);
+
+      const rejected = await attemptShieldedSubscription(sessionId);
+      expect(
+        rejected,
+        `The creation allowance should be exhausted before the refill wait, got: ${String(rejected)}`,
+      ).toBeInstanceOf(Error);
+
+      await sleep(TOKEN_REFILL_WAIT_MS);
+
+      const outcome = await attemptShieldedSubscription(sessionId);
+      expect(
+        outcome,
+        `Expected a creation ${TOKEN_REFILL_WAIT_MS}ms after exhaustion to be accepted, got: ${outcome instanceof Error ? outcome.message : String(outcome)}`,
+      ).toBe('accepted');
+
+      cleanups.forEach((fn) => fn());
+    }, 60_000);
+
+    /**
+     * A rate-limit rejection must not disturb subscriptions that are already
+     * active: a live shielded subscription keeps streaming its periodic progress
+     * updates after further creations for the same session were rejected.
+     *
+     * @given one live shielded subscription for a wallet session
+     * @and the session's creation allowance exhausted by further creations
+     * @when an additional creation is rejected with the rate-limit error
+     * @then the live subscription still receives progress updates after the rejection
+     * @and the WebSocket connection stays open
+     */
+    test('should keep a live shielded subscription streaming while creations are rate-limited', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Subscription', 'Quota', 'Wallet'] };
+
+      const sessionId = await openRandomWalletSession();
+
+      const progressTimestamps: number[] = [];
+      const liveErrors: Error[] = [];
+      const stopLive = client.subscribeToShieldedTransactionEvents(
+        {
+          next: (payload) => {
+            if (payload.data?.shieldedTransactions?.__typename === 'ShieldedTransactionsProgress') {
+              progressTimestamps.push(Date.now());
+            }
+          },
+          error: (err) => {
+            liveErrors.push(err as Error);
+          },
+        },
+        sessionId,
+      );
+
+      const { errors, cleanups } = openShieldedSubscriptions(sessionId, PER_SESSION_RATE_LIMIT - 1);
+      await sleep(REGISTRATION_WAIT_MS);
+      expect(
+        errors,
+        `The live subscription plus ${PER_SESSION_RATE_LIMIT - 1} further creations should all be accepted, got: ${errors.map((e) => e.message).join('; ')}`,
+      ).toHaveLength(0);
+
+      const outcome = await attemptShieldedSubscription(sessionId);
+      expect(
+        outcome,
+        `Expected the creation beyond the allowance to be rejected, got: ${String(outcome)}`,
+      ).toBeInstanceOf(Error);
+      expect((outcome as Error).message.toLowerCase()).toContain('subscription limit exceeded');
+      const rejectionTime = Date.now();
+
+      // The live subscription re-polls progress within its 30s base interval ±20%
+      // jitter; wait for a progress update delivered strictly after the rejection.
+      const deadline = rejectionTime + PROGRESS_AFTER_REJECTION_TIMEOUT_MS;
+      while (Date.now() < deadline && !progressTimestamps.some((t) => t > rejectionTime)) {
+        await sleep(500);
+      }
+
+      expect(
+        progressTimestamps.some((t) => t > rejectionTime),
+        `Expected the live subscription to receive a progress update within ${PROGRESS_AFTER_REJECTION_TIMEOUT_MS}ms after the rejection`,
+      ).toBe(true);
+      expect(
+        liveErrors,
+        `The live subscription should not error while creations are rate-limited, got: ${liveErrors.map((e) => e.message).join('; ')}`,
+      ).toHaveLength(0);
+      expect(
+        client.getState(),
+        `WebSocket connection should stay open, got ${IndexerWsClient.getStateName(client.getState())}`,
+      ).toBe(WS_OPEN);
+
+      stopLive();
+      cleanups.forEach((fn) => fn());
+    }, 120_000);
   });
 });

--- a/qa/tests/tests/integration/basic/subscriptions/subscription-quotas.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/subscription-quotas.test.ts
@@ -13,24 +13,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import type { TestContext } from 'vitest';
 import '@utils/logging/test-logging-hooks';
 import { IndexerWsClient } from '@utils/indexer/websocket-client';
+import { BLOCKS_SUBSCRIPTION_FROM_LATEST_BLOCK } from '@utils/indexer/graphql/subscriptions';
 
+// Shipped default from the indexer-api `infra.api.quota` configuration.
 const PER_CONNECTION_CAP = 20;
+
 const REGISTRATION_WAIT_MS = 1_000;
 const RESPONSE_TIMEOUT_MS = 5_000;
 const WS_OPEN = 1;
 
-const blockSubscriptionQuery = `
-  subscription {
-    blocks {
-      hash
-      height
-    }
-  }
-`;
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-describe('subscription quotas (HAL-03 / SSE-196)', () => {
+describe('subscription quotas', () => {
   let client: IndexerWsClient;
 
   beforeEach(async () => {
@@ -56,12 +53,14 @@ describe('subscription quotas (HAL-03 / SSE-196)', () => {
      * @then the 21st subscription returns a client error mentioning the limit
      * @and the WebSocket connection stays open
      */
-    test('should reject a subscription beyond the per-connection cap', async () => {
+    test('should reject a subscription beyond the per-connection cap', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Subscription', 'Quota', 'Negative'] };
+
       const cleanups: Array<() => void> = [];
 
       for (let i = 0; i < PER_CONNECTION_CAP; i++) {
         const idx = i + 1;
-        const cleanup = client.subscribe(blockSubscriptionQuery, {
+        const cleanup = client.subscribe(BLOCKS_SUBSCRIPTION_FROM_LATEST_BLOCK, {
           next: () => {
             /* drain quietly */
           },
@@ -74,11 +73,11 @@ describe('subscription quotas (HAL-03 / SSE-196)', () => {
         cleanups.push(cleanup);
       }
 
-      await new Promise((resolve) => setTimeout(resolve, REGISTRATION_WAIT_MS));
+      await sleep(REGISTRATION_WAIT_MS);
 
       const rejected = await new Promise<Error | null>((resolve) => {
         const timeout = setTimeout(() => resolve(null), RESPONSE_TIMEOUT_MS);
-        const cleanupExtra = client.subscribe(blockSubscriptionQuery, {
+        const cleanupExtra = client.subscribe(BLOCKS_SUBSCRIPTION_FROM_LATEST_BLOCK, {
           next: () => {
             clearTimeout(timeout);
             cleanupExtra();
@@ -114,11 +113,13 @@ describe('subscription quotas (HAL-03 / SSE-196)', () => {
      * @when one of the active subscriptions is closed
      * @then a new subscription opened on the same connection succeeds
      */
-    test('should free a slot when an active subscription is closed', async () => {
+    test('should free a slot when an active subscription is closed', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Subscription', 'Quota'] };
+
       const cleanups: Array<() => void> = [];
 
       for (let i = 0; i < PER_CONNECTION_CAP; i++) {
-        const cleanup = client.subscribe(blockSubscriptionQuery, {
+        const cleanup = client.subscribe(BLOCKS_SUBSCRIPTION_FROM_LATEST_BLOCK, {
           next: () => {
             /* drain quietly */
           },
@@ -126,16 +127,16 @@ describe('subscription quotas (HAL-03 / SSE-196)', () => {
         cleanups.push(cleanup);
       }
 
-      await new Promise((resolve) => setTimeout(resolve, REGISTRATION_WAIT_MS));
+      await sleep(REGISTRATION_WAIT_MS);
 
       const closed = cleanups.shift();
       closed!();
 
-      await new Promise((resolve) => setTimeout(resolve, REGISTRATION_WAIT_MS));
+      await sleep(REGISTRATION_WAIT_MS);
 
       const succeeded = await new Promise<boolean>((resolve) => {
         const timeout = setTimeout(() => resolve(false), RESPONSE_TIMEOUT_MS);
-        const cleanupExtra = client.subscribe(blockSubscriptionQuery, {
+        const cleanupExtra = client.subscribe(BLOCKS_SUBSCRIPTION_FROM_LATEST_BLOCK, {
           next: () => {
             clearTimeout(timeout);
             cleanupExtra();

--- a/qa/tests/tests/integration/basic/subscriptions/subscription-quotas.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/subscription-quotas.test.ts
@@ -17,6 +17,7 @@ import { randomBytes } from 'crypto';
 import type { TestContext } from 'vitest';
 import '@utils/logging/test-logging-hooks';
 import { IndexerWsClient } from '@utils/indexer/websocket-client';
+import { extractSubscriptionErrorMessage } from '@utils/indexer/subscription-error';
 import { BLOCKS_SUBSCRIPTION_FROM_LATEST_BLOCK } from '@utils/indexer/graphql/subscriptions';
 import { ToolkitWrapper } from '@utils/toolkit/toolkit-wrapper';
 
@@ -75,7 +76,7 @@ describe('subscription quotas', () => {
           },
           error: (err) => {
             throw new Error(
-              `Subscription #${idx} of ${PER_CONNECTION_CAP} unexpectedly errored: ${err.message}`,
+              `Subscription #${idx} of ${PER_CONNECTION_CAP} unexpectedly errored: ${extractSubscriptionErrorMessage(err)}`,
             );
           },
         });
@@ -84,7 +85,7 @@ describe('subscription quotas', () => {
 
       await sleep(REGISTRATION_WAIT_MS);
 
-      const rejected = await new Promise<Error | null>((resolve) => {
+      const rejected = await new Promise<string | null>((resolve) => {
         const timeout = setTimeout(() => resolve(null), RESPONSE_TIMEOUT_MS);
         const cleanupExtra = client.subscribe(BLOCKS_SUBSCRIPTION_FROM_LATEST_BLOCK, {
           next: () => {
@@ -94,7 +95,7 @@ describe('subscription quotas', () => {
           },
           error: (err) => {
             clearTimeout(timeout);
-            resolve(err as Error);
+            resolve(extractSubscriptionErrorMessage(err));
           },
         });
       });
@@ -103,7 +104,7 @@ describe('subscription quotas', () => {
         rejected,
         `Expected the ${PER_CONNECTION_CAP + 1}th subscription to be rejected, but no error was returned within ${RESPONSE_TIMEOUT_MS}ms`,
       ).not.toBeNull();
-      expect(rejected!.message.toLowerCase()).toContain('subscription limit exceeded');
+      expect(rejected!.toLowerCase()).toContain('subscription limit exceeded');
       expect(
         client.getState(),
         `WebSocket connection should stay open after a single subscription is rejected, got ${IndexerWsClient.getStateName(client.getState())}`,
@@ -187,9 +188,10 @@ describe('subscription quotas', () => {
     };
 
     // Starts `count` shielded subscriptions for the session in rapid succession,
-    // collecting unexpected rejections instead of throwing so callers can assert on them.
+    // collecting unexpected rejection messages instead of throwing so callers can
+    // assert on them.
     const openShieldedSubscriptions = (sessionId: string, count: number) => {
-      const errors: Error[] = [];
+      const errors: string[] = [];
       const cleanups: Array<() => void> = [];
       for (let i = 0; i < count; i++) {
         const cleanup = client.subscribeToShieldedTransactionEvents(
@@ -198,7 +200,7 @@ describe('subscription quotas', () => {
               /* drain quietly */
             },
             error: (err) => {
-              errors.push(err as Error);
+              errors.push(extractSubscriptionErrorMessage(err));
             },
           },
           sessionId,
@@ -209,11 +211,9 @@ describe('subscription quotas', () => {
     };
 
     // Attempts one more shielded subscription creation for the session. Resolves with
-    // 'accepted' once its first progress event arrives, the rejection Error if the
-    // creation is refused, or 'no response' if neither happens in time.
-    const attemptShieldedSubscription = (
-      sessionId: string,
-    ): Promise<Error | 'accepted' | 'no response'> => {
+    // 'accepted' once its first progress event arrives, the normalized rejection
+    // message if the creation is refused, or 'no response' if neither happens in time.
+    const attemptShieldedSubscription = (sessionId: string): Promise<string> => {
       return new Promise((resolve) => {
         const timeout = setTimeout(() => resolve('no response'), RESPONSE_TIMEOUT_MS);
         const cleanup = client.subscribeToShieldedTransactionEvents(
@@ -225,7 +225,7 @@ describe('subscription quotas', () => {
             },
             error: (err) => {
               clearTimeout(timeout);
-              resolve(err as Error);
+              resolve(extractSubscriptionErrorMessage(err));
             },
           },
           sessionId,
@@ -257,16 +257,17 @@ describe('subscription quotas', () => {
       await sleep(REGISTRATION_WAIT_MS);
       expect(
         errors,
-        `The first ${PER_SESSION_RATE_LIMIT} subscription creations should all be accepted, got: ${errors.map((e) => e.message).join('; ')}`,
+        `The first ${PER_SESSION_RATE_LIMIT} subscription creations should all be accepted, got: ${errors.join('; ')}`,
       ).toHaveLength(0);
 
       const outcome = await attemptShieldedSubscription(sessionId);
 
+      // 'per-session rate limit' pins the rejection to the rate-limit guardrail;
+      // the per-connection cap shares the same 'subscription limit exceeded' wrapper.
       expect(
-        outcome,
-        `Expected creation ${PER_SESSION_RATE_LIMIT + 1} within the same minute to be rejected, got: ${String(outcome)}`,
-      ).toBeInstanceOf(Error);
-      expect((outcome as Error).message.toLowerCase()).toContain('subscription limit exceeded');
+        outcome.toLowerCase(),
+        `Expected creation ${PER_SESSION_RATE_LIMIT + 1} within the same minute to be rejected by the per-session rate limit, got: ${outcome}`,
+      ).toContain('per-session rate limit');
       expect(
         client.getState(),
         `WebSocket connection should stay open after a rate-limited creation, got ${IndexerWsClient.getStateName(client.getState())}`,
@@ -295,21 +296,21 @@ describe('subscription quotas', () => {
       await sleep(REGISTRATION_WAIT_MS);
       expect(
         errors,
-        `The first ${PER_SESSION_RATE_LIMIT} subscription creations should all be accepted, got: ${errors.map((e) => e.message).join('; ')}`,
+        `The first ${PER_SESSION_RATE_LIMIT} subscription creations should all be accepted, got: ${errors.join('; ')}`,
       ).toHaveLength(0);
 
       const rejected = await attemptShieldedSubscription(sessionId);
       expect(
-        rejected,
-        `The creation allowance should be exhausted before the refill wait, got: ${String(rejected)}`,
-      ).toBeInstanceOf(Error);
+        rejected.toLowerCase(),
+        `The creation allowance should be exhausted before the refill wait, got: ${rejected}`,
+      ).toContain('per-session rate limit');
 
       await sleep(TOKEN_REFILL_WAIT_MS);
 
       const outcome = await attemptShieldedSubscription(sessionId);
       expect(
         outcome,
-        `Expected a creation ${TOKEN_REFILL_WAIT_MS}ms after exhaustion to be accepted, got: ${outcome instanceof Error ? outcome.message : String(outcome)}`,
+        `Expected a creation ${TOKEN_REFILL_WAIT_MS}ms after exhaustion to be accepted, got: ${outcome}`,
       ).toBe('accepted');
 
       cleanups.forEach((fn) => fn());
@@ -332,7 +333,7 @@ describe('subscription quotas', () => {
       const sessionId = await openRandomWalletSession();
 
       const progressTimestamps: number[] = [];
-      const liveErrors: Error[] = [];
+      const liveErrors: string[] = [];
       const stopLive = client.subscribeToShieldedTransactionEvents(
         {
           next: (payload) => {
@@ -341,7 +342,7 @@ describe('subscription quotas', () => {
             }
           },
           error: (err) => {
-            liveErrors.push(err as Error);
+            liveErrors.push(extractSubscriptionErrorMessage(err));
           },
         },
         sessionId,
@@ -351,15 +352,14 @@ describe('subscription quotas', () => {
       await sleep(REGISTRATION_WAIT_MS);
       expect(
         errors,
-        `The live subscription plus ${PER_SESSION_RATE_LIMIT - 1} further creations should all be accepted, got: ${errors.map((e) => e.message).join('; ')}`,
+        `The live subscription plus ${PER_SESSION_RATE_LIMIT - 1} further creations should all be accepted, got: ${errors.join('; ')}`,
       ).toHaveLength(0);
 
       const outcome = await attemptShieldedSubscription(sessionId);
       expect(
-        outcome,
-        `Expected the creation beyond the allowance to be rejected, got: ${String(outcome)}`,
-      ).toBeInstanceOf(Error);
-      expect((outcome as Error).message.toLowerCase()).toContain('subscription limit exceeded');
+        outcome.toLowerCase(),
+        `Expected the creation beyond the allowance to be rejected by the per-session rate limit, got: ${outcome}`,
+      ).toContain('per-session rate limit');
       const rejectionTime = Date.now();
 
       // The live subscription re-polls progress within its 30s base interval ±20%
@@ -375,7 +375,7 @@ describe('subscription quotas', () => {
       ).toBe(true);
       expect(
         liveErrors,
-        `The live subscription should not error while creations are rate-limited, got: ${liveErrors.map((e) => e.message).join('; ')}`,
+        `The live subscription should not error while creations are rate-limited, got: ${liveErrors.join('; ')}`,
       ).toHaveLength(0);
       expect(
         client.getState(),


### PR DESCRIPTION
## Scope

Adds black-box integration coverage for the per-session subscription
creation-rate limit (the guardrail introduced in #1104), extending
`qa/tests/tests/integration/basic/subscriptions/subscription-quotas.test.ts`:

- the 11th `shieldedTransactions` creation for one session within a minute
  is rejected with the specific `per-session rate limit` client error and
  the WebSocket connection stays open;
- after the token bucket refills (~8s > the 6s single-token bound at the
  default 10/min), a new creation for the same session is accepted —
  proven positively by its first progress event;
- a live subscription keeps streaming progress while further creations
  are rate-limited, with no errors on the live stream.

Also aligns the existing per-connection quota tests with the current
test-writing conventions (shared `blocks` subscription builder, labels,
title cleanup) and normalizes all subscription error handling through
`extractSubscriptionErrorMessage()`.

## Why

QA validation for the subscription-guardrails audit finding
(shieldedtech/shielded-security-engineering#280). The per-connection cap
already had integration coverage; the per-session creation-rate limit had
none outside Rust unit tests, so its end-to-end enforcement through the
WS resolvers was unverified.

## Validation

Run against the undeployed stack with INDEXER_TAG=4.4.0-rc.1 and
NODE_TAG=2.0.0-rc.3: `subscription-quotas.test.ts` 5/5 passed (2 existing
+ 3 new); full smoke 26 passed, 1 skipped, 0 failed; lint, compile-check
and format clean. No pre-existing failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
