### PR TITLE
Read contract state from local LedgerState instead of node RPC

### DIFF
--- a/chain-indexer/src/domain/ledger_state.rs
+++ b/chain-indexer/src/domain/ledger_state.rs
@@ -235,8 +235,22 @@ impl LedgerState {
         transaction.estimated_fees = fees;
         transaction.bridge_claim = bridge_claim;
 
-        // Update contract actions.
+        self.fill_contract_actions_from_local_ledger(&mut transaction)?;
+
+        Ok(Transaction::Regular(transaction.into()))
+    }
+
+    /// Fill each contract action's `state` / zswap state / balances from the local ledger.
+    /// Replaces the node `get_contract_state` RPC (midnight-indexer#1040).
+    fn fill_contract_actions_from_local_ledger(
+        &self,
+        transaction: &mut RegularTransaction,
+    ) -> Result<(), Error> {
         for contract_action in transaction.contract_actions.iter_mut() {
+            contract_action.state = self
+                .extract_contract_state(&contract_action.address)
+                .map_err(|error| Error::ExtractContractState(transaction.hash, error))?;
+
             let zswap_state = self
                 .extract_contract_zswap_state(&contract_action.address)
                 .map_err(|error| Error::ExtractContractZswapState(transaction.hash, error))?;
@@ -266,7 +280,7 @@ impl LedgerState {
             }
         }
 
-        Ok(Transaction::Regular(transaction.into()))
+        Ok(())
     }
 
     #[trace(properties = {
@@ -331,6 +345,12 @@ pub enum Error {
         #[source] indexer_common::domain::ledger::Error,
     ),
 
