### PR TITLE
test: fix qa/tests compile-check and gate it in CI

### DIFF
--- a/.github/workflows/ci-qa.yaml
+++ b/.github/workflows/ci-qa.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   qa-tests:
-    name: tests — lint, format, audit
+    name: tests — compile, lint, format, audit
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/ci-qa.yaml
+++ b/.github/workflows/ci-qa.yaml
@@ -37,6 +37,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Compile check
+        run: bun run compile-check
+
       - name: Lint
         run: bun run lint
 

--- a/qa/tests/bun.lock
+++ b/qa/tests/bun.lock
@@ -40,6 +40,7 @@
     "brace-expansion": "^5.0.9",
     "js-yaml": "^4.3.1",
     "minimatch": "^10.2.5",
+    "nanoid": "^3.3.17",
   },
   "packages": {
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
@@ -596,7 +597,7 @@
 
     "nan": ["nan@2.28.0", "", {}, "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ=="],
 
-    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 

--- a/qa/tests/package.json
+++ b/qa/tests/package.json
@@ -64,6 +64,7 @@
   "overrides": {
     "minimatch": "^10.2.5",
     "brace-expansion": "^5.0.9",
-    "js-yaml": "^4.3.1"
+    "js-yaml": "^4.3.1",
+    "nanoid": "^3.3.17"
   }
 }

--- a/qa/tests/tests/integration/basic/queries/bridge-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/bridge-queries.test.ts
@@ -29,7 +29,7 @@
 //
 // Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/941
 
-import log from '@utils/logging/logger';
+import log from '@utils/logging/loggerXX';
 import { env } from 'environment/model';
 import type { TestContext } from 'vitest';
 import '@utils/logging/test-logging-hooks';

--- a/qa/tests/tests/integration/basic/queries/bridge-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/bridge-queries.test.ts
@@ -29,7 +29,7 @@
 //
 // Tracking: https://github.com/midnightntwrk/midnight-indexer/issues/941
 
-import log from '@utils/logging/loggerXX';
+import log from '@utils/logging/logger';
 import { env } from 'environment/model';
 import type { TestContext } from 'vitest';
 import '@utils/logging/test-logging-hooks';

--- a/qa/tests/tests/integration/basic/queries/bridge-queries.test.ts
+++ b/qa/tests/tests/integration/basic/queries/bridge-queries.test.ts
@@ -34,7 +34,7 @@ import { env } from 'environment/model';
 import type { TestContext } from 'vitest';
 import '@utils/logging/test-logging-hooks';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
-import type { BridgeUserTransfer } from '@utils/indexer/indexer-types';
+import type { BridgeEvent, BridgeUserTransfer } from '@utils/indexer/indexer-types';
 
 const httpClient = new IndexerHttpClient();
 
@@ -73,10 +73,11 @@ query BridgeEventsAll($RECIPIENT: HexEncoded, $VARIANT: BridgeEventVariant, $BLO
 const MALFORMED_RECIPIENT_ODD_LENGTH = 'abc';
 const MALFORMED_RECIPIENT_NON_HEX = 'zz'.repeat(32);
 
-// Reads the `id` from any variant (typed as optional on non-UserTransfer).
-const bridgeEventId = (e: { id?: number }): number => Number(e.id);
-// Reads the `recipient` from a recipient-bearing variant.
-const bridgeEventRecipient = (e: { recipient?: string }): string | undefined => e.recipient;
+// Reads the `id` every variant carries (optional only on BridgeEventOther).
+const bridgeEventId = (e: BridgeEvent): number => Number(e.id);
+// Reads `recipient` from the variants that carry one; undefined for the rest.
+const bridgeEventRecipient = (e: BridgeEvent): string | undefined =>
+  'recipient' in e ? e.recipient : undefined;
 
 // Probed once against the target environment: whether the bridge surface exists,
 // a real UserTransfer to assert shape against, and a fully-claimed address (a

--- a/qa/tests/tests/integration/basic/subscriptions/bridge-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/bridge-subscriptions.test.ts
@@ -289,7 +289,7 @@ describe.skipIf(env.isUndeployedEnv())('bridge subscriptions', () => {
       const events = framesToEvents(frames);
       expect(events.length).toBeGreaterThan(0);
       for (const event of events) {
-        expect((event as { recipient?: string }).recipient).toBe(recipient);
+        expect('recipient' in event ? event.recipient : undefined).toBe(recipient);
       }
     }, 60_000);
 

--- a/qa/tests/tsconfig.json
+++ b/qa/tests/tsconfig.json
@@ -15,5 +15,29 @@
     },
     "types": ["vitest/globals"]
   },
