### PR TITLE
fix(qa): make toolkit cache postgres init robust to fresh-start races

### DIFF
--- a/.github/workflows/qa-integration-tests-base-workflow.yml
+++ b/.github/workflows/qa-integration-tests-base-workflow.yml
@@ -140,6 +140,26 @@ jobs:
           username: MidnightCI
           password: ${{ secrets.MIDNIGHTCI_PACKAGES_READ }}
 
+      # Pulling up front keeps registry/auth/tag failures out of the startup
+      # step (they fail here with a one-glance log instead) and lets the step
+      # timings separate download time from environment startup time. Images
+      # already present make this a cheap manifest check.
+      - name: Pull images
+        if: inputs.target_env == 'undeployed'
+        env:
+          NODE_TAG: ${{ inputs.node_tag }}
+          INDEXER_TAG: ${{ inputs.indexer_tag }}
+          NODE_TOOLKIT_TAG: ${{ inputs.node_toolkit_tag }}
+          IMAGE_REGISTRY: ${{ inputs.image_registry }}
+        run: |
+          docker compose --profile cloud pull
+          # Used by qa/scripts/startup-localenv-with-data.sh for volume setup.
+          docker pull alpine
+          # Used by the toolkit wrapper for test data generation; the registry
+          # is hardcoded there (qa/tests/utils/toolkit/toolkit-wrapper.ts) and
+          # the tag default mirrors startup-localenv-with-data.sh.
+          docker pull "ghcr.io/midnight-ntwrk/midnight-node-toolkit:${NODE_TOOLKIT_TAG:-latest-main}"
+
       - name: Startup local environment
         if: inputs.target_env == 'undeployed'
         env:

--- a/qa/tests/bun.lock
+++ b/qa/tests/bun.lock
@@ -40,6 +40,7 @@
     "brace-expansion": "^5.0.9",
     "js-yaml": "^4.3.1",
     "minimatch": "^10.2.5",
+    "nanoid": "^3.3.17",
   },
   "packages": {
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
@@ -596,7 +597,7 @@
 
     "nan": ["nan@2.28.0", "", {}, "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ=="],
 
-    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 

--- a/qa/tests/package.json
+++ b/qa/tests/package.json
@@ -64,6 +64,7 @@
   "overrides": {
     "minimatch": "^10.2.5",
     "brace-expansion": "^5.0.9",
-    "js-yaml": "^4.3.1"
+    "js-yaml": "^4.3.1",
+    "nanoid": "^3.3.17"
   }
 }

--- a/qa/tests/utils/toolkit/toolkit-cache.ts
+++ b/qa/tests/utils/toolkit/toolkit-cache.ts
@@ -85,21 +85,49 @@ async function bootstrap(): Promise<ToolkitCacheConnection> {
 }
 
 async function ensureChainNamesTable(): Promise<void> {
-  await execFileAsync('docker', [
-    'exec',
-    CONTAINER_NAME,
-    'psql',
-    '-U',
-    POSTGRES_USER,
-    '-d',
-    POSTGRES_DB,
-    '-c',
-    `CREATE TABLE IF NOT EXISTS chain_names (
-       chain_id      BYTEA PRIMARY KEY,
-       env_name      TEXT NOT NULL,
-       registered_at TIMESTAMPTZ DEFAULT now()
-     );`,
-  ]);
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  for (;;) {
+    try {
+      await execFileAsync('docker', [
+        'exec',
+        CONTAINER_NAME,
+        'psql',
+        // TCP, not the unix socket: the entrypoint's first-run temporary
+        // server is socket-only, so the socket can reach a server that is
+        // about to be restarted.
+        '-h',
+        '127.0.0.1',
+        '-U',
+        POSTGRES_USER,
+        '-d',
+        POSTGRES_DB,
+        '-c',
+        `CREATE TABLE IF NOT EXISTS chain_names (
+           chain_id      BYTEA PRIMARY KEY,
+           env_name      TEXT NOT NULL,
+           registered_at TIMESTAMPTZ DEFAULT now()
+         );`,
+      ]);
+      return;
+    } catch (err) {
+      const message = errorMessage(err);
+      // IF NOT EXISTS is not concurrency-safe: two workers can both pass the
+      // existence check and race the catalog insert; the loser gets a
+      // duplicate-key error on a pg_* catalog index. The only statement here
+      // is this CREATE TABLE, so any duplicate-key error means the table
+      // already exists — which is all we need.
+      if (message.includes('duplicate key value violates unique constraint')) {
+        return;
+      }
+      const transient =
+        message.includes('the database system is starting up') ||
+        message.includes('connection to server');
+      if (!transient || Date.now() >= deadline) {
+        throw err;
+      }
+      await sleep(READY_POLL_INTERVAL_MS);
+    }
+  }
 }
 
 async function ensureContainer(): Promise<number> {
@@ -189,6 +217,12 @@ async function waitForReady(): Promise<void> {
         'exec',
         CONTAINER_NAME,
         'pg_isready',
+        // TCP, not the unix socket: on a fresh data dir the postgres image
+        // initializes via a temporary socket-only server before restarting
+        // for real, and pg_isready against the socket reports that temporary
+        // server as ready. Only the final server listens on TCP.
+        '-h',
+        '127.0.0.1',
         '-U',
         POSTGRES_USER,
         '-d',


### PR DESCRIPTION
Stacked on #1413 (which is stacked on #1412); GitHub retargets automatically as the stack merges.

## Problem

Both validation runs of #1413 failed in the integration suite inside `ensureToolkitCachePostgres` → `ensureChainNamesTable` (`qa/tests/utils/toolkit/toolkit-cache.ts`), with two different symptoms of one root cause — the `toolkit-postgres` container being created fresh at test time:

1. Run [31406725822 attempt 1](https://github.com/midnightntwrk/midnight-indexer/actions/runs/31406725822/attempts/1): `duplicate key value violates unique constraint "pg_type_typname_nsp_index"` — `CREATE TABLE IF NOT EXISTS` is not concurrency-safe; two vitest workers both pass the existence check and race the catalog insert.
2. Attempt 2: `FATAL: the database system is starting up` — on a fresh data dir the postgres image initializes through a **temporary socket-only server**, then restarts for real. `pg_isready` over the container's unix socket reports the temporary server as ready, so `psql` can land in the restart window.

This flake is independent of #1412/#1413 (it lives in test-framework code and can hit any parallel run against a fresh environment), but it poisons CI validation, so it's fixed here in the stack.

## Fix

- Probe readiness and connect with `-h 127.0.0.1` (TCP): the temporary init server never listens on TCP, only the final one does.
- Treat a duplicate-key error from this statement as success — the only statement is the `CREATE TABLE`, so duplicate-key can only mean the table already exists.
- Retry transient connection errors within the existing `READY_TIMEOUT_MS` budget.

## Validation

`workflow_dispatch` of `qa-tests-main-merge.yml` on this branch (`indexer_tag=4.4.0-rc.2-d093da5a`), exercising the full stack — result linked in a comment when complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)