### PR TITLE
test: fix dust snapshot pinning and cover freshness window

### DIFF
--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -263,29 +263,39 @@ async function assertPinnedSnapshot(
   return highestIndex;
 }
 
+type PinnedSnapshotOutcome = { highestIndex: number } | { rejection: string };
+
 /**
  * Runs the per-block assertions unless the server refuses the block as older than
  * its snapshot freshness window, in which case the rejection message is returned
- * so the caller can step closer to the tip. `max_snapshot_age` is runtime
- * configuration the schema does not expose, so this rejection is the only signal
- * that the deployed window is narrower than the offset this test prefers — it is
- * configuration, not a defect. Every other failure propagates.
+ * so the caller can decide what that means in its context. `max_snapshot_age` is
+ * runtime configuration the schema does not expose, so this rejection is the only
+ * signal that the deployed window is narrower than a caller assumed. Every other
+ * failure propagates.
  */
 async function assertPinnedSnapshotUnlessStale(
   wsClient: IndexerWsClient,
   dustAddress: string,
   block: PinnedBlock,
-): Promise<string | null> {
+): Promise<PinnedSnapshotOutcome> {
   try {
-    await assertPinnedSnapshot(wsClient, dustAddress, block);
-    return null;
+    return { highestIndex: await assertPinnedSnapshot(wsClient, dustAddress, block) };
   } catch (error) {
     const message = extractSubscriptionErrorMessage(error);
     if (message.includes(FRESHNESS_REJECTION)) {
-      return message;
+      return { rejection: message };
     }
     throw error;
   }
+}
+
+/**
+ * Skips the current test, recording the reason in the run log as well as the
+ * report so a reader of either can tell why coverage was reduced.
+ */
+function skipWithReason(ctx: TestContext, reason: string): void {
+  log.warn(reason);
+  ctx.skip(true, reason);
 }
 
 /**
@@ -429,7 +439,8 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
      * invariant always runs, the cross-block comparison runs when a growth
      * boundary exists and reports the measured numbers when it does not.
      *
-     * @given two blocks inside the freshness window, the older one 400 blocks back
+     * @given two blocks inside the freshness window, the older one up to 400 blocks
+     *        back — closer when the deployed window is narrower or the chain shorter
      * @when a dustGenerations subscription is opened at each block's hash
      * @then each final progress event reports highestIndex equal to that block's
      *       dustGenerationEndIndex - 1 (on devnet today, endIndex 2452 yields
@@ -449,31 +460,28 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
       const dustAddress = generateDustAddressForNetworkId(env.getNetworkId().toLowerCase());
       const tipBlock = await fetchBlock();
 
-      if (tipBlock.height <= IN_WINDOW_OFFSET) {
-        return ctx.skip(
-          true,
-          `chain is too short to select a block ${IN_WINDOW_OFFSET} blocks back: tip height ` +
-            `${tipBlock.height}, needs more than ${IN_WINDOW_OFFSET}`,
-        );
-      }
-
       if (tipBlock.dustGenerationEndIndex === 0) {
-        return ctx.skip(
-          true,
+        return skipWithReason(
+          ctx,
           `generation tree is still empty at the tip (block ${tipBlock.height}, endIndex 0), ` +
             'where the resolver saturates highestIndex to 0 instead of endIndex - 1',
         );
       }
 
-      // Tier A — activity-independent, so it asserts on every run and every env.
-      // Start at the preferred offset and step closer to the tip while the server
-      // reports the snapshot out of window (a narrower max_snapshot_age) or the
-      // tree still empty (closer blocks hold a larger tree).
+      // Tier A at the tip is always exercisable — offset 0 is inside any window and
+      // needs no chain length — so it runs before any block discovery can skip.
+      await assertPinnedSnapshot(indexerWsClient, dustAddress, tipBlock);
+
+      // Then step closer to the tip while the server reports the snapshot out of
+      // window (a narrower max_snapshot_age) or the tree still empty (closer blocks
+      // hold a larger tree). The start is clamped so a short chain never addresses a
+      // negative height.
+      const startOffset = Math.min(IN_WINDOW_OFFSET, tipBlock.height - 1);
       let earlierBlock: PinnedBlock | undefined;
       let offsetUsed = 0;
       let lastRejection = '';
       for (
-        let offset = IN_WINDOW_OFFSET;
+        let offset = startOffset;
         offset >= MIN_IN_WINDOW_OFFSET;
         offset = Math.floor(offset / 2)
       ) {
@@ -482,29 +490,39 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
           log.warn(`Generation tree still empty at tip-${offset} (block ${candidate.height})`);
           continue;
         }
-        const rejection = await assertPinnedSnapshotUnlessStale(
+        const outcome = await assertPinnedSnapshotUnlessStale(
           indexerWsClient,
           dustAddress,
           candidate,
         );
-        if (rejection === null) {
+        if (!('rejection' in outcome)) {
           earlierBlock = candidate;
           offsetUsed = offset;
           break;
         }
-        lastRejection = rejection;
-        log.warn(`Snapshot at tip-${offset} (block ${candidate.height}) refused: ${rejection}`);
+        lastRejection = outcome.rejection;
+        log.warn(
+          `Snapshot at tip-${offset} (block ${candidate.height}) refused: ${outcome.rejection}`,
+        );
       }
 
-      await assertPinnedSnapshot(indexerWsClient, dustAddress, tipBlock);
-
       if (earlierBlock === undefined) {
-        return ctx.skip(
-          true,
-          `no usable older block between tip-${IN_WINDOW_OFFSET} and tip-${MIN_IN_WINDOW_OFFSET}: ` +
-            `tip ${tipBlock.height} (endIndex ${tipBlock.dustGenerationEndIndex}), ` +
-            `last rejection: ${lastRejection || 'none — tree empty at every offset tried'}`,
-        );
+        const attempted =
+          `tip ${tipBlock.height} (endIndex ${tipBlock.dustGenerationEndIndex}), offsets ` +
+          `${startOffset} down to ${MIN_IN_WINDOW_OFFSET}`;
+
+        // Being refused even at the smallest offset is not a configuration this
+        // deployment can reach: max_snapshot_age defaults to 500, nothing overrides
+        // it, and a value under MIN_IN_WINDOW_OFFSET would be absurd. The realistic
+        // cause is a regression in the freshness computation, which the negative
+        // test cannot catch either — its block stays rejected either way. Fail.
+        expect(
+          lastRejection,
+          `every candidate offset was refused as outside the snapshot freshness window, which ` +
+            `no deployable max_snapshot_age explains — ${attempted}`,
+        ).toBe('');
+
+        return skipWithReason(ctx, `generation tree empty at every offset tried — ${attempted}`);
       }
 
       // Tier B — the pinning comparison proper, possible only where the tree grew
@@ -517,9 +535,8 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
         `growth boundary found: ${boundaryFound}`;
 
       if (!boundaryFound) {
-        log.warn(`Tier B not exercised — ${measurements}`);
-        return ctx.skip(
-          true,
+        return skipWithReason(
+          ctx,
           `generation tree did not grow within the ${offsetUsed}-block in-window budget, ` +
             `so a cross-block comparison would be vacuous — ${measurements}`,
         );
@@ -528,8 +545,37 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
       const { before, after } = await findNewestGrowthBoundary(earlierBlock, tipBlock);
       log.debug(`Tier B comparing blocks ${before.height} and ${after.height} — ${measurements}`);
 
-      const beforeHighestIndex = await assertPinnedSnapshot(indexerWsClient, dustAddress, before);
-      const afterHighestIndex = await assertPinnedSnapshot(indexerWsClient, dustAddress, after);
+      // Tier B carries the least margin of anything here: the boundary pair is the
+      // oldest thing subscribed to, and the binary search plus these two
+      // subscriptions all run after it was selected. A refusal now is the window
+      // sliding past the boundary, not a pinning defect.
+      const beforeOutcome = await assertPinnedSnapshotUnlessStale(
+        indexerWsClient,
+        dustAddress,
+        before,
+      );
+      if ('rejection' in beforeOutcome) {
+        return skipWithReason(
+          ctx,
+          `growth boundary aged out of the freshness window before it could be compared: block ` +
+            `${before.height} refused (${beforeOutcome.rejection}) — ${measurements}`,
+        );
+      }
+      const afterOutcome = await assertPinnedSnapshotUnlessStale(
+        indexerWsClient,
+        dustAddress,
+        after,
+      );
+      if ('rejection' in afterOutcome) {
+        return skipWithReason(
+          ctx,
+          `growth boundary aged out of the freshness window before it could be compared: block ` +
+            `${after.height} refused (${afterOutcome.rejection}) — ${measurements}`,
+        );
+      }
+
+      const beforeHighestIndex = beforeOutcome.highestIndex;
+      const afterHighestIndex = afterOutcome.highestIndex;
       expect(
         beforeHighestIndex,
         `block ${before.height} should yield a strictly smaller snapshot than block ${after.height}`,
@@ -802,8 +848,8 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
       const tipBlock = await fetchBlock();
       const minimumTipHeight = OUT_OF_WINDOW_OFFSET + OUT_OF_WINDOW_MIN_MARGIN;
       if (tipBlock.height <= minimumTipHeight) {
-        return ctx.skip(
-          true,
+        return skipWithReason(
+          ctx,
           `chain is too short to address a block outside the freshness window: tip height ` +
             `${tipBlock.height}, needs more than ${minimumTipHeight}`,
         );
@@ -825,12 +871,12 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
       // introspection, so a clean completion means the indexer predates it rather
       // than that it regressed. Any other rejection reason is a real failure.
       if (outcome.failure === COMPLETED_WITHOUT_ERROR) {
-        const reason =
+        return skipWithReason(
+          ctx,
           `deployed indexer predates the snapshot freshness guard: a subscription at block ` +
-          `${staleBlock.height}, ${OUT_OF_WINDOW_OFFSET} blocks behind tip ${tipBlock.height}, ` +
-          `streamed a snapshot instead of being rejected`;
-        log.warn(reason);
-        return ctx.skip(true, reason);
+            `${staleBlock.height}, ${OUT_OF_WINDOW_OFFSET} blocks behind tip ` +
+            `${tipBlock.height}, streamed a snapshot instead of being rejected`,
+        );
       }
       expect(outcome.failure, 'the subscription should have surfaced a server error').toBeNull();
 

--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -151,6 +151,10 @@ function collectDustGenerations(
   });
 }
 
+// Rejection reason when the server accepted the subscription instead of failing it.
+// Tests that gate on a server-side guard being present branch on this.
+const COMPLETED_WITHOUT_ERROR = 'Subscription completed without error';
+
 /**
  * Subscribes to dustGenerations and resolves with the subscription error message.
  * Completion without an error, or a timeout, rejects.
@@ -176,7 +180,7 @@ function collectDustGenerationsError(
         },
         complete: () => {
           clearTimeout(timeout);
-          reject(new Error('Subscription completed without error'));
+          reject(new Error(COMPLETED_WITHOUT_ERROR));
         },
       },
       args.dustAddress,
@@ -213,6 +217,10 @@ type PinnedBlock = Awaited<ReturnType<typeof fetchBlock>>;
 // Staying 400 blocks back leaves ~100 blocks (~10 minutes at 6s blocks) of
 // margin for discovery, and survives the window being lowered.
 const IN_WINDOW_OFFSET = 400;
+
+// Far enough outside the window to survive it being raised.
+const OUT_OF_WINDOW_OFFSET = 5_000;
+const OUT_OF_WINDOW_MIN_MARGIN = 1_000;
 
 /**
  * Opens a block-pinned subscription and asserts the activity-independent
@@ -690,6 +698,68 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
       });
 
       expect(errorReceived.toLowerCase()).toMatch(/(invalid block hash|hex)/);
+    });
+
+    /**
+     * A snapshot request older than the freshness window is rejected up front.
+     *
+     * The indexer only keeps recent ledger states loadable, so it refuses a
+     * block-pinned snapshot whose block is more than `max_snapshot_age` behind the
+     * tip rather than failing mid-stream on garbage-collected state. The window is
+     * runtime configuration and is not exposed through the schema, so the block is
+     * chosen far enough back to stay outside any plausible value.
+     *
+     * @given a valid dust address and an indexed block 5000 blocks behind the tip
+     * @when a dustGenerations subscription is opened at that block's hash
+     * @then the subscription is rejected with the snapshot-freshness message, and not
+     *       with either neighbouring rejection (an unknown block hash, or a ledger
+     *       state that is no longer available)
+     *
+     * midnight-indexer#1427
+     */
+    test('should reject a block hash older than the snapshot freshness window', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Subscription', 'Dust', 'Generations', 'Negative'] };
+      if (!blockHashSurfacePresent) return ctx.skip(true, SURFACE_ABSENT_REASON);
+
+      const tipBlock = await fetchBlock();
+      const minimumTipHeight = OUT_OF_WINDOW_OFFSET + OUT_OF_WINDOW_MIN_MARGIN;
+      if (tipBlock.height <= minimumTipHeight) {
+        return ctx.skip(
+          true,
+          `chain is too short to address a block outside the freshness window: tip height ` +
+            `${tipBlock.height}, needs more than ${minimumTipHeight}`,
+        );
+      }
+
+      const staleBlock = await fetchBlock({ height: tipBlock.height - OUT_OF_WINDOW_OFFSET });
+      const dustAddress = generateDustAddressForNetworkId(env.getNetworkId().toLowerCase());
+
+      const outcome = await collectDustGenerationsError(indexerWsClient, {
+        dustAddress,
+        blockHash: staleBlock.hash,
+        dtimeCutoffHeight: 0,
+      }).then(
+        (message) => ({ message, failure: null as string | null }),
+        (failure: Error) => ({ message: null as string | null, failure: failure.message }),
+      );
+
+      // The guard is not present in every deployed build and cannot be detected by
+      // introspection, so a clean completion means the indexer predates it rather
+      // than that it regressed. Any other rejection reason is a real failure.
+      if (outcome.failure === COMPLETED_WITHOUT_ERROR) {
+        return ctx.skip(
+          true,
+          `deployed indexer predates the snapshot freshness guard: a subscription at block ` +
+            `${staleBlock.height}, ${OUT_OF_WINDOW_OFFSET} blocks behind tip ${tipBlock.height}, ` +
+            `streamed a snapshot instead of being rejected`,
+        );
+      }
+      expect(outcome.failure, 'the subscription should have surfaced a server error').toBeNull();
+
+      log.debug(`Received expected freshness rejection: ${outcome.message}`);
+      expect(outcome.message).toContain('older than the snapshot freshness window');
+      expect(outcome.message).not.toMatch(/unknown block hash/);
+      expect(outcome.message).not.toMatch(/no longer available/);
     });
   });
 

