### PR TITLE
fix(indexer-common): use node-identical stateless cost for block_fullness accumulation

### DIFF
--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -624,21 +624,15 @@ impl LedgerState {
                     whitelist: None,
                 };
 
-                // The node accumulates `block_fullness` from the *stateless* `cost`
-                // (midnight-node `Bridge::apply_transaction`), and fee prices derive
-                // from that accumulator via `post_block_update`. The indexer must
-                // match it exactly: with the state-aware cost, the accumulators
-                // diverge on the first contract call, fee prices drift, and any
-                // fee-dependent ledger value (e.g. registration-created dust
-                // outputs) is derived differently from consensus — poisoning every
-                // subsequently derived dust commitment (shielded-sre#515).
+                // Must match the node byte-for-byte: the node feeds `block_fullness`
+                // with the stateless `cost`, and fee prices derive from this
+                // accumulator — a state-aware cost diverges on contract calls and
+                // poisons all fee-derived ledger values (shielded-sre#515).
                 let fullness_cost = transaction
                     .cost(&ledger_state.parameters, true)
                     .map_err(|error| Error::TransactionCost(error.into()))?;
-                // The stateless `cost` estimates verifier-key sizes, under-costing
-                // contract calls; `cost_with_state` reads them from the ledger state.
-                // Kept for the reported `fees` only — informational, never fed back
-                // into consensus-relevant state.
+                // State-aware cost (accurate for contract calls) — for the reported
+                // `fees` only, never for consensus-relevant state.
                 let cost = transaction
                     .cost_with_state(&ledger_state.parameters, ledger_state, true)
                     .map_err(|error| Error::TransactionCost(error.into()))?;