+    #[error("cannot extract contract state for transaction {0}")]
+    ExtractContractState(
+        TransactionHash,
+        #[source] indexer_common::domain::ledger::Error,
+    ),
+
     #[error("cannot extract contract zswap state for transaction {0}")]
     ExtractContractZswapState(
         TransactionHash,
@@ -355,4 +375,165 @@ pub enum Error {
 fn stringify_hash(hash: &Option<TransactionHash>) -> String {
     hash.map(|hash| hash.to_string())
         .unwrap_or_else(|| "<hash unavailable>".to_string())
+}
+
+#[cfg(all(test, any(feature = "cloud", feature = "standalone")))]
+mod extract_contract_state_tests {
+    use super::LedgerState;
+    use crate::domain::{ContractAction, RegularTransaction};
+    use indexer_common::domain::{
+        ByteVec, ContractAttributes, LedgerVersion, NetworkId, ProtocolVersion, TransactionHash,
+    };
+
+    struct LedgerStorageGuard {
+        #[cfg(feature = "cloud")]
+        _postgres: testcontainers::ContainerAsync<testcontainers_modules::postgres::Postgres>,
+        #[cfg(feature = "standalone")]
+        _temp_dir: tempfile::TempDir,
+    }
+
+    async fn init_ledger_storage() -> LedgerStorageGuard {
+        #[cfg(feature = "cloud")]
+        {
+            use indexer_common::infra::{
+                ledger_db, migrations,
+                pool::postgres::{Config, PostgresPool},
+            };
+            use sqlx::postgres::PgSslMode;
+            use std::time::Duration;
+            use testcontainers::{ImageExt, runners::AsyncRunner};
+            use testcontainers_modules::postgres::Postgres;
+
+            let postgres_container = Postgres::default()
+                .with_db_name("indexer")
+                .with_user("indexer")
+                .with_password(env!("APP__INFRA__STORAGE__PASSWORD"))
+                .with_tag("17.1-alpine")
+                .start()
+                .await
+                .expect("start Postgres container");
+            let postgres_port = postgres_container
+                .get_host_port_ipv4(5432)
+                .await
+                .expect("get Postgres port");
+
+            let pool = PostgresPool::new(Config {
+                host: "localhost".to_string(),
+                port: postgres_port,
+                dbname: "indexer".to_string(),
+                user: "indexer".to_string(),
+                password: env!("APP__INFRA__STORAGE__PASSWORD").into(),
+                sslmode: PgSslMode::Prefer,
+                max_connections: 10,
+                idle_timeout: Duration::from_secs(60),
+                max_lifetime: Duration::from_secs(5 * 60),
+            })
+            .await
+            .expect("create pool");
+            migrations::postgres::run(&pool)
+                .await
+                .expect("run migrations");
+
+            ledger_db::init(
+                ledger_db::Config {
+                    cache_max_nodes: 1_024,
+                },
+                pool,
+            );
+
+            LedgerStorageGuard {
+                _postgres: postgres_container,
+            }
+        }
+
+        #[cfg(feature = "standalone")]
+        {
+            use indexer_common::infra::ledger_db;
+
+            let temp_dir = tempfile::tempdir().expect("create tempdir");
+            let cnn_url = temp_dir
+                .path()
+                .join("ledger-db.sqlite")
+                .display()
+                .to_string();
+
+            ledger_db::init(ledger_db::Config {
+                cache_max_nodes: 1_024,
+                cnn_url,
+            })
+            .await
+            .expect("init ledger_db");
+
+            LedgerStorageGuard {
+                _temp_dir: temp_dir,
+            }
+        }
+    }
+
+    fn empty_regular_transaction(address: ByteVec) -> RegularTransaction {
+        RegularTransaction {
+            hash: TransactionHash::from([0u8; 32]),
+            protocol_version: ProtocolVersion::V2_0(2_000_000),
+            raw: Default::default(),
+            identifiers: vec![],
+            contract_actions: vec![ContractAction {
+                address,
+                state: Default::default(),
+                zswap_state: Default::default(),
+                extracted_balances: Default::default(),
+                attributes: ContractAttributes::Call {
+                    entry_point: "test".into(),
+                },
+            }],
+            paid_fees: 0,
+            estimated_fees: 0,
+            transaction_result: Default::default(),
+            zswap_merkle_tree_root: Default::default(),
+            zswap_start_index: 0,
+            zswap_end_index: 0,
+            dust_commitment_start_index: 0,
+            dust_commitment_end_index: 0,
+            dust_generation_start_index: 0,
+            dust_generation_end_index: 0,
+            created_unshielded_utxos: vec![],
+            spent_unshielded_utxos: vec![],
+            ledger_events: vec![],
+            bridge_claim: None,
+        }
+    }
+
+    /// The apply path fills contract actions from local `LedgerState::index`. An unknown
+    /// address must keep the historical empty-state payload and skip balance extraction.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn fill_contract_actions_unknown_address_is_empty() {
+        let _guard = init_ledger_storage().await;
+
+        let state = LedgerState::new(
+            NetworkId::try_from("undeployed").expect("valid network id"),
+            LedgerVersion::V9,
+        )
+        .expect("create ledger state");
+
+        let unknown_address = ByteVec::from(vec![0u8; 32]);
+        let mut transaction = empty_regular_transaction(unknown_address.clone());
+        state
+            .fill_contract_actions_from_local_ledger(&mut transaction)
+            .expect("extract from empty ledger");
+
+        assert_eq!(transaction.contract_actions[0].address, unknown_address);
+        assert!(
+            transaction.contract_actions[0].state.is_empty(),
+            "unknown contract must keep the historical empty-state payload"
+        );
+        assert!(
+            transaction.contract_actions[0]
+                .extracted_balances
+                .is_empty(),
+            "empty state skips balance extraction"
+        );
+        assert!(
+            !transaction.contract_actions[0].zswap_state.is_empty(),
+            "zswap state is still serialized from the local ledger"
+        );
+    }
 }

--- a/chain-indexer/src/infra/subxt_node.rs
+++ b/chain-indexer/src/infra/subxt_node.rs
@@ -24,7 +24,7 @@ use crate::{
 use async_stream::try_stream;
 use const_hex::FromHexError;
 use fastrace::trace;
-use futures::{Stream, StreamExt, TryStreamExt, stream};
+use futures::{Stream, StreamExt, TryStreamExt};
 use http::{
     HeaderMap,
     header::{InvalidHeaderValue, USER_AGENT},
@@ -32,7 +32,6 @@ use http::{
 use indexer_common::{
     domain::{
         BlockAuthor, BlockHash, ByteVec, NodeVersion, ProtocolVersion, ProtocolVersionError,
-        SerializedContractAddress,
         ledger::{self, ZswapMerkleTreeRoot},
     },
     error::BoxError,
@@ -320,10 +319,10 @@ impl SubxtNode {
             None
         };
 
-        let transactions = stream::iter(transactions)
-            .then(|t| make_transaction(t, protocol_version, state_node_version, &block))
-            .try_collect::<Vec<_>>()
-            .await?;
+        let transactions = transactions
+            .into_iter()
+            .map(|t| make_transaction(t, protocol_version))
+            .collect::<Result<Vec<_>, _>>()?;
 
         let block = Block {
             hash,
@@ -691,9 +690,6 @@ pub enum SubxtNodeError {
     #[error("cannot decode genesis cNight registration key")]
     DecodeGenesisCnightRegistrationKey(#[source] Box<subxt::error::StorageKeyError>),
 
-    #[error("cannot get contract state for address {0}")]
-    GetContractState(SerializedContractAddress, #[source] BoxError),
-
     #[error("cannot get zswap state root")]
     GetZswapStateRoot(#[source] BoxError),
 
@@ -824,28 +820,24 @@ fn decode_babe_authority_index(mut pre_digest: &[u8]) -> Result<u32, SubxtNodeEr
     Ok(u32::decode(&mut pre_digest)?)
 }
 
-async fn make_transaction(
+fn make_transaction(
     transaction: runtimes::Transaction,
     protocol_version: ProtocolVersion,
-    state_node_version: NodeVersion,
-    block: &OnlineClientAtBlock,
 ) -> Result<Transaction, SubxtNodeError> {
     match transaction {
         runtimes::Transaction::Regular(transaction) => {
-            make_regular_transaction(transaction, protocol_version, state_node_version, block).await
+            make_regular_transaction(transaction, protocol_version)
         }
 
         runtimes::Transaction::System(transaction) => {
-            make_system_transaction(transaction, protocol_version).await
+            make_system_transaction(transaction, protocol_version)
         }
     }
 }
 
-async fn make_regular_transaction(
+fn make_regular_transaction(
     transaction: ByteVec,
     protocol_version: ProtocolVersion,
-    state_node_version: NodeVersion,
-    block: &OnlineClientAtBlock,
 ) -> Result<Transaction, SubxtNodeError> {
     let ledger_transaction =
         ledger::Transaction::deserialize(&transaction, protocol_version.ledger_version())?;
@@ -855,10 +847,7 @@ async fn make_regular_transaction(
     let identifiers = ledger_transaction.identifiers()?;
 
     let contract_actions = ledger_transaction
-        .contract_actions(|address| async move {
-            runtimes::get_contract_state(address, state_node_version, block).await
-        })
-        .await?
+        .contract_actions()?
         .into_iter()
         .map(Into::into)
         .collect();
@@ -874,7 +863,7 @@ async fn make_regular_transaction(
     Ok(Transaction::Regular(transaction))
 }
 
-async fn make_system_transaction(
+fn make_system_transaction(
     transaction: ByteVec,
     protocol_version: ProtocolVersion,
 ) -> Result<Transaction, SubxtNodeError> {

--- a/chain-indexer/src/infra/subxt_node/runtimes.rs
+++ b/chain-indexer/src/infra/subxt_node/runtimes.rs
@@ -23,9 +23,7 @@ use crate::{
     domain::{DParameter, DustRegistrationEvent, TermsAndConditions},
     infra::subxt_node::{ContentSource, OnlineClientAtBlock, SubxtNodeError},
 };
-use indexer_common::domain::{
-    ByteVec, NodeVersion, SerializedContractAddress, SerializedContractState,
-};
+use indexer_common::domain::{ByteVec, NodeVersion};
 
 /// Runtime specific block details.
 pub struct BlockDetails {
@@ -80,20 +78,6 @@ pub fn decode_slot(slot: &[u8], node_version: NodeVersion) -> Result<u64, SubxtN
         NodeVersion::V1_0 => v1_0_0::decode_slot(slot),
         NodeVersion::V2_0 => v2_0_0::decode_slot(slot),
         NodeVersion::V2_1 => v2_1_0::decode_slot(slot),
-    }
-}
-
-/// Get contract state depending on the given protocol version.
-pub async fn get_contract_state(
-    address: SerializedContractAddress,
-    node_version: NodeVersion,
-    block: &OnlineClientAtBlock,
-) -> Result<SerializedContractState, SubxtNodeError> {
-    match node_version {
-        NodeVersion::V0_22 => v0_22_0::get_contract_state(address, block).await,
-        NodeVersion::V1_0 => v1_0_0::get_contract_state(address, block).await,
-        NodeVersion::V2_0 => v2_0_0::get_contract_state(address, block).await,
-        NodeVersion::V2_1 => v2_1_0::get_contract_state(address, block).await,
     }
 }
 

--- a/chain-indexer/src/infra/subxt_node/runtimes/v0_22_0.rs
+++ b/chain-indexer/src/infra/subxt_node/runtimes/v0_22_0.rs
@@ -19,10 +19,7 @@ use crate::{
     },
 };
 use futures::TryStreamExt;
-use indexer_common::domain::{
-    ByteVec, DustPublicKey, SerializedContractAddress, SerializedContractState,
-    TermsAndConditionsHash,
-};
+use indexer_common::domain::{ByteVec, DustPublicKey, TermsAndConditionsHash};
 use itertools::Itertools;
 use parity_scale_codec::Decode;
 use subxt::error::RuntimeApiError;
@@ -217,25 +214,6 @@ pub fn decode_slot(mut slot: &[u8]) -> Result<u64, SubxtNodeError> {
     let slot = super::runtime_0_22_0::runtime_types::sp_consensus_slots::Slot::decode(&mut slot)
         .map(|x| x.0)?;
     Ok(slot)
-}
-
-pub async fn get_contract_state(
-    address: SerializedContractAddress,
-    block: &OnlineClientAtBlock,
-) -> Result<SerializedContractState, SubxtNodeError> {
-    let get_state = super::runtime_0_22_0::runtime_apis()
-        .midnight_runtime_api()
-        .get_contract_state(address.as_slice().into());
-
-    let state = block
-        .runtime_apis()
-        .call(get_state)
-        .await
-        .map_err(|error| SubxtNodeError::GetContractState(address.clone(), error.into()))?
-        .map_err(|error| SubxtNodeError::GetContractState(address, format!("{error:?}").into()))?
-        .into();
-
-    Ok(state)
 }
 
 pub async fn get_zswap_merkle_tree_root(

--- a/chain-indexer/src/infra/subxt_node/runtimes/v1_0_0.rs
+++ b/chain-indexer/src/infra/subxt_node/runtimes/v1_0_0.rs
@@ -19,10 +19,7 @@ use crate::{
     },
 };
 use futures::TryStreamExt;
-use indexer_common::domain::{
-    ByteVec, DustPublicKey, SerializedContractAddress, SerializedContractState,
-    TermsAndConditionsHash,
-};
+use indexer_common::domain::{ByteVec, DustPublicKey, TermsAndConditionsHash};
 use itertools::Itertools;
 use parity_scale_codec::Decode;
 use subxt::error::RuntimeApiError;
@@ -220,25 +217,6 @@ pub fn decode_slot(mut slot: &[u8]) -> Result<u64, SubxtNodeError> {
     let slot = super::runtime_1_0_0::runtime_types::sp_consensus_slots::Slot::decode(&mut slot)
         .map(|x| x.0)?;
     Ok(slot)
-}
-
-pub async fn get_contract_state(
-    address: SerializedContractAddress,
-    block: &OnlineClientAtBlock,
-) -> Result<SerializedContractState, SubxtNodeError> {
-    let get_state = super::runtime_1_0_0::runtime_apis()
-        .midnight_runtime_api()
-        .get_contract_state(address.as_slice().into());
-
-    let state = block
-        .runtime_apis()
-        .call(get_state)
-        .await
-        .map_err(|error| SubxtNodeError::GetContractState(address.clone(), error.into()))?
-        .map_err(|error| SubxtNodeError::GetContractState(address, format!("{error:?}").into()))?
-        .into();
-
-    Ok(state)
 }
 
 pub async fn get_zswap_merkle_tree_root(

--- a/chain-indexer/src/infra/subxt_node/runtimes/v2_0_0.rs
+++ b/chain-indexer/src/infra/subxt_node/runtimes/v2_0_0.rs
@@ -20,8 +20,7 @@ use crate::{
 };
 use futures::TryStreamExt;
 use indexer_common::domain::{
-    ByteVec, DustPublicKey, SerializedContractAddress, SerializedContractState,
-    TermsAndConditionsHash,
+    ByteVec, DustPublicKey, TermsAndConditionsHash,
     bridge::{BridgeEvent, BridgeRecipient},
 };
 use itertools::Itertools;
@@ -294,25 +293,6 @@ pub fn decode_slot(mut slot: &[u8]) -> Result<u64, SubxtNodeError> {
     let slot = super::runtime_2_0_0::runtime_types::sp_consensus_slots::Slot::decode(&mut slot)
         .map(|x| x.0)?;
     Ok(slot)
-}
-
-pub async fn get_contract_state(
-    address: SerializedContractAddress,
-    block: &OnlineClientAtBlock,
-) -> Result<SerializedContractState, SubxtNodeError> {
-    let get_state = super::runtime_2_0_0::runtime_apis()
-        .midnight_runtime_api()
-        .get_contract_state(address.as_slice().into());
-
-    let state = block
-        .runtime_apis()
-        .call(get_state)
-        .await
-        .map_err(|error| SubxtNodeError::GetContractState(address.clone(), error.into()))?
-        .map_err(|error| SubxtNodeError::GetContractState(address, format!("{error:?}").into()))?
-        .into();
-
-    Ok(state)
 }
 
 pub async fn get_zswap_merkle_tree_root(

--- a/chain-indexer/src/infra/subxt_node/runtimes/v2_1_0.rs
+++ b/chain-indexer/src/infra/subxt_node/runtimes/v2_1_0.rs
@@ -20,8 +20,7 @@ use crate::{
 };
 use futures::TryStreamExt;
 use indexer_common::domain::{
-    ByteVec, DustPublicKey, SerializedContractAddress, SerializedContractState,
-    TermsAndConditionsHash,
+    ByteVec, DustPublicKey, TermsAndConditionsHash,
     bridge::{BridgeEvent, BridgeRecipient},
 };
 use itertools::Itertools;
@@ -294,25 +293,6 @@ pub fn decode_slot(mut slot: &[u8]) -> Result<u64, SubxtNodeError> {
     let slot = super::runtime_2_1_0::runtime_types::sp_consensus_slots::Slot::decode(&mut slot)
         .map(|x| x.0)?;
     Ok(slot)
-}
-
-pub async fn get_contract_state(
-    address: SerializedContractAddress,
-    block: &OnlineClientAtBlock,
-) -> Result<SerializedContractState, SubxtNodeError> {
-    let get_state = super::runtime_2_1_0::runtime_apis()
-        .midnight_runtime_api()
-        .get_contract_state(address.as_slice().into());
-
-    let state = block
-        .runtime_apis()
-        .call(get_state)
-        .await
-        .map_err(|error| SubxtNodeError::GetContractState(address.clone(), error.into()))?
-        .map_err(|error| SubxtNodeError::GetContractState(address, format!("{error:?}").into()))?
-        .into();
-
-    Ok(state)
 }
 
 pub async fn get_zswap_merkle_tree_root(

--- a/chain-indexer/tests/mainnet_runtime.rs
+++ b/chain-indexer/tests/mainnet_runtime.rs
@@ -108,11 +108,13 @@ async fn test_finalized_blocks_node_1_0() -> anyhow::Result<()> {
 
 /// Ingest the exact mainnet blocks at the runtime upgrade boundary via the public mainnet
 /// RPC. This covers both v4.0.x outage failure modes on the very blocks where they occurred:
-/// block 1_774_491 contains a contract call, so ingesting it exercises the node 0.22
-/// `get_contract_state` runtime API against a chain that already runs the 1.0 runtime
-/// ("The static Runtime API address used is not compatible with the live chain" on v4.0.x);
-/// block 1_774_492 is the first block built by the 1.0 runtime ("unsupported protocol
-/// version 1000000" on v4.0.x).
+/// block 1_774_491 contains a contract call. Before #1040, ingesting it exercised the node
+/// 0.22 `get_contract_state` runtime API against a chain that already runs the 1.0 runtime
+/// ("The static Runtime API address used is not compatible with the live chain" on v4.0.x).
+/// Contract state is now read from local LedgerState after apply, so ingest of this block
+/// no longer calls that RPC; the test still asserts the contract *action* is decoded from
+/// the extrinsic. Block 1_774_492 is the first block built by the 1.0 runtime
+/// ("unsupported protocol version 1000000" on v4.0.x).
 ///
 /// Requires network access, hence ignored by default; run explicitly:
 /// `cargo nextest run -p chain-indexer --features cloud --run-ignored all -E
@@ -164,7 +166,10 @@ async fn test_mainnet_runtime_upgrade_boundary() -> anyhow::Result<()> {
                 == const_hex::decode(CONTRACT_ADDRESS).expect("valid address")
         })
         .context("mainnet block 1_774_491 must contain the known contract call")?;
-    assert!(!contract_action.state.as_ref().is_empty());
+    assert!(
+        contract_action.state.as_ref().is_empty(),
+        "contract state is filled from local LedgerState after apply, not at node ingest"
+    );
 
     let block = blocks
         .try_next()

--- a/indexer-common/src/domain/ledger.rs
+++ b/indexer-common/src/domain/ledger.rs
@@ -24,8 +24,7 @@ pub use transaction::*;
 
 use crate::{
     domain::{
-        ByteArrayLenError, ByteVec, LedgerVersion, SerializedContractAddress,
-        SerializedLedgerStateKey, dust::DustParameters,
+        ByteArrayLenError, ByteVec, LedgerVersion, SerializedLedgerStateKey, dust::DustParameters,
     },
     error::BoxError,
 };
@@ -75,9 +74,6 @@ pub enum Error {
 
     #[error("cannot convert {0} to UTF-8 string")]
     FromUtf8(&'static str, #[source] FromUtf8Error),
-
-    #[error("cannot get contract state from node for address {0}")]
-    GetContractState(SerializedContractAddress, #[source] BoxError),
 
     #[error(transparent)]
     ByteArrayLen(ByteArrayLenError),

--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -15,9 +15,10 @@ use crate::{
     domain::{
         AddressOrContract, ApplyRegularTransactionOutcome, ApplySystemTransactionOutcome,
         ByteArray, ByteVec, IntentHash, LedgerEvent, LedgerEventAttributes, LedgerVersion,
-        NetworkId, Nonce, SerializedContractAddress, SerializedLedgerParameters,
-        SerializedLedgerStateKey, SerializedTransaction, SerializedZswapMerkleTreeRoot,
-        SerializedZswapState, TokenType, TransactionResult, UnshieldedAddress, UnshieldedUtxo,
+        NetworkId, Nonce, SerializedContractAddress, SerializedContractState,
+        SerializedLedgerParameters, SerializedLedgerStateKey, SerializedTransaction,
+        SerializedZswapMerkleTreeRoot, SerializedZswapState, TokenType, TransactionResult,
+        UnshieldedAddress, UnshieldedUtxo,
         bridge::BridgeClaim,
         dust::{self},
         ledger::{
@@ -889,6 +890,42 @@ impl LedgerState {
                 .expect("dust generation merkle tree root should exist")
                 .serialize()
                 .map_err(|error| Error::Serialize("DustGenerationMerkleTreeRoot", error)),
+        }
+    }
+
+    /// Extract the serialized contract state for the given address from the local ledger.
+    ///
+    /// Returns empty bytes when the address is not present (failed deploy or unknown
+    /// contract), matching the historical node-RPC payload for failed actions.
+    #[trace(properties = { "address": "{address}" })]
+    pub fn extract_contract_state(
+        &self,
+        address: &SerializedContractAddress,
+    ) -> Result<SerializedContractState, Error> {
+        match self {
+            Self::V8 { ledger_state, .. } => {
+                let address = ContractAddressV8::deserialize(&mut address.as_ref(), 0)
+                    .map_err(|error| Error::Deserialize("ContractAddressV8", error))?;
+
+                match ledger_state.index(address) {
+                    Some(state) => state
+                        .tagged_serialize()
+                        .map_err(|error| Error::Serialize("ContractStateV8", error)),
+                    None => Ok(Default::default()),
+                }
+            }
+
+            Self::V9 { ledger_state, .. } => {
+                let address = ContractAddressV9::deserialize(&mut address.as_ref(), 0)
+                    .map_err(|error| Error::Deserialize("ContractAddressV9", error))?;
+
+                match ledger_state.index(address) {
+                    Some(state) => state
+                        .tagged_serialize()
+                        .map_err(|error| Error::Serialize("ContractStateV9", error)),
+                    None => Ok(Default::default()),
+                }
+            }
         }
     }
 
@@ -3994,5 +4031,232 @@ mod merkle_collapsed_update_tests {
             served_root,
             "tree rebuilt from the collapsed update must match the rehashed served root",
         );
+    }
+}
+
+/// `LedgerState::extract_contract_state` (midnight-indexer#1040): local index instead of node RPC.
+#[cfg(all(test, any(feature = "cloud", feature = "standalone")))]
+mod extract_contract_state_tests {
+    use super::{
+        ContractAddressV8, ContractAddressV9, LedgerState, SerializableExt, TaggedSerializableExt,
+    };
+    use crate::{
+        domain::{
+            ByteArray, LedgerVersion, NetworkId, TokenType,
+            ledger::{ContractState, Error},
+        },
+        error::BoxError,
+        infra::ledger_db::v1_1,
+    };
+    use anyhow::Context;
+    use midnight_base_crypto_v1::hash::HashOutput;
+    use midnight_coin_structure_v2::coin::{
+        TokenType as MidnightTokenTypeV8, UnshieldedTokenType as UnshieldedTokenTypeV8,
+    };
+    use midnight_coin_structure_v3::coin::{
+        TokenType as MidnightTokenTypeV9, UnshieldedTokenType as UnshieldedTokenTypeV9,
+    };
+    use midnight_onchain_runtime_v3::state::ContractState as ContractStateV8;
+    use midnight_onchain_runtime_v4::state::ContractState as ContractStateV9;
+
+    const TOKEN_TYPE: TokenType = ByteArray([7; 32]);
+    const AMOUNT: u128 = 1_000_000;
+    const ADDRESS_BYTES: [u8; 32] = [0x42; 32];
+
+    struct LedgerStorageGuard {
+        #[cfg(feature = "cloud")]
+        _postgres: testcontainers::ContainerAsync<testcontainers_modules::postgres::Postgres>,
+        #[cfg(feature = "standalone")]
+        _temp_dir: tempfile::TempDir,
+    }
+
+    async fn init_ledger_storage() -> Result<LedgerStorageGuard, BoxError> {
+        #[cfg(feature = "cloud")]
+        {
+            use crate::infra::{ledger_db, migrations, pool::postgres::PostgresPool};
+            use sqlx::postgres::PgSslMode;
+            use std::time::Duration;
+            use testcontainers::{ImageExt, runners::AsyncRunner};
+            use testcontainers_modules::postgres::Postgres;
+
+            let postgres_container = Postgres::default()
+                .with_db_name("indexer")
+                .with_user("indexer")
+                .with_password(env!("APP__INFRA__STORAGE__PASSWORD"))
+                .with_tag("17.1-alpine")
+                .start()
+                .await
+                .context("start Postgres container")?;
+            let postgres_port = postgres_container
+                .get_host_port_ipv4(5432)
+                .await
+                .context("get Postgres port")?;
+
+            let config = crate::infra::pool::postgres::Config {
+                host: "localhost".to_string(),
+                port: postgres_port,
+                dbname: "indexer".to_string(),
+                user: "indexer".to_string(),
+                password: env!("APP__INFRA__STORAGE__PASSWORD").into(),
+                sslmode: PgSslMode::Prefer,
+                max_connections: 10,
+                idle_timeout: Duration::from_secs(60),
+                max_lifetime: Duration::from_secs(5 * 60),
+            };
+
+            let pool = PostgresPool::new(config).await.context("create pool")?;
+            migrations::postgres::run(&pool)
+                .await
+                .context("run migrations")?;
+
+            ledger_db::init(
+                ledger_db::Config {
+                    cache_max_nodes: 1_024,
+                },
+                pool,
+            );
+
+            Ok(LedgerStorageGuard {
+                _postgres: postgres_container,
+            })
+        }
+
+        #[cfg(feature = "standalone")]
+        {
+            use crate::infra::{
+                ledger_db, migrations,
+                pool::{self, sqlite::SqlitePool},
+            };
+
+            let temp_dir = tempfile::tempdir().context("cannot create tempdir")?;
+            let sqlite_file = temp_dir.path().join("indexer.sqlite").display().to_string();
+            let sqlite_ledger_db_file = temp_dir
+                .path()
+                .join("ledger-db.sqlite")
+                .display()
+                .to_string();
+
+            let pool = SqlitePool::new(pool::sqlite::Config::with_url(sqlite_file))
+                .await
+                .context("create pool")?;
+            migrations::sqlite::run(&pool)
+                .await
+                .context("run migrations")?;
+
+            ledger_db::init(ledger_db::Config {
+                cache_max_nodes: 1_024,
+                cnn_url: sqlite_ledger_db_file,
+            })
+            .await
+            .expect("ledger DB can be initialized");
+
+            Ok(LedgerStorageGuard {
+                _temp_dir: temp_dir,
+            })
+        }
+    }
+
+    fn network_id() -> NetworkId {
+        NetworkId::try_from("undeployed").expect("valid network id")
+    }
+
+    fn assert_unshielded_balance(
+        serialized: &[u8],
+        ledger_version: LedgerVersion,
+    ) -> Result<(), Error> {
+        let balances = ContractState::deserialize(serialized, ledger_version)?.balances()?;
+        assert_eq!(balances.len(), 1);
+        assert_eq!(balances[0].token_type, TOKEN_TYPE);
+        assert_eq!(balances[0].amount, AMOUNT);
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn extract_contract_state_unknown_address_is_empty() -> Result<(), BoxError> {
+        let _guard = init_ledger_storage().await?;
+
+        for ledger_version in [LedgerVersion::V8, LedgerVersion::V9] {
+            let ledger_state = LedgerState::new(network_id(), ledger_version)?;
+            let unknown = crate::domain::ByteVec::from(vec![0u8; 32]);
+            let extracted = ledger_state.extract_contract_state(&unknown)?;
+            assert!(
+                extracted.is_empty(),
+                "{ledger_version:?}: missing contract must serialize as empty bytes"
+            );
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn extract_contract_state_round_trips_v8() -> Result<(), BoxError> {
+        let _guard = init_ledger_storage().await?;
+
+        let address = ContractAddressV8(HashOutput(ADDRESS_BYTES));
+        let serialized_address = address.serialize()?;
+
+        let mut contract_state = ContractStateV8::<v1_1::LedgerDb>::default();
+        contract_state.balance = contract_state.balance.insert(
+            MidnightTokenTypeV8::Unshielded(UnshieldedTokenTypeV8(HashOutput(TOKEN_TYPE.0))),
+            AMOUNT,
+        );
+        let expected = contract_state.tagged_serialize()?;
+
+        let mut ledger_state = LedgerState::new(network_id(), LedgerVersion::V8)?;
+        match &mut ledger_state {
+            LedgerState::V8 {
+                ledger_state: inner,
+                ..
+            } => {
+                inner.contract = inner.contract.insert(address, contract_state);
+            }
+            LedgerState::V9 { .. } => unreachable!("constructed as V8"),
+        }
+
+        let extracted = ledger_state.extract_contract_state(&serialized_address)?;
+        assert_eq!(
+            extracted.as_ref(),
+            expected.as_ref(),
+            "extracted bytes must match tagged_serialize of the stored ContractState"
+        );
+        assert_unshielded_balance(&extracted, LedgerVersion::V8)?;
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn extract_contract_state_round_trips_v9() -> Result<(), BoxError> {
+        let _guard = init_ledger_storage().await?;
+
+        let address = ContractAddressV9(HashOutput(ADDRESS_BYTES));
+        let serialized_address = address.serialize()?;
+
+        let mut contract_state = ContractStateV9::<v1_1::LedgerDb>::default();
+        contract_state.balance = contract_state.balance.insert(
+            MidnightTokenTypeV9::Unshielded(UnshieldedTokenTypeV9(HashOutput(TOKEN_TYPE.0))),
+            AMOUNT,
+        );
+        let expected = contract_state.tagged_serialize()?;
+
+        let mut ledger_state = LedgerState::new(network_id(), LedgerVersion::V9)?;
+        match &mut ledger_state {
+            LedgerState::V9 {
+                ledger_state: inner,
+                ..
+            } => {
+                inner.contract = inner.contract.insert(address, contract_state);
+            }
+            LedgerState::V8 { .. } => unreachable!("constructed as V9"),
+        }
+
+        let extracted = ledger_state.extract_contract_state(&serialized_address)?;
+        assert_eq!(
+            extracted.as_ref(),
+            expected.as_ref(),
+            "extracted bytes must match tagged_serialize of the stored ContractState"
+        );
+        assert_unshielded_balance(&extracted, LedgerVersion::V9)?;
+
+        Ok(())
     }
 }

--- a/indexer-common/src/domain/ledger/transaction.rs
+++ b/indexer-common/src/domain/ledger/transaction.rs
@@ -14,13 +14,12 @@
 use crate::{
     domain::{
         ContractAction, ContractAttributes, LedgerVersion, SerializedContractAddress,
-        SerializedContractState, SerializedTransactionIdentifier, TransactionHash, ViewingKey,
+        SerializedTransactionIdentifier, TransactionHash, ViewingKey,
         ledger::{Error, SerializableExt, TransactionV8, TransactionV9},
     },
     infra::ledger_db::v1_1,
 };
 use fastrace::trace;
-use futures::{StreamExt, TryStreamExt};
 use midnight_coin_structure_v2::{coin::Info, contract::ContractAddress};
 use midnight_coin_structure_v3::{
     coin::Info as InfoV9, contract::ContractAddress as ContractAddressV9,
@@ -41,7 +40,6 @@ use midnight_transient_crypto_v3::{
 };
 use midnight_zswap_v8::Offer as OfferV8;
 use midnight_zswap_v9::Offer as OfferV9;
-use std::error::Error as StdError;
 
 #[derive(Debug, Clone)]
 pub enum Transaction {
@@ -103,143 +101,75 @@ impl Transaction {
         }
     }
 
-    /// Get the contract actions; this involves node calls.
+    /// Contract actions encoded in this transaction.
+    ///
+    /// `state` is left empty; the chain-indexer fills it from local `LedgerState` after
+    /// apply, which is the same post-transaction state the node RPC used to return.
     #[trace]
-    pub async fn contract_actions<E, F>(
-        &self,
-        get_contract_state: impl Fn(SerializedContractAddress) -> F,
-    ) -> Result<Vec<ContractAction>, Error>
-    where
-        E: StdError + 'static + Send + Sync,
-        F: Future<Output = Result<SerializedContractState, E>>,
-    {
+    pub fn contract_actions(&self) -> Result<Vec<ContractAction>, Error> {
         match self {
             Self::V8(transaction) => match transaction {
-                TransactionV8::Standard(standard_transaction) => {
-                    let contract_actions = futures::stream::iter(standard_transaction.actions())
-                        .then(|(_, contract_action)| async {
-                            match contract_action {
-                                ContractActionV8::Deploy(deploy) => {
-                                    let address = serialize_contract_address(deploy.address())?;
-                                    let state = get_contract_state(address.clone()).await.map_err(
-                                        |error| {
-                                            Error::GetContractState(address.clone(), error.into())
-                                        },
-                                    )?;
+                TransactionV8::Standard(standard_transaction) => standard_transaction
+                    .actions()
+                    .map(|(_, contract_action)| match contract_action {
+                        ContractActionV8::Deploy(deploy) => Ok(ContractAction {
+                            address: serialize_contract_address(deploy.address())?,
+                            state: Default::default(),
+                            attributes: ContractAttributes::Deploy,
+                        }),
 
-                                    Ok::<_, Error>(ContractAction {
-                                        address,
-                                        state,
-                                        attributes: ContractAttributes::Deploy,
-                                    })
-                                }
+                        ContractActionV8::Call(call) => {
+                            let entry_point =
+                                String::from_utf8(call.entry_point.as_ref().to_owned())
+                                    .map_err(|error| Error::FromUtf8("EntryPointBufV8", error))?;
 
-                                ContractActionV8::Call(call) => {
-                                    let address = serialize_contract_address(call.address)?;
-                                    let state = get_contract_state(address.clone()).await.map_err(
-                                        |error| {
-                                            Error::GetContractState(address.clone(), error.into())
-                                        },
-                                    )?;
-                                    let entry_point =
-                                        String::from_utf8(call.entry_point.as_ref().to_owned())
-                                            .map_err(|error| {
-                                                Error::FromUtf8("EntryPointBufV8", error)
-                                            })?;
+                            Ok(ContractAction {
+                                address: serialize_contract_address(call.address)?,
+                                state: Default::default(),
+                                attributes: ContractAttributes::Call { entry_point },
+                            })
+                        }
 
-                                    Ok(ContractAction {
-                                        address,
-                                        state,
-                                        attributes: ContractAttributes::Call { entry_point },
-                                    })
-                                }
-
-                                ContractActionV8::Maintain(update) => {
-                                    let address = serialize_contract_address(update.address)?;
-                                    let state = get_contract_state(address.clone()).await.map_err(
-                                        |error| {
-                                            Error::GetContractState(address.clone(), error.into())
-                                        },
-                                    )?;
-
-                                    Ok(ContractAction {
-                                        address,
-                                        state,
-                                        attributes: ContractAttributes::Update,
-                                    })
-                                }
-                            }
-                        })
-                        .try_collect::<Vec<_>>()
-                        .await?;
-
-                    Ok(contract_actions)
-                }
+                        ContractActionV8::Maintain(update) => Ok(ContractAction {
+                            address: serialize_contract_address(update.address)?,
+                            state: Default::default(),
+                            attributes: ContractAttributes::Update,
+                        }),
+                    })
+                    .collect(),
 
                 TransactionV8::ClaimRewards(_) => Ok(vec![]),
             },
 
             Self::V9(transaction) => match transaction {
-                TransactionV9::Standard(standard_transaction) => {
-                    let contract_actions = futures::stream::iter(standard_transaction.actions())
-                        .then(|(_, contract_action)| async {
-                            match contract_action {
-                                ContractActionV9::Deploy(deploy) => {
-                                    let address = serialize_contract_address_v9(deploy.address())?;
-                                    let state = get_contract_state(address.clone()).await.map_err(
-                                        |error| {
-                                            Error::GetContractState(address.clone(), error.into())
-                                        },
-                                    )?;
+                TransactionV9::Standard(standard_transaction) => standard_transaction
+                    .actions()
+                    .map(|(_, contract_action)| match contract_action {
+                        ContractActionV9::Deploy(deploy) => Ok(ContractAction {
+                            address: serialize_contract_address_v9(deploy.address())?,
+                            state: Default::default(),
+                            attributes: ContractAttributes::Deploy,
+                        }),
 
-                                    Ok::<_, Error>(ContractAction {
-                                        address,
-                                        state,
-                                        attributes: ContractAttributes::Deploy,
-                                    })
-                                }
+                        ContractActionV9::Call(call) => {
+                            let entry_point =
+                                String::from_utf8(call.entry_point.as_ref().to_owned())
+                                    .map_err(|error| Error::FromUtf8("EntryPointBufV9", error))?;
 
-                                ContractActionV9::Call(call) => {
-                                    let address = serialize_contract_address_v9(call.address)?;
-                                    let state = get_contract_state(address.clone()).await.map_err(
-                                        |error| {
-                                            Error::GetContractState(address.clone(), error.into())
-                                        },
-                                    )?;
-                                    let entry_point =
-                                        String::from_utf8(call.entry_point.as_ref().to_owned())
-                                            .map_err(|error| {
-                                                Error::FromUtf8("EntryPointBufV9", error)
-                                            })?;
+                            Ok(ContractAction {
+                                address: serialize_contract_address_v9(call.address)?,
+                                state: Default::default(),
+                                attributes: ContractAttributes::Call { entry_point },
+                            })
+                        }
 
-                                    Ok(ContractAction {
-                                        address,
-                                        state,
-                                        attributes: ContractAttributes::Call { entry_point },
-                                    })
-                                }
-
-                                ContractActionV9::Maintain(update) => {
-                                    let address = serialize_contract_address_v9(update.address)?;
-                                    let state = get_contract_state(address.clone()).await.map_err(
-                                        |error| {
-                                            Error::GetContractState(address.clone(), error.into())
-                                        },
-                                    )?;
-
-                                    Ok(ContractAction {
-                                        address,
-                                        state,
-                                        attributes: ContractAttributes::Update,
-                                    })
-                                }
-                            }
-                        })
-                        .try_collect::<Vec<_>>()
-                        .await?;
-
-                    Ok(contract_actions)
-                }
+                        ContractActionV9::Maintain(update) => Ok(ContractAction {
+                            address: serialize_contract_address_v9(update.address)?,
+                            state: Default::default(),
+                            attributes: ContractAttributes::Update,
+                        }),
+                    })
+                    .collect(),
 
                 TransactionV9::ClaimRewards(_) => Ok(vec![]),
             },
@@ -473,6 +403,17 @@ mod tests {
             .expect("ledger DB can be initialized");
         }
 
+        let ledger_state = crate::domain::ledger::LedgerState::new(
+            crate::domain::NetworkId::try_from("undeployed").expect("valid network id"),
+            LedgerVersion::V9,
+        )
+        .expect("create ledger state");
+        let unknown_address = crate::domain::ByteVec::from(vec![0u8; 32]);
+        let empty_state = ledger_state
+            .extract_contract_state(&unknown_address)
+            .expect("unknown contract is not an error");
+        assert!(empty_state.is_empty());
+
         let transaction = fs::read(format!("{}/tests/tx_1_2_2.raw", env!("CARGO_MANIFEST_DIR")))
             .expect("transaction file can be read");
         let transaction = Transaction::deserialize(transaction, LedgerVersion::V9)
@@ -481,6 +422,12 @@ mod tests {
         assert!(transaction.relevant(viewing_key(1)));
         assert!(transaction.relevant(viewing_key(2)));
         assert!(!transaction.relevant(viewing_key(3)));
+        assert!(
+            transaction
+                .contract_actions()
+                .expect("contract actions can be extracted")
+                .is_empty()
+        );
 
         let transaction = fs::read(format!("{}/tests/tx_1_2_3.raw", env!("CARGO_MANIFEST_DIR")))
             .expect("transaction file can be read");
@@ -490,6 +437,12 @@ mod tests {
         assert!(transaction.relevant(viewing_key(1)));
         assert!(!transaction.relevant(viewing_key(2)));
         assert!(transaction.relevant(viewing_key(3)));
+        assert!(
+            transaction
+                .contract_actions()
+                .expect("contract actions can be extracted")
+                .is_empty()
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Closes midnightntwrk/midnight-indexer#1040

The chain-indexer already keeps a full local `LedgerState`. For every contract action it still called the node's `get_contract_state` runtime API, which does the same `LedgerState::index(address)` lookup the node uses internally.

That extra RPC is gone. Ingest now:

1. Decodes the transaction and records the action (address, deploy/call/update) with an empty `state`
2. Applies the transaction to the local ledger
3. Fills `state` with `LedgerState::index(address)` and the same tagged serialization the RPC used to return

If the contract is missing (failed deploy, unknown address), `state` is still empty bytes, same as before.

This also means we no longer hit the node runtime API at the moment a hardfork is enacted. That was the class of failure that stalled indexing when a contract action landed on an upgrade block (wrong runtime API module vs the live chain).

One behavior change worth flagging: the old RPC was queried `.at(block)`, so every action in the block got the post-block state. We now store the post-transaction state for that action, which matches what the ledger actually looks like after that tx.

`get_contract_state` wrappers were removed from all four runtime versions. `Transaction::contract_actions()` is sync and no longer takes an RPC callback.

### Tests
- Round-trip: insert a contract into a V8/V9 ledger, extract it, check tagged bytes and balances
- Unknown address stays empty
- Apply-path fill leaves empty state / balances for a missing contract, and still writes zswap state from the local ledger
- Existing `test_deserialize_relevant` still passes

`just all-all` and e2e against a live node were not run here. The ignored mainnet upgrade-boundary test still needs the public RPC.