### PR TITLE
chore(release): prepare for 4.4.0-rc.3 (review only — do not merge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.0-rc.3] - 2026-08-24
+
+### 🚀 Features
+
+- *(indexer-common)* Source secrets from files via `APP__*_FILE` environment variables (#1074).
+
+### 🐛 Bug Fixes
+
+- *(indexer-common)* Use the node-identical stateless cost for `block_fullness` accumulation (#1443).
+- *(indexer-standalone)* Fix SQLite deadlocks and socket bloat in standalone mode (#1094).
+
+### ⚙️ Miscellaneous Tasks
+
+- Add standard issue templates and label-automation dispatchers (#1438).
+
 ## [4.4.0-rc.2] - 2026-08-06
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "chain-indexer"
-version = "4.4.0-rc.2"
+version = "4.4.0-rc.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3378,7 +3378,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-api"
-version = "4.4.0-rc.2"
+version = "4.4.0-rc.3"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-standalone"
-version = "4.4.0-rc.2"
+version = "4.4.0-rc.3"
 dependencies = [
  "anyhow",
  "byte-unit-serde",
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-tests"
-version = "4.4.0-rc.2"
+version = "4.4.0-rc.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -7524,7 +7524,7 @@ dependencies = [
 
 [[package]]
 name = "spo-indexer"
-version = "4.4.0-rc.2"
+version = "4.4.0-rc.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -9068,7 +9068,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-indexer"
-version = "4.4.0-rc.2"
+version = "4.4.0-rc.3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version       = "4.4.0-rc.2"
+version       = "4.4.0-rc.3"
 edition       = "2024"
 license       = "Apache-2.0"
 readme        = "README.md"


### PR DESCRIPTION
> **Review only — do not merge.** This branch is the `4.4.0-rc.3` release cut. Releases in this
> repo are tagged on `release/*` branches and are not merged into `main` (see `release/4.3.6`,
> `release/4.3.7` — `v4.3.7` is not an ancestor of `main`). This PR exists purely to give the
> release-prep commit a review surface and to run `ci-cloud` / `ci-standalone` against it.
> Publishing is triggered by pushing the `v4.4.0-rc.3` tag, not by merging this PR.

## What this changes

One commit off `origin/main` (`5e0f6b77`), three files, **zero `.rs` / `.sql` / `.graphql` files**:

- `Cargo.toml` — `[workspace.package] version` `4.4.0-rc.2` → `4.4.0-rc.3`
- `Cargo.lock` — the six corresponding workspace-member version lines. Required, not incidental:
  every `Dockerfile` builds with `cargo build --locked`, so a stale lock fails all five image
  builds *after* the tag is already pushed.
- `CHANGELOG.md` — the `4.4.0-rc.3` section.

## Why rc.3

stagenet currently runs `4.4.0-rc.2-stagenet-hotfix` (commit `0fa19f9f`), which has a git tag but
**no GitHub release**, is not an ancestor of `main`, and whose binary self-reports `4.4.0-rc.2`.
rc.3 gives that code a properly released, self-consistent tag.

Background: the image deployed to stagenet on Aug 19 (`4.4.0-rc.2-0fa19f9f`) was a
`workflow_dispatch` branch build, so `build-indexer-images.yaml:115` compiled it at `dev` profile,
where `midnight-serialize`'s `RECURSION_LIMIT` is 50 instead of 250 (`#[cfg(debug_assertions)]`).
It ran clean and at tip for two days, then began crash-looping ~Aug 21 23:00 with
`exceeded recursion depth deserializing`, at ~11 restarts/hour, falling to ~9.2 h behind tip before
the release-profile rebuild recovered it. No data loss and no gaps.

## Changelog notes

- `git-cliff --unreleased` initially emitted only two entries: the `v4.4.0-rc.2-stagenet-hotfix`
  tag truncated its walk, and #1074 and #1094 are ancestors of it, so they would have been dropped
  from every changelog permanently. Regenerated over `v4.4.0-rc.2..HEAD` instead.
- #1094 is then skipped by `filter_unconventional = true` (subject is `Fix sqlite…`, not
  conventional). Re-added by hand, consistent with how the rc.2 entries were hand-polished.

## Gates

Run locally:

- `cargo fmt --check` — clean
- `cargo check -p chain-indexer --locked --features cloud` — passes
- `cargo check -p indexer-standalone --locked --features standalone` — passes

Not run locally: `just all-all` — the nextest suite needs `APP__INFRA__SECRET`,
`APP__INFRA__STORAGE__PASSWORD` and `APP__INFRA__PUB_SUB__PASSWORD`, which were unset. That is
what CI on this PR is for.

## After this

1. Tag `v4.4.0-rc.3` on this branch → release-profile images for all five components (~1.5 h);
   wait for `merge-manifests` so the unsuffixed multi-arch tag exists.
2. `gh release create v4.4.0-rc.3 --prerelease`.
3. Re-pin stagenet to `4.4.0-rc.3` (plain tag — it is currently pinned to an `-amd64` per-arch tag
   because the Aug 23 rollout beat `merge-manifests`). Migrations are identical to what is running,
   so this is a restart, not a re-index.

## Follow-ups that do need review

- Bump `main`'s `Cargo.toml` to `4.4.0-rc.3` so `main` does not drift behind the release line.
- Fix `build-indexer-images.yaml:115` — the publish workflow should never build at `dev` profile.
  A dev-profile image is indistinguishable from a release one by tag shape and can stay healthy for
  days before failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
