### PR TITLE
fix(indexer-common)!: make the ledger DB cache size a node count and raise it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### 🐛 Bug Fixes
+
+- *(indexer-common)* [**breaking**] Rename the ledger DB's `cache_size` to `cache_max_nodes`, make it a plain node count and raise it to 100000
+
+  The value has always been a *number of arena nodes* (storage-core's own default is 10000), but it
+  was parsed as a byte size, so the shipped `"1kiB"` meant 1024 nodes — about 100x below where it
+  should be. Operators must rename the key in their config and replace any byte-unit string with a
+  plain integer; the `APP__INFRA__LEDGER_DB__CACHE_SIZE` environment variable becomes
+  `APP__INFRA__LEDGER_DB__CACHE_MAX_NODES`. `0` means unbounded.
+
 ## [4.3.5] - 2026-07-25
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3427,7 +3427,6 @@ dependencies = [
  "assert_matches",
  "async-nats",
  "bip32",
- "byte-unit-serde",
  "chacha20poly1305",
  "const-hex",
  "criterion",

--- a/chain-indexer/benches/apply_transaction.rs
+++ b/chain-indexer/benches/apply_transaction.rs
@@ -36,7 +36,7 @@ fn init_ledger_db(rt: &Runtime) -> tempfile::TempDir {
 
     rt.block_on(async {
         ledger_db::init(ledger_db::Config {
-            cache_size: 1_024,
+            cache_max_nodes: 1_024,
             cnn_url: sqlite_file,
         })
         .await

--- a/chain-indexer/benches/ledger_state.rs
+++ b/chain-indexer/benches/ledger_state.rs
@@ -32,7 +32,7 @@ fn init_ledger_db(rt: &Runtime) -> tempfile::TempDir {
 
     rt.block_on(async {
         ledger_db::init(ledger_db::Config {
-            cache_size: 1_024,
+            cache_max_nodes: 1_024,
             cnn_url: sqlite_file,
         })
         .await

--- a/chain-indexer/benches/preprod_genesis.rs
+++ b/chain-indexer/benches/preprod_genesis.rs
@@ -44,7 +44,7 @@ fn init_ledger_db(rt: &Runtime) -> tempfile::TempDir {
         .to_string();
     rt.block_on(async {
         ledger_db::init(ledger_db::Config {
-            cache_size: 1_024,
+            cache_max_nodes: 1_024,
             cnn_url: sqlite_file,
         })
         .await

--- a/chain-indexer/config.yaml
+++ b/chain-indexer/config.yaml
@@ -24,7 +24,7 @@ infra:
     max_lifetime: "5m"
 
   ledger_db:
-    cache_size: "1kiB"
+    cache_max_nodes: 100000
 
   pub_sub:
     url: "localhost:4222"

--- a/chain-indexer/tests/mainnet_runtime.rs
+++ b/chain-indexer/tests/mainnet_runtime.rs
@@ -218,7 +218,12 @@ async fn init_ledger_db()
         .await
         .context("run Postgres migrations")?;
 
-    ledger_db::init(ledger_db::Config { cache_size: 1_024 }, pool);
+    ledger_db::init(
+        ledger_db::Config {
+            cache_max_nodes: 1_024,
+        },
+        pool,
+    );
 
     Ok(postgres_container)
 }
@@ -235,7 +240,7 @@ async fn init_ledger_db() -> anyhow::Result<tempfile::TempDir> {
         .to_string();
 
     ledger_db::init(ledger_db::Config {
-        cache_size: 1_024,
+        cache_max_nodes: 1_024,
         cnn_url,
     })
     .await

--- a/indexer-api/config.yaml
+++ b/indexer-api/config.yaml
@@ -17,7 +17,7 @@ infra:
     max_lifetime: "5m"
 
   ledger_db:
-    cache_size: "1kiB"
+    cache_max_nodes: 100000
 
   pub_sub:
     url: "localhost:4222"

--- a/indexer-common/Cargo.toml
+++ b/indexer-common/Cargo.toml
@@ -33,7 +33,6 @@ midnight-onchain-runtime_v4  = { workspace = true }
 midnight-transient-crypto_v3 = { workspace = true }
 midnight-zswap_v9            = { workspace = true }
 async-nats                   = { workspace = true, optional = true }
-byte-unit-serde              = { workspace = true }
 chacha20poly1305             = { workspace = true, features = [ "std" ] }
 const-hex                    = { workspace = true, features = [ "serde" ] }
 derive_more                  = { workspace = true, features = [ "as_ref", "debug", "deref", "display", "from", "into" ] }

--- a/indexer-common/benches/ledger_transaction.rs
+++ b/indexer-common/benches/ledger_transaction.rs
@@ -33,7 +33,7 @@ fn init_ledger_db(rt: &Runtime) -> tempfile::TempDir {
 
     rt.block_on(async {
         ledger_db::init(ledger_db::Config {
-            cache_size: 1_024,
+            cache_max_nodes: 1_024,
             cnn_url: sqlite_file,
         })
         .await

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -2543,7 +2543,12 @@ mod tests {
                 .await
                 .context("run migrations")?;
 
-            ledger_db::init(ledger_db::Config { cache_size: 1_024 }, pool);
+            ledger_db::init(
+                ledger_db::Config {
+                    cache_max_nodes: 1_024,
+                },
+                pool,
+            );
 
             postgres_container
         };
@@ -2573,7 +2578,7 @@ mod tests {
                 .context("run migrations")?;
 
             ledger_db::init(ledger_db::Config {
-                cache_size: 1_024,
+                cache_max_nodes: 1_024,
                 cnn_url: sqlite_ledger_db_file,
             })
             .await
@@ -2663,7 +2668,12 @@ mod tests {
                 .await
                 .context("run migrations")?;
 
-            ledger_db::init(ledger_db::Config { cache_size: 1_024 }, pool);
+            ledger_db::init(
+                ledger_db::Config {
+                    cache_max_nodes: 1_024,
+                },
+                pool,
+            );
 
             postgres_container
         };
@@ -2680,7 +2690,7 @@ mod tests {
                 .to_string();
 
             ledger_db::init(ledger_db::Config {
-                cache_size: 1_024,
+                cache_max_nodes: 1_024,
                 cnn_url: sqlite_ledger_db_file,
             })
             .await
@@ -2798,7 +2808,12 @@ mod tests {
                 .await
                 .context("run migrations")?;
 
-            ledger_db::init(ledger_db::Config { cache_size: 1_024 }, pool);
+            ledger_db::init(
+                ledger_db::Config {
+                    cache_max_nodes: 1_024,
+                },
+                pool,
+            );
 
             postgres_container
         };
@@ -2815,7 +2830,7 @@ mod tests {
                 .to_string();
 
             ledger_db::init(ledger_db::Config {
-                cache_size: 1_024,
+                cache_max_nodes: 1_024,
                 cnn_url: sqlite_ledger_db_file,
             })
             .await
@@ -3680,7 +3695,7 @@ mod root_count_repair_tests {
             .display()
             .to_string();
         ledger_db::init(ledger_db::Config {
-            cache_size: 1_024,
+            cache_max_nodes: 1_024,
             cnn_url,
         })
         .await

--- a/indexer-common/src/domain/ledger/transaction.rs
+++ b/indexer-common/src/domain/ledger/transaction.rs
@@ -433,7 +433,12 @@ mod tests {
                 .await
                 .context("run migrations")?;
 
-            ledger_db::init(ledger_db::Config { cache_size: 1_024 }, pool);
+            ledger_db::init(
+                ledger_db::Config {
+                    cache_max_nodes: 1_024,
+                },
+                pool,
+            );
 
             postgres_container
         };
@@ -463,7 +468,7 @@ mod tests {
                 .context("run migrations")?;
 
             ledger_db::init(ledger_db::Config {
-                cache_size: 1_024,
+                cache_max_nodes: 1_024,
                 cnn_url: sqlite_ledger_db_file,
             })
             .await

--- a/indexer-common/src/infra/ledger_db.rs
+++ b/indexer-common/src/infra/ledger_db.rs
@@ -19,11 +19,11 @@ use serde::Deserialize;
 
 #[cfg(feature = "cloud")]
 pub fn init(config: Config, pool: crate::infra::pool::postgres::PostgresPool) {
-    let Config { cache_size } = config;
+    let Config { cache_max_nodes } = config;
 
     let db = v1_1::LedgerDb::new(pool);
     let _ = midnight_storage_core_v1::storage::set_default_storage(|| {
-        midnight_storage_core_v1::Storage::new(cache_size as usize, db)
+        midnight_storage_core_v1::Storage::new(cache_max_nodes, db)
     });
 }
 
@@ -32,7 +32,7 @@ pub async fn init(config: Config) -> Result<(), Error> {
     use crate::infra::{migrations, pool::sqlite};
 
     let Config {
-        cache_size,
+        cache_max_nodes,
         cnn_url,
     } = config;
 
@@ -41,7 +41,7 @@ pub async fn init(config: Config) -> Result<(), Error> {
 
     let db = v1_1::LedgerDb::new(pool);
     let _ = midnight_storage_core_v1::storage::set_default_storage(|| {
-        midnight_storage_core_v1::Storage::new(cache_size as usize, db)
+        midnight_storage_core_v1::Storage::new(cache_max_nodes, db)
     });
 
     Ok(())
@@ -49,8 +49,11 @@ pub async fn init(config: Config) -> Result<(), Error> {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Config {
-    #[serde(with = "byte_unit_serde")]
-    pub cache_size: u64,
+    /// Maximum number of arena nodes held in the storage-core caches. This is a node *count*, not
+    /// a byte size: storage-core's read cache is strictly bounded by it and its write cache is
+    /// truncated to it on flush (see `midnight_storage_core_v1::Storage::new`, whose own default
+    /// is `DEFAULT_CACHE_SIZE = 10_000`). `0` means unbounded.
+    pub cache_max_nodes: usize,
 
     #[cfg(feature = "standalone")]
     pub cnn_url: String,

--- a/indexer-standalone/config.yaml
+++ b/indexer-standalone/config.yaml
@@ -29,7 +29,7 @@ infra:
     cnn_url: "/data/indexer.sqlite"
 
   ledger_db:
-    cache_size: "1kiB"
+    cache_max_nodes: 100000
     cnn_url: "/data/ledger-db.sqlite"
 
   node:

--- a/wallet-indexer/config.yaml
+++ b/wallet-indexer/config.yaml
@@ -19,7 +19,7 @@ infra:
     max_lifetime: "5m"
 
   ledger_db:
-    cache_size: "1kiB"
+    cache_max_nodes: 100000
 
   pub_sub:
     url: "localhost:4222"


### PR DESCRIPTION
# Overview

`ledger_db.cache_size` is passed straight to storage-core's `Storage::new`, whose `cache_size` is a
**number of arena nodes**, not a byte size — its own default is `DEFAULT_CACHE_SIZE = 10_000`, and `0`
means unbounded. It was nevertheless parsed with `byte_unit_serde`, so the shipped `"1kiB"` quietly
meant *1024 nodes*: about 100x below where we want it, and unreadable as written.

Both halves of the fix belong in one change — bumping the number while leaving the byte-unit encoding
in place would just entrench the confusion.

- Drop `#[serde(with = "byte_unit_serde")]`, type the field as `usize` (which removes the
  `as usize` cast at both `init` sites) and rename it to **`cache_max_nodes`** so the unit is evident
  from the key. `0` means unbounded, and that is now documented on the field.
- Raise the configured value to `100000` in `chain-indexer`, `indexer-api`, `indexer-standalone` and
  `wallet-indexer`, matching the node's own `storage_cache_size` default.
- The other four `byte_unit_serde` uses are left alone — those are genuinely byte-valued.

## Why the bump matters

It is a prerequisite for prefetching, not an independent tuning lever: `StorageBackend::pre_fetch`
truncates its breadth-first walk at the configured cache capacity, so a DAG larger than the cache is
only *partially* prefetched and the remainder degrades to serial single-row round trips. It also
reduces write-cache eviction spilling in wallet-indexer, whose config carries the same key.

> [!IMPORTANT]
> **Breaking config change.** Operators must rename `ledger_db.cache_size` to
> `ledger_db.cache_max_nodes` and replace any byte-unit string (`"1kiB"`) with a plain integer. The
> `APP__INFRA__LEDGER_DB__CACHE_SIZE` environment variable becomes
> `APP__INFRA__LEDGER_DB__CACHE_MAX_NODES`. There is a `BREAKING` CHANGELOG entry.

## Context

This is the second of two prerequisite fixes split out of the "store contract state as ledger-arena
keys" work (the first was #1378, the `get_root_count` refcount fix). Both stand on their own merits
and are reviewable without any of the arena work in view. The feature branch carries this commit
cherry-picked so it can be measured, and will drop it once this merges.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [ ] Update README.md file (if relevant)
- [x] Update documentation (if relevant)
- [x] No new todos introduced

No new test is warranted: the field is config-only and the ~10 existing construction sites (benches,
`mainnet_runtime.rs`, the `indexer-common` ledger tests) are updated to the new name and keep their
small values, which are appropriate for tests.