-  "include": ["src", "tests", "types", "coverage/src"]
+  "include": [
+    "src",
+    "tests",
+    "types",
+    "coverage/src",
+    "setup",
+    "environment",
+    "utils",
+    // The three project configs import nothing but `path` and `vitest/config`,
+    // so they can be gated now. The root `vitest.config.ts` cannot: it imports
+    // the two reporters parked below.
+    "vitest.config.smoke.ts",
+    "vitest.config.integration.ts",
+    "vitest.config.e2e.ts"
+  ],
+  // Excluded pending #1423: both custom reporters implement the vitest<=3
+  // `onFinished` hook, which vitest 4 no longer dispatches. Deliberate,
+  // tracked park — when #1423 migrates them, drop the `utils/reporters/**`
+  // entry only and add `vitest.config.ts` to `include`. The `exclude` key
+  // and its `node_modules` entry must stay, for the reason below.
+  //
+  // `node_modules` is listed explicitly because naming `exclude` at all
+  // replaces TypeScript's implicit default of
+  // ["node_modules", "bower_components", "jspm_packages", outDir].
+  "exclude": ["node_modules", "utils/reporters/**"]
 }


### PR DESCRIPTION
## Summary

Closes #1415.

`bun run compile-check` (`tsc --noEmit`) failed on `main`, and the script was
wired to no workflow — so the only static check that can catch a broken import
or a bad type in `qa/tests` both failed *and* ran nowhere. A green set of PR
checks did not mean `qa/tests` type-checks.

This PR has four strands. The last two are not in the ticket text but are
required to make the gate meaningful rather than decorative:

| # | Strand | Why it is here |
|---|---|---|
| 1 | Fix the `BridgeEvent` type error | The ticket's first bullet. Without it the gate cannot go green. |
| 2 | Add the `Compile check` CI step | The ticket's third bullet. |
| 3 | Widen `tsconfig.json`'s `include` | Without it the gate misses `setup/` **entirely** — most of the ticket's stated point. |
| 4 | Clear a high `nanoid` audit advisory | `bun audit` exits 1 on the merge-base, so the very job this PR extends would go red on an unrelated pre-existing advisory. |

## 1 — Bridge type fix (`bf66150e`)

`tsc --noEmit` on `main` produced **exactly one** error — the sweep the ticket
asked for is a known quantity, not a pile:

```
tests/integration/basic/queries/bridge-queries.test.ts(172,37): error TS2345:
  Argument of type 'BridgeEvent' is not assignable to parameter of type
  '{ recipient?: string | undefined; }'.
  Type 'BridgeReserveTransfer' has no properties in common with type
  '{ recipient?: string | undefined; }'.
```

This is a **test-side typing bug, not a schema mismatch.** `indexer-api/graphql/schema-v4.graphql`
puts `recipient` on only two of the five `BridgeEvent` implementors
(`BridgeUserTransfer`, `BridgeUnapprovedTransfer`), and the TS mirror in
`qa/tests/utils/indexer/indexer-types.ts` models that correctly. The error is
TypeScript's weak-type rule: the helper's `{ recipient?: string }` parameter is
all-optional, so `BridgeReserveTransfer` — sharing no property with it — is
rejected. The sibling `bridgeEventId` has the same weak shape but every variant
carries `id`, so it slipped through.

Fixed by typing the helper as `BridgeEvent` and narrowing with `in` — no cast,
no `as any`, no `@ts-expect-error`:

```ts
const bridgeEventRecipient = (e: BridgeEvent): string | undefined =>
  'recipient' in e ? e.recipient : undefined;
```

Runtime behaviour is unchanged: `'recipient' in e` is true exactly when the key
is present, which is what reading the property already relied on. The bridge
suites are `describe.skipIf(env.isUndeployedEnv())` and additionally self-skip
when the surface or data is absent, so no execution behaviour changes anywhere.

Two consistency follow-ons in the same commit:
- `bridge-subscriptions.test.ts:292` expressed the identical intent via an
  `as { recipient?: string }` cast, which is why it never errored. A cast that
  silences the union is precisely what this PR's gate is meant to catch, so the
  sibling sites no longer disagree.
- `bridgeEventId` takes `BridgeEvent` too. To be explicit about what this does
  **not** buy: `BridgeEventOther` declares `id?`, so `e.id` is
  `number | undefined` and `Number(e.id)` can still yield `NaN` without a
  compile error. The gain is only that the parameter is constrained to the
  domain union instead of "any object with an optional numeric id" — the weak
  shape that caused the original error.

## 2 — CI gate (`ee3af6f9`, `6397c9b2`)

