### PR TITLE
ci(build-indexer-images): build arm64 natively and restore multi-arch manifests

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,6 +2,7 @@ self-hosted-runner:
   labels:
     - ubuntu-latest-8-core-x64
     - ubuntu-latest-16-core-x64
+    - ubuntu-latest-8-core-arm64
 
 paths:
   .github/workflows/*.{yml,yaml}:

--- a/.github/workflows/build-indexer-images.yaml
+++ b/.github/workflows/build-indexer-images.yaml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   build-and-push:
     name: Build and push (${{ matrix.image.name }}, ${{ matrix.platform.arch }})
-    runs-on: ubuntu-latest-16-core-x64
+    runs-on: ${{ matrix.platform.runner }}
     permissions:
       packages: write
     strategy:
@@ -40,16 +40,15 @@ jobs:
             description: Midnight Indexer
           - name: spo-indexer
             description: Midnight SPO Indexer
-        # Each (image, arch) is an independent parallel job. amd64 keeps the existing (warm)
-        # buildcache ref and the unsuffixed tag and builds natively, so it publishes without
-        # waiting for arm64. arm64 builds in parallel under QEMU and publishes an -arm64-suffixed
-        # tag, so the slow emulated build never blocks the amd64 image from being pushed.
+        # Each (image, arch) is an independent parallel job so neither architecture gates the
+        # other's publication. Both build on native hardware; emulating arm64 under QEMU made
+        # Rust compilation roughly six times slower.
         platform:
           - arch: amd64
-            suffix: ""
+            runner: ubuntu-latest-16-core-x64
             cache_scope: ""
           - arch: arm64
-            suffix: "-arm64"
+            runner: ubuntu-latest-8-core-arm64
             cache_scope: "-arm64"
     steps:
       - name: Checkout repository
@@ -86,8 +85,10 @@ jobs:
           images: |
             ghcr.io/midnight-ntwrk/${{ matrix.image.name }}
             ${{ github.ref_type == 'tag' && format('midnightntwrk/{0}', matrix.image.name) || '' }}
+          # onlatest applies the suffix to `latest` as well; without it both architectures push
+          # the same unsuffixed `latest` and the slower job silently wins.
           flavor: |
-            suffix=${{ matrix.platform.suffix }}
+            suffix=-${{ matrix.platform.arch }},onlatest=true
           tags: |
             type=semver,pattern={{version}}
             ${{ github.ref_type != 'tag' && format('type=sha,prefix={0}-,format=short', env.VERSION) || '' }}
@@ -96,11 +97,21 @@ jobs:
             org.opencontainers.image.title=${{ matrix.image.name }}
             org.opencontainers.image.description=${{ matrix.image.description }}
 
-      - name: Setup QEMU
-        if: matrix.platform.arch == 'arm64'
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      # amd64 also publishes the unsuffixed tag so the deployable image is pullable as soon as it
+      # builds, rather than waiting on arm64 and the manifest merge.
+      - name: Setup Docker Metadata (unsuffixed)
+        id: meta_unsuffixed
+        if: matrix.platform.arch == 'amd64'
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        env:
+          DOCKER_METADATA_SHORT_SHA_LENGTH: 8
         with:
-          image: tonistiigi/binfmt:qemu-v8.1.5
+          images: |
+            ghcr.io/midnight-ntwrk/${{ matrix.image.name }}
+            ${{ github.ref_type == 'tag' && format('midnightntwrk/{0}', matrix.image.name) || '' }}
+          tags: |
+            type=semver,pattern={{version}}
+            ${{ github.ref_type != 'tag' && format('type=sha,prefix={0}-,format=short', env.VERSION) || '' }}
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -117,7 +128,9 @@ jobs:
             PROFILE=${{ env.PROFILE }}
             RUST_VERSION=${{ env.TOOLCHAIN }}
           platforms: linux/${{ matrix.platform.arch }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ steps.meta_unsuffixed.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: |
             type=registry,ref=ghcr.io/midnight-ntwrk/${{ matrix.image.name }}:buildcache${{ matrix.platform.cache_scope }}
@@ -125,6 +138,74 @@ jobs:
           cache-to: |
             type=registry,ref=ghcr.io/midnight-ntwrk/${{ matrix.image.name }}:buildcache${{ matrix.platform.cache_scope }},mode=max
             type=registry,ref=ghcr.io/midnight-ntwrk/${{ matrix.image.name }}:buildcache-${{ env.PROFILE }}${{ matrix.platform.cache_scope }},mode=max
+
+  # Promotes each unsuffixed tag from the single-arch amd64 image to a multi-arch index. If this
+  # job is skipped or fails the tag keeps resolving for amd64, so deployments are never blocked.
+  merge-manifests:
+    name: Merge multi-arch manifest (${{ matrix.image }})
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - chain-indexer
+          - indexer-api
+          - wallet-indexer
+          - indexer-standalone
+          - spo-indexer
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up environment
+        run: |
+          version=$(grep '^version.*=' Cargo.toml | sed -E 's/version.*=.*"(.*)"/\1/')
+          echo "VERSION=$version" | tee -a "$GITHUB_ENV"
+
+      - name: Login to DockerHub
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_USER }}
+          password: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: MidnightCI
+          password: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Setup Docker Metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        env:
+          DOCKER_METADATA_SHORT_SHA_LENGTH: 8
+        with:
+          images: |
+            ghcr.io/midnight-ntwrk/${{ matrix.image }}
+            ${{ github.ref_type == 'tag' && format('midnightntwrk/{0}', matrix.image) || '' }}
+          tags: |
+            type=semver,pattern={{version}}
+            ${{ github.ref_type != 'tag' && format('type=sha,prefix={0}-,format=short', env.VERSION) || '' }}
+
+      - name: Merge per-arch manifests
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          echo "$TAGS" | while read -r tag; do
+            if [ -z "$tag" ]; then
+              continue
+            fi
+            echo "Merging $tag from $tag-amd64 and $tag-arm64"
+            docker buildx imagetools create -t "$tag" "$tag-amd64" "$tag-arm64"
+          done
 
   docker-compose-validation:
     name: Docker Compose Validation


### PR DESCRIPTION
Closes #1384

## Problem

Since #1349 each architecture builds as an independent job — amd64 publishes the unsuffixed tag, arm64 publishes `-arm64`. That kept the deployable amd64 image off the critical path (measured on run `30545739589`: amd64 4-6 min, arm64 35-44 min under QEMU), but left two problems.

**1. `latest` resolved to arm64 for everyone — unreported in #1384's title, and the one with real blast radius.** `docker/metadata-action` does not apply the `suffix` flavor to `latest` unless `onlatest=true`, so both jobs pushed the same unsuffixed `latest` and the slower arm64 job won the race. Verified on ghcr, all five images:

| tag | resolves to |
|---|---|
| `4.3.3` (pre-#1349) | amd64 + arm64 |
| `4.3.5` | amd64 only |
| `4.3.5-arm64` | arm64 only |
| `latest` | **arm64 only — same digest as `4.3.5-arm64`** |
| `latest-arm64` | does not exist |

The `4.3.5-arm64` and `latest` tags sit on one package version, `sha256:ccd2b2a1...`. No K8s deploy was affected — every `shielded-gitops` indexer overlay pins an explicit tag — but `docker-compose.yaml` defaults all five services to `${INDEXER_TAG:-latest}`, so amd64 developers were silently pulling arm64 images.

**2. Version tags carried a single architecture**, so `docker pull <tag>` failed on Apple Silicon. A stated trade-off in #1349, but it blocks local development for the team, which is mostly on Macs.

## Change

**arm64 builds on native hardware.** `ubuntu-latest-8-core-arm64` is already provisioned in the org's `default` runner group and used by `midnight-node` (`.github/workflows/main.yml:242`). Building there instead of emulating removes the QEMU penalty entirely, and the QEMU setup step goes away. Added to `.github/actionlint.yaml` so the label passes lint.

**`onlatest=true`** on the suffix flavor, so arm64 publishes `latest-arm64` instead of overwriting `latest`.

**Multi-arch manifests restored.** Both jobs publish a per-arch `-amd64`/`-arm64` tag; a `merge-manifests` job combines them into an index for each unsuffixed tag via `docker buildx imagetools create`.

## The amd64 fast path is preserved by construction

This is the point of #1349 and it is not weakened. The amd64 job keeps its own 16-core x64 runner, its warm cache, and pushes the unsuffixed tag **from within its own job** — it has no `needs:` edge on anything arm64-related, and `fail-fast: false` is retained. An arm64 failure, an arm64 slowdown, or a merge failure cannot delay the x86 image; the tag simply stays a single-arch amd64 manifest, exactly as today.

| | x86 published | multi-arch `<tag>` | `latest` |
|---|---|---|---|
| Pre-#1349 | 40-90 min | yes | correct |
| Today | ~5 min | no | **arm64** |
| This PR | ~5 min | yes, ~12-15 min | correct |

The ~12-15 min figure is an estimate, not a measurement — the ARM runner is 8-core against amd64's 16-core, so I expect arm64 to land slower than amd64 but nowhere near the 35-44 min QEMU cost. The dispatch run below is what confirms it.

## Validation

`actionlint` clean locally (incl. shellcheck on the merge script). The `actionlint` workflow does trigger on `pull_request`, so the runner-label change is checked by CI here.

`build-indexer-images` has no `pull_request` trigger, so **the build changes need a `workflow_dispatch` run on this branch before merge** — that produces throwaway `<version>-<sha>` dev images and gives the real native-ARM timing. Not merging until that is green. This step was recommended on #1349 and skipped, which is precisely why the `latest` regression shipped unnoticed.

## Follow-up, not in this PR

Already-published tags are not retroactively repaired: `4.3.4`, `4.3.5` and `4.4.0-rc.1` stay single-arch, and `latest` keeps pointing at `4.3.5-arm64` until the next release tag. Both are fixable with a one-off `imagetools create` against the existing per-arch images — worth doing for `latest` at least, since that is the one people hit by accident.

AI-assisted (`bot:ai-assisted`).