@@ -2515,30 +2509,15 @@ fn dag_is_complete(
 
 #[cfg(test)]
 mod tests {
-    /// Regression scaffold for the node/indexer block-fullness divergence
-    /// (shielded-sre#515): the node accumulates `block_fullness` from the
-    /// *stateless* `Transaction::cost`, and fee prices derive from that
-    /// accumulator, so the indexer must use the identical function. The two
-    /// cost functions only differ for transactions with contract operations
-    /// (verifier-key sizes are estimated statelessly but read from state by
-    /// `cost_with_state`), which is why this needs a contract-call fixture.
+    /// Regression scaffold for shielded-sre#515: the node feeds `block_fullness`
+    /// with the stateless `Transaction::cost`; a state-aware cost diverges on
+    /// contract calls and poisons fee-derived dust commitments.
     ///
-    /// To arm this test, generate with the contract tooling and commit:
-    ///   - `tests/contract_deploy_tx.raw` — a contract deployment
-    ///   - `tests/contract_call_tx.raw`   — a call to that contract
-    /// against `tests/genesis_state.raw`, then remove the `#[ignore]`.
-    ///
-    /// It then asserts, after applying both transactions:
-    ///   1. `cost(params, true)` != `cost_with_state(params, state, true)` for
-    ///      the call tx (the divergence vector exists), and
-    ///   2. the ledger state's accumulated `block_fullness` equals the sum of
-    ///      the *stateless* costs (node parity — the actual regression check).
-    ///
-    /// On-chain reproduction that motivated this: stagenet txs
-    /// 0733c136c3015043e7b20830b260f949d5d90baa35eb08bf30ea61ae81fbccae and
-    /// 3c0898a742853dc55375b5017e5136164c11e893ee4011e3f5cf326d53886ecb
-    /// (blocks 33532/33537) produced dust commitments diverging from the node
-    /// after contract calls in blocks 33513–33531 desynced fee prices.
+    /// To arm: commit `tests/contract_deploy_tx.raw` + `tests/contract_call_tx.raw`
+    /// (generated against `tests/genesis_state.raw`), drop the `#[ignore]`, apply
+    /// both, then assert (1) `cost != cost_with_state` for the call tx and
+    /// (2) accumulated `block_fullness` equals the sum of the stateless costs.
+    /// On-chain repro: stagenet txs 0733c136… / 3c0898a7… (blocks 33532/33537).
     #[test]
     #[ignore = "requires contract deploy/call fixtures; see doc comment"]
     fn block_fullness_uses_stateless_cost_node_parity() {

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -624,10 +624,21 @@ impl LedgerState {
                     whitelist: None,
                 };
 
+                // The node accumulates `block_fullness` from the *stateless* `cost`
+                // (midnight-node `Bridge::apply_transaction`), and fee prices derive
+                // from that accumulator via `post_block_update`. The indexer must
+                // match it exactly: with the state-aware cost, the accumulators
+                // diverge on the first contract call, fee prices drift, and any
+                // fee-dependent ledger value (e.g. registration-created dust
+                // outputs) is derived differently from consensus — poisoning every
+                // subsequently derived dust commitment (shielded-sre#515).
+                let fullness_cost = transaction
+                    .cost(&ledger_state.parameters, true)
+                    .map_err(|error| Error::TransactionCost(error.into()))?;
                 // The stateless `cost` estimates verifier-key sizes, under-costing
                 // contract calls; `cost_with_state` reads them from the ledger state.
-                // The ledger has no state-aware `fees`, so the fee is computed from
-                // the cost the same way `Transaction::fees` does.
+                // Kept for the reported `fees` only — informational, never fed back
+                // into consensus-relevant state.
                 let cost = transaction
                     .cost_with_state(&ledger_state.parameters, ledger_state, true)
                     .map_err(|error| Error::TransactionCost(error.into()))?;
@@ -670,7 +681,7 @@ impl LedgerState {
 
                 // Only count cost for successful/partial transactions (match node behavior)
                 let block_fullness = if should_count_cost {
-                    *block_fullness + cost
+                    *block_fullness + fullness_cost
                 } else {
                     *block_fullness
                 };
@@ -2504,6 +2515,44 @@ fn dag_is_complete(
 
 #[cfg(test)]
 mod tests {
+    /// Regression scaffold for the node/indexer block-fullness divergence
+    /// (shielded-sre#515): the node accumulates `block_fullness` from the
+    /// *stateless* `Transaction::cost`, and fee prices derive from that
+    /// accumulator, so the indexer must use the identical function. The two
+    /// cost functions only differ for transactions with contract operations
+    /// (verifier-key sizes are estimated statelessly but read from state by
+    /// `cost_with_state`), which is why this needs a contract-call fixture.
+    ///
+    /// To arm this test, generate with the contract tooling and commit:
+    ///   - `tests/contract_deploy_tx.raw` — a contract deployment
+    ///   - `tests/contract_call_tx.raw`   — a call to that contract
+    /// against `tests/genesis_state.raw`, then remove the `#[ignore]`.
+    ///
+    /// It then asserts, after applying both transactions:
+    ///   1. `cost(params, true)` != `cost_with_state(params, state, true)` for
+    ///      the call tx (the divergence vector exists), and
+    ///   2. the ledger state's accumulated `block_fullness` equals the sum of
+    ///      the *stateless* costs (node parity — the actual regression check).
+    ///
+    /// On-chain reproduction that motivated this: stagenet txs
+    /// 0733c136c3015043e7b20830b260f949d5d90baa35eb08bf30ea61ae81fbccae and
+    /// 3c0898a742853dc55375b5017e5136164c11e893ee4011e3f5cf326d53886ecb
+    /// (blocks 33532/33537) produced dust commitments diverging from the node
+    /// after contract calls in blocks 33513–33531 desynced fee prices.
+    #[test]
+    #[ignore = "requires contract deploy/call fixtures; see doc comment"]
+    fn block_fullness_uses_stateless_cost_node_parity() {
+        let deploy =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/contract_deploy_tx.raw");
+        let call =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/contract_call_tx.raw");
+        assert!(
+            deploy.exists() && call.exists(),
+            "contract fixtures missing — generate per the doc comment above"
+        );
+        unimplemented!("apply genesis + deploy + call; assert invariants 1 and 2 per doc comment");
+    }
+
     use crate::{
         domain::{
             AddressOrContract, LedgerEventAttributes, LedgerVersion,


### PR DESCRIPTION
## Problem

The indexer's re-execution accumulates `block_fullness` from `Transaction::cost_with_state`, while the node (`midnight-node`, `Bridge::apply_transaction`) accumulates from the **stateless** `Transaction::cost`. The two functions agree for plain transfers but differ for transactions with **contract operations** (the stateless cost estimates verifier-key sizes; `cost_with_state` reads them from state — as this file's own comment notes).

Fee prices derive from the fullness accumulator via `post_block_update`, so the first contract call on a chain permanently desyncs the indexer's fee-price state from the node's. From then on, every **fee-dependent value computed during application** diverges — concretely, registration-created dust outputs (`initial_value = ratio × (dust_in − fee_paid) / 10000`) get different commitments on the indexer than on the node, poisoning the derived dust commitment tree for every downstream consumer (wallet SDK, faucet). All dust spend proofs are then correctly rejected by the node with `1010: Invalid Transaction: Custom error: 170` (`InvalidDustSpendProof`).

This is what broke **stagenet** on 2026-08-15: contract calls in blocks ~33513–33531 desynced the accumulators; the registration transactions in blocks 33532/33537 (`0733c136…`, `3c0898a7…`) produced commitment-tree leaves 2450/2451 that differ between the node's state (verified by reading a validator's ParityDB directly) and the derived event stream; no transaction has been accepted since. Full forensic chain: shieldedtech/shielded-sre#515.

## Fix

Accumulate `block_fullness` from the node-identical stateless `Transaction::cost`. `cost_with_state` is retained solely for the reported `fees` field (informational; never fed back into consensus-relevant state).

Also adds an `#[ignore]`d regression-test scaffold (`block_fullness_uses_stateless_cost_node_parity`) documenting exactly which contract deploy/call fixtures are needed to arm it and which two invariants it must assert. Generating those fixtures needs the contract tooling, so it's left for a follow-up — the doc comment contains the full recipe and the on-chain reproduction references.

## Notes for reviewers

- If `cost_with_state` is considered the *better* costing, adopting it is a node-side consensus change that must ship on both sides simultaneously — until then, byte-parity with the node is the correctness criterion for this accumulator.
- Suggested follow-up (also in shielded-sre#515): cross-check the indexer's ledger-state root against the node's `midnight_ledgerStateRoot` per block and alarm on mismatch — this divergence ran silently for days and would have been caught within one block.
- After this ships, affected networks (stagenet) need a re-index; clients must then resync their wallet state.

Disclosure: this fix and the underlying investigation were AI-assisted (Claude Code); analysis verified against live stagenet state and a validator's ledger DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
