### PR TITLE
feat(indexer-api): expose the effective dustGenerations snapshot freshness window (#1430)

### DIFF
--- a/docs/api/v4/api-documentation.md
+++ b/docs/api/v4/api-documentation.md
@@ -24,7 +24,7 @@ The GraphQL schema is defined in [`indexer-api/graphql/schema-v4.graphql`](../..
 
 - **Queries**:
     - *Blocks, transactions, contracts:* `block`, `transactions`, `contractAction`, `zswapMerkleTreeCollapsedUpdate`.
-    - *DUST:* `dustGenerationStatus`, `dustGenerations`, `dustCommitmentMerkleTreeUpdate`, `dustGenerationMerkleTreeUpdate`.
+    - *DUST:* `dustGenerationStatus`, `dustGenerations`, `dustGenerationsSnapshotPolicy`, `dustCommitmentMerkleTreeUpdate`, `dustGenerationMerkleTreeUpdate`.
     - *Governance history:* `dParameterHistory`, `termsAndConditionsHistory`.
     - *Stake Pool Operators (SPO):* identity and metadata (`spoIdentities`, `spoIdentityByPoolId`, `spoByPoolId`, `spoList`, `spoCompositeByPoolId`, `poolMetadata`, `poolMetadataList`, `spoCount`, `stakePoolOperators`), performance and epochs (`spoPerformanceLatest`, `spoPerformanceBySpoSk`, `epochPerformance`, `currentEpochInfo`, `epochUtilization`, `committee`), and registration series (`registeredTotalsSeries`, `registeredSpoSeries`, `registeredPresence`, `registeredFirstValidEpochs`, `stakeDistribution`).
 
@@ -385,6 +385,22 @@ query {
       utxoTxHash
       utxoOutputIndex
     }
+  }
+}
+```
+
+### dustGenerationsSnapshotPolicy: DustGenerationsSnapshotPolicy!
+
+Return the effective freshness policy for `dustGenerations` snapshot subscriptions, reflecting this deployment's **runtime** configuration rather than a compiled-in default. The `DustGenerationsSnapshotPolicy` type has a single field, `maxAgeBlocks: Int!`: the maximum age, in blocks, of a snapshot `blockHash` relative to the latest indexed block. A `dustGenerations` subscription whose block is more than `maxAgeBlocks` blocks below the tip is rejected with a re-subscribe hint.
+
+Query this before opening a `dustGenerations` subscription so you can pick a `blockHash` that will be accepted. Because the tip advances continuously, treat `maxAgeBlocks` as an upper bound and leave headroom for indexing lag: read the current tip and `maxAgeBlocks`, choose a sufficiently recent block, then subscribe.
+
+**Example:**
+
+```graphql
+query {
+  dustGenerationsSnapshotPolicy {
+    maxAgeBlocks
   }
 }
 ```

--- a/indexer-api/graphql/schema-v4.graphql
+++ b/indexer-api/graphql/schema-v4.graphql
@@ -911,6 +911,20 @@ type DustGenerationsProgress @beta {
 	collapsedMerkleTree: MerkleTreeCollapsedUpdate
 }
 
+"""
+The effective freshness policy for `dustGenerations` snapshots, reflecting this deployment's
+runtime configuration rather than a compiled-in default.
+"""
+type DustGenerationsSnapshotPolicy {
+	"""
+	Maximum age, in blocks, of a snapshot `blockHash` relative to the latest indexed block. A
+	`dustGenerations` subscription whose block is more than this many blocks below the tip is
+	rejected with a re-subscribe hint. The tip advances continuously, so treat this as an upper
+	bound and leave headroom for indexing lag when choosing a block.
+	"""
+	maxAgeBlocks: Int!
+}
+
 type DustInitialUtxo implements DustLedgerEvent {
 	"""
 	The ID of this dust ledger event.
@@ -1278,6 +1292,12 @@ type Query {
 	addresses.
 	"""
 	dustGenerations(cardanoRewardAddresses: [CardanoRewardAddress!]!): [DustGenerations!]!
+	"""
+	The effective freshness policy for `dustGenerations` snapshots, reflecting this deployment's
+	runtime configuration. Query this before opening a `dustGenerations` subscription to choose
+	a `blockHash` that will be accepted; account for indexing lag since the tip keeps advancing.
+	"""
+	dustGenerationsSnapshotPolicy: DustGenerationsSnapshotPolicy!
 	"""
 	Get a collapsed Merkle tree update for the dust commitment tree.
 	"""

--- a/indexer-api/src/infra/api/v4.rs
+++ b/indexer-api/src/infra/api/v4.rs
@@ -573,3 +573,76 @@ async fn resolve_height<S: Storage>(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Build a full [`SubscriptionConfig`] mirroring `indexer-api/config.yaml`. When
+    /// `max_snapshot_age` is `None`, the `dust_generations` section omits the key so the serde
+    /// default (500) applies; otherwise it is set to the given override.
+    fn subscription_config(max_snapshot_age: Option<u32>) -> SubscriptionConfig {
+        let mut dust_generations = json!({ "batch_size": 20 });
+        if let Some(max_snapshot_age) = max_snapshot_age {
+            dust_generations["max_snapshot_age"] = json!(max_snapshot_age);
+        }
+
+        serde_json::from_value(json!({
+            "blocks": { "batch_size": 20 },
+            "contract_actions": { "batch_size": 20 },
+            "contract_events": { "batch_size": 20 },
+            "dust_generations": dust_generations,
+            "dust_ledger_events": { "batch_size": 20 },
+            "dust_nullifier_transactions": { "batch_size": 20 },
+            "shielded_nullifier_transactions": { "batch_size": 20 },
+            "shielded_transactions": {
+                "batch_size": 20,
+                "progress_update_interval": "30s",
+                "keep_wallet_alive_interval": "10m",
+            },
+            "unshielded_transactions": {
+                "batch_size": 20,
+                "progress_update_interval": "30s",
+            },
+            "zswap_ledger_events": { "batch_size": 20 },
+            "progress_cache": { "max_capacity": 10000, "time_to_live": "5s" },
+        }))
+        .expect("subscription config can be deserialized")
+    }
+
+    /// Execute the `dustGenerationsSnapshotPolicy` query against a schema carrying `config` and
+    /// return the reported `maxAgeBlocks`.
+    async fn query_max_age_blocks(config: SubscriptionConfig) -> u64 {
+        let schema = schema_builder::<NoopStorage, NoopSubscriber>()
+            .data(config)
+            .finish();
+
+        let response = schema
+            .execute("{ dustGenerationsSnapshotPolicy { maxAgeBlocks } }")
+            .await;
+        assert!(response.errors.is_empty(), "{:?}", response.errors);
+
+        response
+            .data
+            .into_json()
+            .expect("response data is JSON")["dustGenerationsSnapshotPolicy"]["maxAgeBlocks"]
+            .as_u64()
+            .expect("maxAgeBlocks is an integer")
+    }
+
+    #[tokio::test]
+    async fn dust_generations_snapshot_policy_reflects_default() {
+        // No override configured, so the compiled-in default (500) is exposed.
+        assert_eq!(query_max_age_blocks(subscription_config(None)).await, 500);
+    }
+
+    #[tokio::test]
+    async fn dust_generations_snapshot_policy_reflects_override() {
+        // A runtime override must be reflected, proving the field is not a hardcoded constant.
+        assert_eq!(
+            query_max_age_blocks(subscription_config(Some(123))).await,
+            123
+        );
+    }
+}

--- a/indexer-api/src/infra/api/v4/dust_generations.rs
+++ b/indexer-api/src/infra/api/v4/dust_generations.rs
@@ -96,3 +96,14 @@ impl DustGenerations {
         }
     }
 }
+
+/// The effective freshness policy for `dustGenerations` snapshots, reflecting this deployment's
+/// runtime configuration rather than a compiled-in default.
+#[derive(Debug, Clone, Copy, SimpleObject)]
+pub struct DustGenerationsSnapshotPolicy {
+    /// Maximum age, in blocks, of a snapshot `blockHash` relative to the latest indexed block. A
+    /// `dustGenerations` subscription whose block is more than this many blocks below the tip is
+    /// rejected with a re-subscribe hint. The tip advances continuously, so treat this as an upper
+    /// bound and leave headroom for indexing lag when choosing a block.
+    pub max_age_blocks: u32,
+}

--- a/indexer-api/src/infra/api/v4/query.rs
+++ b/indexer-api/src/infra/api/v4/query.rs
@@ -31,7 +31,7 @@ use crate::{
             contract_event::{ContractEvent, ContractEventFilter},
             directives::beta,
             dust::DustGenerationStatus,
-            dust_generations::DustGenerations,
+            dust_generations::{DustGenerations, DustGenerationsSnapshotPolicy},
             merkle_tree_collapsed_update::MerkleTreeCollapsedUpdate,
             spo::{
                 CommitteeMember, EpochInfo, EpochPerf, FirstValidEpoch, PoolMetadata,
@@ -366,6 +366,21 @@ where
             .into_iter()
             .map(|d| DustGenerations::from_domain(d, network_id))
             .collect())
+    }
+
+    /// The effective freshness policy for `dustGenerations` snapshots, reflecting this deployment's
+    /// runtime configuration. Query this before opening a `dustGenerations` subscription to choose
+    /// a `blockHash` that will be accepted; account for indexing lag since the tip keeps advancing.
+    #[trace]
+    async fn dust_generations_snapshot_policy(
+        &self,
+        cx: &Context<'_>,
+    ) -> DustGenerationsSnapshotPolicy {
+        let max_age_blocks = cx
+            .get_subscription_config()
+            .dust_generations
+            .max_snapshot_age;
+        DustGenerationsSnapshotPolicy { max_age_blocks }
     }
 
     /// Get a collapsed Merkle tree update for the dust commitment tree.

--- a/indexer-tests/e2e.graphql
+++ b/indexer-tests/e2e.graphql
@@ -855,6 +855,12 @@ query DustGenerationsQuery($cardanoRewardAddresses: [CardanoRewardAddress!]!) {
     }
 }
 
+query DustGenerationsSnapshotPolicyQuery {
+    dustGenerationsSnapshotPolicy {
+        maxAgeBlocks
+    }
+}
+
 query DustCommitmentMerkleTreeUpdateQuery($startIndex: Int!, $endIndex: Int!) {
     dustCommitmentMerkleTreeUpdate(startIndex: $startIndex, endIndex: $endIndex) {
         startIndex

--- a/indexer-tests/src/e2e.rs
+++ b/indexer-tests/src/e2e.rs
@@ -18,11 +18,12 @@ use crate::{
         BlockQuery, BlockSubscription, ConnectMutation, ContractActionQuery,
         ContractActionSubscription, DParameterHistoryQuery, DisconnectMutation,
         DustCommitmentMerkleTreeUpdateQuery, DustGenerationMerkleTreeUpdateQuery,
-        DustGenerationStatusQuery, DustGenerationsQuery, DustGenerationsSubscription,
-        DustLedgerEventsSubscription, DustNullifierTransactionsSubscription,
-        ShieldedNullifierTransactionsSubscription, ShieldedTransactionsSubscription,
-        TermsAndConditionsHistoryQuery, TransactionsQuery, UnshieldedTransactionsSubscription,
-        ZswapLedgerEventsSubscription, ZswapMerkleTreeCollapsedUpdateQuery, block_query,
+        DustGenerationStatusQuery, DustGenerationsQuery, DustGenerationsSnapshotPolicyQuery,
+        DustGenerationsSubscription, DustLedgerEventsSubscription,
+        DustNullifierTransactionsSubscription, ShieldedNullifierTransactionsSubscription,
+        ShieldedTransactionsSubscription, TermsAndConditionsHistoryQuery, TransactionsQuery,
+        UnshieldedTransactionsSubscription, ZswapLedgerEventsSubscription,
+        ZswapMerkleTreeCollapsedUpdateQuery, block_query,
         block_subscription::{
             self, BlockSubscriptionBlocks, BlockSubscriptionBlocksTransactions,
             BlockSubscriptionBlocksTransactionsContractActions,
@@ -36,7 +37,8 @@ use crate::{
         contract_action_query::{self},
         contract_action_subscription, disconnect_mutation,
         dust_commitment_merkle_tree_update_query, dust_generation_merkle_tree_update_query,
-        dust_generation_status_query, dust_generations_query, dust_generations_subscription,
+        dust_generation_status_query, dust_generations_query,
+        dust_generations_snapshot_policy_query, dust_generations_subscription,
         dust_ledger_events_subscription, dust_nullifier_transactions_subscription,
         shielded_nullifier_transactions_subscription, shielded_transactions_subscription,
         transactions_query, unshielded_transactions_subscription, zswap_ledger_events_subscription,
@@ -118,6 +120,9 @@ pub async fn run(network_id: NetworkId, host: &str, port: u16, secure: bool) -> 
     test_dust_generations_query(&api_client, &api_url)
         .await
         .context("test dust generations query")?;
+    test_dust_generations_snapshot_policy_query(&api_client, &api_url)
+        .await
+        .context("test dust generations snapshot policy query")?;
     test_dust_commitment_merkle_tree_update_query(&api_client, &api_url)
         .await
         .context("test dust commitment merkle tree update query")?;
@@ -745,6 +750,25 @@ async fn test_dust_generations_query(api_client: &Client, api_url: &str) -> anyh
     let response = send_query::<DustGenerationsQuery>(api_client, api_url, variables).await?;
     assert_eq!(response.dust_generations.len(), 1);
     assert!(response.dust_generations[0].registrations.is_empty());
+
+    Ok(())
+}
+
+/// Test the dustGenerationsSnapshotPolicy query (resolves #1430).
+async fn test_dust_generations_snapshot_policy_query(
+    api_client: &Client,
+    api_url: &str,
+) -> anyhow::Result<()> {
+    let variables = dust_generations_snapshot_policy_query::Variables {};
+    let response =
+        send_query::<DustGenerationsSnapshotPolicyQuery>(api_client, api_url, variables).await?;
+
+    // Asserts the shipped default; a deployment that overrides
+    // `subscription.dust_generations.max_snapshot_age` would need this expectation updated.
+    assert_eq!(
+        response.dust_generations_snapshot_policy.max_age_blocks,
+        500
+    );
 
     Ok(())
 }
@@ -1496,6 +1520,14 @@ mod graphql {
         response_derives = "Debug, Clone, Serialize"
     )]
     pub struct DustGenerationsQuery;
+
+    #[derive(GraphQLQuery)]
+    #[graphql(
+        schema_path = "../indexer-api/graphql/schema-v4.graphql",
+        query_path = "./e2e.graphql",
+        response_derives = "Debug, Clone, Serialize"
+    )]
+    pub struct DustGenerationsSnapshotPolicyQuery;
 
     #[derive(GraphQLQuery)]
     #[graphql(


### PR DESCRIPTION
## Summary

Closes #1430.

Exposes the effective `dustGenerations` snapshot freshness window through a new GraphQL query so clients and integration tests can read the runtime value instead of hardcoding the default of `500`.

```graphql
type DustGenerationsSnapshotPolicy {
  maxAgeBlocks: Int!
}

