### PR TITLE
feat(chain-indexer): gate BABE author derivation by presence of pallet-consensus-engine

### DIFF
--- a/chain-indexer/src/infra/subxt_node.rs
+++ b/chain-indexer/src/infra/subxt_node.rs
@@ -61,6 +61,13 @@ type SubxtBlock = subxt::client::Block<SubstrateConfig>;
 
 const AURA_ENGINE_ID: ConsensusEngineId = [b'a', b'u', b'r', b'a'];
 const BABE_ENGINE_ID: ConsensusEngineId = [b'B', b'A', b'B', b'E'];
+
+/// Name of the node runtime API reporting the active block-production engine, declared in
+/// `midnight-primitives-consensus-engine` and implemented alongside the pallet driving the
+/// Aura→BABE transition. Its presence in a block's runtime guarantees the correctness of Aura
+/// and BABE pre-runtime digests during the transition, so BABE digests are only trusted for
+/// author derivation where it exists.
+const CONSENSUS_ENGINE_RUNTIME_API: &str = "ConsensusEngineApi";
 const CATCH_UP_LOG_INTERVAL: u64 = 1_000;
 
 /// One GRANDPA session worth of blocks. Blocks within this distance of the finalized tip are
@@ -220,7 +227,15 @@ impl SubxtNode {
         }
         let author = authorities
             .as_ref()
-            .map(|authorities| extract_block_author(&header, authorities, content_node_version))
+            .map(|authorities| {
+                // The state metadata can only be newer than the runtime that authored the
+                // block, so this can never enable BABE recognition too late.
+                let babe_supported = block
+                    .metadata_ref()
+                    .runtime_api_trait_by_name(CONSENSUS_ENGINE_RUNTIME_API)
+                    .is_some();
+                extract_block_author(&header, authorities, content_node_version, babe_supported)
+            })
             .transpose()?
             .flatten();
 
@@ -663,24 +678,31 @@ fn extract_block_author<H>(
     header: &SubstrateHeader<H>,
     authorities: &[[u8; 32]],
     content_node_version: NodeVersion,
+    babe_supported: bool,
 ) -> Result<Option<BlockAuthor>, SubxtNodeError>
 where
     H: Hash,
 {
-    author_from_digest_logs(&header.digest.logs, authorities, content_node_version)
+    author_from_digest_logs(
+        &header.digest.logs,
+        authorities,
+        content_node_version,
+        babe_supported,
+    )
 }
 
 /// Determine the block author from the pre-runtime digest logs, taking the first log with a
 /// recognized consensus engine that yields an author, in digest order (mirroring polkadot-js
 /// `extractAuthor`): Aura carries the slot (the author is the slot modulo the authority-set
 /// length), BABE carries the authority index explicitly in all of its pre-digest variants. BABE
