### PR TITLE
fix(indexer-api): reject unbounded epoch range queries

### DIFF
--- a/indexer-api/src/infra/api/v4/query.rs
+++ b/indexer-api/src/infra/api/v4/query.rs
@@ -50,6 +50,16 @@ use std::marker::PhantomData;
 
 const DEFAULT_PERFORMANCE_LIMIT: i64 = 20;
 
+/// Maximum number of epochs a single range query may span.
+///
+/// The SPO series resolvers (`registered_totals_series`, `registered_spo_series`) expand the
+/// half-open `[from_epoch, to_epoch]` window into one row per epoch via `generate_series`, then
+/// materialise every row with `fetch_all`. Without a cap, a single ~100-byte unauthenticated
+/// request (e.g. `toEpoch: 9223372036854775807`) can pin a database connection for
+/// minutes-to-hours and drive `indexer-api` toward OOM (GHSA-6746-qxvv-3hwg). No legitimate
+/// caller needs a wider window; requests beyond this bound are rejected as client errors.
+const MAX_EPOCH_SPAN: i64 = 10_000;
+
 /// GraphQL queries.
 pub struct Query<S> {
     _s: PhantomData<S>,
@@ -780,6 +790,8 @@ where
         from_epoch: i64,
         to_epoch: i64,
     ) -> ApiResult<Vec<RegisteredTotals>> {
+        validate_epoch_span(from_epoch, to_epoch)?;
+
         let storage = cx.get_storage::<S>();
 
         let totals = storage
@@ -798,6 +810,8 @@ where
         from_epoch: i64,
         to_epoch: i64,
     ) -> ApiResult<Vec<RegisteredStat>> {
+        validate_epoch_span(from_epoch, to_epoch)?;
+
         let storage = cx.get_storage::<S>();
 
         let stats = storage
@@ -816,6 +830,8 @@ where
         from_epoch: i64,
         to_epoch: i64,
     ) -> ApiResult<Vec<PresenceEvent>> {
+        validate_epoch_span(from_epoch, to_epoch)?;
+
         let storage = cx.get_storage::<S>();
 
         let events = storage
@@ -1061,6 +1077,22 @@ where
     }
 }
 
+/// Reject epoch ranges wider than [`MAX_EPOCH_SPAN`] before they are expanded into per-epoch
+/// rows. Bounds are accepted in either order (the storage layer normalises them), so the span is
+/// computed from the ordered bounds; `saturating_sub` keeps extreme inputs such as `i64::MAX` /
+/// `i64::MIN` from overflowing and simply saturates them into the rejected range.
+fn validate_epoch_span(from_epoch: i64, to_epoch: i64) -> ApiResult<()> {
+    let span = from_epoch
+        .max(to_epoch)
+        .saturating_sub(from_epoch.min(to_epoch));
+
+    (span <= MAX_EPOCH_SPAN)
+        .then_some(())
+        .some_or_client_error(|| {
+            format!("epoch range too large: span {span} exceeds the maximum of {MAX_EPOCH_SPAN}")
+        })
+}
+
 /// Normalize hex string by stripping 0x prefix and lowercasing.
 fn normalize_hex(input: &str) -> String {
     let s = input
@@ -1069,4 +1101,35 @@ fn normalize_hex(input: &str) -> String {
         .strip_prefix("0X")
         .unwrap_or(input);
     s.to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MAX_EPOCH_SPAN, validate_epoch_span};
+    use crate::infra::api::ApiError;
+
+    #[test]
+    fn accepts_spans_within_bound() {
+        assert!(validate_epoch_span(0, 0).is_ok());
+        assert!(validate_epoch_span(10, 20).is_ok());
+        assert!(validate_epoch_span(0, MAX_EPOCH_SPAN).is_ok());
+        // Bounds may arrive reversed; the span is orientation-independent.
+        assert!(validate_epoch_span(MAX_EPOCH_SPAN, 0).is_ok());
+    }
+
+    #[test]
+    fn rejects_spans_beyond_bound_as_client_error() {
+        for (from, to) in [
+            (0, MAX_EPOCH_SPAN + 1),
+            (0, i64::MAX),
+            (i64::MIN, 0),
+            // Extreme opposite bounds must not overflow when the span is computed.
+            (i64::MIN, i64::MAX),
+        ] {
+            assert!(
+                matches!(validate_epoch_span(from, to), Err(ApiError::Client(_))),
+                "expected client error for range ({from}, {to})",
+            );
+        }
+    }
 }


