### PR TITLE
test: unbreak QA workflows calling the base workflow (permissions + image registry)

### DIFF
--- a/.github/workflows/qa-integration-tests-base-workflow.yml
+++ b/.github/workflows/qa-integration-tests-base-workflow.yml
@@ -152,6 +152,16 @@ jobs:
           APP__INFRA__STORAGE__PASSWORD: ${{ secrets.APP__INFRA__STORAGE__PASSWORD }}
           APP__INFRA__PUB_SUB__PASSWORD: ${{ secrets.APP__INFRA__PUB_SUB__PASSWORD }}
         run: |
+          # No APP__INFRA__* secrets are configured for this repo (repo and
+          # org level), leaving these empty — an empty POSTGRES_PASSWORD makes
+          # the postgres container restart-loop and the whole environment
+          # never comes up. The local environment is ephemeral, so random
+          # values suffice (same approach as .github/actions/init-env);
+          # secrets still win when present.
+          export APP__INFRA__SECRET="${APP__INFRA__SECRET:-$(openssl rand -hex 32)}"
+          export APP__INFRA__STORAGE__PASSWORD="${APP__INFRA__STORAGE__PASSWORD:-$(openssl rand -hex 32)}"
+          export APP__INFRA__PUB_SUB__PASSWORD="${APP__INFRA__PUB_SUB__PASSWORD:-$(openssl rand -hex 32)}"
+
           . ./.envrc
           echo "NODE_TAG: $NODE_TAG"
           echo "INDEXER_TAG: $INDEXER_TAG"

--- a/.github/workflows/qa-integration-tests-base-workflow.yml
+++ b/.github/workflows/qa-integration-tests-base-workflow.yml
@@ -140,6 +140,26 @@ jobs:
           username: MidnightCI
           password: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
 
+      # Pulling up front keeps registry/auth/tag failures out of the startup
+      # step (they fail here with a one-glance log instead) and lets the step
+      # timings separate download time from environment startup time. Images
+      # already present make this a cheap manifest check.
+      - name: Pull images
+        if: inputs.target_env == 'undeployed'
+        env:
+          NODE_TAG: ${{ inputs.node_tag }}
+          INDEXER_TAG: ${{ inputs.indexer_tag }}
+          NODE_TOOLKIT_TAG: ${{ inputs.node_toolkit_tag }}
+          IMAGE_REGISTRY: ${{ inputs.image_registry }}
+        run: |
+          docker compose --profile cloud pull
+          # Used by qa/scripts/startup-localenv-with-data.sh for volume setup.
+          docker pull alpine
+          # Used by the toolkit wrapper for test data generation; the registry
+          # is hardcoded there (qa/tests/utils/toolkit/toolkit-wrapper.ts) and
+          # the tag default mirrors startup-localenv-with-data.sh.
+          docker pull "ghcr.io/midnight-ntwrk/midnight-node-toolkit:${NODE_TOOLKIT_TAG:-latest-main}"
+
       - name: Startup local environment
         if: inputs.target_env == 'undeployed'
         env:

--- a/.github/workflows/qa-integration-tests-base-workflow.yml
+++ b/.github/workflows/qa-integration-tests-base-workflow.yml
@@ -80,8 +80,8 @@ on:
         description: >-
           Registry for the indexer images (leave empty for the docker-compose
           default, Docker Hub midnightntwrk). Per-commit main-branch builds
-          are only published to ghcr.io/midnight-ntwrk (the legacy org —
-          publisher and readers must migrate to midnightntwrk together).
+          are published to GHCR only, so callers that test those images must
+          set this explicitly.
         required: false
         default: ""
     secrets:

--- a/.github/workflows/qa-integration-tests-base-workflow.yml
+++ b/.github/workflows/qa-integration-tests-base-workflow.yml
@@ -79,8 +79,9 @@ on:
         type: string
         description: >-
           Registry for the indexer images (leave empty for the docker-compose
-          default, Docker Hub midnightntwrk). Main-branch builds are only
-          published to ghcr.io/midnight-ntwrk.
+          default, Docker Hub midnightntwrk). Per-commit main-branch builds
+          are only published to ghcr.io/midnight-ntwrk (the legacy org —
+          publisher and readers must migrate to midnightntwrk together).
         required: false
         default: ""
     secrets:
