### PR TITLE
chore(deps): route dependabot/renovate PRs to canonical bot:* labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 
 updates:
   - package-ecosystem: "cargo"
+    labels:
+      - "bot:dependencies"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -15,6 +17,8 @@ updates:
       - dependency-name: "fake"
 
   - package-ecosystem: "github-actions"
+    labels:
+      - "bot:github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -26,6 +30,8 @@ updates:
           - "*"
 
   - package-ecosystem: "docker"
+    labels:
+      - "bot:dependencies"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Per-ecosystem `labels` added to `.github/dependabot.yml` (github-actions → `bot:github-actions`, everything else → `bot:dependencies`). Tool-default labels stop accumulating; existing history untouched.

Closes #1432