### PR TITLE
test: clear high bun audit advisories in qa/tests deps

### DIFF
--- a/qa/tests/bun.lock
+++ b/qa/tests/bun.lock
@@ -27,7 +27,7 @@
         "pino": "^9.14.0",
         "pino-pretty": "^13.1.3",
         "prettier": "^3.9.6",
-        "testcontainers": "^12.0.4",
+        "testcontainers": "^12.1.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.10",
         "ws": "^8.21.1",
@@ -37,7 +37,8 @@
     },
   },
   "overrides": {
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
+    "js-yaml": "^4.3.1",
     "minimatch": "^10.2.5",
   },
   "packages": {
@@ -293,7 +294,7 @@
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
-    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -505,7 +506,7 @@
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
-    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
@@ -775,7 +776,7 @@
 
     "teex": ["teex@1.0.1", "", { "dependencies": { "streamx": "^2.12.5" } }, "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg=="],
 
-    "testcontainers": ["testcontainers@12.0.4", "", { "dependencies": { "@balena/dockerignore": "^1.0.2", "@types/dockerode": "^4.0.1", "archiver": "^7.0.1", "async-lock": "^1.4.1", "byline": "^5.0.0", "debug": "^4.4.3", "docker-compose": "^1.4.2", "dockerode": "^5.0.0", "get-port": "^5.1.1", "proper-lockfile": "^4.1.2", "properties-reader": "^3.0.1", "ssh-remote-port-forward": "^1.0.4", "tar-fs": "^3.1.2", "tmp": "^0.2.7", "undici": "^8.5.0" } }, "sha512-QIR/8xF1+F/26cIM+9B4yyxNTbKJxAv3hygZyhPRgZ8Q2AhlPZjDdpXRuk16V37X4bgJRI3hXFhoEICMBA7Adg=="],
+    "testcontainers": ["testcontainers@12.1.0", "", { "dependencies": { "@balena/dockerignore": "^1.0.2", "@types/dockerode": "^4.0.1", "archiver": "^7.0.1", "async-lock": "^1.4.1", "byline": "^5.0.0", "debug": "^4.4.3", "docker-compose": "^1.4.2", "dockerode": "^5.0.1", "get-port": "^5.1.1", "proper-lockfile": "^4.1.2", "properties-reader": "^3.0.1", "ssh-remote-port-forward": "^1.0.4", "tar-fs": "^3.1.3", "tmp": "^0.2.7", "undici": "^8.9.0" } }, "sha512-YjDLqIITuhGLMnM10yhg3oV6lIG5IMpz1R1DPBZoOOks83q7i7IVpeSWRTiyl7roozjiyLmwIoLK/KY8OnZmIA=="],
 
     "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
 
@@ -805,7 +806,7 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "undici": ["undici@8.8.0", "", {}, "sha512-ubshXMXwF3MQIMF1y/WxZdNBnjEKeSg2wF5mcGUtU55YTw34tnVVpKRlLf7ruDXZ5344KokPVX4RBx1wJm64Bw=="],
+    "undici": ["undici@8.10.0", "", {}, "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/qa/tests/package.json
+++ b/qa/tests/package.json
@@ -54,7 +54,7 @@
     "pino": "^9.14.0",
     "pino-pretty": "^13.1.3",
     "prettier": "^3.9.6",
-    "testcontainers": "^12.0.4",
+    "testcontainers": "^12.1.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10",
     "ws": "^8.21.1",
@@ -63,6 +63,7 @@
   },
   "overrides": {
     "minimatch": "^10.2.5",
-    "brace-expansion": "^5.0.8"
+    "brace-expansion": "^5.0.9",
+    "js-yaml": "^4.3.1"
   }
 }


### PR DESCRIPTION
# Overview

`bun audit --audit-level=high` is a **hard PR CI gate** for `qa/tests`, and it is currently failing on `main` — three high advisories reach the package transitively. Any PR touching `qa/tests` inherits the red check, so this clears it standalone rather than smuggling a dependency change into an unrelated test PR.