@@ -157,7 +158,11 @@ jobs:
           docker pull alpine
           # Used by the toolkit wrapper for test data generation; the registry
           # is hardcoded there (qa/tests/utils/toolkit/toolkit-wrapper.ts) and
-          # the tag default mirrors startup-localenv-with-data.sh.
+          # this pull must match it. The tag default mirrors
+          # startup-localenv-with-data.sh. Docker Hub's
+          # midnightntwrk/midnight-node-toolkit cannot be used here: it only
+          # carries the toolkit's own release tags and latest-main, not the
+          # node-paired tags this workflow passes.
           docker pull "ghcr.io/midnight-ntwrk/midnight-node-toolkit:${NODE_TOOLKIT_TAG:-latest-main}"
 
       - name: Startup local environment

--- a/.github/workflows/qa-integration-tests-base-workflow.yml
+++ b/.github/workflows/qa-integration-tests-base-workflow.yml
@@ -75,6 +75,14 @@ on:
         description: Node toolkit tag (leave empty for the startup script default)
         required: false
         default: ""
+      image_registry:
+        type: string
+        description: >-
+          Registry for the indexer images (leave empty for the docker-compose
+          default, Docker Hub midnightntwrk). Main-branch builds are only
+          published to ghcr.io/midnight-ntwrk.
+        required: false
+        default: ""
     secrets:
       MIDNIGHTCI_PACKAGES_READ:
         required: true
@@ -138,6 +146,8 @@ jobs:
           NODE_TAG: ${{ inputs.node_tag }}
           INDEXER_TAG: ${{ inputs.indexer_tag }}
           NODE_TOOLKIT_TAG: ${{ inputs.node_toolkit_tag }}
+          # Empty falls through to the docker-compose default (midnightntwrk).
+          IMAGE_REGISTRY: ${{ inputs.image_registry }}
           APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}
           APP__INFRA__STORAGE__PASSWORD: ${{ secrets.APP__INFRA__STORAGE__PASSWORD }}
           APP__INFRA__PUB_SUB__PASSWORD: ${{ secrets.APP__INFRA__PUB_SUB__PASSWORD }}

--- a/.github/workflows/qa-integration-tests-devnet.yml
+++ b/.github/workflows/qa-integration-tests-devnet.yml
@@ -2,6 +2,10 @@ name: Indexer QA Integration Tests - devnet
 
 permissions:
   contents: read
+  # Required by the called base workflow's job (GHCR image pulls); a called
+  # job cannot escalate beyond the caller's grant, so omitting this fails
+  # run creation with startup_failure.
+  packages: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/qa-integration-tests-undeployed.yml
+++ b/.github/workflows/qa-integration-tests-undeployed.yml
@@ -2,6 +2,10 @@ name: Indexer QA Integration Tests - undeployed
 
 permissions:
   contents: read
+  # Required by the called base workflow's job (GHCR image pulls); a called
+  # job cannot escalate beyond the caller's grant, so omitting this fails
+  # run creation with startup_failure.
+  packages: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/qa-tests-main-merge.yml
+++ b/.github/workflows/qa-tests-main-merge.yml
@@ -129,9 +129,11 @@ jobs:
       # security fixes that must stay internal until released. Those images
       # are published by build-indexer-images to GHCR, which also mirrors the
       # release tags, so this registry works for workflow_dispatch runs too.
-      # NOTE: midnight-ntwrk is the legacy GitHub org; it is what
-      # build-indexer-images still publishes to, so this reader can only
-      # migrate to the midnightntwrk org together with that publisher.
+      # NOTE: build-indexer-images dual-publishes to both GHCR orgs
+      # (midnight-ntwrk is the legacy one, midnightntwrk the current one),
+      # but per-commit tags built before dual-publishing landed exist in the
+      # legacy org only — keep this here so workflow_dispatch runs can still
+      # pull older SHAs. Switch to midnightntwrk once those are irrelevant.
       image_registry: ghcr.io/midnight-ntwrk
     secrets:
       MIDNIGHTCI_PACKAGES_READ: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}

--- a/.github/workflows/qa-tests-main-merge.yml
+++ b/.github/workflows/qa-tests-main-merge.yml
@@ -123,6 +123,11 @@ jobs:
       node_tag: ${{ needs.derive-tags.outputs.node_tag }}
       indexer_tag: ${{ needs.derive-tags.outputs.indexer_tag }}
       node_toolkit_tag: ${{ needs.derive-tags.outputs.node_toolkit_tag }}
