### PR TITLE
docs(changelog): record the out-of-band 4.3.3-hotfix mainnet build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - *(chain-indexer)* Avoid OutOfDustValidityWindow on the first transaction of a block by reproducing the node's mempool `tblock` bump (#1367)
 
+## [4.3.3-hotfix] - 2026-07-20
+
+> **Out-of-band emergency hotfix, not on the 4.3.4/4.3.5 release line.** Cut from `4.3.3` (`a89e1d3`) plus one commit and deployed to mainnet blue/green to recover from the 2026-07-20 runtime-upgrade stall (spec `22000 → 1000000`, enactment block `1,774,491`). Published as a GitHub pre-release for traceability only; it does **not** contain the 4.3.4/4.3.5 fixes. Superseded by the durable fix on `main` (#1346).
+
+### 🐛 Bug Fixes
+
+- *(chain-indexer)* Tolerate a runtime-upgrade enactment block in `get_contract_state` by falling back across runtime modules when the header-digest-selected module is rejected by the live chain
+
 ## [4.3.3] - 2026-06-04
 
 ### 🚀 Features


### PR DESCRIPTION
Records the emergency **`4.3.3-hotfix`** build as an out-of-band CHANGELOG entry so the binary currently running on mainnet blue/green is traceable.

### Context
- Mainnet blue/green run image `4.3.3-hotfix` = tag `v4.3.3-hotfix` (→ `f19c7ac`) = `4.3.3` + a single commit. It recovered mainnet from the 2026-07-20 runtime-upgrade enactment stall (spec `22000 → 1000000`, block `1,774,491`).
- It is **not** on the 4.3.4/4.3.5 line and does not contain their fixes; those tags are a separate, much larger codebase.
- The durable form of the fix already lives on `main` (#1346).

### What this PR does
- Adds a clearly-labelled `## [4.3.3-hotfix]` entry to `CHANGELOG.md` (docs only).
- Pairs with a GitHub **pre-release** published on the existing `v4.3.3-hotfix` tag for traceability.

### Follow-up (not in this PR)
- Roll mainnet forward off the hotfix onto a current, properly-released build, then retire the sidecar.
- Reconcile the 4.3.4/4.3.5 tags (images built, never GitHub-released; CHANGELOG under-describes their actual contents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)