### PR TITLE
feat(chain-indexer): cross the ledger 8→9 runtime upgrade in the indexer (enactment-block handling)

### DIFF
--- a/chain-indexer/src/application.rs
+++ b/chain-indexer/src/application.rs
@@ -424,8 +424,9 @@ async fn index_block<N>(
 where
     N: Node,
 {
-    // The try_into on the next line serializes the zswap merkle tree root, but the domain type is
-    // needed below to compare against the zswap merkle tree root in the ledger state.
+    // Capture the node's zswap merkle tree root (domain type) before `try_into` serializes it, to
+    // compare against the locally derived root below. `None` at a runtime-upgrade enactment block,
+    // where the node cannot serve it (see infra/subxt_node).
     let zswap_merkle_tree_root = block.zswap_merkle_tree_root;
 
     let (mut block, transactions) = block.try_into().context("convert node block into domain")?;
@@ -447,6 +448,11 @@ where
         *parent_block_timestamp = block.timestamp;
     };
 
+    // At a runtime-upgrade enactment block the node cannot serve contract state (the same reason it
+    // cannot serve the zswap root, which is why the node-provided `zswap_merkle_tree_root` is `None`
+    // here); have the apply path resolve contract-action state from the local ledger instead.
+    let defer_contract_state = zswap_merkle_tree_root.is_none();
+
     let apply_transactions = |ledger_state: &mut LedgerState| {
         ledger_state
             .apply_transactions(
@@ -457,6 +463,7 @@ where
                 // Only reproduce the node's mempool-cached first-tx `tblock` bump for non-genesis
                 // blocks; genesis (height 0) transactions never transited the mempool.
                 block.height > 0,
+                defer_contract_state,
             )
             .context("apply transactions to ledger state")
     };
@@ -530,12 +537,26 @@ where
             block.height
         );
     }
