### PR TITLE
chore(release): prepare for 4.4.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [4.4.0-rc.2] - 2026-08-06
+
+### 🚀 Features
+
+- *(indexer)* Index the ledger 8→9 hard-fork crossing (#1395).
+- *(chain-indexer)* Derive block authors from BABE pre-runtime digests (#1321).
+- *(chain-indexer)* Gate BABE author derivation on the presence of `pallet-consensus-engine` (#1377).
 
 ### 🐛 Bug Fixes
+
+- Dispatch runtime API and storage calls by the state runtime version at upgrade enactment blocks (#1346).
+- *(indexer-common)* Read the stored count in `ledger-db` `get_root_count` (#1378).
+- Publish multi-architecture manifests for indexer images (#1391).
 
 - *(indexer-common)* [**breaking**] Rename the ledger DB's `cache_size` to `cache_max_nodes`, make it a plain node count and raise it to 100000
 
@@ -15,6 +25,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   should be. Operators must rename the key in their config and replace any byte-unit string with a
   plain integer; the `APP__INFRA__LEDGER_DB__CACHE_SIZE` environment variable becomes
   `APP__INFRA__LEDGER_DB__CACHE_MAX_NODES`. `0` means unbounded.
+
+### ⚙️ Miscellaneous Tasks
+
+- Add `pallet_session` support for the 2.1.0 runtime upgrade (#1333).
+- Pin `cargo-audit` (#1387).
+
+## [unreleased]
 
 ## [4.3.5] - 2026-07-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "chain-indexer"
-version = "4.3.5"
+version = "4.4.0-rc.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3378,7 +3378,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-api"
-version = "4.3.5"
+version = "4.4.0-rc.2"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-standalone"
-version = "4.3.5"
+version = "4.4.0-rc.2"
 dependencies = [
  "anyhow",
  "byte-unit-serde",
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-tests"
-version = "4.3.5"
+version = "4.4.0-rc.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -7524,7 +7524,7 @@ dependencies = [
 
 [[package]]
 name = "spo-indexer"
-version = "4.3.5"
+version = "4.4.0-rc.2"
 dependencies = [
  "anyhow",
  "blake2",
@@ -9068,7 +9068,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-indexer"
-version = "4.3.5"
+version = "4.4.0-rc.2"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version       = "4.3.5"
+version       = "4.4.0-rc.2"
 edition       = "2024"
 license       = "Apache-2.0"
 readme        = "README.md"

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,8 @@ Maintainer and contributor guides. For local setup see the top-level
 
 - [Creating a release](./releasing.md) - versioning, changelog, tagging, image
   publish.
+- [Ledger 8 → 9 devnet rehearsal](./hardfork-devnet-rehearsal-8to9.md) - release-gate
+  procedure for validating the hard-fork crossing.
 - [Upgrading the node version](./updating-node-version.md) - `NODE_VERSIONS`,
   metadata, per-version runtime modules.
 - [Upgrading the ledger](./upgrading-ledger.md) - the `v8`/`v9` coexistence and

--- a/docs/hardfork-devnet-rehearsal-8to9.md
+++ b/docs/hardfork-devnet-rehearsal-8to9.md
@@ -1,0 +1,52 @@
+# Ledger 8 → 9 Devnet Rehearsal
+
+This runbook is the release gate for an indexer build that supports the ledger
+8 → 9 hard fork. It uses a fresh ledger-8 dev chain, submits ledger-8 traffic,
+enacts the ledger-9 runtime through governance, then submits ledger-9 traffic.
+The indexer must continue indexing across the boundary.
+
+## Required inputs
+
+- A candidate indexer image tag, built from the release commit.
+- A ledger-8 node image and matching toolkit image (normally `1.0.0`).
+- The intended ledger-9 migration-node image and matching toolkit image.
+- The authoritative compressed runtime WASM produced by that migration-node
+  build. Supplying it explicitly prevents a binary-only image swap from causing
+  a no-op upgrade with an embedded ledger-8 WASM.
+
+## Run
+
+From the repository root:
+
+```bash
+IMAGE_REGISTRY=ghcr.io/midnight-ntwrk \
+INDEXER_TAG=4.4.0-rc.2 \
+FROM_NODE_TAG=1.0.0 \
+TO_NODE_TAG=<ledger-9-node-tag> \
+FROM_TOOLKIT_TAG=1.0.0 \
+TO_TOOLKIT_TAG=<ledger-9-toolkit-tag> \
+RUNTIME_WASM=/path/to/midnight_node_runtime.compact.compressed.wasm \
+bash qa/scripts/test-hardfork-8to9.sh
+```
+
+The script is non-interactive by default. Set `AUTO=0` to pause before the
+pre-fork traffic, runtime upgrade, and post-fork traffic.
+
+## Acceptance criteria
+
+- The chain begins below runtime `specVersion` `2_000_000`.
+- Ledger-8 transactions are accepted and indexed before the upgrade.
+- Governance changes the runtime to `specVersion` `2_001_000` or later.
+- Ledger-9 transactions are accepted and indexed after the upgrade.
+- `chain-indexer` logs contain none of: `translate ledger state`, `ledger state
+  root mismatch`, or `zswap state root mismatch`.
+- The script completes with its success message and records a post-fork indexed
+  height.
+
+## Release checklist
+
+- Record the exact node, toolkit, indexer image, and runtime-WASM provenance in
+  the QA evidence.
+- Run smoke and integration QA against the candidate image and intended node /
+  toolkit pair.
+- Obtain QA sign-off for this rehearsal before tagging the release candidate.

--- a/qa/scripts/test-hardfork-8to9.sh
+++ b/qa/scripts/test-hardfork-8to9.sh
@@ -8,14 +8,12 @@
 # submits v9 transactions. The indexer must cross the boundary without a ledger/
 # zswap root mismatch and keep indexing.
 #
-# This is the generative, from-genesis sibling of the snapshot-fork oracle in
-# docs/hardfork-ledger-8-to-9.md (Phase 3). It validates the live transaction path
-# across the fork; it does NOT stress the run(budget) drain path (dev genesis is
-# tiny) -- use the snapshot fork for that. See docs/hardfork-devnet-rehearsal-8to9.md.
+# This is the generative, from-genesis rehearsal described in
+# docs/hardfork-devnet-rehearsal-8to9.md. It validates the live transaction path
+# across the fork; it does not stress a production-sized `run(budget)` drain.
 #
-# Prerequisites (see the doc's Handoff checklist):
-#   - Indexer images that recognize spec_version 2_001_000 (Phase 1 / #1333). Build
-#     from the integration/fork-8to9-e2e branch: INDEXER_TAG=dev just build-docker-image <pkg>
+# Prerequisites (see the runbook's release checklist):
+#   - Indexer images that recognize spec_version 2_001_000.
 #   - The 2.1.0 migration node image + runtime WASM, and a ledger-8 (1.0.x) node image.
 #   - A ledger-9-capable toolkit for the post-fork sends.
 #


### PR DESCRIPTION
## Release candidate preparation

- Bump the workspace to 4.4.0-rc.2
- Record the ledger 8 to 9 hard-fork crossing and related runtime fixes
- Add the hard-fork devnet rehearsal runbook

## Verification

- git diff --check
- bash -n qa/scripts/test-hardfork-8to9.sh
- cargo metadata --no-deps --format-version 1

The Docker-backed ledger translation test compiles with the cloud feature but could not execute in the local environment because Docker was unavailable. QA sign-off must include the documented 8 to 9 devnet rehearsal before tagging.