### PR TITLE
feat(standalone): survive node crashes and sqlite write contention

### DIFF
--- a/indexer-api/src/infra/storage/wallet.rs
+++ b/indexer-api/src/infra/storage/wallet.rs
@@ -66,7 +66,7 @@ impl WalletStorage for Storage {
             .bind(start_index)
             .bind(OffsetDateTime::now_utc())
             .bind(session_id.as_ref())
-            .execute(&*self.pool)
+            .execute(self.pool.writer())
             .await?;
 
         Ok(session_id)
@@ -82,7 +82,7 @@ impl WalletStorage for Storage {
 
         sqlx::query(query)
             .bind(session_id.as_ref())
-            .execute(&*self.pool)
+            .execute(self.pool.writer())
             .await?;
 
         Ok(())
@@ -114,7 +114,7 @@ impl WalletStorage for Storage {
         let result = sqlx::query(query)
             .bind(OffsetDateTime::now_utc())
             .bind(wallet_id)
-            .execute(&*self.pool)
+            .execute(self.pool.writer())
             .map_ok(|_| ())
             .await;
 

--- a/indexer-common/src/infra/migrations/sqlite.rs
+++ b/indexer-common/src/infra/migrations/sqlite.rs
@@ -17,14 +17,14 @@ use thiserror::Error;
 
 /// Run the database migrations for SQLite.
 pub async fn run(pool: &SqlitePool) -> Result<(), Error> {
-    sqlx::migrate!("migrations/sqlite").run(&**pool).await?;
+    sqlx::migrate!("migrations/sqlite").run(pool.writer()).await?;
     Ok(())
 }
 
 /// Run the database migrations for SQLite for the ledger DB.
 pub async fn run_for_ledger_db(pool: &SqlitePool) -> Result<(), Error> {
     sqlx::migrate!("migrations/sqlite-ledger-db")
-        .run(&**pool)
+        .run(pool.writer())
         .await?;
     Ok(())
 }

--- a/indexer-common/src/infra/pool/postgres.rs
+++ b/indexer-common/src/infra/pool/postgres.rs
@@ -61,6 +61,13 @@ impl PostgresPool {
 
         Ok(pool)
     }
+
+    /// The pool for write statements executed outside a transaction. Postgres handles
+    /// concurrent writers itself, so this is the same pool as `Deref`; it exists so code
+    /// shared with the SQLite pool (which splits reads and writes) compiles against both.
+    pub fn writer(&self) -> &sqlx::PgPool {
+        &self.0
+    }
 }
 
 impl Deref for PostgresPool {

--- a/indexer-common/src/infra/pool/sqlite.rs
+++ b/indexer-common/src/infra/pool/sqlite.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use derive_more::Into;
 use log::debug;
 use serde::Deserialize;
 use sqlx::{
@@ -21,76 +20,85 @@ use sqlx::{
 use std::{ops::Deref, time::Duration};
 use thiserror::Error;
 
-/// New type for `sqlx::SqlitePool`, allowing for some custom extensions as well as security.
+/// SQLite pools split by role: one write connection, `max_connections` read connections.
 ///
-/// To use as `&sqlx::SqlitePool` in `Query::execute`, use its `Deref` implementation: `&*pool` or
-/// `pool.deref()`. If an owned `sqlx::SqlitePool` is needed, use `Into::into`.
-#[derive(Debug, Clone, Into)]
-pub struct SqlitePool(sqlx::SqlitePool);
+/// SQLite allows a single writer per database file and its `busy_timeout` handler polls for
+/// the lock without any queueing, so under sustained writes (chain-indexer catching up) a
+/// waiting writer can starve past any timeout and fail with `SQLITE_BUSY`. Routing all
+/// writes through a dedicated single-connection pool replaces that unfair polling with
+/// sqlx's fair FIFO pool checkout: in-process writers queue on `acquire` and the SQLite
+/// write lock itself is never contended from within the process.
+///
+/// `Deref` yields the read pool (`PRAGMA query_only=ON`, so a mis-routed write fails loudly
+/// instead of contending silently). Transactions via [SqlitePool::begin] and bare write
+/// statements via [SqlitePool::writer] use the write pool.
+#[derive(Debug, Clone)]
+pub struct SqlitePool {
+    read: sqlx::SqlitePool,
+    write: sqlx::SqlitePool,
+}
 
 impl SqlitePool {
     /// Try to create a new [SqlitePool] with the given config.
+    ///
+    /// With `max_connections <= 1` the read pool is the write pool: callers like the ledger
+    /// DB require reads to observe the writer connection's own in-progress state (see
+    /// `infra::ledger_db::init`). The same applies to in-memory databases, where every new
+    /// connection would otherwise open its own empty database.
     pub async fn new(config: Config) -> Result<Self, Error> {
         let max_connections = config.max_connections;
+        let single_connection = max_connections <= 1
+            || config.cnn_url.contains(":memory:")
+            || config.cnn_url.contains("mode=memory");
         let connect_options =
             SqliteConnectOptions::try_from(config).map_err(Error::ConvertConfig)?;
-        let inner = SqlitePoolOptions::new()
-            .max_connections(max_connections)
-            .connect_with(connect_options)
+
+        // The write pool connects first: on a fresh database it creates the file and
+        // switches it to WAL before any read-only connection touches it. The generous
+        // acquire timeout replaces `busy_timeout` as the wait bound for writers; the wait
+        // is fair, so it only expires if the writer ahead genuinely holds the connection
+        // that long.
+        let write = SqlitePoolOptions::new()
+            .max_connections(1)
+            .acquire_timeout(Duration::from_secs(300))
+            .connect_with(connect_options.clone())
             .await?;
-        let pool = SqlitePool(inner);
+        let read = if single_connection {
+            write.clone()
+        } else {
+            SqlitePoolOptions::new()
+                .max_connections(max_connections)
+                .connect_with(connect_options.pragma("query_only", "ON"))
+                .await?
+        };
+        let pool = SqlitePool { read, write };
         debug!(pool:?; "created pool");
 
         Ok(pool)
     }
 
-    /// Begin a transaction with `BEGIN IMMEDIATE` semantics, claiming the
+    /// Begin a transaction on the write pool with `BEGIN IMMEDIATE` semantics, claiming the
     /// writer lock up front.
     ///
-    /// SQLite's default `BEGIN DEFERRED` transaction stays a reader until its
-    /// first write statement. When multiple connections run in WAL mode, a
-    /// deferred reader that later tries to upgrade to a writer (while another
-    /// connection has committed in between) gets `SQLITE_BUSY_SNAPSHOT` (517),
-    /// which is not retryable via `busy_timeout`. Every caller in this
-    /// codebase that starts a transaction does so to write, so taking the
-    /// write lock immediately is both correct and avoids the race. Shadowing
-    /// `sqlx::Pool::begin` via inherent method makes the existing
-    /// `self.pool.begin()` call sites pick up the new behavior transparently.
-    ///
-    /// `busy_timeout` bounds a single lock wait, but SQLite's busy handler is unfair polling,
-    /// not a queue: under back-to-back writers (chain-indexer catching up) a waiter can lose
-    /// every retry window and starve past the timeout. A begin failure is fatal to the whole
-    /// standalone process (components propagate it and main exits), so retry a few times
-    /// before giving up.
+    /// In-process writers queue fairly on the pool's single connection, so the lock is
+    /// uncontended here; `BEGIN IMMEDIATE` still guards against `SQLITE_BUSY_SNAPSHOT`
+    /// (517) races with writers outside the process (e.g. the sqlite3 CLI).
     pub async fn begin(&self) -> Result<Transaction<'static, Sqlite>, sqlx::Error> {
-        const ATTEMPTS: u32 = 4;
-
-        let mut attempt = 1;
-        loop {
-            match self.0.begin_with("BEGIN IMMEDIATE").await {
-                Err(error) if is_busy_error(&error) && attempt < ATTEMPTS => {
-                    log::warn!(attempt; "sqlite writer starved past busy_timeout, retrying begin");
-                    attempt += 1;
-                }
-
-                other => return other,
-            }
-        }
+        self.write.begin_with("BEGIN IMMEDIATE").await
     }
-}
 
-/// Whether the error is SQLite's `SQLITE_BUSY` family ("database is locked"), i.e. lock
-/// contention that outlasted `busy_timeout` - transient by nature and safe to retry or skip
-/// for housekeeping writes.
-pub fn is_busy_error(error: &sqlx::Error) -> bool {
-    matches!(error, sqlx::Error::Database(db) if db.message().contains("database is locked"))
+    /// The pool for write statements executed outside a transaction. Reads go through
+    /// `Deref`.
+    pub fn writer(&self) -> &sqlx::SqlitePool {
+        &self.write
+    }
 }
 
 impl Deref for SqlitePool {
     type Target = sqlx::SqlitePool;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.read
     }
 }
 
@@ -109,6 +117,8 @@ pub enum Error {
 pub struct Config {
     pub cnn_url: String,
 
+    /// Size of the read pool; writes always use one dedicated connection. `1` collapses
+    /// reads onto the write connection (see [SqlitePool::new]).
     #[serde(default = "default_max_connections")]
     pub max_connections: u32,
 
@@ -236,7 +246,7 @@ mod tests {
             .expect("create pool");
 
         sqlx::query("CREATE TABLE wallet_txs (id INTEGER PRIMARY KEY, wallet INTEGER, n INTEGER)")
-            .execute(pool.deref())
+            .execute(pool.writer())
             .await
             .expect("create table");
 
@@ -278,5 +288,26 @@ mod tests {
             .await
             .expect("count rows");
         assert_eq!(rows as usize, WRITERS * WRITES_PER_WRITER);
+    }
+
+    /// A write mis-routed to the read pool must fail loudly (`query_only=ON`) instead of
+    /// silently contending with the write connection.
+    #[tokio::test]
+    async fn read_pool_rejects_writes() {
+        let temp_dir = tempfile::tempdir().expect("create tempdir");
+        let db_path = temp_dir.path().join("readonly.sqlite").display().to_string();
+        let pool = SqlitePool::new(Config::with_url(format!("sqlite://{db_path}")))
+            .await
+            .expect("create pool");
+
+        sqlx::query("CREATE TABLE test (id INTEGER PRIMARY KEY)")
+            .execute(pool.writer())
+            .await
+            .expect("create table via write pool");
+
+        let result = sqlx::query("INSERT INTO test (id) VALUES (1)")
+            .execute(pool.deref())
+            .await;
+        assert!(result.is_err());
     }
 }

--- a/spo-indexer/src/application.rs
+++ b/spo-indexer/src/application.rs
@@ -82,7 +82,19 @@ pub async fn run(
     loop {
         select! {
             result = process_next_epoch(poll_interval, &client, &storage) => {
-                result?;
+                // Transient failures (sqlite busy under write contention, node RPC hiccups)
+                // must not kill the whole standalone process; retry next interval. The
+                // backoff races SIGTERM so shutdown is not delayed by up to poll_interval.
+                if let Err(error) = result {
+                    error!("epoch processing failed, retrying next interval: {error:#}");
+                    select! {
+                        _ = sleep(poll_interval) => {}
+                        _ = sigterm.recv() => {
+                            warn!("SIGTERM received");
+                            return Ok(());
+                        }
+                    }
+                }
             }
             _ = sigterm.recv() => {
                 warn!("SIGTERM received");

--- a/spo-indexer/src/infra/storage.rs
+++ b/spo-indexer/src/infra/storage.rs
@@ -385,7 +385,7 @@ impl domain::storage::Storage for Storage {
              ON CONFLICT (id) DO UPDATE SET last_pool_id = EXCLUDED.last_pool_id, updated_at = CURRENT_TIMESTAMP"
         })
         .bind(pool_id)
-        .execute(&*self.pool)
+        .execute(self.pool.writer())
         .await?;
         Ok(())
     }

--- a/wallet-indexer/src/infra/storage.rs
+++ b/wallet-indexer/src/infra/storage.rs
@@ -300,7 +300,7 @@ impl domain::storage::Storage for Storage {
                 sqlx::query(query)
                     .bind(outdated_ids)
                     .bind(min_last_active)
-                    .execute(&*self.pool)
+                    .execute(self.pool.writer())
                     .await
                     .map(|_| ())
                     .or_else(|error| ignore_deadlock_detected(error, || ()))?;
@@ -317,16 +317,17 @@ impl domain::storage::Storage for Storage {
                     AND last_active < $2
                 "};
 
-                // Housekeeping: if the shared writer is starved past busy_timeout, skip this
-                // wallet instead of failing the poll (which would take down the whole
-                // standalone process); the next poll retries.
+                // Housekeeping: if the single writer connection is held so long that the
+                // fair-queue wait times out, skip this wallet instead of failing the poll
+                // (which would take down the whole standalone process); the next poll
+                // retries.
                 let result = sqlx::query(query)
                     .bind(id)
                     .bind(min_last_active)
-                    .execute(&*self.pool)
+                    .execute(self.pool.writer())
                     .await;
                 match result {
-                    Err(error) if indexer_common::infra::pool::sqlite::is_busy_error(&error) => {
+                    Err(sqlx::Error::PoolTimedOut) => {
                         log::warn!("skipping wallet session cleanup, sqlite writer is busy");
                     }
                     other => {


### PR DESCRIPTION
Our preprod standalone binary died after the node it follows crashed. The spo-indexer epoch loop treats every error as fatal, and the resulting write pileup pushed a waiting sqlite writer past busy_timeout into "database is locked" (code 5). One transient failure, whole process gone. We also caught an 11.7s single-row wallet INSERT in the same window: pure lock wait, since SQLite's busy handler polls with no queue.

Two changes:

- spo-indexer's epoch loop now logs and retries transient errors (node down, db contention) instead of exiting.
- The sqlite pool is split: one dedicated write connection, reads on their own pool with PRAGMA query_only=ON. Writers queue in sqlx's fair FIFO checkout, so in-process busy errors can't happen anymore, and a write that sneaks onto the read pool fails loudly instead of contending silently.

The ledger DB keeps its single-connection semantics (reads must observe the writer's in-progress state), and wallet session cleanup skips a wallet on writer timeout rather than dying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)