`.github/workflows/ci-qa.yaml`, job `qa-tests`:

```yaml
      - name: Install dependencies
        run: bun install --frozen-lockfile

      - name: Compile check
        run: bun run compile-check

      - name: Lint
        run: bun run lint
```

- **First among the checks**, deliberately. Actions stops a job at the first
  failing step, so ordering decides what gets reported, and a type error is the
  most severe signal. (This already applied: `lint` masks `format:check` and
  `audit`.)
- **No `continue-on-error`** — verifiable from the diff alone, so a non-zero
  exit fails the job and therefore the PR.
- **The `paths:` filter needs no change.** Every input to the check — the
  TypeScript sources, `tsconfig.json`, and the dependency manifest — lives under
  `qa/**`, so Dependabot bumps to `qa/tests` are covered too.

The job's display name became `tests — compile, lint, format, audit`, **in its
own commit (`6397c9b2`)**. Renaming a job renames the status check it reports,
and I could not verify from the repository API whether the old name is
configured as a required check anywhere. A path-filtered workflow is a poor
candidate for a required check (it would never report on PRs that don't touch
`qa/**`), so this is unlikely — but the rename is isolated so a maintainer can
revert just that commit without losing the gate.

## 3 — Widened type-check coverage (`20a3f097`)

`include` was `["src", "tests", "types", "coverage/src"]`. Measured with
`tsc --listFiles`, that type-checked **none** of `setup/` and missed six `utils`
files — they are entry points referenced from the vitest configs rather than
imported from anything under `include`. ESLint doesn't help either: its
`ignores` list covers `**/*.config.ts`.

So a broken import in `setup/global-setup.ts` or
`utils/undeployed/environment-manager.ts` — the undeployed bootstrap paths —
passed every check in CI. That is the exact failure mode this ticket exists to
close.

Measured effect, `87 → 96` files type-checked; nine files newly covered:

```
setup/global-setup.ts                     utils/logging/setup.ts
setup/undeployed-genesis-setup.ts         utils/undeployed/environment-manager.ts
setup/undeployed-with-data-setup.ts       vitest.config.e2e.ts
utils/custom-matchers.ts                  vitest.config.integration.ts
                                          vitest.config.smoke.ts
```

Two deliberate exclusions, both documented inline:

