### PR TITLE
feat(ci): pull QA environment images in a dedicated step

### DIFF
--- a/.github/workflows/qa-integration-tests-base-workflow.yml
+++ b/.github/workflows/qa-integration-tests-base-workflow.yml
@@ -140,6 +140,26 @@ jobs:
           username: MidnightCI
           password: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
 
+      # Pulling up front keeps registry/auth/tag failures out of the startup
+      # step (they fail here with a one-glance log instead) and lets the step
+      # timings separate download time from environment startup time. Images
+      # already present make this a cheap manifest check.
+      - name: Pull images
+        if: inputs.target_env == 'undeployed'
+        env:
+          NODE_TAG: ${{ inputs.node_tag }}
+          INDEXER_TAG: ${{ inputs.indexer_tag }}
+          NODE_TOOLKIT_TAG: ${{ inputs.node_toolkit_tag }}
+          IMAGE_REGISTRY: ${{ inputs.image_registry }}
+        run: |
+          docker compose --profile cloud pull
+          # Used by qa/scripts/startup-localenv-with-data.sh for volume setup.
+          docker pull alpine
+          # Used by the toolkit wrapper for test data generation; the registry
+          # is hardcoded there (qa/tests/utils/toolkit/toolkit-wrapper.ts) and
+          # the tag default mirrors startup-localenv-with-data.sh.
+          docker pull "ghcr.io/midnight-ntwrk/midnight-node-toolkit:${NODE_TOOLKIT_TAG:-latest-main}"
+
       - name: Startup local environment
         if: inputs.target_env == 'undeployed'
         env:


### PR DESCRIPTION
Follow-up to #1412 (stacked on its branch; GitHub will retarget this PR to `main` automatically when #1412 merges and its branch is deleted).

## Why

During #1412's diagnosis, the `manifest not found` pull failure was buried inside a 1,400-line "Startup local environment" log. Pulling images in a dedicated step means:

- **Failure isolation** — registry/auth/tag problems fail in a step whose name and short log say exactly what went wrong.
- **Timing visibility** — step durations separate image download time from environment startup time (useful baseline if runner-side image caching is considered later).
- **Cost ≈ zero** — pulls of already-present images are quick manifest checks, so local-style warm runs lose nothing.

Note: the pull time was never counted against the 120s `wait_for_indexer_ready` budget (that clock starts after `docker compose up -d` returns), so this is an observability/diagnosability improvement, not a timeout fix.

## What

One new `Pull images` step (undeployed only) before "Startup local environment":

- `docker compose --profile cloud pull` — the five indexer images, node, postgres, NATS
- `alpine` — used by `startup-localenv-with-data.sh` for volume setup
- `ghcr.io/midnight-ntwrk/midnight-node-toolkit:<tag>` — used by the toolkit wrapper for data generation (registry hardcoded in `qa/tests/utils/toolkit/toolkit-wrapper.ts`; tag default mirrors the startup script's `latest-main`)

## Validation

`workflow_dispatch` of `qa-tests-main-merge.yml` on this branch with `indexer_tag=4.4.0-rc.2-d093da5a` — link in PR comment once complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)