+      # Main-branch image builds are only published to GHCR: build-indexer-images
+      # pushes <version>-<sha8> to ghcr.io/midnight-ntwrk, while Docker Hub
+      # (midnightntwrk) only receives release-tag builds. GHCR also mirrors the
+      # release tags, so this registry works for workflow_dispatch runs too.
+      image_registry: ghcr.io/midnight-ntwrk
     secrets:
       MIDNIGHTCI_PACKAGES_READ: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
       APP__INFRA__SECRET: ${{ secrets.APP__INFRA__SECRET }}

--- a/.github/workflows/qa-tests-main-merge.yml
+++ b/.github/workflows/qa-tests-main-merge.yml
@@ -12,6 +12,10 @@ name: Indexer QA Tests - main merge
 
 permissions:
   contents: read
+  # Required by the called base workflow's job (GHCR image pulls); a called
+  # job cannot escalate beyond the caller's grant, so omitting this fails
+  # run creation with startup_failure.
+  packages: read
 
 on:
   workflow_run:

--- a/.github/workflows/qa-tests-main-merge.yml
+++ b/.github/workflows/qa-tests-main-merge.yml
@@ -123,10 +123,15 @@ jobs:
       node_tag: ${{ needs.derive-tags.outputs.node_tag }}
       indexer_tag: ${{ needs.derive-tags.outputs.indexer_tag }}
       node_toolkit_tag: ${{ needs.derive-tags.outputs.node_toolkit_tag }}
-      # Main-branch image builds are only published to GHCR: build-indexer-images
-      # pushes <version>-<sha8> to ghcr.io/midnight-ntwrk, while Docker Hub
-      # (midnightntwrk) only receives release-tag builds. GHCR also mirrors the
+      # Docker Hub (midnightntwrk, the public registry) only receives
+      # release-tag builds — it cannot serve the per-commit <version>-<sha8>
+      # images this workflow tests, and unreleased main builds may carry
+      # security fixes that must stay internal until released. Those images
+      # are published by build-indexer-images to GHCR, which also mirrors the
       # release tags, so this registry works for workflow_dispatch runs too.
+      # NOTE: midnight-ntwrk is the legacy GitHub org; it is what
+      # build-indexer-images still publishes to, so this reader can only
+      # migrate to the midnightntwrk org together with that publisher.
       image_registry: ghcr.io/midnight-ntwrk
     secrets:
       MIDNIGHTCI_PACKAGES_READ: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}

--- a/qa/tests/bun.lock
+++ b/qa/tests/bun.lock
@@ -40,6 +40,7 @@
     "brace-expansion": "^5.0.9",
     "js-yaml": "^4.3.1",
     "minimatch": "^10.2.5",
+    "nanoid": "^3.3.17",
   },
   "packages": {
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
@@ -596,7 +597,7 @@
 
     "nan": ["nan@2.28.0", "", {}, "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ=="],
 
-    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 

--- a/qa/tests/package.json
+++ b/qa/tests/package.json
@@ -64,6 +64,7 @@
   "overrides": {
     "minimatch": "^10.2.5",
     "brace-expansion": "^5.0.9",
-    "js-yaml": "^4.3.1"
+    "js-yaml": "^4.3.1",
+    "nanoid": "^3.3.17"
   }
 }