-/// digests are only recognized on node versions that author under BABE (see
-/// [NodeVersion::supports_babe]); on older versions they are skipped like any unrecognized
-/// engine.
+/// digests are only recognized if `babe_supported`, i.e. if the block's runtime guarantees
+/// their correctness (see [CONSENSUS_ENGINE_RUNTIME_API]); otherwise they are skipped like any
+/// unrecognized engine.
 fn author_from_digest_logs(
     logs: &[DigestItem],
     authorities: &[[u8; 32]],
     content_node_version: NodeVersion,
+    babe_supported: bool,
 ) -> Result<Option<BlockAuthor>, SubxtNodeError> {
     if authorities.is_empty() {
         return Ok(None);
@@ -698,9 +720,7 @@ fn author_from_digest_logs(
                 authorities.get(index as usize).copied().map(Into::into)
             }
 
-            BABE_ENGINE_ID if content_node_version.supports_babe() => {
-                babe_author(pre_digest, authorities)?
-            }
+            BABE_ENGINE_ID if babe_supported => babe_author(pre_digest, authorities)?,
 
             _ => None,
         };
@@ -842,7 +862,7 @@ mod tests {
     fn author_from_aura_digest() {
         let logs = vec![DigestItem::PreRuntime(AURA_ENGINE_ID, 4u64.encode())];
 
-        let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0)
+        let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0, false)
             .expect("author can be determined");
 
         assert_eq!(author, Some([2; 32].into()));
@@ -859,24 +879,41 @@ mod tests {
     }
 
     #[test]
-    fn babe_digest_is_skipped_on_versions_without_babe() {
-        for node_version in [NodeVersion::V0_22, NodeVersion::V1_0, NodeVersion::V2_0] {
-            let logs = vec![DigestItem::PreRuntime(
-                BABE_ENGINE_ID,
-                babe_pre_digest(2, 2),
-            )];
-            let author = author_from_digest_logs(&logs, &AUTHORITIES, node_version)
-                .expect("skipped digest is not an error");
-            assert_eq!(author, None);
+    fn babe_digest_is_skipped_if_babe_not_supported() {
+        let logs = vec![DigestItem::PreRuntime(
+            BABE_ENGINE_ID,
+            babe_pre_digest(2, 2),
+        )];
+        let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0, false)
+            .expect("skipped digest is not an error");
+        assert_eq!(author, None);
 
-            let logs = vec![
-                DigestItem::PreRuntime(BABE_ENGINE_ID, babe_pre_digest(2, 2)),
-                DigestItem::PreRuntime(AURA_ENGINE_ID, 4u64.encode()),
-            ];
-            let author = author_from_digest_logs(&logs, &AUTHORITIES, node_version)
-                .expect("author can be determined");
-            assert_eq!(author, Some([2; 32].into()));
-        }
+        let logs = vec![
+            DigestItem::PreRuntime(BABE_ENGINE_ID, babe_pre_digest(2, 2)),
+            DigestItem::PreRuntime(AURA_ENGINE_ID, 4u64.encode()),
+        ];
+        let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0, false)
+            .expect("author can be determined");
+        assert_eq!(author, Some([2; 32].into()));
+    }
+
+    #[test]
+    fn first_pre_runtime_digest_in_digest_order_wins() {
+        let logs = vec![
+            DigestItem::PreRuntime(BABE_ENGINE_ID, babe_pre_digest(2, 2)),
+            DigestItem::PreRuntime(AURA_ENGINE_ID, 4u64.encode()),
+        ];
+        let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0, true)
+            .expect("author can be determined");
+        assert_eq!(author, Some([3; 32].into()));
+
+        let logs = vec![
+            DigestItem::PreRuntime(AURA_ENGINE_ID, 4u64.encode()),
+            DigestItem::PreRuntime(BABE_ENGINE_ID, babe_pre_digest(2, 2)),
+        ];
+        let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0, true)
+            .expect("author can be determined");
+        assert_eq!(author, Some([2; 32].into()));
     }
 
     #[test]
@@ -886,7 +923,7 @@ mod tests {
             DigestItem::PreRuntime(AURA_ENGINE_ID, 4u64.encode()),
         ];
 
-        let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0)
+        let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0, true)
             .expect("author can be determined");
 
         assert_eq!(author, Some([2; 32].into()));