--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -23,12 +23,21 @@ import {
   DustGenerationsSubscriptionResponse,
 } from '@utils/indexer/websocket-client';
 import { extractSubscriptionErrorMessage } from '@utils/indexer/subscription-error';
+import { isBlockHashDustGenerationsSupported } from '@utils/indexer/schema-feature-probe';
 import { DustGenerationsEventSchema } from '@utils/indexer/graphql/schema';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
 import { env } from 'environment/model';
 import dataProvider from '@utils/testdata-provider';
 
 const indexerHttpClient = new IndexerHttpClient();
+
+// Every case in this file sends the block-hash subscription document, which fails
+// GraphQL validation outright on an environment still serving the older
+// startIndex/endIndex signature. Probed once, then each test skips rather than
+// reporting a missing surface as a behavioural failure.
+let blockHashSurfacePresent = false;
+const SURFACE_ABSENT_REASON =
+  'deployed indexer does not serve the block-hash dustGenerations signature';
 
 function encodeDustAddressAsHex(dustAddress: string): string {
   const { words } = bech32m.decode(dustAddress);
@@ -203,6 +212,16 @@ function eventsOfType(
 describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
   let indexerWsClient: IndexerWsClient;
 
+  beforeAll(async () => {
+    blockHashSurfacePresent = await isBlockHashDustGenerationsSupported();
+    if (!blockHashSurfacePresent) {
+      log.warn(
+        `dustGenerations(blockHash) is absent on ${env.getCurrentEnvironmentName()}; ` +
+          'skipping the whole surface',
+      );
+    }
+  }, 30_000);
+
   beforeEach(async () => {
     indexerWsClient = new IndexerWsClient();
     await indexerWsClient.connectionInit();
@@ -224,6 +243,7 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
      */
     test('should stream a complete generation snapshot for a registered dust address', async (ctx: TestContext) => {
       ctx.task!.meta.custom = { labels: ['Subscription', 'Dust', 'Generations'] };
+      if (!blockHashSurfacePresent) return ctx.skip(true, SURFACE_ABSENT_REASON);
 
       let rewardAddress: string;
       try {
@@ -264,6 +284,7 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
      */
     test('should deliver identical events for repeated subscriptions at the same block', async (ctx: TestContext) => {
       ctx.task!.meta.custom = { labels: ['Subscription', 'Dust', 'Generations'] };
+      if (!blockHashSurfacePresent) return ctx.skip(true, SURFACE_ABSENT_REASON);
 
       let rewardAddress: string;
       try {
@@ -301,6 +322,7 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
      */
     test('should snapshot the generation tree at the queried block rather than the tip', async (ctx: TestContext) => {
       ctx.task!.meta.custom = { labels: ['Subscription', 'Dust', 'Generations'] };
+      if (!blockHashSurfacePresent) return ctx.skip(true, SURFACE_ABSENT_REASON);
 
       let rewardAddress: string;
       try {
@@ -359,6 +381,7 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
      */
     test('should replay owned dtime updates before generation items when the cutoff is zero', async (ctx: TestContext) => {
       ctx.task!.meta.custom = { labels: ['Subscription', 'Dust', 'Generations'] };
+      if (!blockHashSurfacePresent) return ctx.skip(true, SURFACE_ABSENT_REASON);
 
       let rewardAddress: string;
       try {
@@ -412,6 +435,7 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
      */
     test('should deliver no dtime updates when the cutoff equals the snapshot block height', async (ctx: TestContext) => {
       ctx.task!.meta.custom = { labels: ['Subscription', 'Dust', 'Generations'] };
+      if (!blockHashSurfacePresent) return ctx.skip(true, SURFACE_ABSENT_REASON);
 
       let rewardAddress: string;
       try {
@@ -447,6 +471,7 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
      */
     test('should return an error for an invalid dust address', async (ctx: TestContext) => {
       ctx.task!.meta.custom = { labels: ['Subscription', 'Dust', 'Generations', 'Negative'] };
+      if (!blockHashSurfacePresent) return ctx.skip(true, SURFACE_ABSENT_REASON);
 
       const block = await fetchBlock();
       const errorReceived = await collectDustGenerationsError(indexerWsClient, {
@@ -469,6 +494,7 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
      */
     test('should return an error for a valid address that is meant for another networkid', async (ctx: TestContext) => {
       ctx.task!.meta.custom = { labels: ['Subscription', 'Dust', 'Generations', 'Negative'] };
+      if (!blockHashSurfacePresent) return ctx.skip(true, SURFACE_ABSENT_REASON);
 
       const targetNetworkId = env.getNetworkId().toLowerCase();
       const networkIds = env.getAllEnvironmentNames();
@@ -513,6 +539,7 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
      */
     test('should return an error for a valid dust address passed in hex format', async (ctx: TestContext) => {
       ctx.task!.meta.custom = { labels: ['Subscription', 'Dust', 'Generations', 'Negative'] };
+      if (!blockHashSurfacePresent) return ctx.skip(true, SURFACE_ABSENT_REASON);
 
       const targetNetworkId = env.getNetworkId().toLowerCase();
       const bech32DustAddress = generateDustAddressForNetworkId(targetNetworkId);
@@ -542,6 +569,7 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
      */
     test('should return an error for an unknown block hash', async (ctx: TestContext) => {
       ctx.task!.meta.custom = { labels: ['Subscription', 'Dust', 'Generations', 'Negative'] };
+      if (!blockHashSurfacePresent) return ctx.skip(true, SURFACE_ABSENT_REASON);
 
       const targetNetworkId = env.getNetworkId().toLowerCase();
       const dustAddress = generateDustAddressForNetworkId(targetNetworkId);
@@ -567,6 +595,7 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
      */
     test('should return an error for a malformed block hash', async (ctx: TestContext) => {
       ctx.task!.meta.custom = { labels: ['Subscription', 'Dust', 'Generations', 'Negative'] };
+      if (!blockHashSurfacePresent) return ctx.skip(true, SURFACE_ABSENT_REASON);
 
       const targetNetworkId = env.getNetworkId().toLowerCase();
       const dustAddress = generateDustAddressForNetworkId(targetNetworkId);
@@ -607,6 +636,7 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
      */
     test('first item transactionHash resolves via transactions(offset)', async (ctx: TestContext) => {
       ctx.task!.meta.custom = { labels: ['Subscription', 'Dust', 'Generations', 'Transaction'] };
+      if (!blockHashSurfacePresent) return ctx.skip(true, SURFACE_ABSENT_REASON);
 
       let rewardAddress: string;
       try {

--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -126,7 +126,9 @@ function collectDustGenerations(
         },
         error: (error) => {
           safeUnsubscribe(unsubscribe);
-          settle(() => reject(new Error(`Subscription error: ${JSON.stringify(error)}`)));
+          settle(() =>
+            reject(new Error(`Subscription error: ${extractSubscriptionErrorMessage(error)}`)),
+          );
         },
         complete: () => {
           settle(() => resolve(events));

--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -206,6 +206,73 @@ function eventsOfType(
   return events.filter((msg) => msg.data?.dustGenerations?.__typename === typename);
 }
 
+type PinnedBlock = Awaited<ReturnType<typeof fetchBlock>>;
+
+// The indexer rejects snapshots older than its `max_snapshot_age` (500 by
+// default) against the tip *at subscribe time*, not at block-selection time.
+// Staying 400 blocks back leaves ~100 blocks (~10 minutes at 6s blocks) of
+// margin for discovery, and survives the window being lowered.
+const IN_WINDOW_OFFSET = 400;
+
+/**
+ * Opens a block-pinned subscription and asserts the activity-independent
+ * invariants: every event is schema-valid, exactly one progress event terminates
+ * the snapshot, and its highestIndex is the queried block's tree size. Returns
+ * that highestIndex so callers can compare snapshots across blocks.
+ */
+async function assertPinnedSnapshot(
+  wsClient: IndexerWsClient,
+  dustAddress: string,
+  block: PinnedBlock,
+): Promise<number> {
+  const events = await collectDustGenerations(wsClient, {
+    dustAddress,
+    blockHash: block.hash,
+    dtimeCutoffHeight: 0,
+  });
+
+  assertEventsMatchSchema(events);
+  const progressEvents = eventsOfType(events, 'DustGenerationsProgress');
+  expect(progressEvents).toHaveLength(1);
+  const { highestIndex } = progressEvents[0].data!.dustGenerations as { highestIndex: number };
+  log.debug(
+    `Snapshot pinned to block ${block.height}: endIndex ${block.dustGenerationEndIndex}, ` +
+      `highestIndex ${highestIndex}, ${events.length} event(s)`,
+  );
+  expect(
+    highestIndex,
+    `highestIndex at block ${block.height} should reflect that block's tree size`,
+  ).toBe(block.dustGenerationEndIndex - 1);
+  return highestIndex;
+}
+
+/**
+ * Locates the newest block inside `(older, newer]` at which the generation tree
+ * grew — the lowest height whose dustGenerationEndIndex already equals `newer`'s —
+ * and returns the tight pair straddling it. Picking the newest rather than the
+ * oldest boundary in the range maximises the margin against the sliding freshness
+ * window. Callers must have established that the two bounding blocks differ.
+ */
+async function findNewestGrowthBoundary(
+  older: PinnedBlock,
+  newer: PinnedBlock,
+): Promise<{ before: PinnedBlock; after: PinnedBlock }> {
+  let low = older.height; // known to have a smaller endIndex than `newer`
+  let high = newer.height; // known to have `newer`'s endIndex
+
+  while (high - low > 1) {
+    const mid = Math.floor((low + high) / 2);
+    const block = await fetchBlock({ height: mid });
+    if (block.dustGenerationEndIndex === newer.dustGenerationEndIndex) {
+      high = mid;
+    } else {
+      low = mid;
+    }
+  }
+
+  return { before: await fetchBlock({ height: low }), after: await fetchBlock({ height: high }) };
+}
+
 // Dust generation registrations require a Cardano-side mapping which has no
 // counterpart in the `undeployed` environment. Skip the whole surface there;
 // re-enable once #1152 lands local Cardano test-data provisioning.
@@ -312,11 +379,21 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
     /**
      * The snapshot reflects the queried block's generation tree, not the tip's.
      *
-     * @given two blocks between which the dust generation tree has grown
-     *        (their dustGenerationEndIndex values differ)
+     * Blocks are discovered from queried chain state rather than by arithmetic on
+     * the tip height: any tip-relative fraction lands far outside the indexer's
+     * snapshot freshness window on a long-running chain. The strong comparison
+     * additionally needs the tree to have grown inside that window, which a quiet
+     * chain cannot guarantee, so the assertions are tiered — the per-block
+     * invariant always runs, the cross-block comparison runs when a growth
+     * boundary exists and reports the measured numbers when it does not.
+     *
+     * @given two blocks inside the freshness window, the older one 400 blocks back
      * @when a dustGenerations subscription is opened at each block's hash
      * @then each final progress event reports highestIndex equal to that block's
-     *       dustGenerationEndIndex - 1, so the earlier block yields the smaller snapshot
+     *       dustGenerationEndIndex - 1 (on devnet today, endIndex 2452 yields
+     *       highestIndex 2451)
+     * @and when the tree grew between the two blocks, the pair straddling the newest
+     *      growth boundary yields a strictly smaller snapshot before it than after
      *
      * midnight-indexer#1283
      */
@@ -324,47 +401,53 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
       ctx.task!.meta.custom = { labels: ['Subscription', 'Dust', 'Generations'] };
       if (!blockHashSurfacePresent) return ctx.skip(true, SURFACE_ABSENT_REASON);
 
-      let rewardAddress: string;
-      try {
-        rewardAddress = dataProvider.getCardanoRewardAddress('registered-with-dust');
-      } catch (error) {
-        log.warn(error);
-        ctx.skip?.(true, (error as Error).message);
-        return;
-      }
-
-      const dustAddress = await fetchDustAddress(rewardAddress);
+      // highestIndex is a global tree property — the resolver reports the pinned
+      // ledger state's first-free generation index minus one — so it needs no
+      // registered wallet and no Cardano fixture.
+      const dustAddress = generateDustAddressForNetworkId(env.getNetworkId().toLowerCase());
       const tipBlock = await fetchBlock();
-      const earlierBlock = await fetchBlock({ height: Math.floor(tipBlock.height / 2) });
+      const earlierBlock = await fetchBlock({ height: tipBlock.height - IN_WINDOW_OFFSET });
 
-      if (
-        earlierBlock.dustGenerationEndIndex === 0 ||
-        earlierBlock.dustGenerationEndIndex === tipBlock.dustGenerationEndIndex
-      ) {
-        ctx.skip?.(
+      if (earlierBlock.dustGenerationEndIndex === 0) {
+        return ctx.skip(
           true,
-          `generation tree did not grow between block ${earlierBlock.height} ` +
-            `(endIndex ${earlierBlock.dustGenerationEndIndex}) and block ${tipBlock.height} ` +
-            `(endIndex ${tipBlock.dustGenerationEndIndex}) — snapshot comparison is vacuous`,
+          `generation tree is still empty at block ${earlierBlock.height} (endIndex 0), where ` +
+            `the resolver saturates highestIndex to 0 instead of endIndex - 1 — tip ` +
+            `${tipBlock.height} (endIndex ${tipBlock.dustGenerationEndIndex})`,
         );
-        return;
       }
 
-      for (const block of [earlierBlock, tipBlock]) {
-        const events = await collectDustGenerations(indexerWsClient, {
-          dustAddress,
-          blockHash: block.hash,
-          dtimeCutoffHeight: 0,
-        });
+      // Tier A — activity-independent, so it asserts on every run and every env.
+      await assertPinnedSnapshot(indexerWsClient, dustAddress, earlierBlock);
+      await assertPinnedSnapshot(indexerWsClient, dustAddress, tipBlock);
 
-        const progressEvents = eventsOfType(events, 'DustGenerationsProgress');
-        expect(progressEvents).toHaveLength(1);
-        const progress = progressEvents[0].data!.dustGenerations as { highestIndex: number };
-        expect(
-          progress.highestIndex,
-          `highestIndex at block ${block.height} should reflect that block's tree size`,
-        ).toBe(block.dustGenerationEndIndex - 1);
+      // Tier B — the pinning comparison proper, possible only where the tree grew
+      // inside the window.
+      const boundaryFound = earlierBlock.dustGenerationEndIndex !== tipBlock.dustGenerationEndIndex;
+      const measurements =
+        `tip ${tipBlock.height} (endIndex ${tipBlock.dustGenerationEndIndex}), ` +
+        `block ${earlierBlock.height} at tip-${IN_WINDOW_OFFSET} ` +
+        `(endIndex ${earlierBlock.dustGenerationEndIndex}), ` +
+        `growth boundary found: ${boundaryFound}`;
+
+      if (!boundaryFound) {
+        log.warn(`Tier B not exercised — ${measurements}`);
+        return ctx.skip(
+          true,
+          `generation tree did not grow within the ${IN_WINDOW_OFFSET}-block in-window budget, ` +
+            `so a cross-block comparison would be vacuous — ${measurements}`,
+        );
       }
+
+      const { before, after } = await findNewestGrowthBoundary(earlierBlock, tipBlock);
+      log.debug(`Tier B comparing blocks ${before.height} and ${after.height} — ${measurements}`);
+
+      const beforeHighestIndex = await assertPinnedSnapshot(indexerWsClient, dustAddress, before);
+      const afterHighestIndex = await assertPinnedSnapshot(indexerWsClient, dustAddress, after);
+      expect(
+        beforeHighestIndex,
+        `block ${before.height} should yield a strictly smaller snapshot than block ${after.height}`,
+      ).toBeLessThan(afterHighestIndex);
     }, 90_000);
   });
 

--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -212,11 +212,20 @@ function eventsOfType(
 
 type PinnedBlock = Awaited<ReturnType<typeof fetchBlock>>;
 
+// The resolver's rejection for a snapshot older than `max_snapshot_age`.
+const FRESHNESS_REJECTION = 'older than the snapshot freshness window';
+
 // The indexer rejects snapshots older than its `max_snapshot_age` (500 by
 // default) against the tip *at subscribe time*, not at block-selection time.
-// Staying 400 blocks back leaves ~100 blocks (~10 minutes at 6s blocks) of
-// margin for discovery, and survives the window being lowered.
+// Starting 400 blocks back leaves ~100 blocks (~10 minutes at 6s blocks) of
+// margin against the window sliding mid-test. That margin only exists while the
+// window is configured above ~410; below that the server rejects this offset, and
+// the test steps closer to the tip rather than reporting configuration as a defect.
 const IN_WINDOW_OFFSET = 400;
+
+// Floor for stepping closer to the tip: below this there is too little room left
+// for a snapshot comparison to be worth making.
+const MIN_IN_WINDOW_OFFSET = 25;
 
 // Far enough outside the window to survive it being raised.
 const OUT_OF_WINDOW_OFFSET = 5_000;
@@ -252,6 +261,31 @@ async function assertPinnedSnapshot(
     `highestIndex at block ${block.height} should reflect that block's tree size`,
   ).toBe(block.dustGenerationEndIndex - 1);
   return highestIndex;
+}
+
+/**
+ * Runs the per-block assertions unless the server refuses the block as older than
+ * its snapshot freshness window, in which case the rejection message is returned
+ * so the caller can step closer to the tip. `max_snapshot_age` is runtime
+ * configuration the schema does not expose, so this rejection is the only signal
+ * that the deployed window is narrower than the offset this test prefers — it is
+ * configuration, not a defect. Every other failure propagates.
+ */
+async function assertPinnedSnapshotUnlessStale(
+  wsClient: IndexerWsClient,
+  dustAddress: string,
+  block: PinnedBlock,
+): Promise<string | null> {
+  try {
+    await assertPinnedSnapshot(wsClient, dustAddress, block);
+    return null;
+  } catch (error) {
+    const message = extractSubscriptionErrorMessage(error);
+    if (message.includes(FRESHNESS_REJECTION)) {
+      return message;
+    }
+    throw error;
+  }
 }
 
 /**
@@ -414,27 +448,71 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
       // registered wallet and no Cardano fixture.
       const dustAddress = generateDustAddressForNetworkId(env.getNetworkId().toLowerCase());
       const tipBlock = await fetchBlock();
-      const earlierBlock = await fetchBlock({ height: tipBlock.height - IN_WINDOW_OFFSET });
 
-      if (earlierBlock.dustGenerationEndIndex === 0) {
+      if (tipBlock.height <= IN_WINDOW_OFFSET) {
         return ctx.skip(
           true,
-          `generation tree is still empty at block ${earlierBlock.height} (endIndex 0), where ` +
-            `the resolver saturates highestIndex to 0 instead of endIndex - 1 — tip ` +
-            `${tipBlock.height} (endIndex ${tipBlock.dustGenerationEndIndex})`,
+          `chain is too short to select a block ${IN_WINDOW_OFFSET} blocks back: tip height ` +
+            `${tipBlock.height}, needs more than ${IN_WINDOW_OFFSET}`,
+        );
+      }
+
+      if (tipBlock.dustGenerationEndIndex === 0) {
+        return ctx.skip(
+          true,
+          `generation tree is still empty at the tip (block ${tipBlock.height}, endIndex 0), ` +
+            'where the resolver saturates highestIndex to 0 instead of endIndex - 1',
         );
       }
 
       // Tier A — activity-independent, so it asserts on every run and every env.
-      await assertPinnedSnapshot(indexerWsClient, dustAddress, earlierBlock);
+      // Start at the preferred offset and step closer to the tip while the server
+      // reports the snapshot out of window (a narrower max_snapshot_age) or the
+      // tree still empty (closer blocks hold a larger tree).
+      let earlierBlock: PinnedBlock | undefined;
+      let offsetUsed = 0;
+      let lastRejection = '';
+      for (
+        let offset = IN_WINDOW_OFFSET;
+        offset >= MIN_IN_WINDOW_OFFSET;
+        offset = Math.floor(offset / 2)
+      ) {
+        const candidate = await fetchBlock({ height: tipBlock.height - offset });
+        if (candidate.dustGenerationEndIndex === 0) {
+          log.warn(`Generation tree still empty at tip-${offset} (block ${candidate.height})`);
+          continue;
+        }
+        const rejection = await assertPinnedSnapshotUnlessStale(
+          indexerWsClient,
+          dustAddress,
+          candidate,
+        );
+        if (rejection === null) {
+          earlierBlock = candidate;
+          offsetUsed = offset;
+          break;
+        }
+        lastRejection = rejection;
+        log.warn(`Snapshot at tip-${offset} (block ${candidate.height}) refused: ${rejection}`);
+      }
+
       await assertPinnedSnapshot(indexerWsClient, dustAddress, tipBlock);
+
+      if (earlierBlock === undefined) {
+        return ctx.skip(
+          true,
+          `no usable older block between tip-${IN_WINDOW_OFFSET} and tip-${MIN_IN_WINDOW_OFFSET}: ` +
+            `tip ${tipBlock.height} (endIndex ${tipBlock.dustGenerationEndIndex}), ` +
+            `last rejection: ${lastRejection || 'none — tree empty at every offset tried'}`,
+        );
+      }
 
       // Tier B — the pinning comparison proper, possible only where the tree grew
       // inside the window.
       const boundaryFound = earlierBlock.dustGenerationEndIndex !== tipBlock.dustGenerationEndIndex;
       const measurements =
         `tip ${tipBlock.height} (endIndex ${tipBlock.dustGenerationEndIndex}), ` +
-        `block ${earlierBlock.height} at tip-${IN_WINDOW_OFFSET} ` +
+        `block ${earlierBlock.height} at tip-${offsetUsed} ` +
         `(endIndex ${earlierBlock.dustGenerationEndIndex}), ` +
         `growth boundary found: ${boundaryFound}`;
 
@@ -442,7 +520,7 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
         log.warn(`Tier B not exercised — ${measurements}`);
         return ctx.skip(
           true,
-          `generation tree did not grow within the ${IN_WINDOW_OFFSET}-block in-window budget, ` +
+          `generation tree did not grow within the ${offsetUsed}-block in-window budget, ` +
             `so a cross-block comparison would be vacuous — ${measurements}`,
         );
       }
@@ -747,17 +825,17 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
       // introspection, so a clean completion means the indexer predates it rather
       // than that it regressed. Any other rejection reason is a real failure.
       if (outcome.failure === COMPLETED_WITHOUT_ERROR) {
-        return ctx.skip(
-          true,
+        const reason =
           `deployed indexer predates the snapshot freshness guard: a subscription at block ` +
-            `${staleBlock.height}, ${OUT_OF_WINDOW_OFFSET} blocks behind tip ${tipBlock.height}, ` +
-            `streamed a snapshot instead of being rejected`,
-        );
+          `${staleBlock.height}, ${OUT_OF_WINDOW_OFFSET} blocks behind tip ${tipBlock.height}, ` +
+          `streamed a snapshot instead of being rejected`;
+        log.warn(reason);
+        return ctx.skip(true, reason);
       }
       expect(outcome.failure, 'the subscription should have surfaced a server error').toBeNull();
 
       log.debug(`Received expected freshness rejection: ${outcome.message}`);
-      expect(outcome.message).toContain('older than the snapshot freshness window');
+      expect(outcome.message).toContain(FRESHNESS_REJECTION);
       expect(outcome.message).not.toMatch(/unknown block hash/);
       expect(outcome.message).not.toMatch(/no longer available/);
     });

--- a/qa/tests/utils/indexer/schema-feature-probe.ts
+++ b/qa/tests/utils/indexer/schema-feature-probe.ts
@@ -15,43 +15,49 @@
 
 import { env } from 'environment/model';
 
-const BLOCK_FIELD_DESCRIPTIONS_QUERY = `{
-  __type(name: "Block") {
-    fields {
-      name
-      description
-    }
-  }
-}`;
-
 interface IntrospectedField {
   name: string;
-  description: string | null;
+  description?: string | null;
+  args?: { name: string }[];
 }
 
 /**
- * Introspects the deployed schema and returns the description of a `Block` field,
- * or null when the field does not exist.
+ * Introspects the deployed schema and returns the fields of a type, or null when
+ * the type does not exist. `fieldSelection` adds per-field sub-selections on top
+ * of `name` (e.g. `description`, `args { name }`).
  *
  * Uses native fetch (pattern of http-compression-probe) because the typed
  * IndexerHttpClient methods are bound to domain queries, not introspection.
  */
-export async function fetchBlockFieldDescription(fieldName: string): Promise<string | null> {
+async function introspectTypeFields(
+  typeName: string,
+  fieldSelection: string,
+): Promise<IntrospectedField[] | null> {
   const apiVersion = process.env.INDEXER_API_VERSION?.trim() || 'v4';
   const url = `${env.getIndexerHttpBaseURL()}/api/${apiVersion}/graphql`;
 
   const response = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ query: BLOCK_FIELD_DESCRIPTIONS_QUERY }),
+    body: JSON.stringify({
+      query: `{ __type(name: "${typeName}") { fields { name ${fieldSelection} } } }`,
+    }),
     signal: AbortSignal.timeout(30_000),
   });
 
   const body = (await response.json()) as {
     data?: { __type?: { fields?: IntrospectedField[] } };
   };
-  const field = body.data?.__type?.fields?.find((f) => f.name === fieldName);
-  return field?.description ?? null;
+  return body.data?.__type?.fields ?? null;
+}
+
+/**
+ * Introspects the deployed schema and returns the description of a `Block` field,
+ * or null when the field does not exist.
+ */
+export async function fetchBlockFieldDescription(fieldName: string): Promise<string | null> {
+  const fields = await introspectTypeFields('Block', 'description');
+  return fields?.find((f) => f.name === fieldName)?.description ?? null;
 }
 
 /**
@@ -66,4 +72,20 @@ export async function fetchBlockFieldDescription(fieldName: string): Promise<str
 export async function isPerBlockDustRootsSupported(): Promise<boolean> {
   const description = await fetchBlockFieldDescription('dustGenerationMerkleTreeRoot');
   return description !== null && description.includes('at this block');
+}
+
+/**
+ * Whether the deployed indexer serves the block-hash `dustGenerations` signature.
+ *
+ * Up to and including 4.3.3 the subscription takes `(dustAddress, startIndex,
+ * endIndex)`; the block-hash sync replaced those with `(dustAddress, blockHash,
+ * dtimeCutoffHeight)`. The argument names are the only observable marker — the
+ * field name and its event union are identical on both sides. Without this probe
+ * the block-hash subscription document fails GraphQL validation on a pre-4.4
+ * environment, turning a missing surface into a suite of hard failures.
+ */
+export async function isBlockHashDustGenerationsSupported(): Promise<boolean> {
+  const fields = await introspectTypeFields('Subscription', 'args { name }');
+  const dustGenerations = fields?.find((f) => f.name === 'dustGenerations');
+  return dustGenerations?.args?.some((arg) => arg.name === 'blockHash') ?? false;
 }

--- a/qa/tests/utils/indexer/schema-feature-probe.ts
+++ b/qa/tests/utils/indexer/schema-feature-probe.ts
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 import { env } from 'environment/model';
+import { retry } from '@utils/retry-helper';
 
 interface IntrospectedField {
   name: string;
@@ -31,10 +32,25 @@ interface IntrospectedField {
  * schema does not have this", so a failed request must never reach them as null:
  * that reports a feature as absent on evidence that says nothing about it.
  *
+ * A single blip is retried, since one lost request would otherwise fail every
+ * test a probing hook gates.
+ *
  * Uses native fetch (pattern of http-compression-probe) because the typed
  * IndexerHttpClient methods are bound to domain queries, not introspection.
  */
 async function introspectTypeFields(
+  typeName: string,
+  fieldSelection: string,
+): Promise<IntrospectedField[] | null> {
+  return retry(() => introspectTypeFieldsOnce(typeName, fieldSelection), {
+    maxRetries: 1,
+    delayMs: 1000,
+    retryLabel: `introspection of type ${typeName}`,
+  });
+}
+
+/** One introspection attempt. See `introspectTypeFields` for the contract. */
+async function introspectTypeFieldsOnce(
   typeName: string,
   fieldSelection: string,
 ): Promise<IntrospectedField[] | null> {
@@ -108,9 +124,20 @@ export async function isPerBlockDustRootsSupported(): Promise<boolean> {
  * field name and its event union are identical on both sides. Without this probe
  * the block-hash subscription document fails GraphQL validation on a pre-4.4
  * environment, turning a missing surface into a suite of hard failures.
+ *
+ * A probe that cannot run at all throws with its own name in the message: the
+ * suite gates every test on this one call, so a bare `TypeError: fetch failed`
+ * across twelve tests reads like a dustGenerations regression rather than an
+ * unreachable indexer.
  */
 export async function isBlockHashDustGenerationsSupported(): Promise<boolean> {
-  const fields = await introspectTypeFields('Subscription', 'args { name }');
+  const fields = await introspectTypeFields('Subscription', 'args { name }').catch((error) => {
+    throw new Error(
+      `dustGenerations surface probe failed against ${env.getIndexerHttpBaseURL()}: ` +
+        `${(error as Error).message}`,
+      { cause: error },
+    );
+  });
   const dustGenerations = fields?.find((f) => f.name === 'dustGenerations');
   return dustGenerations?.args?.some((arg) => arg.name === 'blockHash') ?? false;
 }

--- a/qa/tests/utils/indexer/schema-feature-probe.ts
+++ b/qa/tests/utils/indexer/schema-feature-probe.ts
@@ -26,6 +26,11 @@ interface IntrospectedField {
  * the type does not exist. `fieldSelection` adds per-field sub-selections on top
  * of `name` (e.g. `description`, `args { name }`).
  *
+ * Throws when the introspection itself does not succeed — a non-2xx response, a
+ * GraphQL error, or a response carrying no `data`. Callers read null as "the
+ * schema does not have this", so a failed request must never reach them as null:
+ * that reports a feature as absent on evidence that says nothing about it.
+ *
  * Uses native fetch (pattern of http-compression-probe) because the typed
  * IndexerHttpClient methods are bound to domain queries, not introspection.
  */
@@ -45,10 +50,30 @@ async function introspectTypeFields(
     signal: AbortSignal.timeout(30_000),
   });
 
+  if (!response.ok) {
+    throw new Error(
+      `Introspection of type ${typeName} against ${url} returned HTTP ` +
+        `${response.status} ${response.statusText}`,
+    );
+  }
+
   const body = (await response.json()) as {
     data?: { __type?: { fields?: IntrospectedField[] } };
+    errors?: { message?: string }[];
   };
-  return body.data?.__type?.fields ?? null;
+
+  if (body.errors?.length) {
+    const messages = body.errors.map((error) => error.message ?? '<no message>').join('; ');
+    throw new Error(`Introspection of type ${typeName} against ${url} failed: ${messages}`);
+  }
+
+  if (body.data === undefined) {
+    throw new Error(`Introspection of type ${typeName} against ${url} returned no data`);
+  }
+
+  // Only now does null mean what the callers take it to mean: the schema served by
+  // this environment has no such type.
+  return body.data.__type?.fields ?? null;
 }
 
 /**


### PR DESCRIPTION
Closes #1427

## Scope

Fixes the deterministically-failing dust snapshot-pinning test and adds the missing coverage
for the snapshot freshness window introduced by #1308.

- **Surface the real error.** `collectDustGenerations()` formatted subscription errors with
  `JSON.stringify()` on an `Error` instance, whose properties are non-enumerable — every
  failure in this helper reported `Subscription error: {}` and threw the server's message
  away. It now uses the repo's `extractSubscriptionErrorMessage()`, which the sibling
  `collectDustGenerationsError()` in the same file already used.
- **Anchor block selection to chain state.** The pinning test picked its older block as
  `tip.height / 2` — ~267k blocks behind the tip on devnet, far outside the 500-block
  `max_snapshot_age` window, so the indexer correctly rejected it and the test failed. Block
  choice is now derived from queried `dustGenerationEndIndex` values: probe the tip and
  tip-400, and when they differ, binary-search the **newest** growth boundary and use the
  tight pair `(H-1, H)`. The 400 is a *preferred starting* offset, not a fixed budget — if
  the deployed `max_snapshot_age` is ever configured narrower, the test halves toward the tip
  (floor: 25) until a block is accepted, so a narrow window costs coverage rather than causing
  the hard failure this ticket exists to remove. The same tolerance covers the Tier B pair, so
  the failure cannot simply relocate there. Two distinct exhaustion outcomes, deliberately kept
  apart: if every candidate was *refused*, the test **fails** with the measured numbers — no
  deployable `max_snapshot_age` explains that, so it means a freshness-computation regression
  and must not be masked; if every candidate tree was merely *empty*, it skips.
- **Tier the assertions** so the test always verifies something:
  - **Tier A** (unconditional, activity-independent): for each in-window block, the progress
    event's `highestIndex == thatBlock.dustGenerationEndIndex - 1`, events are schema-valid,
    and the subscription completes. It asserts at the tip *before* discovery runs, so Tier A
    executes on every run whatever discovery concludes — including on a chain too short to
    address the preferred offset.
  - **Tier B** (only when the probe finds a growth boundary): the full pinning comparison —
    the earlier block yields a strictly smaller snapshot than the later one.
  A fixed in-window pair would have made the old assertion *vacuous*: `dustGenerationEndIndex`
  is identical across the entire last 1000 blocks on devnet, qanet and preview, so the test
  would have gone green without verifying anything.
- **New negative test** for the freshness rejection at `tip-5000` — the coverage gap. It
  asserts the specific "older than the snapshot freshness window" message and explicitly
  distinguishes it from the two neighbouring rejections, `unknown block hash` and
  `ledger state ... no longer available`.
- **Never skip silently.** Tier B's skip reason carries the measured numbers — including the
  offset actually used, which is not necessarily the preferred one — so a reader can tell a
  quiet chain from a narrow window from a broken test:

  ```
  generation tree did not grow within the 400-block in-window budget, so a cross-block
  comparison would be vacuous — tip 631601 (endIndex 2560), block 631201 at tip-400
  (endIndex 2560), growth boundary found: false
  ```

- **Surface-presence gate** — see the next section for why this is in scope.

No indexer/production change: the rejection is intended behaviour and the indexer is correct
throughout.

## Why the surface gate is here (and not scope creep)

Deployed indexer builds are **not** homogeneous, so this file cannot assume the surface or the
guard exists. Measured live by introspection and by live subscriptions on 2026-08-13:

| Env | Indexer tag | `dustGenerations` args | `max_snapshot_age` guard |
|---|---|---|---|
| devnet | `4.4.0-rc.2` | `dustAddress, blockHash, dtimeCutoffHeight` | present (window measured = 500) |
| preview | `4.3.5` | `dustAddress, blockHash, dtimeCutoffHeight` | present |
| stagenet | `4.4.0-pre-alpha.16` | `dustAddress, blockHash, dtimeCutoffHeight` | **absent** — a tip-5000 snapshot streams normally |
| qanet | `4.3.3` | `dustAddress, startIndex, endIndex` (pre-#1291) | n/a — no block-hash surface |
| preprod, mainnet | — | `dustAddress, startIndex, endIndex` (pre-#1291) | n/a — no block-hash surface |

Two consequences this PR handles:

1. On `main` today, **all 12 tests in this file hard-fail on qanet/preprod** with
   `Unknown argument "blockHash"` — the file is only gated on undeployed. A new
   `isBlockHashDustGenerationsSupported()` probe (in the existing
   `utils/indexer/schema-feature-probe.ts`) runs once in `beforeAll` and skips the whole block
   with a reason naming the missing surface.
2. `max_snapshot_age` is runtime config and is **not** exposed via GraphQL — #1308 did not
   touch `schema-v4.graphql` — so introspection cannot detect whether a build carries the
   guard. The negative test therefore gates **behaviourally**: the freshness message asserts,
   a clean completion skips with a reason naming the pre-#1308 build, and any *other* error
   still fails.

Because of the above, #1427's acceptance criteria have been reworded: the original
"deterministically on all hosted environments" was unsatisfiable through no fault of the
tests. They now name the envs that actually serve the behaviour and require an explicit,
numeric skip elsewhere.

## What was validated

Against **devnet**, on the exact committed tree (byte-identity confirmed by SHA-256 against
the `HEAD` blobs) — re-run after the follow-up hardening commit, not just the initial four:

- This file: **11 passed / 1 skipped** — the skip is Tier B, by design (see below).
- Full integration suite: **242 passed / 26 skipped / 20 todo, 0 failures** (28/28 files).
- Smoke: **26 passed / 1 skipped**.
- Baseline on pristine `main` for comparison: 230 passed / **1 failed** — that one failure was
  this ticket's test, reporting `Subscription error: {}`.
- `bun run lint`, `bun run audit` (exit 0), `bun run format` (no resulting diff) and
  `tsc --noEmit` all clean.

Independently re-run on three further environments during review: **stagenet** 10 passed /
2 skipped, **preview** 9 passed / 3 skipped, **qanet** 12 skipped — all green, every skip
carrying its numbers.

Tier A is not vacuous: mutating its assertion (`endIndex - 1` → `endIndex - 2`) makes the test
**fail** rather than skip. It is also a genuine cross-check rather than a tautology —
`Block.dustGenerationEndIndex` is a stored chain-indexer column, while `highestIndex` comes
from loading the pinned ledger state, so the two values travel independent paths.

### Tier B ships unexercised — deliberately, and here is how it was checked

Tier B's discovery-and-compare path did **not** execute on any of the four environments: the
generation tree is flat across the discovery range everywhere right now (devnet's newest
growth boundary sat at ~tip-627, then receded to ~tip-977 as the chain advanced). Growth is
bursty — recent devnet gaps were 1559, 1047, 1, 26, 6, 1184 blocks — and quiet stretches
routinely exceed the window, so a randomly-timed run finds a usable boundary only ~40% of the
time. That is why the strong assertion cannot be unconditional on hosted chains.

The discovery algorithm was therefore validated separately: `findNewestGrowthBoundary` was
copied verbatim into a scratch script and run against devnet over spans of 3000 and 20000
blocks, converging to an adjacent block pair with strictly increasing `endIndex` in 15–19
queries each time.

Genuinely deterministic pinning coverage needs a chain where the test *causes* the growth —
that is #1152 (Cardano test-data provisioning on undeployed), not this PR.

## Notes

- The pinning test no longer needs the `registered-with-dust` Cardano fixture:
  `highestIndex` is `dust_generations_first_free() - 1`, a global tree property, so it is
  address-independent (verified live with an unregistered synthetic address). One fewer skip
  path. The fixture stays in the tests that need item-level richness.
- The `JSON.stringify(error)` antipattern exists in 13 other places across five sibling
  subscription files; that suite-wide sweep is #1428 and is deliberately not in this PR.
- `block-queries.test.ts` uses the same `tip/2` geometry but reads **stored DB columns**, not
  a loaded ledger state, so it is unaffected by the freshness window and is left alone.

Relates to #1308, #1291, #1283, #1152, #1428

----

🤖 Generated with [Claude Code](https://claude.com/claude-code)