Reproduced on `f4bb3b93` (this PR's base):

```
$ bun audit --audit-level=high
3 vulnerabilities (3 high)
exit 1
```

| Advisory | Package | Reaches us via |
|---|---|---|
| [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) / [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) — DoS via unbounded expansion | `brace-expansion` | `minimatch` ← eslint, typescript-eslint, testcontainers → archiver → glob |
| [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) — quadratic CPU in `!!omap` resolution | `js-yaml` | `xmlbuilder2` (JUnit report XML), `@eslint/eslintrc` |
| [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272) — cross-user information disclosure / parse-time crash | `undici` | `testcontainers` (Docker API HTTP) |

All three are transitive dev-tooling dependencies. Neither `js-yaml` nor `undici` is imported directly anywhere under `tests/`, `utils/`, `setup/`, `environment/` or `coverage/`.

## Approach

The guiding rule was **prefer a real dependency bump where upstream offers one, and fall back to `overrides` only where it does not.** Each advisory was checked against the latest published upstream before reaching for a pin.

| Advisory | Upstream fix available? | What this PR does |
|---|---|---|
| `undici` | **Yes** — `testcontainers` 12.1.0 raises its own floor to `undici: ^8.9.0`, resolving 8.10.0 | **No override.** Bump `testcontainers` `^12.0.4` → `^12.1.0` and let resolution follow |
| `js-yaml` | No — `xmlbuilder2` is already at its latest (4.0.3) and still declares `^4.1.1`; `@eslint/eslintrc` declares `^4.3.0` | Override → `^4.3.1` |
| `brace-expansion` | No — `minimatch` declares `^5.0.5`; nothing upstream forces 5.0.9 | Override → `^5.0.9` (pin bump only; the existing `^5.0.8` still resolved *inside* the advisory range) |

Net diff: one direct dev-dependency bump, one new override, one existing override incremented.

```diff
 "devDependencies": {
-  "testcontainers": "^12.0.4",
+  "testcontainers": "^12.1.0",
 },
 "overrides": {
   "minimatch": "^10.2.5",
-  "brace-expansion": "^5.0.8"
+  "brace-expansion": "^5.0.9",
+  "js-yaml": "^4.3.1"
 }
```

**On the two remaining overrides.** They are *within-range nudges, not range violations*: 4.3.1 satisfies both `js-yaml` consumers (`^4.1.1`, `^4.3.0`) and 5.0.9 satisfies `minimatch`'s `^5.0.5`. No package receives a version it does not already declare support for — the override only selects within what upstream permits, because nothing upstream *forces* the patched build and bun will not move a transitive that already satisfies its range. They should be dropped once `xmlbuilder2` and `minimatch` publish releases that carry the fixes on their own.

**Why `js-yaml` v4 and not v5:** `bun update js-yaml` wants 5.2.3, a major bump across both consumers, which expect the v4 API. `^4.3.1` is the v4-legacy line carrying the backported fix. The `xmlbuilder2` path is genuinely exercised — the JUnit reporter writes `reports/junit/test-results.xml` on every run.

### Routes that were tried and rejected

- **`bun update js-yaml undici`** — for a *transitive* dependency this adds a **top-level** entry and leaves the nested resolutions untouched: `testcontainers/undici` stayed at 8.8.0 and `xmlbuilder2/js-yaml` at 4.3.0, still vulnerable, now with two spurious direct dependencies.
- **`bun update`** (whole-tree, range-respecting) — fixes `undici` via the `testcontainers` bump but leaves **2 high advisories** (`js-yaml` 4.3.0, `brace-expansion` 5.0.8, both still satisfying their ranges), and churns five unrelated caret ranges (`@types/pg`, `typescript-eslint` ×2, `graphql`, `graphql-ws`, `ws`) as collateral.

## Validation

Run in a clean worktree off `f4bb3b93`:

| Check | Before | After |
|---|---|---|
| `bun audit --audit-level=high` | **exit 1** — 3 vulnerabilities (3 high) | **exit 0** |
| `bun install --frozen-lockfile` | — | clean, 429 installs / 433 packages, no changes (lockfile consistent with `package.json`) |
| `bun run lint` | — | exit 0 |
| `bun run format:check` | — | exit 0 |
| `bun run compile-check` | 1 error | 1 error, unchanged |

The single `compile-check` error is pre-existing on `main` and untouched by this PR: `tests/integration/basic/queries/bridge-queries.test.ts(172,37): error TS2345` in the integration suite. Delta is zero. Note that `compile-check` is wired into no CI job and no husky hook, so it gates nothing today.

Because this PR bumps `testcontainers` — a direct dependency that drives Docker orchestration for the undeployed environment — a suite run against 12.1.0 is being carried out on top of the fast checks above, rather than relying on the earlier run that used 12.0.4. Results will be posted as a comment.

## Submission Checklist

- [x] Useful pull request description
- [ ] Tests are provided (if possible) — n/a, dependency resolution only
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [ ] Update README.md file (if relevant) — n/a
- [ ] Update documentation (if relevant) — n/a
- [x] No new todos introduced

## Links

No ticket — found while preparing an unrelated `qa/tests` change and split out so the dependency bump lands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
