### PR TITLE
perf: 13x faster chain indexing, bridge-event fix for standalone

### DIFF
--- a/chain-indexer/Cargo.toml
+++ b/chain-indexer/Cargo.toml
@@ -35,7 +35,7 @@ serde              = { workspace = true, features = [ "derive" ] }
 sqlx               = { workspace = true, features = [ "time" ] }
 subxt              = { workspace = true, features = [ "reconnecting-rpc-client" ] }
 thiserror          = { workspace = true }
-tokio              = { workspace = true, features = [ "macros", "rt-multi-thread", "time", "signal" ] }
+tokio              = { workspace = true, features = [ "macros", "rt-multi-thread", "sync", "time", "signal" ] }
 trait-variant      = { workspace = true }
 
 [dev-dependencies]

--- a/chain-indexer/examples/node.rs
+++ b/chain-indexer/examples/node.rs
@@ -36,6 +36,7 @@ impl Cli {
             reconnect_max_delay: Duration::from_secs(1),
             reconnect_max_attempts: 1,
             subscription_recovery_timeout: Duration::from_secs(30),
+            fetch_concurrency: 8,
         };
         let mut node = SubxtNode::new(config).await.context("create SubxtNode")?;
 

--- a/chain-indexer/src/application.rs
+++ b/chain-indexer/src/application.rs
@@ -35,7 +35,6 @@ use serde::Deserialize;
 use std::{
     collections::{HashSet, VecDeque},
     error::Error as StdError,
-    future::ready,
     num::NonZeroUsize,
     pin::pin,
     sync::Arc,
@@ -44,6 +43,7 @@ use std::{
 use tokio::{
     select,
     signal::unix::Signal,
+    sync::mpsc,
     task::{self},
     time::sleep,
 };
@@ -219,9 +219,26 @@ pub async fn run(
         let node = node.clone();
 
         async move {
-            let blocks = node_blocks(highest_block_ref, node.clone())
-                .map(ready)
-                .buffered(blocks_buffer);
+            // Stream combinators only make progress while the consumer polls them, so a
+            // `buffered` adapter cannot fetch ahead while a block is being processed. Run the
+            // block stream on its own task feeding a bounded channel so fetching the next
+            // blocks overlaps indexing, with at most `blocks_buffer` blocks in flight.
+            let (block_tx, mut block_rx) = mpsc::channel(blocks_buffer.max(1));
+            task::spawn({
+                let node = node.clone();
+                async move {
+                    let blocks = node_blocks(highest_block_ref, node);
+                    let mut blocks = pin!(blocks);
+                    while let Some(block) = blocks.next().await
+                        && block_tx.send(block).await.is_ok()
+                    {}
+                }
+            });
+            let blocks = stream! {
+                while let Some(block) = block_rx.recv().await {
+                    yield block;
+                }
+            };
             let mut blocks = pin!(blocks);
             let mut caught_up = false;
             let mut parent_block_timestamp = initial_parent_block_timestamp;

--- a/chain-indexer/src/application.rs
+++ b/chain-indexer/src/application.rs
@@ -370,7 +370,9 @@ where
     E: StdError + Send + Sync + 'static,
     N: Node,
 {
+    let block_fetch_started = Instant::now();
     let block = get_next_block(blocks).await?;
+    metrics.record_block_fetch(block_fetch_started.elapsed());
 
     let result = index_block(
         caught_up_max_distance,
@@ -424,12 +426,17 @@ async fn index_block<N>(
 where
     N: Node,
 {
+    let block_processing_started = Instant::now();
+
     // Capture the node's zswap merkle tree root (domain type) before `try_into` serializes it, to
     // compare against the zswap merkle tree root in the ledger state below.
     let zswap_merkle_tree_root = block.zswap_merkle_tree_root;
 
+    let block_conversion_started = Instant::now();
     let (mut block, transactions) = block.try_into().context("convert node block into domain")?;
+    metrics.record_block_conversion(block_conversion_started.elapsed());
 
+    let ledger_update_started = Instant::now();
     let ledger_version = block.protocol_version.ledger_version();
     ledger_state = if block.height == 0 {
         // The genesis block establishes the chain's ledger version. The inherited
@@ -548,6 +555,7 @@ where
             local_zswap_merkle_tree_root,
         );
     }
+    metrics.record_ledger_update(ledger_update_started.elapsed());
 
     // Determine whether caught up, also allowing to fall back a little in that state.
     // Use saturating subtraction to handle the case where streams are temporarily out of order.
@@ -574,16 +582,21 @@ where
     }
 
     // Persist ledger state.
+    let ledger_persist_started = Instant::now();
     let (new_ledger_state, ledger_state_key) =
         ledger_state.0.persist().context("persist ledger state")?;
     ledger_state = new_ledger_state.into();
+    metrics.record_ledger_persist(ledger_persist_started.elapsed());
 
     // Determine system parameters change if any.
+    let system_parameters_started = Instant::now();
     let system_parameters_change = determine_system_parameters_change(&block, storage, node)
         .await
         .context("determine system parameters change")?;
+    metrics.record_system_parameters(system_parameters_started.elapsed());
 
     // Save the block with its related data and system parameters atomically.
+    let block_storage_started = Instant::now();
     let max_transaction_id = storage
         .save_block(
             &block,
@@ -594,8 +607,10 @@ where
         )
         .await
         .context("save block")?;
+    metrics.record_block_storage(block_storage_started.elapsed());
 
     // Publish BlockIndexed.
+    let event_publish_started = Instant::now();
     publisher
         .publish(&BlockIndexed {
             height: block.height,
@@ -637,6 +652,7 @@ where
             .await
             .context("publish BridgeEventIndexed event")?;
     }
+    metrics.record_event_publish(event_publish_started.elapsed());
 
     // Update metrics.
     metrics.update(&block, &transactions, node_block_height, *caught_up);
@@ -650,6 +666,8 @@ where
         caught_up = *caught_up;
         "block indexed"
     );
+
+    metrics.record_block_processing(block_processing_started.elapsed());
 
     Ok((ledger_state, ledger_state_key))
 }

--- a/chain-indexer/src/application.rs
+++ b/chain-indexer/src/application.rs
@@ -36,7 +36,7 @@ use serde::Deserialize;
 use std::{
     collections::{HashSet, VecDeque},
     error::Error as StdError,
-    num::NonZeroUsize,
+    num::{NonZeroU64, NonZeroUsize},
     pin::pin,
     sync::Arc,
     time::{Duration, Instant},
@@ -61,10 +61,20 @@ pub struct Config {
     #[serde(with = "humantime_serde")]
     pub gc_bound: Duration,
 
+    /// Run the gc pass every this many blocks (default 1). During catch-up a pass rarely finds
+    /// orphans, so amortizing it over several blocks trades a slightly larger arena for less
+    /// per-block overhead; the time budget per pass stays gc_bound.
+    #[serde(default = "gc_block_interval_default")]
+    pub gc_block_interval: NonZeroU64,
+
     /// How many recent blocks' ledger state keys stay persisted as gc roots before the oldest
     /// is unpersisted. Must comfortably exceed indexer-api's block-hash snapshot reads, e.g.
     /// the dust generations subscription's max_snapshot_age, or those reads hit culled state.
     pub ledger_state_retention: NonZeroUsize,
+}
+
+fn gc_block_interval_default() -> NonZeroU64 {
+    NonZeroU64::MIN
 }
 
 pub async fn run(
@@ -80,6 +90,7 @@ pub async fn run(
         caught_up_max_distance,
         caught_up_leeway,
         gc_bound,
+        gc_block_interval,
         ledger_state_retention,
     } = config;
 
@@ -242,6 +253,7 @@ pub async fn run(
             };
             let mut blocks = pin!(blocks);
             let mut caught_up = false;
+            let mut blocks_since_gc = 0;
             let mut parent_block_timestamp = initial_parent_block_timestamp;
 
             loop {
@@ -278,8 +290,11 @@ pub async fn run(
                     }
                 }
 
-                // Run a time-bounded mark-and-sweep pass; skip when disabled.
-                if !gc_bound.is_zero() {
+                // Run a time-bounded mark-and-sweep pass every gc_block_interval blocks; skip
+                // when disabled.
+                blocks_since_gc += 1;
+                if !gc_bound.is_zero() && blocks_since_gc >= gc_block_interval.get() {
+                    blocks_since_gc = 0;
                     let started = Instant::now();
                     let nodes_culled = LedgerState::gc(gc_bound);
                     let elapsed = started.elapsed();

--- a/chain-indexer/src/application.rs
+++ b/chain-indexer/src/application.rs
@@ -16,7 +16,8 @@ mod metrics;
 use crate::{
     application::metrics::Metrics,
     domain::{
-        Block, BlockRef, LedgerState, SystemParametersChange, Transaction,
+        Block, BlockRef, DParameter, LedgerState, SystemParametersChange, TermsAndConditions,
+        Transaction,
         node::{self, Node},
         storage::Storage,
     },
@@ -449,6 +450,10 @@ where
     // compare against the zswap merkle tree root in the ledger state below.
     let zswap_merkle_tree_root = block.zswap_merkle_tree_root;
 
+    // System parameters ride on the node block; capture them before the conversion consumes it.
+    let d_parameter = block.d_parameter.clone();
+    let terms_and_conditions = block.terms_and_conditions.clone();
+
     let block_conversion_started = Instant::now();
     let (mut block, transactions) = block.try_into().context("convert node block into domain")?;
     metrics.record_block_conversion(block_conversion_started.elapsed());
@@ -607,9 +612,10 @@ where
 
     // Determine system parameters change if any.
     let system_parameters_started = Instant::now();
-    let system_parameters_change = determine_system_parameters_change(&block, storage, node)
-        .await
-        .context("determine system parameters change")?;
+    let system_parameters_change =
+        determine_system_parameters_change(&block, d_parameter, terms_and_conditions, storage)
+            .await
+            .context("determine system parameters change")?;
     metrics.record_system_parameters(system_parameters_started.elapsed());
 
     // Save the block with its related data and system parameters atomically.
@@ -689,27 +695,14 @@ where
     Ok((ledger_state, ledger_state_key))
 }
 
-/// Fetch system parameters from the node and determine if they changed.
+/// Determine whether the system parameters carried on the block differ from the stored ones.
 #[trace]
-async fn determine_system_parameters_change<N>(
+async fn determine_system_parameters_change(
     block: &Block,
+    d_parameter: Option<DParameter>,
+    terms_and_conditions: Option<TermsAndConditions>,
     storage: &mut impl Storage,
-    node: &N,
-) -> anyhow::Result<Option<SystemParametersChange>>
-where
-    N: Node,
-{
-    // Fetch current system parameters from the node.
-    let current = node
-        .fetch_system_parameters(
-            block.hash,
-            block.height,
-            block.timestamp,
-            block.protocol_version.node_version(),
-        )
-        .await
-        .map_err(|error| anyhow::anyhow!("fetch system parameters: {error}"))?;
-
+) -> anyhow::Result<Option<SystemParametersChange>> {
     // Get the latest stored parameters.
     let stored_d_param = storage
         .get_latest_d_parameter()
@@ -721,14 +714,14 @@ where
         .context("get latest terms and conditions")?;
 
     // Determine what has changed.
-    let d_param_changed = current.d_parameter.as_ref().is_some_and(|current_d| {
+    let d_param_changed = d_parameter.as_ref().is_some_and(|current_d| {
         stored_d_param.as_ref().is_none_or(|stored_d| {
             current_d.num_permissioned_candidates != stored_d.num_permissioned_candidates
                 || current_d.num_registered_candidates != stored_d.num_registered_candidates
         })
     });
 
-    let tc_changed = match (&current.terms_and_conditions, &stored_tc) {
+    let tc_changed = match (&terms_and_conditions, &stored_tc) {
         (Some(current_tc), Some(stored_tc)) => {
             current_tc.hash != stored_tc.hash || current_tc.url != stored_tc.url
         }
@@ -742,13 +735,9 @@ where
             block_height: block.height,
             block_hash: block.hash,
             timestamp: block.timestamp,
-            d_parameter: if d_param_changed {
-                current.d_parameter
-            } else {
-                None
-            },
+            d_parameter: if d_param_changed { d_parameter } else { None },
             terms_and_conditions: if tc_changed {
-                current.terms_and_conditions
+                terms_and_conditions
             } else {
                 None
             },
@@ -772,17 +761,14 @@ mod tests {
     use crate::{
         application::node_blocks,
         domain::{
-            BlockRef, SystemParametersChange,
+            BlockRef,
             node::{self, Node},
         },
     };
     use fake::{Fake, Faker};
     use futures::{Stream, StreamExt, TryStreamExt, stream};
     use indexer_common::{
-        domain::{
-            BlockHash, ByteArray, ByteVec, NodeVersion, ProtocolVersion,
-            ledger::ZswapMerkleTreeRoot,
-        },
+        domain::{BlockHash, ByteArray, ByteVec, ProtocolVersion, ledger::ZswapMerkleTreeRoot},
         error::BoxError,
     };
     use std::{convert::Infallible, sync::LazyLock};
@@ -820,22 +806,6 @@ mod tests {
                 .map(|block| Ok(block.to_owned()))
         }
 
-        async fn fetch_system_parameters(
-            &self,
-            block_hash: BlockHash,
-            block_height: u64,
-            timestamp: u64,
-            _node_version: NodeVersion,
-        ) -> Result<SystemParametersChange, Self::Error> {
-            Ok(SystemParametersChange {
-                block_height,
-                block_hash,
-                timestamp,
-                d_parameter: None,
-                terms_and_conditions: None,
-            })
-        }
-
         async fn fetch_genesis_ledger_state(&self) -> Result<ByteVec, Self::Error> {
             Ok(Default::default())
         }
@@ -853,6 +823,8 @@ mod tests {
         transactions: Default::default(),
         dust_registration_events: Default::default(),
         bridge_events: Default::default(),
+        d_parameter: None,
+        terms_and_conditions: None,
     });
 
     static BLOCK_1: LazyLock<node::Block> = LazyLock::new(|| node::Block {
@@ -867,6 +839,8 @@ mod tests {
         transactions: Default::default(),
         dust_registration_events: Default::default(),
         bridge_events: Default::default(),
+        d_parameter: None,
+        terms_and_conditions: None,
     });
 
     static BLOCK_2: LazyLock<node::Block> = LazyLock::new(|| node::Block {
@@ -881,6 +855,8 @@ mod tests {
         transactions: Default::default(),
         dust_registration_events: Default::default(),
         bridge_events: Default::default(),
+        d_parameter: None,
+        terms_and_conditions: None,
     });
 
     static BLOCK_3: LazyLock<node::Block> = LazyLock::new(|| node::Block {
@@ -895,6 +871,8 @@ mod tests {
         transactions: Default::default(),
         dust_registration_events: Default::default(),
         bridge_events: Default::default(),
+        d_parameter: None,
+        terms_and_conditions: None,
     });
 
     const ZERO_HASH: BlockHash = ByteArray([0; 32]);

--- a/chain-indexer/src/application/metrics.rs
+++ b/chain-indexer/src/application/metrics.rs
@@ -27,6 +27,14 @@ pub struct Metrics {
     gc_run_count: Counter,
     gc_culled_node_count: Counter,
     gc_duration_seconds: Histogram,
+    block_fetch_duration_seconds: Histogram,
+    block_conversion_duration_seconds: Histogram,
+    ledger_update_duration_seconds: Histogram,
+    ledger_persist_duration_seconds: Histogram,
+    system_parameters_duration_seconds: Histogram,
+    block_storage_duration_seconds: Histogram,
+    event_publish_duration_seconds: Histogram,
+    block_processing_duration_seconds: Histogram,
 }
 
 impl Metrics {
@@ -46,6 +54,20 @@ impl Metrics {
             gc_run_count: counter!("indexer_gc_run_count"),
             gc_culled_node_count: counter!("indexer_gc_culled_node_count"),
             gc_duration_seconds: histogram!("indexer_gc_duration_seconds"),
+            block_fetch_duration_seconds: histogram!("indexer_block_fetch_duration_seconds"),
+            block_conversion_duration_seconds: histogram!(
+                "indexer_block_conversion_duration_seconds"
+            ),
+            ledger_update_duration_seconds: histogram!("indexer_ledger_update_duration_seconds"),
+            ledger_persist_duration_seconds: histogram!("indexer_ledger_persist_duration_seconds"),
+            system_parameters_duration_seconds: histogram!(
+                "indexer_system_parameters_duration_seconds"
+            ),
+            block_storage_duration_seconds: histogram!("indexer_block_storage_duration_seconds"),
+            event_publish_duration_seconds: histogram!("indexer_event_publish_duration_seconds"),
+            block_processing_duration_seconds: histogram!(
+                "indexer_block_processing_duration_seconds"
+            ),
         };
 
         if let Some(block_height) = block_height {
@@ -147,5 +169,45 @@ impl Metrics {
         self.gc_run_count.increment(1);
         self.gc_culled_node_count.increment(nodes_culled as u64);
         self.gc_duration_seconds.record(duration.as_secs_f64());
+    }
+
+    pub fn record_block_fetch(&self, duration: Duration) {
+        self.block_fetch_duration_seconds
+            .record(duration.as_secs_f64());
+    }
+
+    pub fn record_block_conversion(&self, duration: Duration) {
+        self.block_conversion_duration_seconds
+            .record(duration.as_secs_f64());
+    }
+
+    pub fn record_ledger_update(&self, duration: Duration) {
+        self.ledger_update_duration_seconds
+            .record(duration.as_secs_f64());
+    }
+
+    pub fn record_ledger_persist(&self, duration: Duration) {
+        self.ledger_persist_duration_seconds
+            .record(duration.as_secs_f64());
+    }
+
+    pub fn record_system_parameters(&self, duration: Duration) {
+        self.system_parameters_duration_seconds
+            .record(duration.as_secs_f64());
+    }
+
+    pub fn record_block_storage(&self, duration: Duration) {
+        self.block_storage_duration_seconds
+            .record(duration.as_secs_f64());
+    }
+
+    pub fn record_event_publish(&self, duration: Duration) {
+        self.event_publish_duration_seconds
+            .record(duration.as_secs_f64());
+    }
+
+    pub fn record_block_processing(&self, duration: Duration) {
+        self.block_processing_duration_seconds
+            .record(duration.as_secs_f64());
     }
 }

--- a/chain-indexer/src/domain/node.rs
+++ b/chain-indexer/src/domain/node.rs
@@ -12,11 +12,11 @@
 // limitations under the License.
 
 use crate::domain::{
-    self, BlockRef, ContractAction, DustRegistrationEvent, SystemParametersChange,
+    self, BlockRef, ContractAction, DParameter, DustRegistrationEvent, TermsAndConditions,
 };
 use futures::Stream;
 use indexer_common::domain::{
-    BlockAuthor, BlockHash, ByteVec, NodeVersion, ProtocolVersion, SerializedTransaction,
+    BlockAuthor, BlockHash, ByteVec, ProtocolVersion, SerializedTransaction,
     SerializedTransactionIdentifier, TransactionHash,
     ledger::{self, ZswapMerkleTreeRoot},
 };
@@ -43,15 +43,6 @@ where
         after: Option<BlockRef>,
     ) -> impl Stream<Item = Result<Block, Self::Error>>;
 
-    /// Fetch system parameters (D-Parameter and Terms & Conditions) at a given block.
-    async fn fetch_system_parameters(
-        &self,
-        block_hash: BlockHash,
-        block_height: u64,
-        timestamp: u64,
-        node_version: NodeVersion,
-    ) -> Result<SystemParametersChange, Self::Error>;
-
     /// Fetch serialized genesis ledger state from the chain spec's system properties.
     /// Returns the raw bytes of the genesis `LedgerState`, errs if unavailable.
     async fn fetch_genesis_ledger_state(&self) -> Result<ByteVec, Self::Error>;
@@ -70,6 +61,10 @@ pub struct Block {
     pub transactions: Vec<Transaction>,
     pub dust_registration_events: Vec<DustRegistrationEvent>,
     pub bridge_events: Vec<indexer_common::domain::bridge::BridgeEvent>,
+    /// D-parameter in this block's state, fetched alongside the block.
+    pub d_parameter: Option<DParameter>,
+    /// Terms and conditions in this block's state, if set.
+    pub terms_and_conditions: Option<TermsAndConditions>,
 }
 
 impl TryFrom<Block> for (domain::Block, Vec<Transaction>) {

--- a/chain-indexer/src/infra/subxt_node.rs
+++ b/chain-indexer/src/infra/subxt_node.rs
@@ -40,7 +40,7 @@ use indexer_common::{
 use log::{debug, info, warn};
 use parity_scale_codec::Decode;
 use serde::Deserialize;
-use std::{future::ready, time::Duration};
+use std::{future::ready, pin::pin, time::Duration};
 use subxt::{
     OnlineClient, SubstrateConfig,
     config::{
@@ -70,6 +70,63 @@ pub(crate) struct ContentSource {
     pub(crate) extrinsic_bodies: Vec<Vec<u8>>,
 }
 
+/// A block with everything fetched except the author, which depends on the sequentially
+/// maintained authority cache. Produced by [SubxtNode::make_raw_block], possibly concurrently
+/// for multiple blocks, and completed in block order by [finish_block].
+struct RawBlock {
+    client: OnlineClientAtBlock,
+    header: SubstrateHeader<H256>,
+    state_node_version: NodeVersion,
+    content_node_version: NodeVersion,
+    babe_supported: bool,
+    new_session: bool,
+    block: Block,
+}
+
+/// Resolve the block author against the sequential authority cache and apply this block's
+/// session change to the cache. Must be called in block order.
+async fn finish_block(
+    authorities: &mut Option<Vec<[u8; 32]>>,
+    raw_block: RawBlock,
+) -> Result<Block, SubxtNodeError> {
+    let RawBlock {
+        client,
+        header,
+        state_node_version,
+        content_node_version,
+        babe_supported,
+        new_session,
+        mut block,
+    } = raw_block;
+
+    // Fetch authorities if `None`, either initially or because of a `NewSession` event in the
+    // previous block.
+    if authorities.is_none() {
+        *authorities = Some(runtimes::fetch_authorities(state_node_version, &client).await?);
+    }
+    block.author = authorities
+        .as_ref()
+        .map(|authorities| {
+            extract_block_author(&header, authorities, content_node_version, babe_supported)
+        })
+        .transpose()?
+        .flatten();
+
+    if new_session {
+        *authorities = None;
+    }
+
+    debug!(
+        hash:% = block.hash,
+        height = block.height,
+        parent_hash:% = block.parent_hash,
+        transactions_len = block.transactions.len();
+        "block made"
+    );
+
+    Ok(block)
+}
+
 const AURA_ENGINE_ID: ConsensusEngineId = [b'a', b'u', b'r', b'a'];
 const BABE_ENGINE_ID: ConsensusEngineId = [b'B', b'A', b'B', b'E'];
 
@@ -92,6 +149,7 @@ pub struct SubxtNode {
     rpc_client: ReconnectingRpcClient,
     online_client: OnlineClient<SubstrateConfig>,
     subscription_recovery_timeout: Duration,
+    fetch_concurrency: usize,
 }
 
 impl SubxtNode {
@@ -102,6 +160,7 @@ impl SubxtNode {
             reconnect_max_delay: retry_max_delay,
             reconnect_max_attempts: retry_max_attempts,
             subscription_recovery_timeout,
+            fetch_concurrency,
         } = config;
 
         let retry_policy = ExponentialBackoff::from_millis(10)
@@ -123,6 +182,7 @@ impl SubxtNode {
             rpc_client,
             online_client,
             subscription_recovery_timeout,
+            fetch_concurrency,
         })
     }
 
@@ -183,10 +243,18 @@ impl SubxtNode {
     }
 
     async fn make_block(
-        &mut self,
+        &self,
         authorities: &mut Option<Vec<[u8; 32]>>,
         block: OnlineClientAtBlock,
     ) -> Result<Block, SubxtNodeError> {
+        let raw_block = self.make_raw_block(block).await?;
+        finish_block(authorities, raw_block).await
+    }
+
+    /// Fetch and assemble everything of a block that does not depend on the sequential
+    /// authority cache, so it can run concurrently for multiple blocks. [finish_block]
+    /// resolves the author and applies session changes in block order.
+    async fn make_raw_block(&self, block: OnlineClientAtBlock) -> Result<RawBlock, SubxtNodeError> {
         let hash = block.block_hash().0.into();
         let height = block.block_number();
         let header = block_header(&block).await?;
@@ -232,23 +300,12 @@ impl SubxtNode {
             "making block"
         );
 
-        // Fetch authorities if `None`, either initially or because of a `NewSession` event (below).
-        if authorities.is_none() {
-            *authorities = Some(runtimes::fetch_authorities(state_node_version, &block).await?);
-        }
-        let author = authorities
-            .as_ref()
-            .map(|authorities| {
-                // The state metadata can only be newer than the runtime that authored the
-                // block, so this can never enable BABE recognition too late.
-                let babe_supported = block
-                    .metadata_ref()
-                    .runtime_api_trait_by_name(CONSENSUS_ENGINE_RUNTIME_API)
-                    .is_some();
-                extract_block_author(&header, authorities, content_node_version, babe_supported)
-            })
-            .transpose()?
-            .flatten();
+        // The state metadata can only be newer than the runtime that authored the
+        // block, so this can never enable BABE recognition too late.
+        let babe_supported = block
+            .metadata_ref()
+            .runtime_api_trait_by_name(CONSENSUS_ENGINE_RUNTIME_API)
+            .is_some();
 
         // The node's ledger-9 host API detects the v8 StateKey at the 8->9 enactment block and
         // dispatches this read to the v8 bridge. The MNSV protocol version remains the right
@@ -294,16 +351,12 @@ impl SubxtNode {
 
         let BlockDetails {
             timestamp,
+            new_session,
             transactions,
             mut dust_registration_events,
             bridge_events,
-        } = runtimes::make_block_details(
-            authorities,
-            content_node_version,
-            &block,
-            content_source.as_ref(),
-        )
-        .await?;
+        } = runtimes::make_block_details(content_node_version, &block, content_source.as_ref())
+            .await?;
 
         // At genesis, Substrate does not emit events (Parity PR #5463). Fetch cNight
         // registrations from pallet storage instead.
@@ -325,29 +378,27 @@ impl SubxtNode {
             .try_collect::<Vec<_>>()
             .await?;
 
-        let block = Block {
-            hash,
-            height,
-            parent_hash,
-            protocol_version,
-            author,
-            timestamp: timestamp.unwrap_or(0),
-            zswap_merkle_tree_root,
-            ledger_state_root,
-            transactions,
-            dust_registration_events,
-            bridge_events,
-        };
-
-        debug!(
-            hash:% = block.hash,
-            height = block.height,
-            parent_hash:% = block.parent_hash,
-            transactions_len = block.transactions.len();
-            "block made"
-        );
-
-        Ok(block)
+        Ok(RawBlock {
+            header,
+            state_node_version,
+            content_node_version,
+            babe_supported,
+            new_session,
+            block: Block {
+                hash,
+                height,
+                parent_hash,
+                protocol_version,
+                author: None,
+                timestamp: timestamp.unwrap_or(0),
+                zswap_merkle_tree_root,
+                ledger_state_root,
+                transactions,
+                dust_registration_events,
+                bridge_events,
+            },
+            client: block,
+        })
     }
 
     #[trace]
@@ -433,7 +484,22 @@ impl Node for SubxtNode {
                 // Initialize from the stored block hash so the first forward-fetched block
                 // is verified against it too.
                 let mut last_forward_hash = after_height.map(|_| H256(after_hash.0));
-                for height in start_height..safe_height {
+                // Fetch blocks for multiple heights concurrently; `buffered` preserves height
+                // order. Author resolution and parent-hash verification stay sequential below.
+                let fetch_node = self.clone();
+                let raw_blocks = stream::iter(start_height..safe_height)
+                    .map(move |height| {
+                        let fetch_node = fetch_node.clone();
+                        async move {
+                            let block = fetch_node.block_at_height(height).await?;
+                            fetch_node.make_raw_block(block).await
+                        }
+                    })
+                    .buffered(self.fetch_concurrency.max(1));
+                let mut raw_blocks = pin!(raw_blocks);
+
+                let mut height = start_height;
+                while let Some(raw_block) = raw_blocks.next().await {
                     if height % CATCH_UP_LOG_INTERVAL == 0 {
                         info!(
                             highest_stored_height:? = after_height,
@@ -442,9 +508,9 @@ impl Node for SubxtNode {
                             "catching up by height"
                         );
                     }
-                    let block = self.block_at_height(height).await?;
-                    let block_hash = block.block_hash();
-                    let made_block = self.make_block(&mut authorities, block).await?;
+                    let raw_block = raw_block?;
+                    let block_hash = raw_block.client.block_hash();
+                    let made_block = finish_block(&mut authorities, raw_block).await?;
                     if let Some(expected_parent) = last_forward_hash
                         && made_block.parent_hash.0 != expected_parent.0
                     {
@@ -455,6 +521,7 @@ impl Node for SubxtNode {
                         ))?;
                     }
                     last_forward_hash = Some(block_hash);
+                    height += 1;
                     yield made_block;
                 }
 
@@ -603,10 +670,19 @@ pub struct Config {
         default = "default_subscription_recovery_timeout"
     )]
     pub subscription_recovery_timeout: Duration,
+
+    /// Number of blocks fetched concurrently while catching up by height. Author resolution
+    /// stays sequential, so this only bounds in-flight block fetches. Defaults to 8.
+    #[serde(default = "default_fetch_concurrency")]
+    pub fetch_concurrency: usize,
 }
 
 fn default_subscription_recovery_timeout() -> Duration {
     Duration::from_secs(30)
+}
+
+fn default_fetch_concurrency() -> usize {
+    8
 }
 
 /// Error possibly returned by [SubxtNode::new].

--- a/chain-indexer/src/infra/subxt_node.rs
+++ b/chain-indexer/src/infra/subxt_node.rs
@@ -16,7 +16,7 @@ mod runtimes;
 
 use crate::{
     domain::{
-        BlockRef, SystemParametersChange,
+        BlockRef,
         node::{Block, Node, RegularTransaction, SystemTransaction, Transaction},
     },
     infra::subxt_node::{header::SubstrateHeaderExt, runtimes::BlockDetails},
@@ -378,6 +378,15 @@ impl SubxtNode {
             .try_collect::<Vec<_>>()
             .await?;
 
+        // System parameters live in this block's state; fetching them here lets the lookups
+        // ride the concurrent block prefetch instead of the sequential indexing path. Both are
+        // storage/runtime-API reads, so both use the runtime in this block's state, which at an
+        // enactment block is already the next one; see above.
+        let (d_parameter, terms_and_conditions) = tokio::try_join!(
+            runtimes::get_d_parameter(state_node_version, &block),
+            runtimes::get_terms_and_conditions(state_node_version, &block),
+        )?;
+
         Ok(RawBlock {
             header,
             state_node_version,
@@ -396,6 +405,8 @@ impl SubxtNode {
                 transactions,
                 dust_registration_events,
                 bridge_events,
+                d_parameter: Some(d_parameter),
+                terms_and_conditions,
             },
             client: block,
         })
@@ -591,34 +602,6 @@ impl Node for SubxtNode {
                 }
             }
         }
-    }
-
-    async fn fetch_system_parameters(
-        &self,
-        block_hash: BlockHash,
-        block_height: u64,
-        timestamp: u64,
-        _node_version: NodeVersion,
-    ) -> Result<SystemParametersChange, Self::Error> {
-        let block = self.block_at(H256(block_hash.0)).await?;
-
-        // Both are storage/runtime-API reads, so both need the runtime in this block's state,
-        // which at an enactment block is already the next one; see `make_block`. The
-        // `_node_version` parameter carries the MNSV based version and is deliberately unused.
-        let state_node_version = ProtocolVersion::try_from(block.spec_version())?.node_version();
-
-        let (d_parameter, terms_and_conditions) = tokio::try_join!(
-            runtimes::get_d_parameter(state_node_version, &block),
-            runtimes::get_terms_and_conditions(state_node_version, &block),
-        )?;
-
-        Ok(SystemParametersChange {
-            block_height,
-            block_hash,
-            timestamp,
-            d_parameter: Some(d_parameter),
-            terms_and_conditions,
-        })
     }
 
     async fn fetch_genesis_ledger_state(&self) -> Result<ByteVec, Self::Error> {

--- a/chain-indexer/src/infra/subxt_node/runtimes.rs
+++ b/chain-indexer/src/infra/subxt_node/runtimes.rs
@@ -30,6 +30,9 @@ use indexer_common::domain::{
 /// Runtime specific block details.
 pub struct BlockDetails {
     pub timestamp: Option<u64>,
+    /// True when this block emitted a `NewSession` event, i.e. the authority set used to
+    /// resolve block authors must be refetched for the next block.
+    pub new_session: bool,
     pub transactions: Vec<Transaction>,
     pub dust_registration_events: Vec<DustRegistrationEvent>,
     /// c2m-bridge events. Only populated for node 2.0+, where the
@@ -46,17 +49,16 @@ pub enum Transaction {
 
 /// Make block details depending on the given protocol version.
 pub async fn make_block_details(
-    authorities: &mut Option<Vec<[u8; 32]>>,
     node_version: NodeVersion,
     block: &OnlineClientAtBlock,
     content: Option<&ContentSource>,
 ) -> Result<BlockDetails, SubxtNodeError> {
     // TODO Replace this often repeated pattern with a macro?
     match node_version {
-        NodeVersion::V0_22 => v0_22_0::make_block_details(authorities, block, content).await,
-        NodeVersion::V1_0 => v1_0_0::make_block_details(authorities, block, content).await,
-        NodeVersion::V2_0 => v2_0_0::make_block_details(authorities, block, content).await,
-        NodeVersion::V2_1 => v2_1_0::make_block_details(authorities, block, content).await,
+        NodeVersion::V0_22 => v0_22_0::make_block_details(block, content).await,
+        NodeVersion::V1_0 => v1_0_0::make_block_details(block, content).await,
+        NodeVersion::V2_0 => v2_0_0::make_block_details(block, content).await,
+        NodeVersion::V2_1 => v2_1_0::make_block_details(block, content).await,
     }
 }
 

--- a/chain-indexer/src/infra/subxt_node/runtimes/v0_22_0.rs
+++ b/chain-indexer/src/infra/subxt_node/runtimes/v0_22_0.rs
@@ -28,7 +28,6 @@ use parity_scale_codec::Decode;
 use subxt::error::RuntimeApiError;
 
 pub async fn make_block_details(
-    authorities: &mut Option<Vec<[u8; 32]>>,
     block: &OnlineClientAtBlock,
     content: Option<&ContentSource>,
 ) -> Result<BlockDetails, SubxtNodeError> {
@@ -99,6 +98,7 @@ pub async fn make_block_details(
         })
         .collect::<Vec<_>>();
 
+    let mut new_session = false;
     let mut dust_registration_events = vec![];
     let mut system_transactions_from_events = vec![];
 
@@ -130,7 +130,7 @@ pub async fn make_block_details(
 
         match event {
             Event::Session(NewSession { .. }) => {
-                *authorities = None;
+                new_session = true;
             }
 
             // System transaction created by the node (not from extrinsics).
@@ -190,6 +190,7 @@ pub async fn make_block_details(
 
     Ok(BlockDetails {
         timestamp,
+        new_session,
         transactions,
         dust_registration_events,
         bridge_events: vec![],

--- a/chain-indexer/src/infra/subxt_node/runtimes/v1_0_0.rs
+++ b/chain-indexer/src/infra/subxt_node/runtimes/v1_0_0.rs
@@ -28,7 +28,6 @@ use parity_scale_codec::Decode;
 use subxt::error::RuntimeApiError;
 
 pub async fn make_block_details(
-    authorities: &mut Option<Vec<[u8; 32]>>,
     block: &OnlineClientAtBlock,
     content: Option<&ContentSource>,
 ) -> Result<BlockDetails, SubxtNodeError> {
@@ -99,6 +98,7 @@ pub async fn make_block_details(
         })
         .collect::<Vec<_>>();
 
+    let mut new_session = false;
     let mut dust_registration_events = vec![];
     let mut system_transactions_from_events = vec![];
 
@@ -130,7 +130,7 @@ pub async fn make_block_details(
 
         match event {
             Event::Session(NewSession { .. }) => {
-                *authorities = None;
+                new_session = true;
             }
 
             // System transaction created by the node (not from extrinsics).
@@ -193,6 +193,7 @@ pub async fn make_block_details(
 
     Ok(BlockDetails {
         timestamp,
+        new_session,
         transactions,
         dust_registration_events,
         bridge_events: vec![],

--- a/chain-indexer/src/infra/subxt_node/runtimes/v2_0_0.rs
+++ b/chain-indexer/src/infra/subxt_node/runtimes/v2_0_0.rs
@@ -29,7 +29,6 @@ use parity_scale_codec::Decode;
 use subxt::error::RuntimeApiError;
 
 pub async fn make_block_details(
-    authorities: &mut Option<Vec<[u8; 32]>>,
     block: &OnlineClientAtBlock,
     content: Option<&ContentSource>,
 ) -> Result<BlockDetails, SubxtNodeError> {
@@ -101,6 +100,7 @@ pub async fn make_block_details(
         })
         .collect::<Vec<_>>();
 
+    let mut new_session = false;
     let mut dust_registration_events = vec![];
     let mut system_transactions_from_events = vec![];
     let mut bridge_events = vec![];
@@ -133,7 +133,7 @@ pub async fn make_block_details(
 
         match event {
             Event::Session(NewSession { .. }) => {
-                *authorities = None;
+                new_session = true;
             }
 
             // System transaction created by the node (not from extrinsics).
@@ -267,6 +267,7 @@ pub async fn make_block_details(
 
     Ok(BlockDetails {
         timestamp,
+        new_session,
         transactions,
         dust_registration_events,
         bridge_events,

--- a/chain-indexer/src/infra/subxt_node/runtimes/v2_1_0.rs
+++ b/chain-indexer/src/infra/subxt_node/runtimes/v2_1_0.rs
@@ -29,7 +29,6 @@ use parity_scale_codec::Decode;
 use subxt::error::RuntimeApiError;
 
 pub async fn make_block_details(
-    authorities: &mut Option<Vec<[u8; 32]>>,
     block: &OnlineClientAtBlock,
     content: Option<&ContentSource>,
 ) -> Result<BlockDetails, SubxtNodeError> {
@@ -101,6 +100,7 @@ pub async fn make_block_details(
         })
         .collect::<Vec<_>>();
 
+    let mut new_session = false;
     let mut dust_registration_events = vec![];
     let mut system_transactions_from_events = vec![];
     let mut bridge_events = vec![];
@@ -133,7 +133,7 @@ pub async fn make_block_details(
 
         match event {
             Event::Session(NewSession { .. }) => {
-                *authorities = None;
+                new_session = true;
             }
 
             // System transaction created by the node (not from extrinsics).
@@ -267,6 +267,7 @@ pub async fn make_block_details(
 
     Ok(BlockDetails {
         timestamp,
+        new_session,
         transactions,
         dust_registration_events,
         bridge_events,

--- a/chain-indexer/tests/mainnet_runtime.rs
+++ b/chain-indexer/tests/mainnet_runtime.rs
@@ -89,6 +89,7 @@ async fn test_finalized_blocks_node_1_0() -> anyhow::Result<()> {
         reconnect_max_delay: Duration::from_secs(1),
         reconnect_max_attempts: 1,
         subscription_recovery_timeout: Duration::from_secs(30),
+        fetch_concurrency: 8,
     };
     let mut node = SubxtNode::new(config).await.context("create SubxtNode")?;
 
@@ -130,6 +131,7 @@ async fn test_mainnet_runtime_upgrade_boundary() -> anyhow::Result<()> {
         reconnect_max_delay: Duration::from_secs(1),
         reconnect_max_attempts: 3,
         subscription_recovery_timeout: Duration::from_secs(30),
+        fetch_concurrency: 8,
     };
     let mut node = SubxtNode::new(config).await.context("create SubxtNode")?;
 

--- a/indexer-common/src/infra/pub_sub/in_mem.rs
+++ b/indexer-common/src/infra/pub_sub/in_mem.rs
@@ -28,6 +28,7 @@ pub struct InMemPubSub {
     block_indexed_sender: Sender<Value>,
     wallet_indexed_sender: Sender<Value>,
     unshielded_utxo_sender: Sender<Value>,
+    bridge_event_sender: Sender<Value>,
 }
 
 impl InMemPubSub {
@@ -47,11 +48,13 @@ impl Default for InMemPubSub {
         let (block_indexed_sender, block_indexed_receiver) = broadcast::channel(42);
         let (wallet_indexed_sender, wallet_indexed_receiver) = broadcast::channel(42);
         let (unshielded_utxo_sender, unshielded_utxo_receiver) = broadcast::channel(42);
+        let (bridge_event_sender, bridge_event_receiver) = broadcast::channel(42);
 
         let pub_sub = InMemPubSub {
             block_indexed_sender,
             wallet_indexed_sender,
             unshielded_utxo_sender,
+            bridge_event_sender,
         };
 
         // Keep one receiver alive per topic for as long as the `InMemPubSub`
@@ -63,6 +66,7 @@ impl Default for InMemPubSub {
         spawn_drain("block_indexed_receiver", block_indexed_receiver);
         spawn_drain("wallet_indexed_receiver", wallet_indexed_receiver);
         spawn_drain("unshielded_utxo_receiver", unshielded_utxo_receiver);
+        spawn_drain("bridge_event_receiver", bridge_event_receiver);
 
         pub_sub
     }
@@ -88,7 +92,10 @@ fn spawn_drain(name: &'static str, mut receiver: Receiver<Value>) {
 #[cfg(test)]
 mod tests {
     use crate::{
-        domain::{BlockIndexed, Publisher, Subscriber, WalletIndexed},
+        domain::{
+            BlockIndexed, BridgeEventIndexed, Publisher, Subscriber, WalletIndexed,
+            bridge::BridgeEvent,
+        },
         infra::pub_sub::in_mem::InMemPubSub,
     };
     use assert_matches::assert_matches;
@@ -121,6 +128,31 @@ mod tests {
 
         let message = messages.next().await;
         assert_matches!(message, Some(Ok(message)) if message == wallet_indexed);
+
+        Ok(())
+    }
+
+    /// Regression test: publishing a bridge event through the in-memory pub-sub used to panic
+    /// with "unexpected topic" because `BridgeEventIndexed` had no channel.
+    #[tokio::test]
+    async fn test_publish_subscribe_bridge_event() -> Result<(), Box<dyn StdError>> {
+        let pub_sub = InMemPubSub::default();
+
+        let subscriber = pub_sub.subscriber();
+        let mut messages = subscriber.subscribe::<BridgeEventIndexed>();
+
+        let bridge_event_indexed = BridgeEventIndexed {
+            block_height: 42,
+            event: BridgeEvent::ReserveTransfer {
+                mc_tx_hash: [1u8; 32].into(),
+                amount: 1_000_000,
+                midnight_tx_hash: [2u8; 32].into(),
+            },
+        };
+        pub_sub.publisher().publish(&bridge_event_indexed).await?;
+
+        let message = messages.next().await;
+        assert_matches!(message, Some(Ok(message)) if message == bridge_event_indexed);
 
         Ok(())
     }

--- a/indexer-common/src/infra/pub_sub/in_mem/publisher.rs
+++ b/indexer-common/src/infra/pub_sub/in_mem/publisher.rs
@@ -52,6 +52,10 @@ impl Publisher for InMemPublisher {
                 self.0.unshielded_utxo_sender.send(value)?;
             }
 
+            Topic("BridgeEventIndexed") => {
+                self.0.bridge_event_sender.send(value)?;
+            }
+
             // This must not happen; if it happens, we forgot to add an arm for the topic above!
             _ => panic!("unexpected topic {:?}", T::TOPIC),
         }

--- a/indexer-common/src/infra/pub_sub/in_mem/subscriber.rs
+++ b/indexer-common/src/infra/pub_sub/in_mem/subscriber.rs
@@ -54,6 +54,11 @@ impl Subscriber for InMemSubscriber {
                 BroadcastStream::new(receiver)
             }
 
+            Topic("BridgeEventIndexed") => {
+                let receiver = self.0.bridge_event_sender.subscribe();
+                BroadcastStream::new(receiver)
+            }
+
             // This must not happen; if it happens, we forgot to add an arm for the topic above!
             _ => panic!("unexpected topic {:?}", T::TOPIC),
         };

--- a/indexer-standalone/src/config.rs
+++ b/indexer-standalone/src/config.rs
@@ -19,7 +19,10 @@ use spo_indexer::{
     application::{self as spo_app, StakeRefreshConfig},
     infra::spo_client::{self, HttpPoolConfig},
 };
-use std::{num::NonZeroUsize, time::Duration};
+use std::{
+    num::{NonZeroU64, NonZeroUsize},
+    time::Duration,
+};
 use wallet_indexer::application as wallet_app;
 
 #[derive(Debug, Clone, Deserialize)]
@@ -48,6 +51,8 @@ pub struct ApplicationConfig {
     pub caught_up_leeway: u32,
     #[serde(with = "humantime_serde", default = "gc_bound_default")]
     pub gc_bound: Duration,
+    #[serde(default = "gc_block_interval_default")]
+    pub gc_block_interval: NonZeroU64,
     #[serde(default = "ledger_state_retention_default")]
     pub ledger_state_retention: NonZeroUsize,
     #[serde(with = "humantime_serde")]
@@ -61,6 +66,10 @@ pub struct ApplicationConfig {
 
 fn gc_bound_default() -> Duration {
     Duration::from_millis(200)
+}
+
+fn gc_block_interval_default() -> NonZeroU64 {
+    NonZeroU64::MIN
 }
 
 fn ledger_state_retention_default() -> NonZeroUsize {
@@ -92,6 +101,7 @@ impl From<ApplicationConfig> for chain_app::Config {
             caught_up_max_distance,
             caught_up_leeway,
             gc_bound,
+            gc_block_interval,
             ledger_state_retention,
             ..
         } = config;
@@ -102,6 +112,7 @@ impl From<ApplicationConfig> for chain_app::Config {
             caught_up_max_distance,
             caught_up_leeway,
             gc_bound,
+            gc_block_interval,
             ledger_state_retention,
         }
     }


### PR DESCRIPTION
## Summary

Backports the chain-indexing performance work and a standalone-flavor bug fix developed on the midnight-node embedded-indexer branch (midnightntwrk/midnight-node#2051), so the improvements land in this codebase regardless of how the embedding discussion resolves. All changes are indexer-internal — none depend on colocation with a node.

- `fix(indexer-common)`: the in-memory pub-sub had no channel for `BridgeEventIndexed`, so the standalone flavor panics the chain-indexer task on every indexed c2m-bridge event (reproduced on devnet). Adds the channel plus a regression test.
- `feat(chain-indexer)`: per-phase Prometheus histograms for the replay loop, which drove and can verify the rest.
- `perf(chain-indexer)`: prefetch blocks concurrently with indexing — the existing `.buffered()` adapter cannot prefetch because stream combinators only run while polled.
- `perf(chain-indexer)`: fetch several catch-up blocks concurrently (`fetch_concurrency`, default 8), keeping author resolution sequential so output is byte-identical.
- `perf(chain-indexer)`: fetch the D-parameter and T&C with the block on the prefetch path instead of 3 sequential RPCs per block.
- `perf(chain-indexer)`: configurable gc cadence (`gc_block_interval`, default 1 = unchanged behavior).

## Measured results (devnet, ~685k blocks)

| Change | blocks/s | Cumulative |
|---|---:|---:|
| Unmodified | 8.3 | 1.0x |
| + pipelining | 9.8 | 1.18x |
| + fetch_concurrency=8 | 12.2 | 1.47x |
| + system parameters with the block | 36.8 | 4.4x |
| + gc_block_interval=16, fetch_concurrency=16 | 71.9 | 8.7x |
| + fetch_concurrency=32 | 111.2 | **13.4x** |

- Full devnet sync, fresh SQLite, in-cluster RPC: **1 h 34 m measured end-to-end** (vs ~26 h for the unmodified code in identical topology), zero process restarts.
- Correctness: byte-exact GraphQL parity with the deployed devnet indexer across blocks/authors/transactions at six heights, and a fresh replay re-detects the devnet D-parameter change at exactly the same block (144,981). 2.4 h load soak at ~19,500 req/s: 133.8 M requests, zero errors.
- `fetch_concurrency` sweep: 8 -> 47.8, 16 -> 98.6, 32 -> 165.0, 64 -> 126.6 blocks/s (fresh-replay segments); 32 is the sweet spot, 64 over-subscribes.

## Behavior notes for review

- Defaults: `gc_block_interval` defaults to 1 (identical behavior); `fetch_concurrency` defaults to 8, which changes catch-up behavior from strictly serial to 8 concurrent block fetches — output is provably order- and content-identical, but reviewers may prefer a different default.
- The cloud flavor shares all of this code; only the bridge fix is standalone-specific (NATS publishes by topic generically and is unaffected).
- The `Node` trait loses `fetch_system_parameters` (no remaining callers); `node::Block` gains `d_parameter`/`terms_and_conditions`.
- Memory: the standalone needs roughly a 6 GiB limit at `fetch_concurrency=32` (2 GiB gets OOM-killed).

## Remaining validation

- [ ] CI (cloud + standalone) on this branch
- [ ] fresh devnet sync from an image built from this exact branch (in progress; the measurements above are from the byte-identical port of these files in midnight-node#2051)
