### PR TITLE
backport fix: dispatch runtime API and storage calls by state runtime version …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,6 +1209,7 @@ dependencies = [
  "derive_more 2.1.1",
  "fake",
  "fastrace",
+ "fs_extra",
  "futures",
  "http",
  "humantime-serde",
@@ -1225,9 +1226,12 @@ dependencies = [
  "sqlx",
  "subxt",
  "tempfile",
+ "testcontainers",
+ "testcontainers-modules",
  "thiserror 2.0.18",
  "tokio",
  "trait-variant",
+ "walkdir",
 ]
 
 [[package]]

--- a/chain-indexer/Cargo.toml
+++ b/chain-indexer/Cargo.toml
@@ -43,10 +43,14 @@ clap      = { workspace = true, features = [ "derive" ] }
 const-hex = { workspace = true }
 criterion = { workspace = true }
 fake      = { workspace = true }
+fs_extra  = { workspace = true }
 reqwest   = { workspace = true, features = [ "json", "rustls" ] }
 serde     = { workspace = true, features = [ "derive" ] }
 serde_json = { workspace = true }
 tempfile  = { workspace = true }
+testcontainers = { workspace = true }
+testcontainers-modules = { workspace = true, features = [ "postgres" ] }
+walkdir   = { workspace = true }
 
 [[bench]]
 name              = "ledger_state"

--- a/chain-indexer/src/infra/subxt_node.rs
+++ b/chain-indexer/src/infra/subxt_node.rs
@@ -174,31 +174,56 @@ impl SubxtNode {
         let protocol_version = header
             .protocol_version()?
             .ok_or(SubxtNodeError::MissingProtocolVersionHeader)?;
-        let node_version = protocol_version.node_version();
+        // Two runtime versions are in play at a runtime-upgrade enactment block, and every call
+        // below must pick the one matching what it touches:
+        //
+        // - `content_node_version` decodes bytes produced by the runtime that BUILT this block, as
+        //   recorded in the MNSV digest: extrinsics, events and header digests.
+        // - `state_node_version` addresses the runtime present in this block's STATE. At an
+        //   enactment block `set_code` landed inside this very block, so every RPC at this hash
+        //   (runtime API, storage, metadata) already executes against the next runtime, whose
+        //   version is therefore newer than the MNSV digest's.
+        //
+        // Away from enactment blocks the two are equal; getting the pairing wrong there is
+        // invisible, which is exactly why each call site names the version it needs.
+        let content_node_version = protocol_version.node_version();
+        let state_node_version = ProtocolVersion::try_from(block.spec_version())?.node_version();
         let ledger_version = protocol_version.ledger_version();
+
+        if content_node_version != state_node_version {
+            info!(
+                hash:%,
+                height,
+                content_node_version:%,
+                state_node_version:%;
+                "runtime upgrade enacted in this block; block contents and block state are on \
+                 different runtimes"
+            );
+        }
 
         debug!(
             hash:%,
             height,
             parent_hash:%,
             protocol_version:?,
-            node_version:%,
+            content_node_version:%,
+            state_node_version:%,
             ledger_version:%;
             "making block"
         );
 
         // Fetch authorities if `None`, either initially or because of a `NewSession` event (below).
         if authorities.is_none() {
-            *authorities = Some(runtimes::fetch_authorities(node_version, &block).await?);
+            *authorities = Some(runtimes::fetch_authorities(state_node_version, &block).await?);
         }
         let author = authorities
             .as_ref()
-            .map(|authorities| extract_block_author(&header, authorities, node_version))
+            .map(|authorities| extract_block_author(&header, authorities, content_node_version))
             .transpose()?
             .flatten();
 
         let zswap_merkle_tree_root =
-            runtimes::get_zswap_merkle_tree_root(node_version, &block).await?;
+            runtimes::get_zswap_merkle_tree_root(state_node_version, &block).await?;
         let zswap_merkle_tree_root =
             ZswapMerkleTreeRoot::deserialize(zswap_merkle_tree_root, ledger_version)?;
 
@@ -207,17 +232,17 @@ impl SubxtNode {
             transactions,
             mut dust_registration_events,
             bridge_events,
-        } = runtimes::make_block_details(authorities, node_version, &block).await?;
+        } = runtimes::make_block_details(authorities, content_node_version, &block).await?;
 
         // At genesis, Substrate does not emit events (Parity PR #5463). Fetch cNight
         // registrations from pallet storage instead.
         // Also fetch the ledger state root for genesis ledger state detection.
         let ledger_state_root = if height == 0 {
             let genesis_registrations =
-                runtimes::fetch_genesis_cnight_registrations(node_version, &block).await?;
+                runtimes::fetch_genesis_cnight_registrations(state_node_version, &block).await?;
             dust_registration_events.extend(genesis_registrations);
 
-            runtimes::get_ledger_state_root(node_version, &block)
+            runtimes::get_ledger_state_root(state_node_version, &block)
                 .await?
                 .map(Into::into)
         } else {
@@ -225,7 +250,7 @@ impl SubxtNode {
         };
 
         let transactions = stream::iter(transactions)
-            .then(|t| make_transaction(t, protocol_version, &block))
+            .then(|t| make_transaction(t, protocol_version, state_node_version, &block))
             .try_collect::<Vec<_>>()
             .await?;
 
@@ -435,13 +460,18 @@ impl Node for SubxtNode {
         block_hash: BlockHash,
         block_height: u64,
         timestamp: u64,
-        node_version: NodeVersion,
+        _node_version: NodeVersion,
     ) -> Result<SystemParametersChange, Self::Error> {
         let block = self.block_at(H256(block_hash.0)).await?;
 
+        // Both are storage/runtime-API reads, so both need the runtime in this block's state,
+        // which at an enactment block is already the next one; see `make_block`. The
+        // `_node_version` parameter carries the MNSV based version and is deliberately unused.
+        let state_node_version = ProtocolVersion::try_from(block.spec_version())?.node_version();
+
         let (d_parameter, terms_and_conditions) = tokio::try_join!(
-            runtimes::get_d_parameter(node_version, &block),
-            runtimes::get_terms_and_conditions(node_version, &block),
+            runtimes::get_d_parameter(state_node_version, &block),
+            runtimes::get_terms_and_conditions(state_node_version, &block),
         )?;
 
         Ok(SystemParametersChange {
@@ -627,7 +657,7 @@ async fn receive_block(
 fn extract_block_author<H>(
     header: &SubstrateHeader<H>,
     authorities: &[[u8; 32]],
-    node_version: NodeVersion,
+    content_node_version: NodeVersion,
 ) -> Result<Option<BlockAuthor>, SubxtNodeError>
 where
     H: Hash,
@@ -644,7 +674,7 @@ where
             DigestItem::PreRuntime(AURA_ENGINE_ID, inner) => Some(inner.as_slice()),
             _ => None,
         })
-        .map(|slot| runtimes::decode_slot(slot, node_version))
+        .map(|slot| runtimes::decode_slot(slot, content_node_version))
         .transpose()?
         .and_then(|slot| {
             let index = slot % authorities.len() as u64;
@@ -657,11 +687,12 @@ where
 async fn make_transaction(
     transaction: runtimes::Transaction,
     protocol_version: ProtocolVersion,
+    state_node_version: NodeVersion,
     block: &OnlineClientAtBlock,
 ) -> Result<Transaction, SubxtNodeError> {
     match transaction {
         runtimes::Transaction::Regular(transaction) => {
-            make_regular_transaction(transaction, protocol_version, block).await
+            make_regular_transaction(transaction, protocol_version, state_node_version, block).await
         }
 
         runtimes::Transaction::System(transaction) => {
@@ -673,10 +704,9 @@ async fn make_transaction(
 async fn make_regular_transaction(
     transaction: ByteVec,
     protocol_version: ProtocolVersion,
+    state_node_version: NodeVersion,
     block: &OnlineClientAtBlock,
 ) -> Result<Transaction, SubxtNodeError> {
-    let node_version = protocol_version.node_version();
-
     let ledger_transaction =
         ledger::Transaction::deserialize(&transaction, protocol_version.ledger_version())?;
 
@@ -686,7 +716,7 @@ async fn make_regular_transaction(
 
     let contract_actions = ledger_transaction
         .contract_actions(|address| async move {
-            runtimes::get_contract_state(address, node_version, block).await
+            runtimes::get_contract_state(address, state_node_version, block).await
         })
         .await?
         .into_iter()

--- a/chain-indexer/src/infra/subxt_node/header.rs
+++ b/chain-indexer/src/infra/subxt_node/header.rs
@@ -41,3 +41,58 @@ where
             .transpose()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parity_scale_codec::Decode;
+    use subxt::utils::H256;
+
+    /// SCALE-encoded header of mainnet block 1_774_491, the last block produced by the node
+    /// 0.22 runtime; its Blake2b-256 hash is the on-chain block hash
+    /// 0x40e3f67939e6f53e9f36b0a19fd27d484d29c008698f3a2336c5f2529a85dd23.
+    const MAINNET_HEADER_1_774_491: &str = "e23dc07f65b1194d134b6d9b3c2f7433329d0512896a1c4543048a166d4fabd96e4e6c0066b383edaece956474a21cad7e4ec177413e76d548e3bf28b9027bccf0d07bb042e5b79564f4e58339a09acb809d7317c5005dfdf032e359282a15ca803eb5b318066175726120b85cba1100000000066d637368805e2e516f21164918a9e2596aa1e4e53ba17d9e2f26630d0bd6332e29ef2b0d4c044d4e535610f055000004424545468403efac35b32306d7f8616834bd0d120d4288f6e6bfe1bf80b859a50bcc7c6417c00805617572610101447e1cc34e163696ea3d8e9d02def8ab8139c1acacc8f02c8c299b0ebd494c02b9e40da3bd66ffb585bbf84547238a5bfd1490bd6a341f5349ad9199c3edfc86";
+
+    /// SCALE-encoded header of mainnet block 1_774_492, the first block produced by the node
+    /// 1.0 runtime after the runtime upgrade on 2026-07-20; its Blake2b-256 hash is the
+    /// on-chain block hash 0x380266656e11208adbcaa5ab62a6beb9c09ef86de1cb886eac721099177a1a0b.
+    const MAINNET_HEADER_1_774_492: &str = "40e3f67939e6f53e9f36b0a19fd27d484d29c008698f3a2336c5f2529a85dd23724e6c0043b0bdbc7c7c66ebdee28b8a792e4ec9b8b5785ed0f9fd7b0a6bc7d91e95fb0f2678fc5f4818323105c833dbe82e79db20cc427a63b8aabb23f1b49c2fcf9beb14066175726120b95cba1100000000066d637368805e2e516f21164918a9e2596aa1e4e53ba17d9e2f26630d0bd6332e29ef2b0d4c044d4e53561040420f0004424545468403447acfb14643dba1a29f4105527ccac0412ee86baf40f8f1ad23df611b83b8e205617572610101febce836e4bf69ac6e5476086a85d77ea484fa3960ad1591e5b37152876782271e582d3f82d66aacf5c022ebaa0a74ce61be837a25b416efd666988079fc3c80";
+
+    /// The protocol versions at the mainnet runtime upgrade boundary must both be supported:
+    /// 22_000 before, 1_000_000 after. Indexer versions without node 1.0 support fail on the
+    /// first post-upgrade block with `ProtocolVersionError::Unsupported(1_000_000)`.
+    #[test]
+    fn test_protocol_version_mainnet_runtime_upgrade() {
+        let last_pre_upgrade = decode_header(MAINNET_HEADER_1_774_491);
+        let first_post_upgrade = decode_header(MAINNET_HEADER_1_774_492);
+
+        assert_eq!(last_pre_upgrade.number, 1_774_491);
+        assert_eq!(first_post_upgrade.number, 1_774_492);
+        assert_eq!(
+            first_post_upgrade.parent_hash,
+            H256(
+                const_hex::decode_to_array(
+                    "40e3f67939e6f53e9f36b0a19fd27d484d29c008698f3a2336c5f2529a85dd23"
+                )
+                .expect("valid block hash")
+            )
+        );
+
+        let version = last_pre_upgrade
+            .protocol_version()
+            .expect("protocol version of mainnet block 1_774_491 must be supported")
+            .expect("mainnet block 1_774_491 must have a MNSV digest");
+        assert_eq!(u32::from(version), 22_000);
+
+        let version = first_post_upgrade
+            .protocol_version()
+            .expect("protocol version of mainnet block 1_774_492 must be supported")
+            .expect("mainnet block 1_774_492 must have a MNSV digest");
+        assert_eq!(u32::from(version), 1_000_000);
+    }
+
+    fn decode_header(header: &str) -> SubstrateHeader<H256> {
+        let header = const_hex::decode(header).expect("valid hex");
+        SubstrateHeader::decode(&mut header.as_slice()).expect("SCALE decode header")
+    }
+}

--- a/chain-indexer/tests/mainnet_runtime.rs
+++ b/chain-indexer/tests/mainnet_runtime.rs
@@ -1,0 +1,245 @@
+// This file is part of midnight-indexer.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Blocks produced by the node 1.0 runtime — the runtime mainnet upgraded to at block
+//! 1_774_492 (protocol version 1_000_000) — must be ingestible. Indexer versions without
+//! node 1.0 support fail here, either with `ProtocolVersionError::Unsupported(1_000_000)`
+//! or with subxt metadata validation errors.
+
+#![cfg(any(feature = "cloud", feature = "standalone"))]
+
+use anyhow::Context;
+use chain_indexer::{
+    domain::{
+        BlockRef,
+        node::{Node, Transaction},
+    },
+    infra::subxt_node::{Config, SubxtNode},
+};
+use fs_extra::dir::{CopyOptions, copy};
+use futures::TryStreamExt;
+use std::{fs, path::Path, pin::pin, time::Duration};
+use testcontainers::{
+    GenericImage, ImageExt,
+    core::{Mount, WaitFor},
+    runners::AsyncRunner,
+};
+use walkdir::WalkDir;
+
+/// The node version running the same runtime (identical metadata) as mainnet after the
+/// upgrade at block 1_774_492.
+const NODE_VERSION: &str = "1.0.0";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_finalized_blocks_node_1_0() -> anyhow::Result<()> {
+    let _ledger_db = init_ledger_db().await?;
+
+    let node_dir = Path::new(&format!("{}/../.node", env!("CARGO_MANIFEST_DIR")))
+        .join(NODE_VERSION)
+        .canonicalize()
+        .context("create path to node directory")?;
+    let temp_dir = tempfile::tempdir().context("create tempdir")?;
+    copy(&node_dir, &temp_dir, &CopyOptions::default())
+        .context("copy .node directory into tempdir")?;
+
+    // The node container runs as non-root user (appuser), so the bind-mounted directory
+    // must be writable by all users.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let chain_dir = temp_dir.path().join(NODE_VERSION).join("chain");
+        if chain_dir.exists() {
+            for entry in WalkDir::new(&chain_dir) {
+                let entry = entry.context("walk chain directory")?;
+                let path = entry.path();
+                let mode = if path.is_dir() { 0o777 } else { 0o666 };
+                fs::set_permissions(path, fs::Permissions::from_mode(mode))
+                    .with_context(|| format!("set permissions on {}", path.display()))?;
+            }
+        }
+    }
+
+    let node_path = temp_dir.path().join(NODE_VERSION).display().to_string();
+    let node_container = GenericImage::new("midnightntwrk/midnight-node", NODE_VERSION)
+        .with_wait_for(WaitFor::message_on_stderr("9944"))
+        .with_mount(Mount::bind_mount(node_path, "/node"))
+        .with_env_var("SHOW_CONFIG", "false")
+        .with_env_var("CFG_PRESET", "dev")
+        .start()
+        .await
+        .context("start node container")?;
+    let node_port = node_container
+        .get_host_port_ipv4(9944)
+        .await
+        .context("get node port")?;
+
+    let config = Config {
+        url: format!("ws://localhost:{node_port}"),
+        reconnect_max_delay: Duration::from_secs(1),
+        reconnect_max_attempts: 1,
+        subscription_recovery_timeout: Duration::from_secs(30),
+    };
+    let mut node = SubxtNode::new(config).await.context("create SubxtNode")?;
+
+    let blocks = node.finalized_blocks(None);
+    let mut blocks = pin!(blocks);
+    for _ in 0..3 {
+        let block = blocks
+            .try_next()
+            .await
+            .context("get next finalized block")?
+            .context("stream of finalized blocks must not end")?;
+        assert_eq!(u32::from(block.protocol_version), 1_000_000);
+    }
+
+    Ok(())
+}
+
+/// Ingest the exact mainnet blocks at the runtime upgrade boundary via the public mainnet
+/// RPC. This covers both v4.0.x outage failure modes on the very blocks where they occurred:
+/// block 1_774_491 contains a contract call, so ingesting it exercises the node 0.22
+/// `get_contract_state` runtime API against a chain that already runs the 1.0 runtime
+/// ("The static Runtime API address used is not compatible with the live chain" on v4.0.x);
+/// block 1_774_492 is the first block built by the 1.0 runtime ("unsupported protocol
+/// version 1000000" on v4.0.x).
+///
+/// Requires network access, hence ignored by default; run explicitly:
+/// `cargo nextest run -p chain-indexer --features cloud --run-ignored all -E
+/// 'test(test_mainnet_runtime_upgrade_boundary)'`
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires network access to the public mainnet RPC"]
+async fn test_mainnet_runtime_upgrade_boundary() -> anyhow::Result<()> {
+    const CONTRACT_ADDRESS: &str =
+        "9ef16e583fbc361ba6016b2751e6f26a5ab2bbf2f7102ea5e28dc8810696eb9c";
+
+    let _ledger_db = init_ledger_db().await?;
+
+    let config = Config {
+        url: "wss://rpc.mainnet.midnight.network".to_string(),
+        reconnect_max_delay: Duration::from_secs(1),
+        reconnect_max_attempts: 3,
+        subscription_recovery_timeout: Duration::from_secs(30),
+    };
+    let mut node = SubxtNode::new(config).await.context("create SubxtNode")?;
+
+    let after = BlockRef {
+        hash: const_hex::decode_to_array::<_, 32>(
+            "e23dc07f65b1194d134b6d9b3c2f7433329d0512896a1c4543048a166d4fabd9",
+        )
+        .expect("valid block hash")
+        .into(),
+        height: 1_774_490,
+    };
+    let blocks = node.finalized_blocks(Some(after));
+    let mut blocks = pin!(blocks);
+
+    let block = blocks
+        .try_next()
+        .await
+        .context("get mainnet block 1_774_491")?
+        .context("stream of finalized blocks must not end")?;
+    assert_eq!(block.height, 1_774_491);
+    assert_eq!(u32::from(block.protocol_version), 22_000);
+    let contract_action = block
+        .transactions
+        .iter()
+        .filter_map(|transaction| match transaction {
+            Transaction::Regular(transaction) => Some(&transaction.contract_actions),
+            Transaction::System(_) => None,
+        })
+        .flatten()
+        .find(|contract_action| {
+            contract_action.address.as_ref()
+                == const_hex::decode(CONTRACT_ADDRESS).expect("valid address")
+        })
+        .context("mainnet block 1_774_491 must contain the known contract call")?;
+    assert!(!contract_action.state.as_ref().is_empty());
+
+    let block = blocks
+        .try_next()
+        .await
+        .context("get mainnet block 1_774_492")?
+        .context("stream of finalized blocks must not end")?;
+    assert_eq!(block.height, 1_774_492);
+    assert_eq!(u32::from(block.protocol_version), 1_000_000);
+
+    Ok(())
+}
+
+#[cfg(feature = "cloud")]
+async fn init_ledger_db()
+-> anyhow::Result<testcontainers::ContainerAsync<testcontainers_modules::postgres::Postgres>> {
+    use indexer_common::infra::{
+        ledger_db, migrations,
+        pool::postgres::{Config, PostgresPool},
+    };
+    use sqlx::postgres::PgSslMode;
+    use testcontainers_modules::postgres::Postgres;
+
+    let postgres_container = Postgres::default()
+        .with_db_name("indexer")
+        .with_user("indexer")
+        .with_password("postgres")
+        .with_tag("17.1-alpine")
+        .start()
+        .await
+        .context("start Postgres container")?;
+    let postgres_port = postgres_container
+        .get_host_port_ipv4(5432)
+        .await
+        .context("get Postgres port")?;
+
+    let config = Config {
+        host: "localhost".to_string(),
+        port: postgres_port,
+        dbname: "indexer".to_string(),
+        user: "indexer".to_string(),
+        password: "postgres".to_string().into(),
+        sslmode: PgSslMode::Prefer,
+        max_connections: 10,
+        idle_timeout: Duration::from_secs(60),
+        max_lifetime: Duration::from_secs(5 * 60),
+    };
+    let pool = PostgresPool::new(config)
+        .await
+        .context("create PostgresPool")?;
+    migrations::postgres::run(&pool)
+        .await
+        .context("run Postgres migrations")?;
+
+    ledger_db::init(ledger_db::Config { cache_size: 1_024 }, pool);
+
+    Ok(postgres_container)
+}
+
+#[cfg(feature = "standalone")]
+async fn init_ledger_db() -> anyhow::Result<tempfile::TempDir> {
+    use indexer_common::infra::ledger_db;
+
+    let temp_dir = tempfile::tempdir().context("create tempdir")?;
+    let cnn_url = temp_dir
+        .path()
+        .join("ledger-db.sqlite")
+        .display()
+        .to_string();
+
+    ledger_db::init(ledger_db::Config {
+        cache_size: 1_024,
+        cnn_url,
+    })
+    .await
+    .context("init ledger db")?;
+
+    Ok(temp_dir)
+}


### PR DESCRIPTION
Backport fix for durable indexer behavior during runtime upgrades with other ledger transactions within the same block via reading runtime apis consistent with the node runtime version.



(cherry picked from commit 54f96c8d8fa5625f1326fda97a6321b6d0296c44)