### PR TITLE
feat(indexer-common): retry failed well-formed checks at the transaction's own time bounds

### DIFF
--- a/indexer-common/src/domain/ledger/ledger_state.rs
+++ b/indexer-common/src/domain/ledger/ledger_state.rs
@@ -552,6 +552,39 @@ impl LedgerState {
                         *STRICTNESS_V8,
                         timestamp(well_formed_timestamp),
                     )
+                    .or_else(|error| {
+                        // The node validates mempool transactions against a `tblock` ahead of
+                        // block time and caches the result keyed on (tx_hash, ledger_state_key);
+                        // at inclusion a transaction still matching a cached key skips
+                        // re-validation against real block time. So a chain-accepted transaction
+                        // can fail this strict replay, and its valid window (latest dust `ctime`
+                        // ..= earliest intent `ttl`) can be seconds wide at an arbitrary offset
+                        // from block time, so no fixed tolerance covers it. Retry at the
+                        // transaction's own bounds: earliest intent TTL (covers "TTL has
+                        // expired"), then latest dust ctime (covers "not valid yet"). If no
+                        // retry passes, return the original error.
+                        let min_ttl = transaction.intents().map(|(_, intent)| intent.ttl).min();
+                        let max_ctime = transaction
+                            .intents()
+                            .filter_map(|(_, intent)| {
+                                intent.dust_actions.as_ref().map(|dust| dust.ctime)
+                            })
+                            .max();
+                        warn!(
+                            error:%, well_formed_timestamp, min_ttl:?, max_ctime:?;
+                            "well-formed check failed against block time, \
+                             retrying at transaction time bounds"
+                        );
+                        [min_ttl, max_ctime]
+                            .into_iter()
+                            .flatten()
+                            .find_map(|tblock| {
+                                transaction
+                                    .well_formed(&cx.ref_state, *STRICTNESS_V8, tblock)
+                                    .ok()
+                            })
+                            .ok_or(error)
+                    })
                     .map_err(|error| Error::MalformedTransaction(error.into()))?;
                 let (ledger_state, transaction_result) =
                     ledger_state.apply(&verified_ledger_transaction, &cx);
@@ -653,6 +686,31 @@ impl LedgerState {
                         *STRICTNESS_V9,
                         timestamp(well_formed_timestamp),
                     )
+                    .or_else(|error| {
+                        // See the V8 arm above for why a failed well-formed check is retried at
+                        // the transaction's own time bounds.
+                        let min_ttl = transaction.intents().map(|(_, intent)| intent.ttl).min();
+                        let max_ctime = transaction
+                            .intents()
+                            .filter_map(|(_, intent)| {
+                                intent.dust_actions.as_ref().map(|dust| dust.ctime)
+                            })
+                            .max();
+                        warn!(
+                            error:%, well_formed_timestamp, min_ttl:?, max_ctime:?;
+                            "well-formed check failed against block time, \
+                             retrying at transaction time bounds"
+                        );
+                        [min_ttl, max_ctime]
+                            .into_iter()
+                            .flatten()
+                            .find_map(|tblock| {
+                                transaction
+                                    .well_formed(&cx.ref_state, *STRICTNESS_V9, tblock)
+                                    .ok()
+                            })
+                            .ok_or(error)
+                    })
                     .map_err(|error| Error::MalformedTransaction(error.into()))?;
                 let (ledger_state, transaction_result) =
                     ledger_state.apply(&verified_ledger_transaction, &cx);


### PR DESCRIPTION
Closes #1461.

## Problem

The chain-indexer replays every transaction's `well_formed` check at strict block time. The node does not: it validates mempool transactions against a bumped `tblock` and caches the result keyed on `(tx_hash, ledger_state_key)`; at block inclusion, a transaction that still matches a cached key skips re-validation (midnightntwrk/midnight-node#1924). So the chain contains transactions that fail strict replay by a few seconds. Observed on preprod: transaction `6a1005ee…` with `Intent TTL has expired. TTL: Timestamp(1775081620), Current block: Timestamp(1775081622)` — the indexer exits, and resyncing hits the same block again.

#1371 covers the common case by reproducing the node's first-tx bump, but a cached result can also survive for a non-first transaction when preceding transactions leave the ledger state key unchanged. And a forward bump cannot cover this case at all: the node validated the transaction earlier than block time, so replay needs backward tolerance. The node-side fix (midnightntwrk/midnight-node#1964) does not help either — blocks produced before it are permanent.

A fixed tolerance does not work. `well_formed` bounds `tblock` in both directions: `ttl_check_weak` requires `tblock <= intent.ttl`, and the dust check requires `dust.ctime <= tblock`. For the observed transaction that window is at most a few seconds wide and ends 2 seconds before block time, so retries at fixed offsets (we tried ±30s) jump over it — backward lands before `ctime` and fails `OutOfDustValidityWindow`, forward is even more expired.

## Fix

When `well_formed` fails at block time, retry at the transaction's own time bounds instead: first its earliest intent TTL (covers "TTL has expired" — the last instant the transaction was valid), then its latest dust `ctime` (covers "not valid yet" — the earliest). Both are chain data the node itself accepted, and `well_formed` only validates — the retry timestamp never reaches the applied state, whose block context keeps the real block time. If no retry passes, the original error is returned. Each retry logs a warning so tolerated transactions stay visible. Applied to both the v8 and v9 ledger paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
