### PR TITLE
fix(chain-indexer): check ledger root every block

### DIFF
--- a/chain-indexer/src/infra/subxt_node.rs
+++ b/chain-indexer/src/infra/subxt_node.rs
@@ -307,18 +307,19 @@ impl SubxtNode {
 
         // At genesis, Substrate does not emit events (Parity PR #5463). Fetch cNight
         // registrations from pallet storage instead.
-        // Also fetch the ledger state root for genesis ledger state detection.
-        let ledger_state_root = if height == 0 {
+        if height == 0 {
             let genesis_registrations =
                 runtimes::fetch_genesis_cnight_registrations(state_node_version, &block).await?;
             dust_registration_events.extend(genesis_registrations);
+        }
 
-            runtimes::get_ledger_state_root(state_node_version, &block)
-                .await?
-                .map(Into::into)
-        } else {
-            None
-        };
+        // Fetch the ledger state root for *every* block, not just genesis, so any divergence
+        // between the Node's ledger state and the one derived here by re-executing
+        // transactions fails loudly at the block where it happens, instead of silently
+        // corrupting derived data (dust commitments, ...) for the rest of the chain.
+        let ledger_state_root = runtimes::get_ledger_state_root(state_node_version, &block)
+            .await?
+            .map(Into::into);
 
         let transactions = stream::iter(transactions)
             .then(|t| make_transaction(t, protocol_version, state_node_version, &block))


### PR DESCRIPTION
## What

Fetch the Node's ledger state root for **every** block instead of only at genesis, so the
comparison already present in `chain-indexer/src/application.rs` actually runs.

## Why

`SubxtNode::block_info` set `ledger_state_root` only when `height == 0`. The comparison in
`application.rs` is guarded by `if let Some(..)`, so for every block after genesis it was a
no-op. A divergence between the Node's ledger state and the one the indexer derives by
re-executing transactions was therefore invisible, and silently corrupted everything
computed from that state — dust commitment and generation merkle roots, zswap indices — for
the remainder of the chain. Only the zswap root was compared per block.

A per-block version of this check was written in #782 and closed as "Superseeded by #772";
#772 landed the genesis-only form, so the per-block comparison never shipped. The blocker
recorded at the time was a serialization mismatch between the Node's root and the indexer's
wrapped `StorableLedgerState`. That no longer applies — see below.

## Verification

Built from this change and run against `wss://rpc.stagenet.shielded.tools` with
`network_id=stagenet`:

- **Blocks 1–15,615 compared equal.** The Node's `get_ledger_state_root` is directly
  comparable to the indexer's `LedgerState::root()` at every block, and the check produced
  no false positives over 15k consecutive blocks.
- **Block 15,616 failed with a real mismatch**, naming the exact height:

  ```
  ledger state root mismatch for block b7840d11… at height 15616:
    node    = 00df7a18…
    indexer = 009e6bae…
  ```

  That divergence is under separate investigation (#1443, shieldedtech/shielded-sre#515).
  It is a pre-existing condition on stagenet that this change *surfaces*, not one it
  introduces.

All four supported Node versions (`V0_22`, `V1_0`, `V2_0`, `V2_1`) implement the runtime
API, so no version gating is required. `just fmt-check` and `just lint` pass locally.

## Reviewer note — operational consequence

The comparison is a `bail!`, which kills `index_blocks_task`. With this merged, an indexer
pointed at a chain where its derived state diverges will **stop indexing at the divergent
block** rather than continue past it. On stagenet today that means stopping at 15,616.

That is the intent — failing loudly beats serving silently wrong derived data — but it is a
behaviour change for any environment currently carrying a divergence, so it deserves an
explicit decision: merge as-is, or put the per-block comparison behind a config flag so it
can be enabled per environment.
