### PR TITLE
chore(deps): bump h2 to 0.4.17 (RUSTSEC-2026-0258)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2799,9 +2799,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Problem

`rust-security-scan` is failing on `main`, blocking every merge.

The break is not caused by any change in this repository. `git log 49fe051a..9194c34d -- Cargo.lock Cargo.toml deny.toml` returns no commits: RUSTSEC-2026-0258 was published on 2026-08-17, which is exactly the boundary between the last green run (49fe051a, 08-17) and the first red one (9194c34d, 08-18). The advisory database gained an entry for a dependency that had been pinned for a long time.

Of the six findings cargo-deny reports, only this one gates CI:

| Finding | ID | Crate | Gating |
|---|---|---|---|
| Unbounded empty DATA frames | RUSTSEC-2026-0258 | h2 0.4.14 | **yes** |
| Bincode unmaintained | RUSTSEC-2025-0141 | bincode 2.0.1 | no (`-Aunmaintained`) |
| paste unmaintained | RUSTSEC-2024-0436 | paste 1.0.15 | no (`-Aunmaintained`) |
| proc-macro-error2 unmaintained | RUSTSEC-2026-0173 | proc-macro-error2 2.0.1 | no (`-Aunmaintained`) |
| smallstr unmaintained | RUSTSEC-2026-0215 | smallstr 0.3.1 | no (`-Aunmaintained`) |
| Yanked crate | — | spin 0.9.8 | no (warning only) |

## Fix

`Cargo.lock` only: `h2` 0.4.14 to 0.4.17. The advisory's patched range is `>= 0.4.16`. `h2` is a transitive dependency via hyper and 0.4.17 is semver-compatible, so no manifest change is required and no `deny.toml` ignore is needed.

The single lock entry was edited directly rather than committing the output of `cargo update -p h2`, because a plain update also re-resolved seven unrelated `windows-sys` edges. The two are equivalent: h2 0.4.17's manifest dependency set matches the lock entry, and `cargo metadata --locked` leaves the file untouched.

## Verification

| Command | Exit |
|---|---|
| the workflow's cargo-deny invocation, verbatim | 0 — `advisories ok, bans ok, licenses ok, sources ok` |
| `cargo metadata --format-version 1 --locked` | 0 |
| `just feature=cloud check` | 0 |
| `just feature=standalone check` | 0 |

Local cargo-deny is 0.20.2, matching the version CI pins.

## Not included

- `spin 0.9.8` is yanked but only produces a warning, so it does not gate CI. 0.9.9 is un-yanked and semver-compatible if the warning is worth clearing separately.
- The four `unmaintained` advisories have no safe upgrade available and reach the tree through `subxt` and ledger crates; CI already suppresses that class.