-    if ledger_state.zswap_merkle_tree_root() != zswap_merkle_tree_root {
-        bail!(
-            "zswap state root mismatch for block {} at height {}",
-            block.hash,
-            block.height
-        );
+    // Compare the locally derived zswap root against the node's when the node provided one. At a
+    // runtime-upgrade enactment block the node cannot serve it (see infra/subxt_node), so store the
+    // locally derived root — authoritative and equal to what a fixed node would serve — and skip the
+    // cross-check for this one block; it resumes at apply+1.
+    let local_zswap_merkle_tree_root = ledger_state.zswap_merkle_tree_root();
+    match zswap_merkle_tree_root {
+        Some(node_zswap_merkle_tree_root) => {
+            if local_zswap_merkle_tree_root != node_zswap_merkle_tree_root {
+                bail!(
+                    "zswap state root mismatch for block {} at height {}",
+                    block.hash,
+                    block.height
+                );
+            }
+        }
+        None => {
+            block.zswap_merkle_tree_root = local_zswap_merkle_tree_root
+                .serialize()
+                .context("serialize locally derived zswap merkle tree root")?;
+        }
     }
 
     // Determine whether caught up, also allowing to fall back a little in that state.
@@ -802,7 +823,7 @@ mod tests {
         parent_hash: ZERO_HASH,
         author: Default::default(),
         timestamp: Default::default(),
-        zswap_merkle_tree_root: ZswapMerkleTreeRoot::V8(Faker.fake()),
+        zswap_merkle_tree_root: Some(ZswapMerkleTreeRoot::V8(Faker.fake())),
         ledger_state_root: None,
         transactions: Default::default(),
         dust_registration_events: Default::default(),
@@ -816,7 +837,7 @@ mod tests {
         parent_hash: BLOCK_0_HASH,
         author: Default::default(),
         timestamp: Default::default(),
-        zswap_merkle_tree_root: ZswapMerkleTreeRoot::V8(Faker.fake()),
+        zswap_merkle_tree_root: Some(ZswapMerkleTreeRoot::V8(Faker.fake())),
         ledger_state_root: None,
         transactions: Default::default(),
         dust_registration_events: Default::default(),
@@ -830,7 +851,7 @@ mod tests {
         parent_hash: BLOCK_1_HASH,
         author: Default::default(),
         timestamp: Default::default(),
-        zswap_merkle_tree_root: ZswapMerkleTreeRoot::V8(Faker.fake()),
+        zswap_merkle_tree_root: Some(ZswapMerkleTreeRoot::V8(Faker.fake())),
         ledger_state_root: None,
         transactions: Default::default(),
         dust_registration_events: Default::default(),
@@ -844,7 +865,7 @@ mod tests {
         parent_hash: BLOCK_2_HASH,
         author: Default::default(),
         timestamp: Default::default(),
-        zswap_merkle_tree_root: ZswapMerkleTreeRoot::V8(Faker.fake()),
+        zswap_merkle_tree_root: Some(ZswapMerkleTreeRoot::V8(Faker.fake())),
         ledger_state_root: None,
         transactions: Default::default(),
         dust_registration_events: Default::default(),

--- a/chain-indexer/src/domain/ledger_state.rs
+++ b/chain-indexer/src/domain/ledger_state.rs
@@ -124,6 +124,9 @@ impl LedgerState {
         block_timestamp: u64,
         parent_block_timestamp: u64,
         bump_first_regular_tblock: bool,
+        // True at a runtime-upgrade enactment block, where the node cannot serve contract state, so
+        // `subxt_node` left it empty; resolve it from this (local, post-apply) ledger state instead.
+        defer_contract_state: bool,
     ) -> Result<(Vec<Transaction>, LedgerParameters), Error> {
         // The node validates a mempool transaction against a `tblock` bumped two slots ahead of the
         // *parent* (last produced) block's time, then caches the well-formed result keyed on
@@ -158,6 +161,7 @@ impl LedgerState {
                         block_timestamp,
                         parent_block_timestamp,
                         well_formed_timestamp,
+                        defer_contract_state,
                     )
                 }
 
@@ -191,6 +195,7 @@ impl LedgerState {
         block_timestamp: u64,
         parent_block_timestamp: u64,
         well_formed_timestamp: u64,
+        defer_contract_state: bool,
     ) -> Result<Transaction, Error> {
         let mut transaction = RegularTransaction::from(transaction);
 
@@ -241,6 +246,26 @@ impl LedgerState {
                 .extract_contract_zswap_state(&contract_action.address)
                 .map_err(|error| Error::ExtractContractZswapState(transaction.hash, error))?;
             contract_action.zswap_state = zswap_state;
+
+            // At a runtime-upgrade enactment block the node could not serve contract state, so
+            // `subxt_node` left it empty. Read it from this (local, post-apply) ledger state — the
+            // same `index(address)` lookup the node performs — so a contract-action transaction in
+            // the upgrade block resolves without the node. The `balances` extraction below then runs
+            // on the filled-in state.
+            if defer_contract_state && contract_action.state.is_empty() {
+                if let Some(state) = self
+                    .contract_state(&contract_action.address)
+                    .map_err(|error| {
+                        Error::ReadContractState(
+                            transaction.hash,
+                            contract_action.address.clone(),
+                            error,
+                        )
+                    })?
+                {
+                    contract_action.state = state;
+                }
+            }
 
             // TODO: Workaround until we filter failed contract actions (empty state means failed).
             if !contract_action.state.is_empty() {
@@ -334,6 +359,13 @@ pub enum Error {
     #[error("cannot extract contract zswap state for transaction {0}")]
     ExtractContractZswapState(
         TransactionHash,
+        #[source] indexer_common::domain::ledger::Error,
+    ),
+
+    #[error("cannot read local contract state for transaction {0} and contract address {1}")]
+    ReadContractState(
+        TransactionHash,
+        SerializedContractAddress,
         #[source] indexer_common::domain::ledger::Error,
     ),
 

--- a/chain-indexer/src/domain/node.rs
+++ b/chain-indexer/src/domain/node.rs
@@ -65,7 +65,10 @@ pub struct Block {
     pub parent_hash: BlockHash,
     pub author: Option<BlockAuthor>,
     pub timestamp: u64,
-    pub zswap_merkle_tree_root: ZswapMerkleTreeRoot,
+    /// `None` at a runtime-upgrade enactment block, where the node cannot serve the zswap root
+    /// (the next runtime cannot read the still-previous-runtime state); `application.rs` fills in
+    /// the locally derived root once transactions are applied. See `infra/subxt_node`.
+    pub zswap_merkle_tree_root: Option<ZswapMerkleTreeRoot>,
     pub ledger_state_root: Option<ByteVec>,
     pub transactions: Vec<Transaction>,
     pub dust_registration_events: Vec<DustRegistrationEvent>,
@@ -76,7 +79,13 @@ impl TryFrom<Block> for (domain::Block, Vec<Transaction>) {
     type Error = ledger::Error;
 
     fn try_from(block: Block) -> Result<(domain::Block, Vec<Transaction>), Self::Error> {
-        let zswap_merkle_tree_root = block.zswap_merkle_tree_root.serialize()?;
+        // `None` at a runtime-upgrade enactment block (the node cannot serve the zswap root there;
+        // see infra/subxt_node). Store a placeholder now; `application.rs` overwrites it with the
+        // locally derived root once this block's transactions are applied.
+        let zswap_merkle_tree_root = match block.zswap_merkle_tree_root {
+            Some(root) => root.serialize()?,
+            None => Default::default(),
+        };
 
         let transactions = block.transactions;
 

--- a/chain-indexer/src/infra/subxt_node.rs
+++ b/chain-indexer/src/infra/subxt_node.rs
@@ -32,7 +32,7 @@ use http::{
 use indexer_common::{
     domain::{
         BlockAuthor, BlockHash, ByteVec, NodeVersion, ProtocolVersion, ProtocolVersionError,
-        SerializedContractAddress,
+        SerializedContractAddress, SerializedContractState,
         ledger::{self, ZswapMerkleTreeRoot},
     },
     error::BoxError,
@@ -58,6 +58,17 @@ use tokio::time::timeout;
 
 type OnlineClientAtBlock = subxt::client::OnlineClientAtBlock<SubstrateConfig>;
 type SubxtBlock = subxt::client::Block<SubstrateConfig>;
+
+/// Where to decode a block's content (extrinsics + events) from. At a runtime-upgrade
+/// enactment block the block's own metadata is the new runtime's, but its content was produced
+/// by the old runtime; `client` is the parent (old-runtime) at-block client and `extrinsic_bodies`
+/// are THIS block's raw extrinsic bytes, so content decodes against the old metadata. Raw bytes
+/// are metadata-independent, so feeding this block's bytes to the parent client decodes the
+/// content the old runtime actually produced.
+pub(crate) struct ContentSource {
+    pub(crate) client: OnlineClientAtBlock,
+    pub(crate) extrinsic_bodies: Vec<Vec<u8>>,
+}
 
 const AURA_ENGINE_ID: ConsensusEngineId = [b'a', b'u', b'r', b'a'];
 const BABE_ENGINE_ID: ConsensusEngineId = [b'B', b'A', b'B', b'E'];
@@ -239,17 +250,66 @@ impl SubxtNode {
             .transpose()?
             .flatten();
 
-        let zswap_merkle_tree_root =
-            runtimes::get_zswap_merkle_tree_root(state_node_version, &block).await?;
-        let zswap_merkle_tree_root =
-            ZswapMerkleTreeRoot::deserialize(zswap_merkle_tree_root, ledger_version)?;
+        // At a runtime-upgrade enactment block the block's ledger state is still on the previous
+        // runtime (the v8->v9 migration re-points `StateKey` only at apply+1), yet every RPC at this
+        // hash already executes the next runtime, whose state reader cannot decode the previous arena
+        // and fails the zswap-root call. Skip it here and let `application.rs` substitute the
+        // indexer's own locally derived root — identical to what the node would serve — for this one
+        // block; the node-vs-local cross-check resumes at apply+1. This keeps the 8->9 crossing
+        // self-contained on the indexer side, with no dependency on a node-side fallback.
+        let zswap_merkle_tree_root = if content_node_version == state_node_version {
+            let root = runtimes::get_zswap_merkle_tree_root(state_node_version, &block).await?;
+            Some(ZswapMerkleTreeRoot::deserialize(root, ledger_version)?)
+        } else {
+            None
+        };
+
+        // At a runtime-upgrade enactment block the block reports the next runtime, so subxt binds
+        // it to the next runtime's metadata even though its extrinsics and events were produced by
+        // the previous runtime. Decode the content against the parent block's client (which carries
+        // the previous runtime's metadata), fed this block's raw, metadata-independent bytes. Away
+        // from enactment blocks the two runtimes are equal and no parent client is needed.
+        let content_source = if content_node_version != state_node_version {
+            let parent = block
+                .online_client()
+                .at_block(header.parent_hash)
+                .await
+                .map_err(|error| {
+                    SubxtNodeError::GetOnlineClientAt(header.parent_hash, error.into())
+                })?;
+            let legacy_rpc_methods = LegacyRpcMethods::<RpcConfigFor<SubstrateConfig>>::new(
+                self.rpc_client.to_owned().into(),
+            );
+            let extrinsic_bodies = legacy_rpc_methods
+                .chain_get_block(Some(block.block_hash()))
+                .await
+                .map_err(SubxtNodeError::FetchBlockBody)?
+                .ok_or(SubxtNodeError::BlockBodyNotFound)?
+                .block
+                .extrinsics
+                .into_iter()
+                .map(|bytes| bytes.0)
+                .collect::<Vec<_>>();
+            Some(ContentSource {
+                client: parent,
+                extrinsic_bodies,
+            })
+        } else {
+            None
+        };
 
         let BlockDetails {
             timestamp,
             transactions,
             mut dust_registration_events,
             bridge_events,
-        } = runtimes::make_block_details(authorities, content_node_version, &block).await?;
+        } = runtimes::make_block_details(
+            authorities,
+            content_node_version,
+            &block,
+            content_source.as_ref(),
+        )
+        .await?;
 
         // At genesis, Substrate does not emit events (Parity PR #5463). Fetch cNight
         // registrations from pallet storage instead.
@@ -266,8 +326,19 @@ impl SubxtNode {
             None
         };
 
+        // At an enactment block the node cannot serve contract state, so resolve contract-action
+        // state from the local ledger later (application.rs) rather than via the node here.
+        let defer_contract_state = content_node_version != state_node_version;
         let transactions = stream::iter(transactions)
-            .then(|t| make_transaction(t, protocol_version, state_node_version, &block))
+            .then(|t| {
+                make_transaction(
+                    t,
+                    protocol_version,
+                    state_node_version,
+                    defer_contract_state,
+                    &block,
+                )
+            })
             .try_collect::<Vec<_>>()
             .await?;
 
@@ -589,6 +660,12 @@ pub enum SubxtNodeError {
     #[error("cannot fetch extrinsics")]
     FetchExtrinsics(#[source] Box<subxt::error::ExtrinsicError>),
 
+    #[error("cannot fetch block body via legacy RPC")]
+    FetchBlockBody(#[source] subxt::rpcs::Error),
+
+    #[error("block body not found")]
+    BlockBodyNotFound,
+
     #[error("cannot fetch events")]
     FetchEvents(#[source] Box<subxt::error::EventsError>),
 
@@ -768,11 +845,19 @@ async fn make_transaction(
     transaction: runtimes::Transaction,
     protocol_version: ProtocolVersion,
     state_node_version: NodeVersion,
+    defer_contract_state: bool,
     block: &OnlineClientAtBlock,
 ) -> Result<Transaction, SubxtNodeError> {
     match transaction {
         runtimes::Transaction::Regular(transaction) => {
-            make_regular_transaction(transaction, protocol_version, state_node_version, block).await
+            make_regular_transaction(
+                transaction,
+                protocol_version,
+                state_node_version,
+                defer_contract_state,
+                block,
+            )
+            .await
         }
 
         runtimes::Transaction::System(transaction) => {
@@ -785,6 +870,7 @@ async fn make_regular_transaction(
     transaction: ByteVec,
     protocol_version: ProtocolVersion,
     state_node_version: NodeVersion,
+    defer_contract_state: bool,
     block: &OnlineClientAtBlock,
 ) -> Result<Transaction, SubxtNodeError> {
     let ledger_transaction =
@@ -794,14 +880,24 @@ async fn make_regular_transaction(
 
     let identifiers = ledger_transaction.identifiers()?;
 
-    let contract_actions = ledger_transaction
-        .contract_actions(|address| async move {
-            runtimes::get_contract_state(address, state_node_version, block).await
-        })
-        .await?
-        .into_iter()
-        .map(Into::into)
-        .collect();
+    // Contract-action addresses and attributes come from the transaction itself; only the resulting
+    // contract state needs a lookup. At a runtime-upgrade enactment block the node cannot serve that
+    // state (its next runtime cannot read the still-previous-runtime arena), so resolve with an empty
+    // placeholder here and let `application.rs` fill it from the local post-apply ledger state.
+    let contract_actions = if defer_contract_state {
+        ledger_transaction
+            .contract_actions(|_address| async move {
+                Ok::<_, SubxtNodeError>(SerializedContractState::default())
+            })
+            .await?
+    } else {
+        ledger_transaction
+            .contract_actions(|address| async move {
+                runtimes::get_contract_state(address, state_node_version, block).await
+            })
+            .await?
+    };
+    let contract_actions = contract_actions.into_iter().map(Into::into).collect();
 
     let transaction = RegularTransaction {
         hash,

--- a/chain-indexer/src/infra/subxt_node/runtimes.rs
+++ b/chain-indexer/src/infra/subxt_node/runtimes.rs
@@ -21,7 +21,7 @@ include!(concat!(env!("OUT_DIR"), "/generated_runtime.rs"));
 
 use crate::{
     domain::{DParameter, DustRegistrationEvent, TermsAndConditions},
-    infra::subxt_node::{OnlineClientAtBlock, SubxtNodeError},
+    infra::subxt_node::{ContentSource, OnlineClientAtBlock, SubxtNodeError},
 };
 use indexer_common::domain::{
     ByteVec, NodeVersion, SerializedContractAddress, SerializedContractState,
@@ -49,13 +49,14 @@ pub async fn make_block_details(
     authorities: &mut Option<Vec<[u8; 32]>>,
     node_version: NodeVersion,
     block: &OnlineClientAtBlock,
+    content: Option<&ContentSource>,
 ) -> Result<BlockDetails, SubxtNodeError> {
     // TODO Replace this often repeated pattern with a macro?
     match node_version {
-        NodeVersion::V0_22 => v0_22_0::make_block_details(authorities, block).await,
-        NodeVersion::V1_0 => v1_0_0::make_block_details(authorities, block).await,
-        NodeVersion::V2_0 => v2_0_0::make_block_details(authorities, block).await,
-        NodeVersion::V2_1 => v2_1_0::make_block_details(authorities, block).await,
+        NodeVersion::V0_22 => v0_22_0::make_block_details(authorities, block, content).await,
+        NodeVersion::V1_0 => v1_0_0::make_block_details(authorities, block, content).await,
+        NodeVersion::V2_0 => v2_0_0::make_block_details(authorities, block, content).await,
+        NodeVersion::V2_1 => v2_1_0::make_block_details(authorities, block, content).await,
     }
 }
 

--- a/chain-indexer/src/infra/subxt_node/runtimes/v0_22_0.rs
+++ b/chain-indexer/src/infra/subxt_node/runtimes/v0_22_0.rs
@@ -14,7 +14,7 @@
 use crate::{
     domain::{DParameter, DustRegistrationEvent, TermsAndConditions},
     infra::subxt_node::{
-        OnlineClientAtBlock, SubxtNodeError,
+        ContentSource, OnlineClientAtBlock, SubxtNodeError,
         runtimes::{BlockDetails, Transaction},
     },
 };
@@ -30,6 +30,7 @@ use subxt::error::RuntimeApiError;
 pub async fn make_block_details(
     authorities: &mut Option<Vec<[u8; 32]>>,
     block: &OnlineClientAtBlock,
+    content: Option<&ContentSource>,
 ) -> Result<BlockDetails, SubxtNodeError> {
     use super::runtime_0_22_0::{
         Call, Event,
@@ -44,11 +45,22 @@ pub async fn make_block_details(
         timestamp,
     };
 
-    let extrinsics = block
-        .extrinsics()
-        .fetch()
-        .await
-        .map_err(|error| SubxtNodeError::FetchExtrinsics(error.into()))?;
+    let extrinsics = match content {
+        // Enactment block: decode this block's raw extrinsic bytes against the parent
+        // (old-runtime) client. `from_bytes` is async but infallible.
+        Some(content) => {
+            content
+                .client
+                .extrinsics()
+                .from_bytes(content.extrinsic_bodies.clone())
+                .await
+        }
+        None => block
+            .extrinsics()
+            .fetch()
+            .await
+            .map_err(|error| SubxtNodeError::FetchExtrinsics(error.into()))?,
+    };
 
     let calls = extrinsics
         .iter()
@@ -90,11 +102,25 @@ pub async fn make_block_details(
     let mut dust_registration_events = vec![];
     let mut system_transactions_from_events = vec![];
 
-    let events = block
-        .events()
-        .fetch()
-        .await
-        .map_err(|error| SubxtNodeError::FetchEvents(error.into()))?;
+    let events = match content {
+        // Enactment block: raw event bytes are metadata-independent, so fetch them from this
+        // block and re-decode against the parent (old-runtime) client. `from_bytes` is sync.
+        Some(content) => {
+            let raw = block
+                .events()
+                .fetch()
+                .await
+                .map_err(|error| SubxtNodeError::FetchEvents(error.into()))?
+                .bytes()
+                .to_vec();
+            content.client.events().from_bytes(raw)
+        }
+        None => block
+            .events()
+            .fetch()
+            .await
+            .map_err(|error| SubxtNodeError::FetchEvents(error.into()))?,
+    };
 
     for event in events.iter() {
         let event = event

--- a/chain-indexer/src/infra/subxt_node/runtimes/v1_0_0.rs
+++ b/chain-indexer/src/infra/subxt_node/runtimes/v1_0_0.rs
@@ -14,7 +14,7 @@
 use crate::{
     domain::{DParameter, DustRegistrationEvent, TermsAndConditions},
     infra::subxt_node::{
-        OnlineClientAtBlock, SubxtNodeError,
+        ContentSource, OnlineClientAtBlock, SubxtNodeError,
         runtimes::{BlockDetails, Transaction},
     },
 };
@@ -30,6 +30,7 @@ use subxt::error::RuntimeApiError;
 pub async fn make_block_details(
     authorities: &mut Option<Vec<[u8; 32]>>,
     block: &OnlineClientAtBlock,
+    content: Option<&ContentSource>,
 ) -> Result<BlockDetails, SubxtNodeError> {
     use super::runtime_1_0_0::{
         Call, Event,
@@ -44,11 +45,22 @@ pub async fn make_block_details(
         timestamp,
     };
 
-    let extrinsics = block
-        .extrinsics()
-        .fetch()
-        .await
-        .map_err(|error| SubxtNodeError::FetchExtrinsics(error.into()))?;
+    let extrinsics = match content {
+        // Enactment block: decode this block's raw extrinsic bytes against the parent
+        // (old-runtime) client. `from_bytes` is async but infallible.
+        Some(content) => {
+            content
+                .client
+                .extrinsics()
+                .from_bytes(content.extrinsic_bodies.clone())
+                .await
+        }
+        None => block
+            .extrinsics()
+            .fetch()
+            .await
+            .map_err(|error| SubxtNodeError::FetchExtrinsics(error.into()))?,
+    };
 
     let calls = extrinsics
         .iter()
@@ -90,11 +102,25 @@ pub async fn make_block_details(
     let mut dust_registration_events = vec![];
     let mut system_transactions_from_events = vec![];
 
-    let events = block
-        .events()
-        .fetch()
-        .await
-        .map_err(|error| SubxtNodeError::FetchEvents(error.into()))?;
+    let events = match content {
+        // Enactment block: raw event bytes are metadata-independent, so fetch them from this
+        // block and re-decode against the parent (old-runtime) client. `from_bytes` is sync.
+        Some(content) => {
+            let raw = block
+                .events()
+                .fetch()
+                .await
+                .map_err(|error| SubxtNodeError::FetchEvents(error.into()))?
+                .bytes()
+                .to_vec();
+            content.client.events().from_bytes(raw)
+        }
+        None => block
+            .events()
+            .fetch()
+            .await
+            .map_err(|error| SubxtNodeError::FetchEvents(error.into()))?,
+    };
 
     for event in events.iter() {
         let event = event

--- a/chain-indexer/src/infra/subxt_node/runtimes/v2_0_0.rs
+++ b/chain-indexer/src/infra/subxt_node/runtimes/v2_0_0.rs
@@ -14,7 +14,7 @@
 use crate::{
     domain::{DParameter, DustRegistrationEvent, TermsAndConditions},
     infra::subxt_node::{
-        OnlineClientAtBlock, SubxtNodeError,
+        ContentSource, OnlineClientAtBlock, SubxtNodeError,
         runtimes::{BlockDetails, Transaction},
     },
 };
@@ -31,6 +31,7 @@ use subxt::error::RuntimeApiError;
 pub async fn make_block_details(
     authorities: &mut Option<Vec<[u8; 32]>>,
     block: &OnlineClientAtBlock,
+    content: Option<&ContentSource>,
 ) -> Result<BlockDetails, SubxtNodeError> {
     use super::runtime_2_0_0::{
         Call, Event,
@@ -46,11 +47,22 @@ pub async fn make_block_details(
         timestamp,
     };
 
-    let extrinsics = block
-        .extrinsics()
-        .fetch()
-        .await
-        .map_err(|error| SubxtNodeError::FetchExtrinsics(error.into()))?;
+    let extrinsics = match content {
+        // Enactment block: decode this block's raw extrinsic bytes against the parent
+        // (old-runtime) client. `from_bytes` is async but infallible.
+        Some(content) => {
+            content
+                .client
+                .extrinsics()
+                .from_bytes(content.extrinsic_bodies.clone())
+                .await
+        }
+        None => block
+            .extrinsics()
+            .fetch()
+            .await
+            .map_err(|error| SubxtNodeError::FetchExtrinsics(error.into()))?,
+    };
 
     let calls = extrinsics
         .iter()
@@ -93,11 +105,25 @@ pub async fn make_block_details(
     let mut system_transactions_from_events = vec![];
     let mut bridge_events = vec![];
 
-    let events = block
-        .events()
-        .fetch()
-        .await
-        .map_err(|error| SubxtNodeError::FetchEvents(error.into()))?;
+    let events = match content {
+        // Enactment block: raw event bytes are metadata-independent, so fetch them from this
+        // block and re-decode against the parent (old-runtime) client. `from_bytes` is sync.
+        Some(content) => {
+            let raw = block
+                .events()
+                .fetch()
+                .await
+                .map_err(|error| SubxtNodeError::FetchEvents(error.into()))?
+                .bytes()
+                .to_vec();
+            content.client.events().from_bytes(raw)
+        }
+        None => block
+            .events()
+            .fetch()
+            .await
+            .map_err(|error| SubxtNodeError::FetchEvents(error.into()))?,
+    };
 
     for event in events.iter() {
         let event = event

--- a/chain-indexer/src/infra/subxt_node/runtimes/v2_1_0.rs
+++ b/chain-indexer/src/infra/subxt_node/runtimes/v2_1_0.rs
@@ -14,7 +14,7 @@
 use crate::{
     domain::{DParameter, DustRegistrationEvent, TermsAndConditions},
     infra::subxt_node::{
-        OnlineClientAtBlock, SubxtNodeError,
+        ContentSource, OnlineClientAtBlock, SubxtNodeError,
         runtimes::{BlockDetails, Transaction},
     },
 };
@@ -31,6 +31,7 @@ use subxt::error::RuntimeApiError;
 pub async fn make_block_details(
     authorities: &mut Option<Vec<[u8; 32]>>,
     block: &OnlineClientAtBlock,
+    content: Option<&ContentSource>,
 ) -> Result<BlockDetails, SubxtNodeError> {
     use super::runtime_2_1_0::{
         Call, Event,
@@ -46,11 +47,22 @@ pub async fn make_block_details(
         timestamp,
     };
 
-    let extrinsics = block
-        .extrinsics()
-        .fetch()
-        .await
-        .map_err(|error| SubxtNodeError::FetchExtrinsics(error.into()))?;
+    let extrinsics = match content {
+        // Enactment block: decode this block's raw extrinsic bytes against the parent
+        // (old-runtime) client. `from_bytes` is async but infallible.
+        Some(content) => {
+            content
+                .client
+                .extrinsics()
+                .from_bytes(content.extrinsic_bodies.clone())
+                .await
+        }
+        None => block
+            .extrinsics()
+            .fetch()
+            .await
+            .map_err(|error| SubxtNodeError::FetchExtrinsics(error.into()))?,
+    };
 
     let calls = extrinsics
         .iter()
@@ -93,11 +105,25 @@ pub async fn make_block_details(
     let mut system_transactions_from_events = vec![];
     let mut bridge_events = vec![];
 
-    let events = block
-        .events()
-        .fetch()
-        .await
-        .map_err(|error| SubxtNodeError::FetchEvents(error.into()))?;
+    let events = match content {
+        // Enactment block: raw event bytes are metadata-independent, so fetch them from this
+        // block and re-decode against the parent (old-runtime) client. `from_bytes` is sync.
+        Some(content) => {
+            let raw = block
+                .events()
+                .fetch()
+                .await
+                .map_err(|error| SubxtNodeError::FetchEvents(error.into()))?
+                .bytes()
+                .to_vec();
+            content.client.events().from_bytes(raw)
+        }
+        None => block
+            .events()
+            .fetch()
+            .await
+            .map_err(|error| SubxtNodeError::FetchEvents(error.into()))?,
+    };
 
     for event in events.iter() {
         let event = event

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -15,7 +15,8 @@ use crate::{
     domain::{
         AddressOrContract, ApplyRegularTransactionOutcome, ApplySystemTransactionOutcome,
         ByteArray, ByteVec, IntentHash, LedgerEvent, LedgerEventAttributes, LedgerVersion,
-        NetworkId, Nonce, SerializedContractAddress, SerializedLedgerParameters,
+        NetworkId, Nonce, SerializedContractAddress, SerializedContractState,
+        SerializedLedgerParameters,
         SerializedLedgerStateKey, SerializedTransaction, SerializedZswapMerkleTreeRoot,
         SerializedZswapState, TokenType, TransactionResult, UnshieldedAddress, UnshieldedUtxo,
         bridge::BridgeClaim,
@@ -916,6 +917,48 @@ impl LedgerState {
                 contract_zswap_state
                     .tagged_serialize()
                     .map_err(|error| Error::Serialize("ZswapStateV9", error))
+            }
+        }
+    }
+
+    /// Read the serialized state of the contract at `address` from this (local) ledger state,
+    /// producing the exact bytes the node's `get_contract_state` runtime API returns: it is
+    /// `self.state.index(address)` tagged-serialized. Used to resolve contract actions at a
+    /// runtime-upgrade enactment block, where the node cannot serve contract state (the next
+    /// runtime cannot decode the still-previous-runtime arena). Returns `None` when the contract
+    /// is absent, mirroring the node's `ContractNotPresent`.
+    #[trace(properties = { "address": "{address}" })]
+    pub fn contract_state(
+        &self,
+        address: &SerializedContractAddress,
+    ) -> Result<Option<SerializedContractState>, Error> {
+        match self {
+            Self::V8 { ledger_state, .. } => {
+                let address = ContractAddressV8::deserialize(&mut address.as_ref(), 0)
+                    .map_err(|error| Error::Deserialize("ContractAddressV8", error))?;
+
+                ledger_state
+                    .index(address)
+                    .map(|state| {
+                        state
+                            .tagged_serialize()
+                            .map_err(|error| Error::Serialize("ContractStateV8", error))
+                    })
+                    .transpose()
+            }
+
+            Self::V9 { ledger_state, .. } => {
+                let address = ContractAddressV9::deserialize(&mut address.as_ref(), 0)
+                    .map_err(|error| Error::Deserialize("ContractAddressV9", error))?;
+
+                ledger_state
+                    .index(address)
+                    .map(|state| {
+                        state
+                            .tagged_serialize()
+                            .map_err(|error| Error::Serialize("ContractStateV9", error))
+                    })
+                    .transpose()
             }
         }
     }

--- a/qa/scripts/test-hardfork-8to9.sh
+++ b/qa/scripts/test-hardfork-8to9.sh
@@ -1,0 +1,308 @@
+#!/bin/bash
+# Devnet rehearsal of the ledger 8 -> 9 hard fork.
+#
+# Boots a fresh ledger-8 dev chain on the *2.1.0 migration node binary* (so the
+# `migrate_state_v8_to_v9` host fn is present from genesis), attaches the cloud
+# indexer stack, submits v8 transactions, drives the governance runtime upgrade to
+# the 2.1.0 WASM (spec_version -> 2_001_000, migration fires at apply+1), then
+# submits v9 transactions. The indexer must cross the boundary without a ledger/
+# zswap root mismatch and keep indexing.
+#
+# This is the generative, from-genesis sibling of the snapshot-fork oracle in
+# docs/hardfork-ledger-8-to-9.md (Phase 3). It validates the live transaction path
+# across the fork; it does NOT stress the run(budget) drain path (dev genesis is
+# tiny) -- use the snapshot fork for that. See docs/hardfork-devnet-rehearsal-8to9.md.
+#
+# Prerequisites (see the doc's Handoff checklist):
+#   - Indexer images that recognize spec_version 2_001_000 (Phase 1 / #1333). Build
+#     from the integration/fork-8to9-e2e branch: INDEXER_TAG=dev just build-docker-image <pkg>
+#   - The 2.1.0 migration node image + runtime WASM, and a ledger-8 (1.0.x) node image.
+#   - A ledger-9-capable toolkit for the post-fork sends.
+#
+# Usage:
+#   IMAGE_REGISTRY=midnightntwrk INDEXER_TAG=<sha> \
+#   FROM_NODE_TAG=1.0.0 TO_NODE_TAG=<2.1.0-local-tag> \
+#   FROM_TOOLKIT_TAG=1.0.0 TO_TOOLKIT_TAG=<2.1.0-local-tag> \
+#   RUNTIME_WASM=/path/to/midnight_node_runtime.compact.compressed.wasm \
+#     bash qa/scripts/test-hardfork-8to9.sh
+#
+# Environment knobs:
+#   AUTO=0                 pause for manual inspection at each phase (default: run straight through)
+#   RUNTIME_WASM=<file>    use this 2.1.0 runtime WASM instead of extracting it from the TO node
+#                          image. REQUIRED when the 2.1.0 image was built by swapping only the
+#                          binary into a 1.0.x base -- the embedded WASM is then still ledger-8 and
+#                          the "upgrade" would be a no-op.
+#   STORAGE_SEPARATION, TBLOCK_CORRECTION_OFFSET, TBLOCK_CORRECTION_DISABLE_AFTER
+#                          passed through to the node service if the 2.1.0 binary refuses to boot
+#                          on the dev chain-spec citing missing config (values from the node's
+#                          res/cfg/default.toml).
+
+set -euo pipefail
+
+# --- Configuration ---
+FROM_NODE_TAG="${FROM_NODE_TAG:-1.0.0}"          # ledger-8 node (chain-spec source)
+TO_NODE_TAG="${TO_NODE_TAG:-2.1.0}"              # ledger-9 migration node (binary + WASM)
+INDEXER_TAG="${INDEXER_TAG:?INDEXER_TAG is required (e.g. dev)}"
+FROM_TOOLKIT_TAG="${FROM_TOOLKIT_TAG:-$FROM_NODE_TAG}"  # toolkit for v8 sends
+TO_TOOLKIT_TAG="${TO_TOOLKIT_TAG:-$TO_NODE_TAG}"        # toolkit for v9 sends
+export IMAGE_REGISTRY="${IMAGE_REGISTRY:-midnightntwrk}"
+AUTO="${AUTO:-1}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TMPDIR="${REPO_ROOT}/target/hardfork-8to9-test"
+NODE_RPC_HTTP="http://localhost:9944"
+NODE_RPC_WS_HOST="ws://localhost:9944"           # from a --network host toolkit container
+NODE_RPC_WS_COMPOSE="ws://node:9944"             # from inside the compose network
+INDEXER_API="http://localhost:8088"
+
+echo "=== Hard-fork 8 -> 9 devnet rehearsal ==="
+echo "From (ledger-8): ${FROM_NODE_TAG}   To (ledger-9): ${TO_NODE_TAG}"
+echo "Indexer: ${INDEXER_TAG}   Toolkits: ${FROM_TOOLKIT_TAG} / ${TO_TOOLKIT_TAG}"
+
+mkdir -p "$TMPDIR"
+
+# Read the current on-chain specVersion from the node RPC. Empty on failure.
+spec_version() {
+  curl -sf -H "Content-Type: application/json" \
+    -d '{"id":1,"jsonrpc":"2.0","method":"state_getRuntimeVersion"}' \
+    "$NODE_RPC_HTTP" 2>/dev/null \
+    | python3 -c "import json,sys; print(json.load(sys.stdin)['result']['specVersion'])" 2>/dev/null || echo ""
+}
+
+# Latest indexed block height via GraphQL. Empty on failure.
+indexer_height() {
+  curl -sf -H "Content-Type: application/json" \
+    -d '{"query":"{ block { height } }"}' \
+    "${INDEXER_API}/api/v4/graphql" 2>/dev/null \
+    | python3 -c "import json,sys; print(json.load(sys.stdin)['data']['block']['height'])" 2>/dev/null || echo ""
+}
+
+# Block until the node has finalized at least $1 blocks. The toolkit's generate-txs
+# refuses to build a transaction against a chain that has only finalized genesis
+# (`GetTransactions(NodeClientError(OnlyGenesisFinalized))`), so on a freshly booted
+# dev chain we must wait past block 0 before submitting the pre-fork batch.
+wait_for_finalized() {
+  local want="$1" n=""
+  echo ">>> Waiting for finalized height >= ${want}..."
+  for i in {1..40}; do
+    local fh
+    fh=$(curl -sf -H "Content-Type: application/json" \
+      -d '{"id":1,"jsonrpc":"2.0","method":"chain_getFinalizedHead"}' "$NODE_RPC_HTTP" 2>/dev/null \
+      | python3 -c "import json,sys; print(json.load(sys.stdin)['result'])" 2>/dev/null)
+    if [ -n "$fh" ]; then
+      n=$(curl -sf -H "Content-Type: application/json" \
+        -d "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"chain_getHeader\",\"params\":[\"$fh\"]}" "$NODE_RPC_HTTP" 2>/dev/null \
+        | python3 -c "import json,sys; print(int(json.load(sys.stdin)['result']['number'],16))" 2>/dev/null)
+      if [ -n "$n" ] && [ "$n" -ge "$want" ]; then echo "Finalized height: $n"; return 0; fi
+    fi
+    echo "Finalized not yet >= ${want} (got '${n:-}')... ($i)"; sleep 3
+  done
+  echo "ERROR: node did not finalize >= ${want} blocks in time" >&2
+  return 1
+}
+
+pause() {
+  [ "$AUTO" = "1" ] && return 0
+  echo ">>> $1"
+  echo "    Press Enter to continue..."
+  read -r
+}
+
+# Generate a single shielded+unshielded tx against the live node, then submit it.
+# Args: $1 = toolkit tag, $2 = label used for the dest-file name.
+#
+# The toolkit container attaches to the compose network and reaches the node as
+# `node:9944` (NODE_RPC_WS_COMPOSE) rather than `--network host` + localhost:9944:
+# Docker Desktop for Mac does not give containers real host networking, so
+# `--network host` toolkit runs cannot reach the published port reliably.
+submit_tx() {
+  local toolkit_tag="$1" label="$2"
+  local dest="/out/${label}.mn"
+  echo ">>> Generating ${label} tx with toolkit ${toolkit_tag}..."
+  docker run --rm --network "${NETWORK_NAME}" -v "${TMPDIR}:/out" \
+    "${IMAGE_REGISTRY}/midnight-node-toolkit:${toolkit_tag}" \
+    generate-txs \
+    --src-url "$NODE_RPC_WS_COMPOSE" \
+    --dest-file "$dest" \
+    single-tx \
+    --shielded-amount 10 \
+    --unshielded-amount 10 \
+    --source-seed "0000000000000000000000000000000000000000000000000000000000000001" \
+    --destination-address mn_shield-addr_undeployed1tth9g6jf8he6cmhgtme6arty0jde7wnypsg53qc3x5navl9za355jqqvfftm8asg986dx9puzwkmedeune9nfkuqvtmccmxtjwvlrvccwypcs \
+    --destination-address mn_addr_undeployed1gkasr3z3vwyscy2jpp53nzr37v7n4r3lsfgj6v5g584dakjzt0xqun4d4r
+  echo ">>> Submitting ${label} tx..."
+  docker run --rm --network "${NETWORK_NAME}" -v "${TMPDIR}:/out" \
+    "${IMAGE_REGISTRY}/midnight-node-toolkit:${toolkit_tag}" \
+    generate-txs \
+    --src-file "$dest" \
+    send \
+    -d "$NODE_RPC_WS_COMPOSE"
+}
+
+# --- Step 1: ledger-8 chain-spec from the old node ---
+echo ""
+echo ">>> Step 1: Building ledger-8 chain-spec from node ${FROM_NODE_TAG}..."
+docker run --rm -e CFG_PRESET=dev "${IMAGE_REGISTRY}/midnight-node:${FROM_NODE_TAG}" build-spec \
+  > "${TMPDIR}/chainspec.json"
+echo "Chain-spec saved ($(wc -c < "${TMPDIR}/chainspec.json") bytes)"
+
+# --- Step 2: 2.1.0 runtime WASM ---
+# Prefer an explicitly provided WASM file. Extracting from the TO node image is only
+# correct when that image genuinely carries the 2.1.0 runtime; a binary-swap-into-1.0.x
+# image still embeds the ledger-8 WASM, which would make the upgrade a silent no-op.
+echo ""
+if [ -n "${RUNTIME_WASM:-}" ]; then
+  echo ">>> Step 2: Using provided runtime WASM: ${RUNTIME_WASM}"
+  [ -f "${RUNTIME_WASM}" ] || { echo "ERROR: RUNTIME_WASM file not found: ${RUNTIME_WASM}" >&2; exit 1; }
+  cp "${RUNTIME_WASM}" "${TMPDIR}/runtime.wasm"
+else
+  echo ">>> Step 2: Extracting runtime WASM from node ${TO_NODE_TAG}..."
+  echo "    WARNING: if that image was built by swapping only the binary into a 1.0.x"
+  echo "    base, its embedded WASM is still ledger-8 and the upgrade will be a no-op."
+  echo "    Pass RUNTIME_WASM=/path/to/...compact.compressed.wasm to be safe."
+  ARCH=$(uname -m)
+  if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
+    WASM_PATH="/artifacts-arm64/midnight_node_runtime.compact.compressed.wasm"
+  else
+    WASM_PATH="/artifacts-amd64/midnight_node_runtime.compact.compressed.wasm"
+  fi
+  docker run --rm --entrypoint cat "${IMAGE_REGISTRY}/midnight-node:${TO_NODE_TAG}" "$WASM_PATH" \
+    > "${TMPDIR}/runtime.wasm"
+fi
+echo "Runtime WASM ready ($(wc -c < "${TMPDIR}/runtime.wasm") bytes)"
+
+# --- Step 3: boot the 2.1.0 binary on the ledger-8 chain-spec + indexer stack ---
+echo ""
+echo ">>> Step 3: Starting stack (node ${TO_NODE_TAG} binary on ${FROM_NODE_TAG} chain-spec)..."
+export NODE_TAG="${TO_NODE_TAG}"                 # the binary that runs
+export CHAINSPEC_PATH="${TMPDIR}/chainspec.json" # consumed by docker-compose.runtime-upgrade.yaml
+
+cd "$REPO_ROOT"
+
+# Clean prior containers/volumes (same approach as test-runtime-upgrade.sh).
+if [ -n "$(docker ps -a | grep -e ghcr.io -e nats -e postgres | awk '{print $1}')" ]; then
+  docker rm -f $(docker ps -a | grep -e ghcr.io -e nats -e postgres | awk '{print $1}')
+fi
+PROJECT_DIR=$(basename "$(pwd)")
+DOCKER_PROJECT_NAME=$(echo "$PROJECT_DIR" | tr '[:upper:]' '[:lower:]' | sed 's/\.//g')
+DOCKER_VOLUME_NAME="${DOCKER_PROJECT_NAME}_node_data"
+NETWORK_NAME="${DOCKER_PROJECT_NAME}_default"   # compose network; toolkit + runtime-upgrade attach here
+docker volume rm "$DOCKER_VOLUME_NAME" 2>/dev/null || true
+if [ -d "target/data/postgres" ] || [ -d "target/data/nats" ]; then
+  docker run --rm -v "$(pwd):/project" alpine sh -c "rm -rf /project/target/data/postgres /project/target/data/nats"
+fi
+mkdir -p target/data/postgres target/data/nats target/debug
+docker volume create "$DOCKER_VOLUME_NAME"
+
+# The 2.1.0 binary may reject the dev chain-spec unless these config fields are set
+# (they came from the node's res/cfg/default.toml on the snapshot path). Inject them via
+# a generated override only when the operator supplies them, so committed compose files
+# and the same-ledger runtime-upgrade test stay untouched.
+COMPOSE_FILES=(-f docker-compose.yaml -f docker-compose.runtime-upgrade.yaml)
+if [ -n "${STORAGE_SEPARATION:-}${TBLOCK_CORRECTION_OFFSET:-}${TBLOCK_CORRECTION_DISABLE_AFTER:-}" ]; then
+  NODE_ENV_OVERRIDE="${TMPDIR}/docker-compose.node-env.yaml"
+  {
+    echo "services:"
+    echo "  node:"
+    echo "    environment:"
+    [ -n "${STORAGE_SEPARATION:-}" ] && echo "      STORAGE_SEPARATION: \"${STORAGE_SEPARATION}\""
+    [ -n "${TBLOCK_CORRECTION_OFFSET:-}" ] && echo "      TBLOCK_CORRECTION_OFFSET: \"${TBLOCK_CORRECTION_OFFSET}\""
+    [ -n "${TBLOCK_CORRECTION_DISABLE_AFTER:-}" ] && echo "      TBLOCK_CORRECTION_DISABLE_AFTER: \"${TBLOCK_CORRECTION_DISABLE_AFTER}\""
+  } > "$NODE_ENV_OVERRIDE"
+  COMPOSE_FILES+=(-f "$NODE_ENV_OVERRIDE")
+  echo "Applying node-env override:"; cat "$NODE_ENV_OVERRIDE"
+fi
+
+docker compose "${COMPOSE_FILES[@]}" --profile cloud up -d
+
+echo "Waiting for indexer API to become ready..."
+for i in {1..60}; do
+  if curl -sf "${INDEXER_API}/ready" >/dev/null; then echo "Indexer API is ready"; break; fi
+  echo "Not ready yet... ($i)"; sleep 2
+done
+
+echo "Confirming the chain started at ledger-8..."
+for i in {1..10}; do
+  PRE_SPEC=$(spec_version)
+  [ -n "$PRE_SPEC" ] && { echo "Pre-fork specVersion: ${PRE_SPEC}"; break; }
+  echo "Waiting for node RPC... ($i)"; sleep 3
+done
+if [ -z "${PRE_SPEC:-}" ] || [ "$PRE_SPEC" -ge 2000000 ]; then
+  echo "ERROR: chain did not start at a ledger-8 specVersion (got '${PRE_SPEC:-}'). Expected < 2_000_000." >&2
+  exit 1
+fi
+
+# --- Step 4: submit v8 transactions and confirm the indexer follows ---
+echo ""
+echo ">>> Step 4: Submitting ledger-8 transactions..."
+pause "About to submit pre-fork (v8) transactions."
+wait_for_finalized 2
+submit_tx "$FROM_TOOLKIT_TAG" "pre_fork_v8"
+sleep 6
+echo "Indexer height after v8 traffic: $(indexer_height)"
+
+# --- Step 5: governance runtime upgrade to the 2.1.0 WASM ---
+echo ""
+echo ">>> Step 5: Governance runtime upgrade to the 2.1.0 WASM..."
+pause "About to trigger the runtime upgrade (spec_version -> 2_001_000)."
+docker run --rm \
+  --network "${NETWORK_NAME}" \
+  -v "${TMPDIR}/runtime.wasm:/wasm/runtime.wasm" \
+  "${IMAGE_REGISTRY}/midnight-node-toolkit:${TO_TOOLKIT_TAG}" \
+  runtime-upgrade \
+  --wasm-file /wasm/runtime.wasm \
+  --rpc-url "$NODE_RPC_WS_COMPOSE" \
+  -c "//Eve" -c "//Ferdie" -c "//Dave" \
+  -t "//Alice" -t "//Bob" -t "//Charlie" \
+  --signer-key "//Alice"
+
+# --- Step 6: verify the bump to 2_001_000 ---
+echo ""
+echo ">>> Step 6: Verifying the runtime upgrade..."
+sleep 6
+for i in {1..10}; do
+  POST_SPEC=$(spec_version)
+  if [ -n "$POST_SPEC" ] && [ "$POST_SPEC" != "$PRE_SPEC" ]; then
+    echo "Runtime upgraded: specVersion ${PRE_SPEC} -> ${POST_SPEC}"; break
+  fi
+  echo "Waiting for runtime upgrade to take effect... ($i)"; sleep 6
+done
+if [ "${POST_SPEC:-}" = "$PRE_SPEC" ] || [ -z "${POST_SPEC:-}" ]; then
+  echo "ERROR: runtime upgrade did not take effect. specVersion still ${PRE_SPEC}" >&2
+  exit 1
+fi
+if [ "$POST_SPEC" -lt 2000000 ]; then
+  echo "ERROR: post-upgrade specVersion ${POST_SPEC} is still ledger-8 (< 2_000_000)." >&2
+  exit 1
+fi
+
+# --- Step 7: submit v9 transactions ---
+echo ""
+echo ">>> Step 7: Submitting ledger-9 transactions..."
+pause "About to submit post-fork (v9) transactions."
+submit_tx "$TO_TOOLKIT_TAG" "post_fork_v9"
+sleep 6
+
+# --- Step 8: assert the crossing ---
+echo ""
+echo ">>> Step 8: Asserting the indexer crossed the boundary..."
+# A failed crossing bails in chain-indexer with one of these (application.rs):
+#   "translate ledger state" | "ledger state root mismatch ..." | "zswap state root mismatch ..."
+if docker compose --profile cloud logs chain-indexer 2>&1 \
+     | grep -Eiq "ledger state root mismatch|zswap state root mismatch|translate ledger state"; then
+  echo "ERROR: chain-indexer reported a boundary failure. Offending log lines:" >&2
+  docker compose --profile cloud logs chain-indexer 2>&1 \
+    | grep -Ei "ledger state root mismatch|zswap state root mismatch|translate ledger state" >&2
+  exit 1
+fi
+
+FINAL_HEIGHT=$(indexer_height)
+echo "Final indexed height: ${FINAL_HEIGHT} (post-fork specVersion ${POST_SPEC})"
+echo ""
+echo "SUCCESS: no boundary root/translate mismatch; the indexer crossed 8 -> 9 and kept indexing."
+echo "Inspect further:"
+echo "  docker compose --profile cloud logs -f chain-indexer"
+echo "  curl -s ${INDEXER_API}/api/v4/graphql -H 'Content-Type: application/json' -d '{\"query\":\"{ block { height } }\"}'"
+echo "Tear down:"
+echo "  docker compose --profile cloud down --volumes --remove-orphans"


### PR DESCRIPTION
**Stacked on #1383** (`feat/idx01-translate-v8-to-v9`) — review/merge that first; this PR's diff is only the crossing fix on top of it.

## What
Makes the chain-indexer cross the ledger **8 → 9 runtime-upgrade enactment block** entirely on the indexer side, with **no node-side change** (validated against an *unfixed* 2.1.0 node). Builds on the V8→V9 translate from #1383 and the v2_1_0 runtime support from #1333 (already in `main`).

## Why
At the enactment block, the block's *content* was produced by the old runtime, but its *state* is already on the new runtime (`set_code` landed in this very block). Every RPC at that hash executes the new runtime, which cannot read the still-old-runtime arena — so the node fails `get_zswap_state_root` and `get_contract_state` there, and subxt binds the block to the new metadata even though its extrinsics/events are old-runtime. Without this, the indexer bails at the boundary (`Deserialization(TypedArenaKey)` / root mismatch).

## How — all keyed off a dynamic condition, no hardcoded block height or spec version
The enactment block is detected as `content_node_version != state_node_version`, computed per block from the header's MNSV digest vs the node's `spec_version`. When they differ:
- **Content decode** uses the parent (old-runtime) client fed this block's raw, metadata-independent extrinsic/event bytes (`ContentSource`).
- **Zswap root** is derived locally from the post-apply ledger instead of the node RPC; the node cross-check resumes at apply+1.
- **Contract-action state** is resolved from the local ledger (`LedgerState::contract_state` = `index(addr)` tagged-serialized — byte-identical to the node's `get_contract_state`).

Away from enactment blocks the two versions are equal and behavior is unchanged.

## Validation
Two live from-genesis devnet 8→9 runs against an **unfixed** node (`2.1.0-b430ab01f0aa`):
- Clean crossing — **0** boundary bails (no root mismatch / translate / Deserialization / panic).
- Transfers + contract deploys indexed on both ledgers with the correct `protocolVersion`.
- A user transaction indexed **inside the enactment block itself** (old-runtime content, `SUCCESS`).
- Contract state **byte-exact** vs the node (post-fork at head; pre-fork at its own-era block).
- Confirmed the unfixed node returns `Err` for `get_zswap_state_root` at the enactment block — the indexer derives it locally.

Scripted spine included: `qa/scripts/test-hardfork-8to9.sh`.

## Generality
Block- and network-agnostic (dev/testnet/mainnet), direction-agnostic, and generalizes to future runtime upgrades. The only per-fork maintenance is the existing `NodeVersion` registry (adding a runtime arm), which this PR does not change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