- **`utils/reporters/**` — parked, tracked in #1423.** Including them surfaces a
  real pre-existing defect: both custom reporters implement the vitest<=3
  `onFinished` hook, which vitest 4 no longer dispatches, so **neither reporter
  has been invoked since vitest 4 landed (#1215, 2026-06-02)**. The
  custom-JUnit and Xray-JSON evidence path has been silently empty since — the
  built-in `junit`/`json` reports kept updating while the custom ones stopped
  dead on that date. Fixing it is behavioural work on the evidence pipeline that
  needs its own review and a suite run, so it is out of scope here.
- **Root `vitest.config.ts`** — excluded only because it imports those two
  reporters. The three *project* configs import nothing but `path` and
  `vitest/config`, so they are gated now.
- **`node_modules` is listed explicitly** in the new `exclude` because naming
  `exclude` at all replaces TypeScript's implicit default of
  `["node_modules", "bower_components", "jspm_packages", outDir]`.

## 4 — `nanoid` high audit advisory (`cd79f55c`)

`bun audit --audit-level=high` exits **1 on this PR's merge-base**:

```
nanoid  <3.3.17
  vitest › @vitest/mocker › vite › postcss › nanoid
  high: nanoid: custom generators can loop indefinitely when size is zero
        https://github.com/advisories/GHSA-2v37-7h3g-55p8
```

Since `audit` is a hard gate that fails on advisories pre-existing on `main`,
leaving it would have turned this PR's own job red on something unrelated to the
change. Fixed via an `overrides` entry, joining the three already in the file.

Worth recording, because the obvious command is wrong here: **`bun update nanoid`
does not fix this** — it adds `nanoid` as a *direct* dependency at `^6.0.1` and
leaves the vulnerable transitive copy in place as `postcss/nanoid@3.3.16`. An
override is required because `postcss` 8.5.19 is already the version `vite`
resolves and still declares `nanoid: ^3.3.12`, so nothing upstream forces the
patched build. Pinned to the v3 line (`^3.3.17`, resolves 3.3.18) so `postcss`
keeps the v3 API — a within-range nudge, not a range violation, and `nanoid` is
not imported directly anywhere under `tests/`, `utils/`, `setup/`,
`environment/` or `coverage/`.

**If a reviewer would rather see this as a separate `chore(deps)` PR** mirroring
#1408, `cd79f55c` is the base commit of this branch and cherry-picks cleanly on
its own.

## Acceptance criteria

| AC | Status | Evidence |
|---|---|---|
| **AC1** — `compile-check` exits 0 | Met | `cd qa/tests && bun install --frozen-lockfile && bun run compile-check` → **exit 0** on this branch (was exit 2 on the merge-base with exactly one error). Strictly satisfied on `main` at merge; this branch is the evidence. |
| **AC2** — the job runs it and fails the PR | Met | The `Compile check` step is visible and green in this PR's own `ci-qa / tests — compile, lint, format, audit` run, positioned first among the checks with no `continue-on-error`. |
| **AC3** — a deliberately broken import fails the new gate | Met | See below. |

**AC3 — CI demonstration.** Two commits on this branch, both permanently visible
in the check history:

1. `d82ceb5c` — `demo: TEMPORARY broken import to prove the gate`.
   **Failed run: https://github.com/midnightntwrk/midnight-indexer/actions/runs/31538510829**

   ```
   Compile check    $ tsc --noEmit
   Compile check    tests/integration/basic/queries/bridge-queries.test.ts(32,17): error TS2307:
                      Cannot find module '@utils/logging/loggerXX' or its corresponding type declarations.
   Compile check    ##[error]Process completed with exit code 2.
   ```

   The job's step outcomes are the substantive proof — the gate does not merely
   report, it **blocks**:

   | Step | Outcome |
   |---|---|
   | Install dependencies | success |
   | **Compile check** | **failure** |
   | Lint | skipped |
   | Format check | skipped |
   | Audit | skipped |

   Note that `tools/block-scanner` and `scripts — shellcheck` both stayed green
   in that same run, so the failure is attributable to this step alone.

2. `653dc384` — `Revert "demo: TEMPORARY broken import to prove the gate"`.
   **Green run: https://github.com/midnightntwrk/midnight-indexer/actions/runs/31538632695**
   — `Compile check`, `Lint`, `Format check` and `Audit` all success. The
   reverted tree is byte-identical to the pre-demo tree (`a65b23d0`).

Both runs remain permanently visible in this PR's check history, so the
demonstration is auditable without leaving the break in the tree.

**AC3 — local counter-proof, which is what makes the gate's *value* reviewable
rather than just its existence.** With the same break in place:

| Check | Result |
|---|---|
| `bun run compile-check` | **exit 2** — `error TS2307: Cannot find module '@utils/logging/loggerXX'` |
| `bun run lint` | exit **0** (passes) |
| `bun run format:check` | exit **0** (passes) |

Root cause is structural: `qa/tests/eslint.config.mjs` has no
`eslint-plugin-import` and no type-aware linting (`parserOptions` has no
`project`), so ESLint cannot resolve or check import paths at all. Adding those
would be duplicate machinery — `tsc` already covers unresolvable imports.

**The widening is a real gate, not just extra files in a list.** Breaking an
import in two *newly covered* files — `setup/global-setup.ts` (a bootstrap path)
and `vitest.config.smoke.ts`, both invisible to every check on `main`:

```
setup/global-setup.ts(17,16): error TS2307: Cannot find module 'fsXX' ...
vitest.config.smoke.ts(17,30): error TS2307: Cannot find module 'vitest/configXX' ...
exit 2          # while lint and format:check both still exit 0
```

## Validation

All on the exact committed tree:

```
bun install --frozen-lockfile   Checked 429 installs across 433 packages (no changes)   exit 0
bun run compile-check           (no output)                                             exit 0
bun run lint                    (no output)                                             exit 0
bun run format                  (no resulting diff)                                     exit 0
bun run format:check            All matched files use Prettier code style!              exit 0
bun run audit                   (no advisories)                                         exit 0
actionlint (all workflows)      (no output)                                             exit 0
```

No test suites were run: this PR adds no test cases and changes no runtime
behaviour, and nothing in it touches a deployed stack or a chain.

## Out of scope

| Item | Where it lives |
|---|---|
| Wiring `test:e2e` into PR CI | #999 (ticket-excluded; needs a provisioned stack) |
| Migrating the two custom reporters to vitest 4's `onTestRunEnd`, then unparking them | **#1423** |
| Adding `eslint-plugin-import` / type-aware linting | Duplicate of what `tsc` already covers |
| Gating `qa/tools/block-scanner` | Already gated — `ci-qa.yaml` job `block-scanner`, step "Lint (typecheck)" |
| `indexer-tests` | Rust crate, no TypeScript |

`qa/tests` was the only package with this hole; the repo has exactly two
`package.json` files outside `node_modules` and the other one was already gated.
