### PR TITLE
fix(ci): publish multi-arch manifests for indexer images

### DIFF
--- a/.github/workflows/build-indexer-images.yaml
+++ b/.github/workflows/build-indexer-images.yaml
@@ -40,13 +40,14 @@ jobs:
             description: Midnight Indexer
           - name: spo-indexer
             description: Midnight SPO Indexer
-        # Each (image, arch) is an independent parallel job. amd64 keeps the existing (warm)
-        # buildcache ref and the unsuffixed tag and builds natively, so it publishes without
-        # waiting for arm64. arm64 builds in parallel under QEMU and publishes an -arm64-suffixed
-        # tag, so the slow emulated build never blocks the amd64 image from being pushed.
+        # Each (image, arch) is an independent parallel job publishing an arch-suffixed tag.
+        # amd64 keeps the existing (warm) buildcache ref and builds natively; arm64 builds in
+        # parallel under QEMU. Neither blocks the other, and each -amd64/-arm64 tag is available
+        # as soon as that arch finishes. The downstream merge-manifests job then assembles the
+        # unsuffixed tag into a real multi-arch manifest referencing both arches.
         platform:
           - arch: amd64
-            suffix: ""
+            suffix: "-amd64"
             cache_scope: ""
           - arch: arm64
             suffix: "-arm64"
@@ -126,9 +127,76 @@ jobs:
             type=registry,ref=ghcr.io/midnight-ntwrk/${{ matrix.image.name }}:buildcache${{ matrix.platform.cache_scope }},mode=max
             type=registry,ref=ghcr.io/midnight-ntwrk/${{ matrix.image.name }}:buildcache-${{ env.PROFILE }}${{ matrix.platform.cache_scope }},mode=max
 
+  merge-manifests:
+    name: Merge multi-arch manifest (${{ matrix.image.name }})
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - name: chain-indexer
+          - name: indexer-api
+          - name: wallet-indexer
+          - name: indexer-standalone
+          - name: spo-indexer
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up environment
+        run: |
+          version=$(grep '^version.*=' Cargo.toml | sed -E 's/version.*=.*"(.*)"/\1/')
+          echo "VERSION=$version" | tee -a "$GITHUB_ENV"
+
+      - name: Login to DockerHub
+        uses: docker/login-action@06fb636fac595d6fb4b28a5dfcb21a6f5091859c # v4.5.0
+        with:
+          username: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_USER }}
+          password: ${{ secrets.DOCKERHUB_MIDNIGHTNTWRK_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@06fb636fac595d6fb4b28a5dfcb21a6f5091859c # v4.5.0
+        with:
+          registry: ghcr.io
+          username: MidnightCI
+          password: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      # Recompute the unsuffixed tags exactly as the build-and-push job did (same images/tags,
+      # no suffix). For each tag T we combine the already-published T-amd64 and T-arm64 into a
+      # single multi-arch manifest published as T.
+      - name: Setup Docker Metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        env:
+          DOCKER_METADATA_SHORT_SHA_LENGTH: 8
+        with:
+          images: |
+            ghcr.io/midnight-ntwrk/${{ matrix.image.name }}
+            ${{ github.ref_type == 'tag' && format('midnightntwrk/{0}', matrix.image.name) || '' }}
+          tags: |
+            type=semver,pattern={{version}}
+            ${{ github.ref_type != 'tag' && format('type=sha,prefix={0}-,format=short', env.VERSION) || '' }}
+
+      - name: Merge per-arch images into multi-arch manifests
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          echo "$TAGS" | while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            echo "Merging ${tag} from ${tag}-amd64 + ${tag}-arm64"
+            docker buildx imagetools create -t "${tag}" "${tag}-amd64" "${tag}-arm64"
+            docker buildx imagetools inspect "${tag}"
+          done
+
   docker-compose-validation:
     name: Docker Compose Validation
-    needs: build-and-push
+    needs: merge-manifests
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:


### PR DESCRIPTION
# Overview

Published indexer image tags were **amd64-only**. In `build-indexer-images.yaml` each `(image, arch)` build job baked the arch into the tag via the `docker/metadata-action` `flavor.suffix`, and amd64 used an **empty** suffix. So the bare tag (e.g. `chain-indexer:4.3.5-24f87014`) was an OCI index containing only `amd64` (plus the SLSA provenance `unknown/unknown` entry), while arm64 was reachable only under the `-arm64` suffix. There was no manifest-merge step, so `docker pull <image>:<tag>` fails on arm64 hosts:

```
$ docker pull ghcr.io/midnight-ntwrk/chain-indexer:4.3.5-24f87014
Error response from daemon: no matching manifest for linux/arm64/v8 ...
```

This affects all five published images and breaks arm64 consumers of the bare tag — e.g. midnight-node's `local-environment`, whose `.envrc` references `INDEXER_*_IMAGE` without an arch suffix.

## What changed

- **amd64 now publishes an explicit `-amd64`-suffixed tag** (was empty suffix). Its warm buildcache ref (`cache_scope: ""`) is unchanged.
- **New `merge-manifests` job** (one per image, `needs: build-and-push`) recomputes the unsuffixed tags with the same `metadata-action` config and assembles each into a real multi-arch manifest from the already-published `-amd64` + `-arm64` tags via `docker buildx imagetools create`.
- **`docker-compose-validation` now `needs: merge-manifests`** so it pulls the assembled multi-arch bare tag.

The per-arch `-amd64`/`-arm64` tags still publish independently as each arch finishes (arm64's slow QEMU build never blocks amd64); only the merged bare tag waits for both — which is inherent to a multi-arch bare tag. After this, `docker pull <image>:<tag>` resolves correctly on both `linux/amd64` and `linux/arm64`.

## Submission Checklist

- [x] Useful pull request description
- [ ] Tests are provided (if possible)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [ ] Self-reviewed the diff
- [ ] Reviewer requested
- [ ] Update README.md file (if relevant)
- [ ] Update documentation (if relevant)
- [x] No new todos introduced

## Links

Closes #1390

_Assisted-by: Claude:claude-opus-4-8_