### PR DESCRIPTION
Forward-ports `fcf93b4e` from `release/4.3.800` onto `main`. Cherry-picked with `-x`, so the commit carries its provenance line.

## Why this is a forward-port and not a new fix

The 4.3.x line and `main` forked at `v4.3.3` and never rejoined. Three fixes ended up on the 4.3.x side; two of them already have an equivalent here under a different SHA:

| fix | on 4.3.x as | on `main` as |
|---|---|---|
| runtime-upgrade enactment block | `f19c7acc` (narrow retry fallback) | `54f96c8d` (#1346) — dispatch by state runtime version, the durable form |
| mempool tblock bump off parent block time | `d7036820` | `4565e5ba` (#1371) |
| **unbounded epoch range queries** | `fcf93b4e` | **nothing** |

So this is the single commit needed to make `main` a superset of the 4.3.x line. After it merges, that branch owes nothing in either direction.

## What it fixes

The SPO series resolvers — `registeredTotalsSeries`, `registeredSpoSeries`, `registeredPresence` — expand `[fromEpoch, toEpoch]` into one row per epoch via `generate_series` and materialise every row with `fetch_all`. Unbounded, a single ~100-byte unauthenticated request (`toEpoch: 9223372036854775807`) can pin a database connection for minutes-to-hours and drive `indexer-api` toward OOM.

The fix rejects spans wider than `MAX_EPOCH_SPAN` (10_000) as client errors before the range reaches storage. Bounds are accepted in either order and the span uses `saturating_sub`, so `i64::MIN` / `i64::MAX` saturate into the rejected range rather than overflowing.

Refs GHSA-6746-qxvv-3hwg.

## Scope check on `main`

The fix was written against 4.3.3, so I confirmed it still covers this branch's query surface rather than only applying cleanly:

- `generate_series` appears on `main` in exactly two places, both in `indexer-api/src/infra/storage/spo.rs` (lines 761 and 896) — the sites this guard protects.
- The three resolvers are present unchanged at `indexer-api/src/infra/api/v4/query.rs:777`, `:795`, `:813`.
- The range-taking surfaces added since 4.3.3 are not a second instance of the same bug: contract events accept `fromBlock`/`toBlock`, but `indexer-api/src/infra/storage/contract_event.rs` appends a `LIMIT`, so there is no unbounded row expansion there.

## Testing

Run locally against this branch, both features:

| step | cloud | standalone |
|---|---|---|
| `just check` | pass | pass |
| `just lint` | pass | pass |
| `just doc` | pass | pass |
| `just test` | **153 passed, 2 skipped, 0 failed** | not run — see below |

- `cargo fmt --check` clean.
- The two unit tests that ship with the commit pass: `infra::api::v4::query::tests::accepts_spans_within_bound` and `::rejects_spans_beyond_bound_as_client_error`, the latter covering `i64::MIN` / `i64::MAX` and reversed bounds.
- `indexer-api-cli print-api-schema-v4` output is byte-identical to the committed `indexer-api/graphql/schema-v4.graphql` — validation only, no schema change.
- Standalone `just test` was not run locally; the change is in a shared `indexer-api` code path with no feature gating, and standalone `check`/`lint`/`doc` all pass. CI covers it.

## Follow-ups (not in this PR)

- **4.4.0-rc.4 still needs cutting.** devnet (`4.4.0-rc.2`) and perfnet (`4.4.0-rc.1`) do not get this fix from the merge alone.
- **`release/4.4.0` is stale.** It sits at `8f3f470a` (21 Jul) and lacks even the tblock fix. Worth deleting so it stops reading as "the 4.4 line" alongside `main` and the per-rc branches.
- GHSA-6746-qxvv-3hwg is still in `draft`. The fix, its rationale, and its images have been public on `release/4.3.800` since 25 Aug, so publishing it is a paperwork step rather than a disclosure decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