--- a/qa/tests/utils/toolkit/toolkit-cache.ts
+++ b/qa/tests/utils/toolkit/toolkit-cache.ts
@@ -85,21 +85,49 @@ async function bootstrap(): Promise<ToolkitCacheConnection> {
 }
 
 async function ensureChainNamesTable(): Promise<void> {
-  await execFileAsync('docker', [
-    'exec',
-    CONTAINER_NAME,
-    'psql',
-    '-U',
-    POSTGRES_USER,
-    '-d',
-    POSTGRES_DB,
-    '-c',
-    `CREATE TABLE IF NOT EXISTS chain_names (
-       chain_id      BYTEA PRIMARY KEY,
-       env_name      TEXT NOT NULL,
-       registered_at TIMESTAMPTZ DEFAULT now()
-     );`,
-  ]);
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  for (;;) {
+    try {
+      await execFileAsync('docker', [
+        'exec',
+        CONTAINER_NAME,
+        'psql',
+        // TCP, not the unix socket: the entrypoint's first-run temporary
+        // server is socket-only, so the socket can reach a server that is
+        // about to be restarted.
+        '-h',
+        '127.0.0.1',
+        '-U',
+        POSTGRES_USER,
+        '-d',
+        POSTGRES_DB,
+        '-c',
+        `CREATE TABLE IF NOT EXISTS chain_names (
+           chain_id      BYTEA PRIMARY KEY,
+           env_name      TEXT NOT NULL,
+           registered_at TIMESTAMPTZ DEFAULT now()
+         );`,
+      ]);
+      return;
+    } catch (err) {
+      const message = errorMessage(err);
+      // IF NOT EXISTS is not concurrency-safe: two workers can both pass the
+      // existence check and race the catalog insert; the loser gets a
+      // duplicate-key error on a pg_* catalog index. The only statement here
+      // is this CREATE TABLE, so any duplicate-key error means the table
+      // already exists — which is all we need.
+      if (message.includes('duplicate key value violates unique constraint')) {
+        return;
+      }
+      const transient =
+        message.includes('the database system is starting up') ||
+        message.includes('connection to server');
+      if (!transient || Date.now() >= deadline) {
+        throw err;
+      }
+      await sleep(READY_POLL_INTERVAL_MS);
+    }
+  }
 }
 
 async function ensureContainer(): Promise<number> {
@@ -189,6 +217,12 @@ async function waitForReady(): Promise<void> {
         'exec',
         CONTAINER_NAME,
         'pg_isready',
+        // TCP, not the unix socket: on a fresh data dir the postgres image
+        // initializes via a temporary socket-only server before restarting
+        // for real, and pg_isready against the socket reports that temporary
+        // server as ready. Only the final server listens on TCP.
+        '-h',
+        '127.0.0.1',
         '-U',
         POSTGRES_USER,
         '-d',


### PR DESCRIPTION
## Problem

Every run of the `qa-tests-main-merge` workflow since its creation on 2026-07-29 (16 runs) ended in `startup_failure` with zero jobs — same for the latest manual dispatches of the devnet (2026-03-16) and undeployed QA integration workflows. Three stacked defects:

### 1. Callers deny the `packages: read` the base workflow's job requests

> Invalid workflow file: `.github/workflows/qa-tests-main-merge.yml` (Line: 111, Col: 3): Error calling workflow `qa-integration-tests-base-workflow.yml`. The nested job 'basic-integration-tests' is requesting 'packages: read', but is only allowed 'packages: none'.

`qa-integration-tests-base-workflow.yml`'s job declares `permissions: packages: read` (GHCR login / image pulls). The permissions hardening in #869 added top-level `permissions: contents: read` to the caller workflows, which implicitly sets `packages: none` — and a called reusable workflow can only downgrade, never escalate, the caller's token permissions. GitHub rejects the run at plan time: `startup_failure`, no jobs, no logs.

The block-subscription and ledger-events QA families are unaffected — their base workflows don't request `packages: read`.

### 2. Main-merge derives a tag that only exists on GHCR, but pulls from Docker Hub

With the permissions fixed, the first real run failed in "Startup local environment":

> manifest for midnightntwrk/chain-indexer:4.4.0-rc.2-d093da5a not found: manifest unknown

`build-indexer-images` publishes `<version>-<sha8>` tags **only to `ghcr.io/midnight-ntwrk`**; Docker Hub (`midnightntwrk`) receives release-tag builds only. That's why the build workflow's own docker-compose-validation job sets `IMAGE_REGISTRY=ghcr.io/midnight-ntwrk` for non-tag refs. The QA base workflow never set `IMAGE_REGISTRY`, so compose fell back to Docker Hub.

### 3. No `APP__INFRA__*` secrets exist, so postgres never comes up

With the registry fixed, the next run pulled images fine but "Startup local environment" timed out: the postgres container was in a restart loop because `POSTGRES_PASSWORD` (from `APP__INFRA__STORAGE__PASSWORD`) was empty — those secrets are not configured at repo or org level (verified via the API). This means the undeployed QA environment has never come up in CI through these workflows.

## Fix

- Add `packages: read` to the top-level permissions of the three callers of `qa-integration-tests-base-workflow.yml` (`qa-tests-main-merge`, `qa-integration-tests-devnet`, `qa-integration-tests-undeployed`). Still least-privilege: read-only and genuinely required.
- Generate ephemeral `APP__INFRA__*` values in the startup step when the secrets are absent, mirroring `.github/actions/init-env` used by `build-indexer-images`' docker-compose-validation job. Configured secrets still take precedence.
- Add an optional `image_registry` input to the base workflow (empty keeps the docker-compose Docker Hub default, so devnet/undeployed behave exactly as before) and set it to `ghcr.io/midnight-ntwrk` in `qa-tests-main-merge`. GHCR also mirrors the release tags (verified `4.4.0-rc.2` returns 200), so the workflow_dispatch path works too. Only the five indexer images use `IMAGE_REGISTRY`; the node image is hardcoded to Docker Hub and unaffected.

## Also included (follow-ups merged into this branch)

- **Dedicated "Pull images" step** (was #1413): pulls everything the undeployed environment needs before "Startup local environment" — registry/auth/tag failures now fail in a small, obvious step log, and step timings separate download time (~85s) from environment startup (~29s, down from ~46s).
- **Toolkit cache postgres init robustness** (was #1414): the `toolkit-postgres` readiness probe used the container's unix socket, which the postgres image's temporary init-phase server also answers — so `psql` could land in the restart window (`the database system is starting up`), and two vitest workers could race the non-concurrency-safe `CREATE TABLE IF NOT EXISTS` (`duplicate key ... pg_type_typname_nsp_index`). Now probes/connects over TCP (only the final server listens on TCP), treats duplicate-key from that lone statement as "table exists", and retries transient connection errors within the existing budget.
- **Audit fix**: pin `nanoid` to `^3.3.17` via the existing `overrides` block (GHSA-2v37-7h3g-55p8, high, transitive via vitest → vite → postcss) — the `tests — lint, format, audit` CI gate fails on any high advisory, pre-existing or not.

## Registry situation (verified 2026-08-11)

A reviewer flagged the `ghcr.io/midnight-ntwrk` references. Verified state of the three registries:

| Registry | Status | Indexer images | Per-commit `<version>-<sha8>` tags |
|---|---|---|---|
| `ghcr.io/midnight-ntwrk` | **legacy org** (2023), all packages private | all 5 (+ node-toolkit) | ✅ (sole source) |
| `ghcr.io/midnightntwrk` | current org (2025) | **none exist** | — |
| Docker Hub `midnightntwrk` | public | all 5 (release tags only) | ❌ 404 |

Docker Hub was tested first per review feedback and cannot serve this workflow: no per-commit indexer tags, no node-paired toolkit tags — and unreleased main builds may carry security fixes that must stay internal until released, so per-commit images belong on the internal registry anyway. The PR therefore keeps `ghcr.io/midnight-ntwrk` but now explicitly marks it as the legacy org in the workflow comments.

**Flagged separately (pre-existing, outside this PR's scope):** `build-indexer-images.yaml` *publishes* all indexer images and build caches to the legacy org (lines 88/124–128/180/277), and `qa/tests/utils/toolkit/toolkit-wrapper.ts:361` + three docs reference it. Publisher and readers must migrate to `ghcr.io/midnightntwrk` together. Also noted: `ghcr.io/midnightntwrk/midnight-node` is currently **public**, which contradicts the "current GHCR org is internal" expectation.

## Validation

`workflow_dispatch` of `qa-tests-main-merge.yml` on this branch with `indexer_tag=4.4.0-rc.2-d093da5a` (the image built for current main):

- After fix 1: run [31404223574](https://github.com/midnightntwrk/midnight-indexer/actions/runs/31404223574) got past run creation (previously impossible), then failed pulling the image from Docker Hub — defect 2.
- After fix 2: run [31404863517](https://github.com/midnightntwrk/midnight-indexer/actions/runs/31404863517) pulled all images from GHCR, then timed out on the postgres restart loop — defect 3.
- After fix 3: run [31405548031](https://github.com/midnightntwrk/midnight-indexer/actions/runs/31405548031) — **fully green**: environment up, smoke and integration suites passed, reports uploaded.
- Full stack (with pull step + toolkit-cache fix): run [31407929986](https://github.com/midnightntwrk/midnight-indexer/actions/runs/31407929986) — fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