type Query {
  dustGenerationsSnapshotPolicy: DustGenerationsSnapshotPolicy!
}
```

`maxAgeBlocks` is the effective `subscription.dust_generations.max_snapshot_age` — the maximum age, in blocks, of a snapshot `blockHash` relative to the tip. A `dustGenerations` subscription whose block is more than `maxAgeBlocks` blocks below the latest indexed block is rejected with a re-subscribe hint (enforcement added in #1308). Clients query this first, then pick a sufficiently recent block, accounting for indexing lag since the tip keeps advancing.

## Why

The threshold was invisible over GraphQL, so callers and e2e tests had to hardcode `500`. That silently breaks under a different deployment config, or stops exercising the rejection path. The resolver reads the **same** `SubscriptionConfig` value the subscription enforces on, so the exposed value cannot drift from the enforced one.

## Design notes

- Purely additive — `SubscriptionConfig` is already in the schema context, so no config plumbing was needed.
- **Stable field** (no `@beta`).
- Enforcement is unchanged; this only reads config.

## Acceptance criteria

- [x] GraphQL exposes the effective `dust_generations.max_snapshot_age`.
- [x] Reflects runtime configuration, not compiled defaults (proven by the override unit test).
- [x] Field documented as a block-age measurement, with the tip-advancement caveat.
- [x] Subscription enforcement unchanged.
- [x] Tests cover default and override scenarios.
- [x] Schema and documentation updated.

## Testing

- Unit tests (`indexer-api/src/infra/api/v4.rs`): execute the query against a `NoopStorage` schema with a default config (asserts `500`) and an overridden config (asserts `123`).
- e2e smoke test (`indexer-tests`): asserts the deployment default of `500`.
- `just fmt-check`, `just lint` (cloud) clean; unit tests pass under both `cloud` and `standalone`; regenerated `schema-v4.graphql` is byte-identical across features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)