@@ -921,7 +958,7 @@ mod tests {
 
     #[test]
     fn no_pre_runtime_digest_yields_no_author() {
-        let author = author_from_digest_logs(&[], &AUTHORITIES, NodeVersion::V2_0)
+        let author = author_from_digest_logs(&[], &AUTHORITIES, NodeVersion::V2_0, true)
             .expect("no digest is not an error");
 
         assert_eq!(author, None);
@@ -931,7 +968,7 @@ mod tests {
     fn empty_authorities_yield_no_author() {
         let logs = vec![DigestItem::PreRuntime(AURA_ENGINE_ID, 4u64.encode())];
 
-        let author = author_from_digest_logs(&logs, &[], NodeVersion::V2_0)
+        let author = author_from_digest_logs(&logs, &[], NodeVersion::V2_0, true)
             .expect("empty authorities are not an error");
 
         assert_eq!(author, None);

--- a/chain-indexer/src/infra/subxt_node.rs
+++ b/chain-indexer/src/infra/subxt_node.rs
@@ -673,7 +673,10 @@ where
 /// Determine the block author from the pre-runtime digest logs, taking the first log with a
 /// recognized consensus engine that yields an author, in digest order (mirroring polkadot-js
 /// `extractAuthor`): Aura carries the slot (the author is the slot modulo the authority-set
-/// length), BABE carries the authority index explicitly in all of its pre-digest variants.
+/// length), BABE carries the authority index explicitly in all of its pre-digest variants. BABE
+/// digests are only recognized on node versions that author under BABE (see
+/// [NodeVersion::supports_babe]); on older versions they are skipped like any unrecognized
+/// engine.
 fn author_from_digest_logs(
     logs: &[DigestItem],
     authorities: &[[u8; 32]],
@@ -695,15 +698,8 @@ fn author_from_digest_logs(
                 authorities.get(index as usize).copied().map(Into::into)
             }
 
-            BABE_ENGINE_ID => {
-                let index = decode_babe_authority_index(pre_digest)?;
-                // An out-of-range index means the cached authority set does not match the
-                // block's epoch; report an unknown author instead of failing block processing.
-                usize::try_from(index)
-                    .ok()
-                    .and_then(|index| authorities.get(index))
-                    .copied()
-                    .map(Into::into)
+            BABE_ENGINE_ID if content_node_version.supports_babe() => {
+                babe_author(pre_digest, authorities)?
             }
 
             _ => None,
@@ -715,6 +711,24 @@ fn author_from_digest_logs(
     }
 
     Ok(None)
+}
+
+/// Determine the block author from a BABE pre-runtime digest. An out-of-range authority index
+/// means the cached authority set does not match the block's epoch; report an unknown author
+/// instead of failing block processing.
+fn babe_author(
+    pre_digest: &[u8],
+    authorities: &[[u8; 32]],
+) -> Result<Option<BlockAuthor>, SubxtNodeError> {
+    let index = decode_babe_authority_index(pre_digest)?;
+
+    let author = usize::try_from(index)
+        .ok()
+        .and_then(|index| authorities.get(index))
+        .copied()
+        .map(Into::into);
+
+    Ok(author)
 }
 
 /// Extract the authority index from a BABE pre-runtime digest. All `PreDigest` variants
@@ -835,14 +849,9 @@ mod tests {
     }
 
     #[test]
-    fn author_from_babe_digest_for_all_variants() {
+    fn babe_author_for_all_variants() {
         for tag in 1..=3 {
-            let logs = vec![DigestItem::PreRuntime(
-                BABE_ENGINE_ID,
-                babe_pre_digest(tag, 2),
-            )];
-
-            let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0)
+            let author = babe_author(&babe_pre_digest(tag, 2), &AUTHORITIES)
                 .expect("author can be determined");
 
             assert_eq!(author, Some([3; 32].into()));
@@ -850,29 +859,30 @@ mod tests {
     }
 
     #[test]
-    fn first_pre_runtime_digest_in_digest_order_wins() {
-        let logs = vec![
-            DigestItem::PreRuntime(BABE_ENGINE_ID, babe_pre_digest(2, 2)),
-            DigestItem::PreRuntime(AURA_ENGINE_ID, 4u64.encode()),
-        ];
-        let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0)
-            .expect("author can be determined");
-        assert_eq!(author, Some([3; 32].into()));
+    fn babe_digest_is_skipped_on_versions_without_babe() {
+        for node_version in [NodeVersion::V0_22, NodeVersion::V1_0, NodeVersion::V2_0] {
+            let logs = vec![DigestItem::PreRuntime(
+                BABE_ENGINE_ID,
+                babe_pre_digest(2, 2),
+            )];
+            let author = author_from_digest_logs(&logs, &AUTHORITIES, node_version)
+                .expect("skipped digest is not an error");
+            assert_eq!(author, None);
 
-        let logs = vec![
-            DigestItem::PreRuntime(AURA_ENGINE_ID, 4u64.encode()),
-            DigestItem::PreRuntime(BABE_ENGINE_ID, babe_pre_digest(2, 2)),
-        ];
-        let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0)
-            .expect("author can be determined");
-        assert_eq!(author, Some([2; 32].into()));
+            let logs = vec![
+                DigestItem::PreRuntime(BABE_ENGINE_ID, babe_pre_digest(2, 2)),
+                DigestItem::PreRuntime(AURA_ENGINE_ID, 4u64.encode()),
+            ];
+            let author = author_from_digest_logs(&logs, &AUTHORITIES, node_version)
+                .expect("author can be determined");
+            assert_eq!(author, Some([2; 32].into()));
+        }
     }
 
     #[test]
-    fn unrecognized_engine_and_authorless_digest_are_skipped() {
+    fn unrecognized_engine_is_skipped() {
         let logs = vec![
             DigestItem::PreRuntime(*b"test", vec![0xaa]),
-            DigestItem::PreRuntime(BABE_ENGINE_ID, babe_pre_digest(2, 7)),
             DigestItem::PreRuntime(AURA_ENGINE_ID, 4u64.encode()),
         ];
 
@@ -884,12 +894,7 @@ mod tests {
 
     #[test]
     fn babe_out_of_range_authority_index_yields_no_author() {
-        let logs = vec![DigestItem::PreRuntime(
-            BABE_ENGINE_ID,
-            babe_pre_digest(2, 7),
-        )];
-
-        let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0)
+        let author = babe_author(&babe_pre_digest(2, 7), &AUTHORITIES)
             .expect("out-of-range index is not an error");
 
         assert_eq!(author, None);
@@ -898,12 +903,7 @@ mod tests {
     #[test]
     fn invalid_babe_pre_digest_tag_is_an_error() {
         for tag in [0, 4] {
-            let logs = vec![DigestItem::PreRuntime(
-                BABE_ENGINE_ID,
-                babe_pre_digest(tag, 2),
-            )];
-
-            let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0);
+            let author = babe_author(&babe_pre_digest(tag, 2), &AUTHORITIES);
 
             assert!(matches!(
                 author,
@@ -914,9 +914,7 @@ mod tests {
 
     #[test]
     fn truncated_babe_pre_digest_is_an_error() {
-        let logs = vec![DigestItem::PreRuntime(BABE_ENGINE_ID, vec![1, 0xaa])];
-
-        let author = author_from_digest_logs(&logs, &AUTHORITIES, NodeVersion::V2_0);
+        let author = babe_author(&[1, 0xaa], &AUTHORITIES);
 
         assert!(matches!(author, Err(SubxtNodeError::ScaleDecode(_))));
     }

--- a/indexer-common/src/domain/protocol_version.rs
+++ b/indexer-common/src/domain/protocol_version.rs
@@ -124,6 +124,17 @@ pub enum NodeVersion {
     V2_0,
 }
 
+impl NodeVersion {
+    /// Whether the node runtime can author blocks under BABE: the Aura to BABE transition is
+    /// planned for node 2.1, so every currently supported version authors under Aura only.
+    /// Deliberately matched exhaustively so that adding a new version forces this decision.
+    pub fn supports_babe(self) -> bool {
+        match self {
+            NodeVersion::V0_22 | NodeVersion::V1_0 | NodeVersion::V2_0 => false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::domain::{LedgerVersion, NodeVersion, ProtocolVersion, ProtocolVersionError};

--- a/indexer-common/src/domain/protocol_version.rs
+++ b/indexer-common/src/domain/protocol_version.rs
@@ -124,17 +124,6 @@ pub enum NodeVersion {
     V2_0,
 }
 
-impl NodeVersion {
-    /// Whether the node runtime can author blocks under BABE: the Aura to BABE transition is
-    /// planned for node 2.1, so every currently supported version authors under Aura only.
-    /// Deliberately matched exhaustively so that adding a new version forces this decision.
-    pub fn supports_babe(self) -> bool {
-        match self {
-            NodeVersion::V0_22 | NodeVersion::V1_0 | NodeVersion::V2_0 => false,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::domain::{LedgerVersion, NodeVersion, ProtocolVersion, ProtocolVersionError};


### PR DESCRIPTION
## Gate BABE author derivation by ConsensusEngineApi

Block-author derivation currently accepts BABE pre-runtime digests
unconditionally, even though only Aura authors blocks today. This PR gates BABE
recognition on the block's runtime metadata exposing the `ConsensusEngineApi`
runtime API, which ships with the consensus-engine pallet driving the Aura→BABE
transition (node 2.1) and guarantees Aura/BABE pre-digest correctness while the
transition is under way.

- Runtimes without the API derive authors from Aura digests only; BABE digests
  are skipped like any unrecognized engine.
- The gate is a per-block metadata lookup (no extra RPC) and is checked instead
  of the runtime spec version, since spec versioning is not currently
  consistent across networks.
- At an upgrade enactment block the state metadata can only be newer than the
  authoring runtime, so the gate may open one block early (harmless) but never
  late.