### PR TITLE
fix(indexer): sweep stray ledger-db gc roots at startup and vacuum standalone ledger DB

### DIFF
--- a/chain-indexer/benches/apply_transaction.rs
+++ b/chain-indexer/benches/apply_transaction.rs
@@ -38,6 +38,7 @@ fn init_ledger_db(rt: &Runtime) -> tempfile::TempDir {
         ledger_db::init(ledger_db::Config {
             cache_max_nodes: 1_024,
             cnn_url: sqlite_file,
+            vacuum_on_startup: false,
         })
         .await
         .expect("init ledger_db");

--- a/chain-indexer/benches/ledger_state.rs
+++ b/chain-indexer/benches/ledger_state.rs
@@ -34,6 +34,7 @@ fn init_ledger_db(rt: &Runtime) -> tempfile::TempDir {
         ledger_db::init(ledger_db::Config {
             cache_max_nodes: 1_024,
             cnn_url: sqlite_file,
+            vacuum_on_startup: false,
         })
         .await
         .expect("init ledger_db");

--- a/chain-indexer/benches/preprod_genesis.rs
+++ b/chain-indexer/benches/preprod_genesis.rs
@@ -46,6 +46,7 @@ fn init_ledger_db(rt: &Runtime) -> tempfile::TempDir {
         ledger_db::init(ledger_db::Config {
             cache_max_nodes: 1_024,
             cnn_url: sqlite_file,
+            vacuum_on_startup: false,
         })
         .await
         .expect("init ledger_db");

--- a/chain-indexer/src/application.rs
+++ b/chain-indexer/src/application.rs
@@ -140,6 +140,27 @@ pub async fn run(
         .context("get ledger state root hashes")?;
     let newest_count = newest_ledger_state_keys.len();
 
+    // Sweep stored roots outside the window NOW, before the repair below performs this
+    // process's first flush - see `LedgerState::sweep_stray_roots` for why deleting after a
+    // flush can split a concurrent component's root accounting and panic a later flush.
+    // Such roots never get an unpersist and pin their DAGs forever, growing the ledger DB
+    // without bound (strandings predating the retention fix reached millions of roots and
+    // hundreds of GB). At least one window root among the stored rows proves this ledger DB
+    // belongs to the block storage above, so everything else stored really is stray; a
+    // mis-paired or fresh DB is left untouched. Gc reclaims the orphaned nodes incrementally
+    // afterwards.
+    let window_root_hashes = newest_ledger_state_keys
+        .iter()
+        .map(|(_, _, root_hash)| root_hash.clone())
+        .collect::<HashSet<_>>();
+    let (window_rooted, stray_roots) = LedgerState::stored_root_keys()
+        .into_iter()
+        .partition::<Vec<_>, _>(|key| window_root_hashes.contains(key));
+    if !window_rooted.is_empty() && !stray_roots.is_empty() {
+        let swept_roots = LedgerState::sweep_stray_roots(&stray_roots);
+        info!(swept_roots; "swept stray ledger state gc roots");
+    }
+
     // Must precede the seeding below, and is idempotent, hence unconditional; see
     // `LedgerState::repair_root_counts`.
     let repair = LedgerState::repair_root_counts(

--- a/chain-indexer/src/domain/ledger_state.rs
+++ b/chain-indexer/src/domain/ledger_state.rs
@@ -95,6 +95,16 @@ impl LedgerState {
         indexer_common::domain::ledger::LedgerState::persisted_root_hashes()
     }
 
+    /// See [`indexer_common::domain::ledger::LedgerState::stored_root_keys`].
+    pub fn stored_root_keys() -> Vec<Vec<u8>> {
+        indexer_common::domain::ledger::LedgerState::stored_root_keys()
+    }
+
+    /// See [`indexer_common::domain::ledger::LedgerState::sweep_stray_roots`].
+    pub fn sweep_stray_roots(doomed: &[Vec<u8>]) -> u64 {
+        indexer_common::domain::ledger::LedgerState::sweep_stray_roots(doomed)
+    }
+
     /// See [`indexer_common::domain::ledger::LedgerState::repair_root_counts`].
     pub fn repair_root_counts<'a>(
         window: impl IntoIterator<Item = (&'a SerializedLedgerStateKey, LedgerVersion)>,

--- a/chain-indexer/tests/mainnet_runtime.rs
+++ b/chain-indexer/tests/mainnet_runtime.rs
@@ -242,6 +242,7 @@ async fn init_ledger_db() -> anyhow::Result<tempfile::TempDir> {
     ledger_db::init(ledger_db::Config {
         cache_max_nodes: 1_024,
         cnn_url,
+        vacuum_on_startup: false,
     })
     .await
     .context("init ledger db")?;

--- a/indexer-common/benches/ledger_transaction.rs
+++ b/indexer-common/benches/ledger_transaction.rs
@@ -35,6 +35,7 @@ fn init_ledger_db(rt: &Runtime) -> tempfile::TempDir {
         ledger_db::init(ledger_db::Config {
             cache_max_nodes: 1_024,
             cnn_url: sqlite_file,
+            vacuum_on_startup: false,
         })
         .await
         .expect("init ledger_db");

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -467,6 +467,32 @@ impl LedgerState {
             .map(|wanted| raise_root_counts(&default_storage::<v1_1::LedgerDb>(), &wanted))
     }
 
+    /// The keys of all stored gc root rows, straight from the DB - no in-memory root-count
+    /// deltas merged in, unlike [Self::persisted_root_hashes]. See [Self::sweep_stray_roots]
+    /// for the ordering this enables.
+    pub fn stored_root_keys() -> Vec<Vec<u8>> {
+        v1_1::LedgerDb::new(crate::infra::ledger_db::pool()).root_keys()
+    }
+
+    /// Delete the given stray gc root rows - stored roots outside the retention window, which
+    /// never get an unpersist ([RootCountRepair::strays]) and would pin their DAGs forever.
+    /// Returns the number of deleted roots.
+    ///
+    /// Call BEFORE this process's first flush (in particular before
+    /// [Self::repair_root_counts]): rows deleted then carry only dead runs' accounting, since
+    /// any live in-memory root delta held by a concurrent component (e.g. wallet-indexer's
+    /// `ChildRef` charged keys in standalone mode) is still unflushed, so a later flush
+    /// recreates its row from zero and stays balanced. Deleting after a flush can split a
+    /// component's +1 (already merged into the row and gone from the cache) from its pending
+    /// -1, tripping storage-core's non-negative root count assert.
+    ///
+    /// A window root shared with pre-window blocks keeps its full stored count and may pin
+    /// one snapshot's DAG; accepted, since lowering counts risks the resync the repair
+    /// machinery exists to avoid.
+    pub fn sweep_stray_roots(doomed: &[Vec<u8>]) -> u64 {
+        v1_1::LedgerDb::new(crate::infra::ledger_db::pool()).delete_roots(doomed)
+    }
+
     fn arena_root_hash(
         key: &SerializedLedgerStateKey,
         ledger_version: LedgerVersion,
@@ -2400,8 +2426,9 @@ pub struct RootCountRepair {
     /// raise, are never checked, so they never land here.
     pub culled_roots: usize,
 
-    /// Root rows outside the window. Left alone - nothing will ever unpersist them, so they leak
-    /// disk, but deleting one that is still needed costs a resync.
+    /// Root rows outside the window. Normally zero: the startup sweep deletes them before the
+    /// repair runs (see [LedgerState::sweep_stray_roots]). Non-zero only when the sweep was
+    /// skipped because no window root was stored (mis-paired or fresh DB).
     pub strays: usize,
 }
 
@@ -2601,6 +2628,7 @@ mod tests {
             ledger_db::init(ledger_db::Config {
                 cache_max_nodes: 1_024,
                 cnn_url: sqlite_ledger_db_file,
+                vacuum_on_startup: false,
             })
             .await
             .expect("ledger DB can be initialized");
@@ -2772,6 +2800,7 @@ mod tests {
             ledger_db::init(ledger_db::Config {
                 cache_max_nodes: 1_024,
                 cnn_url: sqlite_ledger_db_file,
+                vacuum_on_startup: false,
             })
             .await
             .expect("ledger DB can be initialized");
@@ -2912,6 +2941,7 @@ mod tests {
             ledger_db::init(ledger_db::Config {
                 cache_max_nodes: 1_024,
                 cnn_url: sqlite_ledger_db_file,
+                vacuum_on_startup: false,
             })
             .await
             .expect("ledger DB can be initialized");
@@ -3718,6 +3748,44 @@ mod root_count_repair_tests {
         Ok(())
     }
 
+    /// The snapshot-then-delete sweep removes exactly the roots outside the window - whatever
+    /// their stored count - and leaves window roots untouched, also when the doomed set spans
+    /// several delete batches.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sweep_deletes_only_strays() -> Result<(), Box<dyn StdError>> {
+        let (pool, storage) = pool_and_storage().await?;
+        let kept = persisted_root(&storage, 42);
+        let stray = persisted_root(&storage, 43);
+        let multi_count_stray = persisted_root(&storage, 44);
+        set_stored_root_count(&pool, &multi_count_stray.hash(), 3);
+
+        // Push the doomed set past one delete batch (BATCH_INSERT_SIZE = 1000).
+        for n in 0..1050_u32 {
+            let mut bytes = [0xd0; 32];
+            bytes[..4].copy_from_slice(&n.to_be_bytes());
+            set_stored_root_count(&pool, &arena_hash(bytes), 1);
+        }
+
+        let db = LedgerDb::new(pool.clone());
+        let window = std::collections::HashSet::from([kept.hash().0.to_vec()]);
+        let doomed = db
+            .root_keys()
+            .into_iter()
+            .filter(|key| !window.contains(key))
+            .collect::<Vec<_>>();
+        let swept = db.delete_roots(&doomed);
+
+        assert_eq!(swept, 1052);
+        assert_eq!(stored_root_count(&pool, &kept.hash()).await?, Some(1));
+        assert_eq!(stored_root_count(&pool, &stray.hash()).await?, None);
+        assert_eq!(
+            stored_root_count(&pool, &multi_count_stray.hash()).await?,
+            None
+        );
+
+        Ok(())
+    }
+
     /// Repairing is idempotent: a second pass over an already-repaired DB changes nothing.
     #[tokio::test(flavor = "multi_thread")]
     async fn repair_is_idempotent() -> Result<(), Box<dyn StdError>> {
@@ -3777,6 +3845,7 @@ mod root_count_repair_tests {
         ledger_db::init(ledger_db::Config {
             cache_max_nodes: 1_024,
             cnn_url,
+            vacuum_on_startup: false,
         })
         .await
         .context("init ledger DB")?;

--- a/indexer-common/src/domain/ledger/transaction.rs
+++ b/indexer-common/src/domain/ledger/transaction.rs
@@ -468,6 +468,7 @@ mod tests {
             ledger_db::init(ledger_db::Config {
                 cache_max_nodes: 1_024,
                 cnn_url: sqlite_ledger_db_file,
+                vacuum_on_startup: false,
             })
             .await
             .expect("ledger DB can be initialized");

--- a/indexer-common/src/infra/ledger_db.rs
+++ b/indexer-common/src/infra/ledger_db.rs
@@ -18,9 +18,26 @@ pub mod v1_1;
 use serde::Deserialize;
 
 #[cfg(feature = "cloud")]
+type Pool = crate::infra::pool::postgres::PostgresPool;
+
+#[cfg(feature = "standalone")]
+type Pool = crate::infra::pool::sqlite::SqlitePool;
+
+/// The pool the ledger DB was initialized with. Storage-core keeps its copy private, and
+/// maintenance SQL like [v1_1::LedgerDb::delete_roots] needs direct access.
+#[cfg(any(feature = "cloud", feature = "standalone"))]
+static POOL: std::sync::OnceLock<Pool> = std::sync::OnceLock::new();
+
+#[cfg(any(feature = "cloud", feature = "standalone"))]
+pub(crate) fn pool() -> Pool {
+    POOL.get().expect("ledger DB is initialized").clone()
+}
+
+#[cfg(feature = "cloud")]
 pub fn init(config: Config, pool: crate::infra::pool::postgres::PostgresPool) {
     let Config { cache_max_nodes } = config;
 
+    let _ = POOL.set(pool.clone());
     let db = v1_1::LedgerDb::new(pool);
     let _ = midnight_storage_core_v1::storage::set_default_storage(|| {
         midnight_storage_core_v1::Storage::new(cache_max_nodes, db)
@@ -30,10 +47,12 @@ pub fn init(config: Config, pool: crate::infra::pool::postgres::PostgresPool) {
 #[cfg(feature = "standalone")]
 pub async fn init(config: Config) -> Result<(), Error> {
     use crate::infra::{migrations, pool::sqlite};
+    use log::warn;
 
     let Config {
         cache_max_nodes,
         cnn_url,
+        vacuum_on_startup,
     } = config;
 
     // storage-core assumes a single writer: `flush_*` reads root counts and
@@ -48,20 +67,234 @@ pub async fn init(config: Config) -> Result<(), Error> {
     // loss could keep block N in the main DB while dropping N's ledger state here - the
     // startup filter would then silently seed from an older state and diverge. FULL keeps
     // the cross-file ordering: a ledger state is durable before its block row can be.
-    let pool = sqlite::SqlitePool::new(sqlite::Config {
-        cnn_url,
+    let mut pool = sqlite::SqlitePool::new(sqlite::Config {
+        cnn_url: cnn_url.clone(),
         max_connections: 1,
         synchronous_full: true,
     })
     .await?;
     migrations::sqlite::run_for_ledger_db(&pool).await?;
 
+    // Nodes culled by gc only land on SQLite's freelist; giving the pages back to the OS takes
+    // a vacuum, run here while nothing else uses the pool. A failed copy (e.g. no disk
+    // headroom) just postpones the shrink to a later startup; only a failure after the
+    // compacted copy was swapped in panics.
+    if vacuum_on_startup {
+        match vacuum_if_mostly_free(pool, &cnn_url).await {
+            Ok(vacuumed_pool) => pool = vacuumed_pool,
+            Err((error, recovered_pool)) => {
+                warn!(error:%; "cannot vacuum ledger DB");
+                pool = recovered_pool;
+            }
+        }
+    }
+
+    let _ = POOL.set(pool.clone());
     let db = v1_1::LedgerDb::new(pool);
     let _ = midnight_storage_core_v1::storage::set_default_storage(|| {
         midnight_storage_core_v1::Storage::new(cache_max_nodes, db)
     });
 
     Ok(())
+}
+
+/// Compact the ledger DB when the freelist dominates the file: at least twice the live pages,
+/// and worth at least 1 GiB. `VACUUM INTO` a sibling file (same volume - the system temp dir
+/// may be a smaller filesystem) then swap it in, so live pages are copied once, not twice.
+/// A copy left behind by a killed run is removed and rebuilt. Steady-state startups, whose
+/// freelist stays small, never pay any of this.
+///
+/// Returns the pool to continue with; on error the original file stays in place and the
+/// returned pool points at it.
+#[cfg(feature = "standalone")]
+async fn vacuum_if_mostly_free(
+    pool: crate::infra::pool::sqlite::SqlitePool,
+    cnn_url: &str,
+) -> Result<
+    crate::infra::pool::sqlite::SqlitePool,
+    (sqlx::Error, crate::infra::pool::sqlite::SqlitePool),
+> {
+    use log::info;
+
+    let stats = async {
+        let page_size = sqlx::query_scalar::<_, i64>("PRAGMA page_size")
+            .fetch_one(&*pool)
+            .await?;
+        let page_count = sqlx::query_scalar::<_, i64>("PRAGMA page_count")
+            .fetch_one(&*pool)
+            .await?;
+        let freelist_count = sqlx::query_scalar::<_, i64>("PRAGMA freelist_count")
+            .fetch_one(&*pool)
+            .await?;
+        let db_path = sqlx::query_scalar::<_, String>(
+            "SELECT file FROM pragma_database_list WHERE name = 'main'",
+        )
+        .fetch_one(&*pool)
+        .await?;
+        let journal_mode = sqlx::query_scalar::<_, String>("PRAGMA journal_mode")
+            .fetch_one(&*pool)
+            .await?;
+
+        Ok::<_, sqlx::Error>((page_size, page_count, freelist_count, db_path, journal_mode))
+    }
+    .await;
+    let (page_size, page_count, freelist_count, db_path, journal_mode) = match stats {
+        Ok(stats) => stats,
+        Err(error) => return Err((error, pool)),
+    };
+
+    // A copy left behind by a killed earlier run; remove it also when the thresholds below
+    // no longer fire.
+    let _ = std::fs::remove_file(format!("{db_path}.vacuum"));
+
+    if !should_vacuum(page_size, page_count, freelist_count) {
+        return Ok(pool);
+    }
+
+    info!(
+        page_count,
+        freelist_count;
+        "vacuuming ledger DB; this copies all live pages and can take a while"
+    );
+    let pool = vacuum_into_sibling(pool, cnn_url, &db_path, &journal_mode).await?;
+    info!("vacuumed ledger DB");
+
+    Ok(pool)
+}
+
+/// `VACUUM INTO` a sibling of the DB file and swap it in, returning a pool on the compacted
+/// file. On copy failure the original file and pool stay in place; a failure after the swap
+/// panics, since the half-finished state must not be built on silently.
+#[cfg(feature = "standalone")]
+async fn vacuum_into_sibling(
+    pool: crate::infra::pool::sqlite::SqlitePool,
+    cnn_url: &str,
+    db_path: &str,
+    journal_mode: &str,
+) -> Result<
+    crate::infra::pool::sqlite::SqlitePool,
+    (sqlx::Error, crate::infra::pool::sqlite::SqlitePool),
+> {
+    use crate::infra::pool::sqlite;
+
+    let compacted_path = format!("{db_path}.vacuum");
+
+    if let Err(error) = sqlx::query("VACUUM INTO $1")
+        .bind(&compacted_path)
+        .execute(&*pool)
+        .await
+    {
+        let _ = std::fs::remove_file(&compacted_path);
+        return Err((error, pool));
+    }
+
+    // Swap in the compacted copy. Closing the pool checkpoints and removes the WAL; the
+    // leftovers are removed before the rename anyway so the swapped-in file cannot see a
+    // stale WAL and nothing lingers.
+    pool.close().await;
+    let _ = std::fs::remove_file(format!("{db_path}-wal"));
+    let _ = std::fs::remove_file(format!("{db_path}-shm"));
+    std::fs::rename(&compacted_path, db_path).expect("cannot swap compacted ledger DB into place");
+
+    // Reopen with the same constraints as `init`: single writer and synchronous=FULL.
+    let pool = sqlite::SqlitePool::new(sqlite::Config {
+        cnn_url: cnn_url.to_owned(),
+        max_connections: 1,
+        synchronous_full: true,
+    })
+    .await
+    .unwrap_or_else(|error| panic!("cannot reopen vacuumed ledger DB: {error}"));
+
+    // VACUUM INTO always writes a rollback-journal file; restore the original mode (WAL in
+    // production) so the swap does not silently downgrade write performance.
+    sqlx::query_scalar::<_, String>(&format!("PRAGMA journal_mode = {journal_mode}"))
+        .fetch_one(&*pool)
+        .await
+        .unwrap_or_else(|error| panic!("cannot restore ledger DB journal mode: {error}"));
+
+    Ok(pool)
+}
+
+#[cfg(feature = "standalone")]
+fn should_vacuum(page_size: i64, page_count: i64, freelist_count: i64) -> bool {
+    const GIB: i64 = 1 << 30;
+    freelist_count * page_size >= GIB && freelist_count >= 2 * (page_count - freelist_count)
+}
+
+#[cfg(all(test, feature = "standalone"))]
+mod tests {
+    use super::{should_vacuum, vacuum_into_sibling};
+    use crate::infra::{migrations, pool::sqlite};
+
+    const PAGE_SIZE: i64 = 4096;
+    const GIB_PAGES: i64 = (1 << 30) / PAGE_SIZE;
+
+    /// The copy-and-swap keeps the data, reopens on the compacted file, and leaves no
+    /// temporary sibling behind.
+    #[tokio::test]
+    async fn vacuum_into_sibling_swaps_and_keeps_data() {
+        let temp_dir = tempfile::tempdir().expect("create tempdir");
+        let db_path = temp_dir
+            .path()
+            .join("ledger-db.sqlite")
+            .display()
+            .to_string();
+
+        let pool = sqlite::SqlitePool::new(sqlite::Config {
+            cnn_url: db_path.clone(),
+            max_connections: 1,
+            synchronous_full: true,
+        })
+        .await
+        .expect("create pool");
+        migrations::sqlite::run_for_ledger_db(&pool)
+            .await
+            .expect("run migrations");
+        sqlx::query("INSERT INTO ledger_db_roots (key, count) VALUES ($1, 7)")
+            .bind([0xab_u8; 32].as_slice())
+            .execute(&*pool)
+            .await
+            .expect("insert root");
+
+        let pool = vacuum_into_sibling(pool, &db_path, &db_path, "wal")
+            .await
+            .expect("vacuum into sibling");
+
+        let count =
+            sqlx::query_scalar::<_, i64>("SELECT count FROM ledger_db_roots WHERE key = $1")
+                .bind([0xab_u8; 32].as_slice())
+                .fetch_one(&*pool)
+                .await
+                .expect("read root back");
+        assert_eq!(count, 7);
+        assert!(!std::path::Path::new(&format!("{db_path}.vacuum")).exists());
+
+        // The compacted copy is rollback-journal; the swap must restore the original mode.
+        let journal_mode = sqlx::query_scalar::<_, String>("PRAGMA journal_mode")
+            .fetch_one(&*pool)
+            .await
+            .expect("read journal mode");
+        assert_eq!(journal_mode, "wal");
+    }
+
+    #[test]
+    fn vacuums_only_when_mostly_free_and_worthwhile() {
+        // The post-purge shape: freelist dwarfs the live pages.
+        assert!(should_vacuum(PAGE_SIZE, 50 * GIB_PAGES, 49 * GIB_PAGES));
+
+        // Steady state: file large, freelist small.
+        assert!(!should_vacuum(PAGE_SIZE, 50 * GIB_PAGES, GIB_PAGES));
+
+        // Mostly free but tiny: not worth a rewrite below 1 GiB reclaimed.
+        assert!(!should_vacuum(PAGE_SIZE, 300, 299));
+
+        // Exactly at both bounds: freelist worth 1 GiB and twice the live pages.
+        assert!(should_vacuum(
+            PAGE_SIZE,
+            GIB_PAGES + GIB_PAGES / 2,
+            GIB_PAGES
+        ));
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -74,6 +307,19 @@ pub struct Config {
 
     #[cfg(feature = "standalone")]
     pub cnn_url: String,
+
+    /// Compact the ledger DB at startup when gc has freed most of the file (see
+    /// `vacuum_if_mostly_free`). The compaction can take a while on a large backlog and runs
+    /// before anything else starts, so supervisors with tight startup timeouts may want this
+    /// off.
+    #[cfg(feature = "standalone")]
+    #[serde(default = "default_vacuum_on_startup")]
+    pub vacuum_on_startup: bool,
+}
+
+#[cfg(feature = "standalone")]
+fn default_vacuum_on_startup() -> bool {
+    true
 }
 
 #[cfg(feature = "standalone")]

--- a/indexer-common/src/infra/ledger_db/v1_1.rs
+++ b/indexer-common/src/infra/ledger_db/v1_1.rs
@@ -53,6 +53,72 @@ impl LedgerDb {
     pub fn new(pool: crate::infra::pool::sqlite::SqlitePool) -> Self {
         Self { pool }
     }
+
+    /// The keys of all gc root rows, straight from the DB. Unlike storage-core's `get_roots`,
+    /// no in-memory root-count deltas are merged in: a snapshot taken before this process's
+    /// first flush therefore cannot contain roots that concurrent components (e.g.
+    /// wallet-indexer's `ChildRef`s in standalone mode) only hold in memory yet.
+    pub fn root_keys(&self) -> Vec<Vec<u8>> {
+        block_in_place(|| {
+            Handle::current().block_on(async {
+                let query = indoc! {"
+                    SELECT key
+                    FROM ledger_db_roots
+                "};
+
+                sqlx::query_as::<_, (Vec<u8>,)>(query)
+                    .fetch_all(&*self.pool)
+                    .await
+                    .unwrap_or_panic("cannot get root keys")
+                    .into_iter()
+                    .map(|(key,)| key)
+                    .collect()
+            })
+        })
+    }
+
+    /// Delete the given gc root rows - whatever their stored count - in one transaction,
+    /// returning the number of deleted rows. Batched, so any number of keys fits the
+    /// backends' bind limits.
+    ///
+    /// This is the unpersist that never ran for roots stranded outside the retention window
+    /// (see `RootCountRepair::strays`); the DAGs they pinned become eligible for gc. Bypasses
+    /// storage-core on purpose: its backend adjusts counts one root at a time, each with its
+    /// own count read.
+    pub fn delete_roots(&self, doomed: &[Vec<u8>]) -> u64 {
+        block_in_place(|| {
+            Handle::current().block_on(async {
+                let mut tx = self
+                    .pool
+                    .begin()
+                    .await
+                    .unwrap_or_panic("begin transaction for delete roots");
+
+                let mut deleted = 0;
+                for chunk in doomed.chunks(BATCH_INSERT_SIZE) {
+                    let mut query = QueryBuilder::new("DELETE FROM ledger_db_roots WHERE key IN (");
+                    let mut keys = query.separated(", ");
+                    for key in chunk {
+                        keys.push_bind(key.as_slice());
+                    }
+                    query.push(")");
+
+                    deleted += query
+                        .build()
+                        .execute(&mut *tx)
+                        .await
+                        .unwrap_or_panic("cannot delete roots")
+                        .rows_affected();
+                }
+
+                tx.commit()
+                    .await
+                    .unwrap_or_panic("commit transaction for delete roots");
+
+                deleted
+            })
+        })
+    }
 }
 
 impl DB for LedgerDb {

--- a/indexer-standalone/config.yaml
+++ b/indexer-standalone/config.yaml
@@ -31,6 +31,10 @@ infra:
   ledger_db:
     cache_max_nodes: 100000
     cnn_url: "/data/ledger-db.sqlite"
+    # Compact the ledger DB at startup once gc has freed most of the file (>= 1 GiB and >= 2x
+    # the live pages). Copies the live pages next to the DB and swaps; can take a while on a
+    # large backlog, so raise the supervisor's startup timeout or turn this off if that bites.
+    vacuum_on_startup: true
 
   node:
     url: "ws://localhost:9944"


### PR DESCRIPTION
Addresses the ledger-db half of #1417 (the `contract_actions` half is #1075).

## What we found

Running standalone indexers against preprod, our `ledger-db.sqlite` files grew to 203 GB while the node's pruned ledger sat at 156 GB. Digging into the file showed why: `ledger_db_roots` held **1.75 million rows — one per block ever indexed** — instead of the ~1000 the retention window implies. These are gc roots stranded by runs that predate the retention/unpersist balancing, and `repair_root_counts` already counts them (`strays`) but deliberately leaves them alone. Every one of them pins a full historical ledger state, so the gc-v1 mark-and-sweep from #1086 had nothing it was allowed to cull: of 46 M arena nodes (172 GB payload), nearly all were garbage no query could ever reach, exactly the composition described in #1417.

We validated the remediation on two production preprod boxes before writing any code: stop the indexer, delete every root not reachable from the newest blocks' `ledger_state_key`s (the key column is a 1-byte tag followed by the raw arena hash; the mapping matched 1000/1000 on live data), restart. The indexer resumed cleanly, kept exactly its retention window (1003 roots), and gc started reclaiming the backlog on the next block.

## What this PR does

**1. Sweeps stray roots at startup (cloud and standalone).** Before the process's first flush, the chain-indexer snapshots the stored root keys, and — provided at least one retention-window root is among them, proving the ledger DB and the block storage belong together — deletes everything outside the window in one chunked transaction. This is precisely the unpersist that never ran for those roots. Every deployment heals itself on its next restart; no resync, no manual SQL.

**2. Compacts the file at startup (standalone).** Gc only moves pages to SQLite's freelist; nothing in the codebase ever returned them to the OS (#1417's point 3). Once the freelist is worth at least 1 GiB and twice the live pages, startup runs `VACUUM INTO` a sibling of the DB file (same volume — the system temp dir may be smaller), swaps it in, and restores the original journal mode (`VACUUM INTO` always emits a rollback-journal file, which would otherwise silently downgrade WAL). The thresholds mean a healthy deployment never pays for this; `ledger_db.vacuum_on_startup: false` opts out for supervisors with tight startup timeouts.

On our boxes this takes the file from 203 GB to single-digit GB after gc works through the backlog, and growth stops immediately after the sweep.

## Why the sweep runs where it does

The ordering is load-bearing. In standalone mode all components share one storage backend, and wallet-indexer's relevance checks create `ChildRef`s that hold +1 root deltas in memory. Deleting root rows after a flush could split such a component's accounting — its +1 merged into a row we then delete, its −1 still pending — and trip storage-core's `roots counts can't be negative` assert (the #1392/#1393 family). Deleting **before** the first flush makes that impossible: any live delta still starts from zero on a fresh row at its first flush. The sweep also runs before `repair_root_counts`, which on a bloated DB makes the repair scan ~1000 rows instead of millions.

Deliberate limits: rows are deleted whole, never decremented, so a window root that also served pre-window blocks keeps its inflated count and may pin one snapshot's DAG — lowering counts risks the resync the repair machinery exists to avoid. On Postgres the sweep works the same way and autovacuum reuses the space; returning it to the OS (`VACUUM FULL`) stays an operator decision.

## Testing

- Sweep: deletes exactly the strays (including multi-count rows), spares window roots, spans multiple delete batches (1050 keys).
- Vacuum: copy-and-swap keeps data, leaves no temp file, restores WAL; threshold arithmetic covered at its bounds.
- Full suite passes for both `standalone` and `cloud` features; clippy clean.
- The root cleanup itself has been running on two preprod deployments since 2026-07-30 (applied manually with the same statement this PR automates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
