### PR TITLE
test: cover protocolVersion on progress updates and across the 8→9 fork

### DIFF
--- a/indexer-tests/src/graphql_ws_client.rs
+++ b/indexer-tests/src/graphql_ws_client.rs
@@ -48,6 +48,39 @@ pub async fn subscribe<T>(
 where
     T: GraphQLQuery,
 {
+    let QueryBody {
+        variables,
+        query,
+        operation_name,
+    } = T::build_query(variables);
+    let variables = serde_json::to_value(variables).context("serialize query variables")?;
+
+    let data = subscribe_raw(url, operation_name, query, variables).await?;
+
+    Ok(data.map(|data| {
+        data.and_then(|data| {
+            serde_json::from_value::<T::ResponseData>(data).context("deserialize response data")
+        })
+    }))
+}
+
+/// Subscribe with a query document given as text, yielding the untyped `data` of every
+/// received message.
+///
+/// The typed [subscribe] above is the default. This one exists for documents that cannot be
+/// generated from `e2e.graphql`, in particular one selecting a field the build under test may
+/// not serve: `e2e.graphql` is shared by every typed operation, so a field that has to be
+/// probed before it is requested cannot live in it.
+///
+/// `use<>`: the stream borrows nothing — the arguments are consumed into the subscribe message
+/// before the socket is read — so it must not capture their lifetimes, or callers cannot hold it
+/// past the call (e.g. move it into a spawned task).
+pub async fn subscribe_raw(
+    url: &str,
+    operation_name: &str,
+    query: &str,
+    variables: Value,
+) -> anyhow::Result<impl Stream<Item = anyhow::Result<Value>> + use<>> {
     let ws_stream = connect_graphql_ws(url)
         .await
         .context("connect graphql websocket connection")?;
@@ -57,12 +90,6 @@ where
     init_graphql_ws(&mut write, &mut read)
         .await
         .context("initialize graphql websocket connection")?;
-
-    let QueryBody {
-        variables,
-        query,
-        operation_name,
-    } = T::build_query(variables);
 
     let subscribe_message = json!({
         "type": "subscribe",
@@ -94,9 +121,7 @@ where
         })
         .try_filter_map(|message| match message {
             ServerMessage::Next { payload } => match (payload.data, payload.errors) {
-                (Some(data), None) => serde_json::from_value::<T::ResponseData>(data)
-                    .map(|data| ok(Some(data)))
-                    .unwrap_or_else(|error| err(anyhow!(error))),
+                (Some(data), None) => ok(Some(data)),
 
                 (None, Some(errors)) => err(anyhow!(
                     errors
@@ -112,6 +137,8 @@ where
             ServerMessage::Complete => ok(None),
 
             ServerMessage::Error { payload } => err(anyhow!(payload)),
+
+            ServerMessage::Other => ok(None),
         });
 
     Ok(messages)
@@ -121,9 +148,18 @@ where
 #[serde(tag = "type")]
 #[serde(rename_all = "snake_case")]
 pub enum ServerMessage {
-    Next { payload: ExecutionResult },
+    Next {
+        payload: ExecutionResult,
+    },
     Complete,
-    Error { payload: Value },
+    Error {
+        payload: Value,
+    },
+
+    /// Anything else, `ping`/`pong` keepalives in particular. A subscription held open for
+    /// minutes has to tolerate those rather than fail on them.
+    #[serde(other)]
+    Other,
 }
 
 #[derive(Debug, Deserialize)]

--- a/indexer-tests/src/graphql_ws_client.rs
+++ b/indexer-tests/src/graphql_ws_client.rs
@@ -15,8 +15,7 @@ use anyhow::{Context, anyhow, bail};
 use derive_more::Display;
 use futures::{
     SinkExt, Stream, StreamExt, TryStreamExt,
-    future::{err, ok},
-    stream::{SplitSink, SplitStream},
+    stream::{SplitSink, SplitStream, unfold},
 };
 use graphql_client::{GraphQLQuery, QueryBody};
 use serde::Deserialize;
@@ -35,6 +34,13 @@ type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 static CONNECTION_INIT: LazyLock<String> = LazyLock::new(|| {
     json!({
         "type": "connection_init",
+    })
+    .to_string()
+});
+
+static PONG: LazyLock<String> = LazyLock::new(|| {
+    json!({
+        "type": "pong",
     })
     .to_string()
 });
@@ -106,40 +112,81 @@ pub async fn subscribe_raw(
         .await
         .context("send subscribe message")?;
 
-    let messages = read
-        .map(|result| {
-            result
-                .context("get next message")
-                .and_then(|message| match message {
-                    Message::Text(text) => serde_json::from_str::<ServerMessage>(&text)
-                        .with_context(|| {
-                            format!("deserialize text message to ServerMessage: {text}")
-                        }),
+    // The write half is carried alongside the read half rather than dropped here: a
+    // `ping` has to be answered with a `pong`, and a dropped sink cannot answer. A
+    // `None` next-state ends the stream, so an error is terminal, as it was when this
+    // was a `try_filter_map`.
+    let messages = unfold(Some((read, write)), |state| async move {
+        let (mut read, mut write) = state?;
 
-                    _ => Err(anyhow!("unexpected non-text message")),
-                })
-        })
-        .try_filter_map(|message| match message {
-            ServerMessage::Next { payload } => match (payload.data, payload.errors) {
-                (Some(data), None) => ok(Some(data)),
+        loop {
+            let text = match read.next().await {
+                Some(Ok(Message::Text(text))) => text,
 
-                (None, Some(errors)) => err(anyhow!(
-                    errors
-                        .iter()
-                        .map(|e| e.message.to_owned())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )),
+                // Transport-level frames carry nothing for a subscriber. Keepalives and
+                // the peer's own pongs are handled by tungstenite; ignore and read on.
+                Some(Ok(Message::Ping(_) | Message::Pong(_) | Message::Frame(_))) => continue,
 
-                _ => err(anyhow!("unexpected GraphQL execution result")),
-            },
+                Some(Ok(Message::Close(_))) => return None,
 
-            ServerMessage::Complete => ok(None),
+                Some(Ok(message)) => {
+                    return Some((Err(anyhow!("unexpected message: {message:?}")), None));
+                }
 
-            ServerMessage::Error { payload } => err(anyhow!(payload)),
+                Some(Err(error)) => {
+                    return Some((Err(anyhow!(error).context("get next message")), None));
+                }
 
-            ServerMessage::Other => ok(None),
-        });
+                None => return None,
+            };
+
+            let message = match serde_json::from_str::<ServerMessage>(&text) {
+                Ok(message) => message,
+
+                // Deliberately loud: an unrecognised `type` means the server speaks a
+                // protocol this client does not, which a subscriber must not silently
+                // read as "no data".
+                Err(error) => {
+                    return Some((
+                        Err(anyhow!(error)
+                            .context(format!("deserialize text message to ServerMessage: {text}"))),
+                        None,
+                    ));
+                }
+            };
+
+            match message {
+                ServerMessage::Next { payload } => match (payload.data, payload.errors) {
+                    (Some(data), None) => return Some((Ok(data), Some((read, write)))),
+
+                    (None, Some(errors)) => {
+                        let errors = errors
+                            .iter()
+                            .map(|e| e.message.to_owned())
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        return Some((Err(anyhow!(errors)), None));
+                    }
+
+                    _ => {
+                        return Some((Err(anyhow!("unexpected GraphQL execution result")), None));
+                    }
+                },
+
+                ServerMessage::Complete => return None,
+
+                ServerMessage::Error { payload } => return Some((Err(anyhow!(payload)), None)),
+
+                ServerMessage::Ping => {
+                    if let Err(error) = write.send(Message::text(&*PONG)).await {
+                        return Some((Err(anyhow!(error).context("send pong")), None));
+                    }
+                }
+
+                ServerMessage::Pong => {}
+            }
+        }
+    });
 
     Ok(messages)
 }
@@ -156,10 +203,11 @@ pub enum ServerMessage {
         payload: Value,
     },
 
-    /// Anything else, `ping`/`pong` keepalives in particular. A subscription held open for
-    /// minutes has to tolerate those rather than fail on them.
-    #[serde(other)]
-    Other,
+    /// Keepalives from `graphql-transport-ws`. Either side may send `ping` at any time and the
+    /// receiver answers `pong`; a subscription held open for minutes has to tolerate both rather
+    /// than fail on them. Every *other* `type` still fails to deserialize, and so fails loudly.
+    Ping,
+    Pong,
 }
 
 #[derive(Debug, Deserialize)]

--- a/indexer-tests/tests/hardfork_e2e.rs
+++ b/indexer-tests/tests/hardfork_e2e.rs
@@ -106,6 +106,12 @@ const UNSHIELDED_PROGRESS_SUBSCRIPTION: &str = "
 
 const WS_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/..");
 
+/// Fallback for the one secret `indexer-standalone` refuses to start without. CI supplies it
+/// (`.github/actions/init-env`) and so does `qa/scripts/test-hardfork-8to9.sh`; a developer
+/// running this test by hand usually has not, and without a default the omission surfaces as a
+/// readiness timeout rather than as the configuration error it is. An ambient value still wins.
+const FALLBACK_SECRET: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
 fn image_registry() -> String {
     env::var("IMAGE_REGISTRY").unwrap_or_else(|_| "midnightntwrk".to_string())
 }
@@ -316,6 +322,18 @@ impl Harness {
         fs::read_to_string(self.temp_dir.path().join("indexer.log")).context("read indexer log")
     }
 
+    /// The last `lines` lines of the indexer's log, in order, or empty if it cannot be read.
+    ///
+    /// The log lives in the `TempDir`, which is dropped the moment this test returns `Err`, so
+    /// anything that fails has to carry the tail into its own error message or the only
+    /// explanation of the failure is deleted along with it.
+    fn indexer_log_tail(&self, lines: usize) -> String {
+        let log = self.indexer_log().unwrap_or_default();
+        let mut tail = log.lines().rev().take(lines).collect::<Vec<_>>();
+        tail.reverse();
+        tail.join("\n")
+    }
+
     /// The indexer bails on a boundary failure rather than indexing on, so a
     /// dead process *is* the failure signal. Surface the reason, not just the
     /// exit.
@@ -340,7 +358,7 @@ impl Harness {
         if let Some(indexer) = guard.as_mut()
             && let Some(status) = indexer.try_wait().context("poll indexer")?
         {
-            let tail = log.lines().rev().take(10).collect::<Vec<_>>().join("\n");
+            let tail = self.indexer_log_tail(10);
             bail!("indexer exited ({status}) at {stage}; last lines:\n{tail}");
         }
         Ok(())
@@ -666,7 +684,13 @@ async fn hardfork_8_to_9_crossing() -> anyhow::Result<()> {
             .unwrap_or(false);
         Ok(ready.then_some(()))
     })
-    .await?;
+    .await
+    .with_context(|| {
+        format!(
+            "indexer-standalone never became ready; its log said:\n{}",
+            harness.indexer_log_tail(15)
+        )
+    })?;
 
     // Index a few pre-fork blocks, then read the dust generation tree size the
     // indexer reconstructed. This is the assertion the whole test rests on: if
@@ -1150,6 +1174,10 @@ fn start_indexer(dir: &Path, node_rpc_port: u16, api_port: u16) -> anyhow::Resul
             format!("ws://localhost:{node_rpc_port}"),
         )
         .env("APP__INFRA__SPO_NODE__BLOCKFROST_ID", "hardfork-e2e-dummy")
+        .env(
+            "APP__INFRA__SECRET",
+            env::var("APP__INFRA__SECRET").unwrap_or_else(|_| FALLBACK_SECRET.to_string()),
+        )
         .env(
             "APP__INFRA__STORAGE__CNN_URL",
             dir.join("indexer.sqlite").display().to_string(),

--- a/indexer-tests/tests/hardfork_e2e.rs
+++ b/indexer-tests/tests/hardfork_e2e.rs
@@ -529,7 +529,12 @@ fn const_hex_decode(s: &str) -> anyhow::Result<Vec<u8>> {
 // for minutes. On a single thread those park the only worker, so the progress subscription task
 // cannot poll and its frames arrive as one drained burst — which both starves the subscription
 // this test depends on and makes the frame arrival times meaningless.
-#[tokio::test(flavor = "multi_thread")]
+//
+// `worker_threads` is pinned rather than left to the host's available parallelism: only one of
+// those blocking calls is ever in flight, so two workers keep the watcher fed on any host,
+// including a single-core one where the default pool would be one worker and the starvation
+// would return as a spurious "never backed off before the fork" failure.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "boots docker containers and drives a live runtime upgrade; run explicitly"]
 async fn hardfork_8_to_9_crossing() -> anyhow::Result<()> {
     let registry = image_registry();

--- a/indexer-tests/tests/hardfork_e2e.rs
+++ b/indexer-tests/tests/hardfork_e2e.rs
@@ -81,11 +81,14 @@ const SOURCE_SEED: &str = "00000000000000000000000000000000000000000000000000000
 const LEDGER_9_SPEC_VERSION: u64 = 2_000_000;
 
 /// Progress update interval the indexer is started with, overriding the 30s production default.
-/// Production also backs a *quiet* subscription off by up to `IDLE_BACKOFF_MAX_MULTIPLE` (8), so
-/// a real wallet can be minutes behind the fork; that latency is deliberately not what this test
-/// measures. Compressing the interval keeps the run from idling for those minutes while still
-/// exercising the same detection path.
-const PROGRESS_UPDATE_INTERVAL: &str = "2s";
+/// Compressing it keeps the run from idling for the minutes a production interval would need,
+/// while exercising the same detection path and the same backoff arithmetic.
+const PROGRESS_UPDATE_INTERVAL: Duration = Duration::from_secs(2);
+
+/// `indexer-api`'s idle backoff caps a quiet subscription at `IDLE_BACKOFF_MAX_MULTIPLE` (8)
+/// times the base interval, and jitters every interval by `JITTER_FRACTION` (±20%). Both live in
+/// `indexer-api/src/infra/api/v4/subscription/polling.rs`.
+const IDLE_BACKOFF_MAX_MULTIPLE: u32 = 8;
 
 /// Progress-only subscription for an address that never receives a transaction: the frames it
 /// yields carry nothing but `highestTransactionId` and the tip protocol version.
@@ -290,22 +293,6 @@ impl Harness {
         format!("{}/ws", self.api_url.replacen("http://", "ws://", 1))
     }
 
-    /// Whether this build serves `protocolVersion` on unshielded progress updates.
-    ///
-    /// Probed rather than assumed: the field arrived with midnight-indexer#1463, and asking for
-    /// it against a build that predates it fails the subscription outright.
-    async fn progress_protocol_version_supported(&self) -> anyhow::Result<bool> {
-        let data = self
-            .graphql(
-                r#"{ __type(name: "UnshieldedTransactionsProgress") { fields { name } } }"#,
-                json!({}),
-            )
-            .await?;
-        Ok(data["__type"]["fields"]
-            .as_array()
-            .is_some_and(|fields| fields.iter().any(|f| f["name"] == "protocolVersion")))
-    }
-
     async fn indexed_height(&self) -> anyhow::Result<u64> {
         let data = self.graphql("{ block { height } }", json!({})).await?;
         data["block"]["height"]
@@ -360,8 +347,35 @@ impl Harness {
     }
 }
 
-/// An unshielded progress subscription held open for the whole crossing, recording every
-/// `(highest_transaction_id, protocol_version)` frame it receives.
+/// One progress frame, with the moment it arrived. The arrival times are what make the second
+/// half of midnight-indexer#1463 observable: the tip protocol version joins each stream's idle
+/// backoff change detection, so a subscription that slept through a fork returns to the base
+/// interval instead of staying backed off at the cap.
+#[derive(Debug, Clone, Copy)]
+struct ProgressFrame {
+    highest_transaction_id: u64,
+    protocol_version: u64,
+    at: Instant,
+}
+
+/// What the watcher task has seen so far.
+#[derive(Debug, Default)]
+struct ProgressState {
+    frames: Vec<ProgressFrame>,
+
+    /// The first stream error, if any. This test's premise is that the subscription is never
+    /// re-established across a live governance runtime upgrade, which makes a dropped socket its
+    /// likeliest failure and the one most in need of a legible message — so the error is kept
+    /// rather than discarded, and the wait below fails on it instead of timing out blind.
+    error: Option<String>,
+
+    /// Whether the stream ended, for any reason. Distinguishes "closed after N frames" from
+    /// "still open, N frames, no ledger-9 version yet".
+    closed: bool,
+}
+
+/// An unshielded progress subscription held open for the whole crossing, recording every frame
+/// it receives.
 ///
 /// This is the wallet the field exists for: it owns an address that never transacts, so it
 /// receives nothing but progress updates and the protocol version they carry is the only thing
@@ -369,7 +383,7 @@ impl Harness {
 /// makes the observation meaningful — a reconnect would read the new version from a fresh query
 /// rather than from the stream.
 struct ProgressWatcher {
-    frames: Arc<Mutex<Vec<(u64, u64)>>>,
+    state: Arc<Mutex<ProgressState>>,
     task: JoinHandle<()>,
 }
 
@@ -390,33 +404,77 @@ impl ProgressWatcher {
         .await
         .context("subscribe to unshielded progress")?;
 
-        let frames = Arc::new(Mutex::new(Vec::new()));
-        let sink = frames.clone();
+        let state = Arc::new(Mutex::new(ProgressState::default()));
+        let sink = state.clone();
 
         let task = tokio::spawn(async move {
             let mut events = pin!(events);
-            while let Some(Ok(event)) = events.next().await {
-                let progress = &event["unshieldedTransactions"];
-                if let (Some(id), Some(version)) = (
-                    progress["highestTransactionId"].as_u64(),
-                    progress["protocolVersion"].as_u64(),
-                ) {
-                    sink.lock()
-                        .expect("progress frames mutex poisoned")
-                        .push((id, version));
+
+            loop {
+                match events.next().await {
+                    Some(Ok(event)) => {
+                        let progress = &event["unshieldedTransactions"];
+                        if let (Some(highest_transaction_id), Some(protocol_version)) = (
+                            progress["highestTransactionId"].as_u64(),
+                            progress["protocolVersion"].as_u64(),
+                        ) {
+                            sink.lock()
+                                .expect("progress state mutex poisoned")
+                                .frames
+                                .push(ProgressFrame {
+                                    highest_transaction_id,
+                                    protocol_version,
+                                    at: Instant::now(),
+                                });
+                        }
+                    }
+
+                    Some(Err(error)) => {
+                        let mut state = sink.lock().expect("progress state mutex poisoned");
+                        state.error = Some(format!("{error:#}"));
+                        state.closed = true;
+                        break;
+                    }
+
+                    None => {
+                        sink.lock().expect("progress state mutex poisoned").closed = true;
+                        break;
+                    }
                 }
             }
         });
 
-        Ok(Self { frames, task })
+        Ok(Self { state, task })
     }
 
-    fn frames(&self) -> Vec<(u64, u64)> {
-        self.frames
-            .lock()
-            .expect("progress frames mutex poisoned")
-            .clone()
+    /// The frames so far, plus the stream error and whether it ended.
+    fn snapshot(&self) -> (Vec<ProgressFrame>, Option<String>, bool) {
+        let state = self.state.lock().expect("progress state mutex poisoned");
+        (state.frames.clone(), state.error.clone(), state.closed)
     }
+
+    /// Describes what the subscription has done, for a failure message.
+    fn describe(&self) -> String {
+        let (frames, error, closed) = self.snapshot();
+        let versions = frames
+            .iter()
+            .map(|frame| frame.protocol_version)
+            .collect::<Vec<_>>();
+        let liveness = match (&error, closed) {
+            (Some(error), _) => format!("stream failed: {error}"),
+            (None, true) => "stream closed cleanly".to_string(),
+            (None, false) => "stream still open".to_string(),
+        };
+        format!("{} frame(s) {versions:?}, {liveness}", frames.len())
+    }
+}
+
+/// Gaps between consecutive frame arrivals, in order.
+fn frame_gaps(frames: &[ProgressFrame]) -> Vec<Duration> {
+    frames
+        .windows(2)
+        .map(|pair| pair[1].at.duration_since(pair[0].at))
+        .collect()
 }
 
 /// Poll `f` until it returns `Some`, or fail after `timeout`.
@@ -466,7 +524,12 @@ fn const_hex_decode(s: &str) -> anyhow::Result<Vec<u8>> {
         .collect()
 }
 
-#[tokio::test]
+// A multi-threaded runtime, not the `#[tokio::test]` default of one thread: every docker and
+// toolkit call below is a *blocking* `std::process::Command`, and the runtime-upgrade one runs
+// for minutes. On a single thread those park the only worker, so the progress subscription task
+// cannot poll and its frames arrive as one drained burst — which both starves the subscription
+// this test depends on and makes the frame arrival times meaningless.
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "boots docker containers and drives a live runtime upgrade; run explicitly"]
 async fn hardfork_8_to_9_crossing() -> anyhow::Result<()> {
     let registry = image_registry();
@@ -629,21 +692,15 @@ async fn hardfork_8_to_9_crossing() -> anyhow::Result<()> {
         pre_fork_balances.len()
     );
 
-    // Open the idle progress subscription now, so it spans the upgrade rather than being
-    // established after it. Skipped, loudly, on a build without the field.
+    // --- 4b. Hold an idle progress subscription open across the fork --------
+    //
+    // Opened now, before the upgrade, so it spans the crossing rather than being established
+    // after it. Not gated on a probe: `protocolVersion` is served by the very tree this test
+    // compiles and runs, so its absence is a defect to fail on, not an environment to skip for.
     let network_id = NetworkId::try_from("undeployed").expect("undeployed is a network id");
     let unused_address = encode_address([0u8; 32], AddressType::Unshielded, &network_id);
-    let progress = if harness.progress_protocol_version_supported().await? {
-        let watcher = ProgressWatcher::start(&harness.ws_api_url(), &unused_address).await?;
-        println!("[4] watching progress updates for an address with no transactions");
-        Some(watcher)
-    } else {
-        println!(
-            "[4] WARNING: this build does not serve UnshieldedTransactionsProgress.\
-             protocolVersion (midnight-indexer#1463), so the fork-observation check is skipped"
-        );
-        None
-    };
+    let progress = ProgressWatcher::start(&harness.ws_api_url(), &unused_address).await?;
+    println!("[4b] watching progress updates for an address with no transactions");
 
     // --- 5. Governance runtime upgrade --------------------------------------
     println!("[5] driving the governance runtime upgrade");
@@ -713,41 +770,105 @@ async fn hardfork_8_to_9_crossing() -> anyhow::Result<()> {
     // Everything above proves the indexer crossed. This proves a wallet can *tell*: without the
     // protocol version on progress updates, an address with no transactions has no way to learn
     // that the codec its stream is encoded at has changed.
-    if let Some(progress) = &progress {
-        let frames = wait_for(
-            "a ledger-9 protocol version on the idle subscription",
-            Duration::from_secs(120),
-            || async {
-                harness.assert_indexer_healthy("progress observation")?;
-                let frames = progress.frames();
-                Ok(frames
-                    .iter()
-                    .any(|(_, version)| *version >= LEDGER_9_SPEC_VERSION)
-                    .then_some(frames))
-            },
-        )
-        .await?;
+    //
+    // Waits for a *second* ledger-9 frame, because the gap between the two is what shows the
+    // idle backoff reset (the other half of the change) — the frame carrying the new version is
+    // emitted with the interval already back at base, so the sleep that follows it is the
+    // measurement.
+    let frames = wait_for(
+        "two ledger-9 protocol versions on the idle subscription",
+        Duration::from_secs(120),
+        || async {
+            harness.assert_indexer_healthy("progress observation")?;
 
-        assert!(
-            frames
+            let (frames, error, closed) = progress.snapshot();
+            if let Some(error) = error {
+                bail!(
+                    "the progress subscription failed after {} frame(s): {error}",
+                    frames.len()
+                );
+            }
+            if closed {
+                bail!(
+                    "the progress subscription closed after {} frame(s) without reporting a \
+                     ledger-9 protocol version",
+                    frames.len()
+                );
+            }
+
+            let crossed = frames
                 .iter()
-                .any(|(_, version)| *version < LEDGER_9_SPEC_VERSION),
-            "the subscription never reported a ledger-8 protocol version, so it cannot have \
-             observed a crossing: {frames:?}"
-        );
-        assert!(
-            frames.iter().all(|(id, _)| *id == 0),
-            "the watched address received a transaction, so any version it learned could have \
-             come from that instead of from the progress updates: {frames:?}"
-        );
-        println!(
-            "[6] idle subscription observed protocol version {:?} -> {:?} over {} frames, \
-             never receiving a transaction",
-            frames.first().map(|(_, version)| *version),
-            frames.last().map(|(_, version)| *version),
-            frames.len()
-        );
-    }
+                .position(|frame| frame.protocol_version >= LEDGER_9_SPEC_VERSION);
+            Ok(crossed
+                .filter(|first| frames.len() > first + 1)
+                .map(|_| frames))
+        },
+    )
+    .await
+    .with_context(|| format!("idle progress subscription: {}", progress.describe()))?;
+
+    let first_ledger_9 = frames
+        .iter()
+        .position(|frame| frame.protocol_version >= LEDGER_9_SPEC_VERSION)
+        .expect("the wait above only returns once a ledger-9 frame exists");
+
+    assert!(
+        frames[..first_ledger_9]
+            .iter()
+            .any(|frame| frame.protocol_version < LEDGER_9_SPEC_VERSION),
+        "the subscription never reported a ledger-8 protocol version, so it cannot have \
+         observed a crossing: {}",
+        progress.describe()
+    );
+    assert!(
+        frames.iter().all(|frame| frame.highest_transaction_id == 0),
+        "the watched address received a transaction, so any version it learned could have come \
+         from that instead of from the progress updates: {}",
+        progress.describe()
+    );
+
+    // The protocol version also feeds idle-backoff change detection, so the fork must pull the
+    // interval back to base. Bounds are deliberately loose: the frame arrival times include
+    // request latency on top of the server's jittered sleep, so they bracket the two regimes
+    // (base 2s ±20%, cap 8x base = 16s ±20%) rather than pinning either.
+    let gaps = frame_gaps(&frames);
+    let backed_off = gaps[..first_ledger_9]
+        .iter()
+        .max()
+        .copied()
+        .unwrap_or_default();
+    let after_crossing = gaps[first_ledger_9];
+
+    assert!(
+        backed_off >= PROGRESS_UPDATE_INTERVAL * 2,
+        "the idle subscription never backed off before the fork (longest pre-fork gap {:?}, \
+         base {:?}), so the reset it is meant to demonstrate would be vacuous: {}",
+        backed_off,
+        PROGRESS_UPDATE_INTERVAL,
+        progress.describe()
+    );
+    assert!(
+        after_crossing <= PROGRESS_UPDATE_INTERVAL * 2,
+        "the protocol version moved but the poll interval stayed backed off: the gap after the \
+         first ledger-9 frame was {:?}, expected about the base interval {:?} (the pre-fork gap \
+         had reached {:?}, cap is {}x base): {}",
+        after_crossing,
+        PROGRESS_UPDATE_INTERVAL,
+        backed_off,
+        IDLE_BACKOFF_MAX_MULTIPLE,
+        progress.describe()
+    );
+
+    println!(
+        "[6b] idle subscription observed protocol version {} -> {} over {} frames, never \
+         receiving a transaction; poll gap {:?} before the crossing -> {:?} after it (base {:?})",
+        frames[0].protocol_version,
+        frames[frames.len() - 1].protocol_version,
+        frames.len(),
+        backed_off,
+        after_crossing,
+        PROGRESS_UPDATE_INTERVAL
+    );
 
     // --- 7. The node's cNIGHT dust replay actually restored something -------
     //
@@ -1013,7 +1134,7 @@ fn start_indexer(dir: &Path, node_rpc_port: u16, api_port: u16) -> anyhow::Resul
         // subscription off to 8x that, which this test has no reason to sit through.
         .env(
             "APP__INFRA__API__SUBSCRIPTION__UNSHIELDED_TRANSACTIONS__PROGRESS_UPDATE_INTERVAL",
-            PROGRESS_UPDATE_INTERVAL,
+            format!("{}s", PROGRESS_UPDATE_INTERVAL.as_secs()),
         )
         .env(
             "APP__INFRA__API__SUBSCRIPTION__PROGRESS_CACHE__TIME_TO_LIVE",

--- a/indexer-tests/tests/hardfork_e2e.rs
+++ b/indexer-tests/tests/hardfork_e2e.rs
@@ -52,18 +52,23 @@
 #![cfg(feature = "standalone")]
 
 use anyhow::{Context, bail};
+use futures::StreamExt;
+use indexer_api::infra::api::v4::{AddressType, encode_address};
+use indexer_common::domain::NetworkId;
+use indexer_tests::graphql_ws_client;
 use serde_json::{Value, json};
 use std::{
     collections::BTreeMap,
     env, fs,
     net::TcpListener,
     path::Path,
+    pin::pin,
     process::{Child, Command, Stdio},
-    sync::Mutex,
+    sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
 use tempfile::TempDir;
-use tokio::time::sleep;
+use tokio::{task::JoinHandle, time::sleep};
 
 /// Ledger-8 node whose `dev` preset provides the fork-from chain-spec.
 const FROM_NODE_TAG: &str = "1.0.0";
@@ -71,8 +76,30 @@ const FROM_NODE_TAG: &str = "1.0.0";
 /// Genesis-funded dev wallet the test transacts from.
 const SOURCE_SEED: &str = "0000000000000000000000000000000000000000000000000000000000000001";
 
-/// Any `spec_version` at or above this is a ledger-9 runtime.
+/// Any `spec_version` at or above this is a ledger-9 runtime. Block protocol versions share the
+/// scale, so the same threshold separates the two ledger windows in progress updates.
 const LEDGER_9_SPEC_VERSION: u64 = 2_000_000;
+
+/// Progress update interval the indexer is started with, overriding the 30s production default.
+/// Production also backs a *quiet* subscription off by up to `IDLE_BACKOFF_MAX_MULTIPLE` (8), so
+/// a real wallet can be minutes behind the fork; that latency is deliberately not what this test
+/// measures. Compressing the interval keeps the run from idling for those minutes while still
+/// exercising the same detection path.
+const PROGRESS_UPDATE_INTERVAL: &str = "2s";
+
+/// Progress-only subscription for an address that never receives a transaction: the frames it
+/// yields carry nothing but `highestTransactionId` and the tip protocol version.
+const UNSHIELDED_PROGRESS_SUBSCRIPTION: &str = "
+    subscription UnshieldedProgress($address: UnshieldedAddress!) {
+        unshieldedTransactions(address: $address) {
+            __typename
+            ... on UnshieldedTransactionsProgress {
+                highestTransactionId
+                protocolVersion
+            }
+        }
+    }
+";
 
 const WS_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/..");
 
@@ -259,6 +286,26 @@ impl Harness {
         Ok(balances)
     }
 
+    fn ws_api_url(&self) -> String {
+        format!("{}/ws", self.api_url.replacen("http://", "ws://", 1))
+    }
+
+    /// Whether this build serves `protocolVersion` on unshielded progress updates.
+    ///
+    /// Probed rather than assumed: the field arrived with midnight-indexer#1463, and asking for
+    /// it against a build that predates it fails the subscription outright.
+    async fn progress_protocol_version_supported(&self) -> anyhow::Result<bool> {
+        let data = self
+            .graphql(
+                r#"{ __type(name: "UnshieldedTransactionsProgress") { fields { name } } }"#,
+                json!({}),
+            )
+            .await?;
+        Ok(data["__type"]["fields"]
+            .as_array()
+            .is_some_and(|fields| fields.iter().any(|f| f["name"] == "protocolVersion")))
+    }
+
     async fn indexed_height(&self) -> anyhow::Result<u64> {
         let data = self.graphql("{ block { height } }", json!({})).await?;
         data["block"]["height"]
@@ -310,6 +357,65 @@ impl Harness {
             bail!("indexer exited ({status}) at {stage}; last lines:\n{tail}");
         }
         Ok(())
+    }
+}
+
+/// An unshielded progress subscription held open for the whole crossing, recording every
+/// `(highest_transaction_id, protocol_version)` frame it receives.
+///
+/// This is the wallet the field exists for: it owns an address that never transacts, so it
+/// receives nothing but progress updates and the protocol version they carry is the only thing
+/// about them that changes at a fork. The subscription is never re-established, which is what
+/// makes the observation meaningful — a reconnect would read the new version from a fresh query
+/// rather than from the stream.
+struct ProgressWatcher {
+    frames: Arc<Mutex<Vec<(u64, u64)>>>,
+    task: JoinHandle<()>,
+}
+
+impl Drop for ProgressWatcher {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+impl ProgressWatcher {
+    async fn start(ws_api_url: &str, address: &str) -> anyhow::Result<Self> {
+        let events = graphql_ws_client::subscribe_raw(
+            ws_api_url,
+            "UnshieldedProgress",
+            UNSHIELDED_PROGRESS_SUBSCRIPTION,
+            json!({ "address": address }),
+        )
+        .await
+        .context("subscribe to unshielded progress")?;
+
+        let frames = Arc::new(Mutex::new(Vec::new()));
+        let sink = frames.clone();
+
+        let task = tokio::spawn(async move {
+            let mut events = pin!(events);
+            while let Some(Ok(event)) = events.next().await {
+                let progress = &event["unshieldedTransactions"];
+                if let (Some(id), Some(version)) = (
+                    progress["highestTransactionId"].as_u64(),
+                    progress["protocolVersion"].as_u64(),
+                ) {
+                    sink.lock()
+                        .expect("progress frames mutex poisoned")
+                        .push((id, version));
+                }
+            }
+        });
+
+        Ok(Self { frames, task })
+    }
+
+    fn frames(&self) -> Vec<(u64, u64)> {
+        self.frames
+            .lock()
+            .expect("progress frames mutex poisoned")
+            .clone()
     }
 }
 
@@ -523,6 +629,22 @@ async fn hardfork_8_to_9_crossing() -> anyhow::Result<()> {
         pre_fork_balances.len()
     );
 
+    // Open the idle progress subscription now, so it spans the upgrade rather than being
+    // established after it. Skipped, loudly, on a build without the field.
+    let network_id = NetworkId::try_from("undeployed").expect("undeployed is a network id");
+    let unused_address = encode_address([0u8; 32], AddressType::Unshielded, &network_id);
+    let progress = if harness.progress_protocol_version_supported().await? {
+        let watcher = ProgressWatcher::start(&harness.ws_api_url(), &unused_address).await?;
+        println!("[4] watching progress updates for an address with no transactions");
+        Some(watcher)
+    } else {
+        println!(
+            "[4] WARNING: this build does not serve UnshieldedTransactionsProgress.\
+             protocolVersion (midnight-indexer#1463), so the fork-observation check is skipped"
+        );
+        None
+    };
+
     // --- 5. Governance runtime upgrade --------------------------------------
     println!("[5] driving the governance runtime upgrade");
     // Not via `Harness::toolkit`: this one call needs the WASM bind-mounted.
@@ -585,6 +707,47 @@ async fn hardfork_8_to_9_crossing() -> anyhow::Result<()> {
     .await?;
     harness.assert_indexer_healthy("post-fork")?;
     println!("[6] indexer crossed the boundary, now at height {post_fork_height}");
+
+    // --- 6b. The idle wallet observed the crossing ---------------------------
+    //
+    // Everything above proves the indexer crossed. This proves a wallet can *tell*: without the
+    // protocol version on progress updates, an address with no transactions has no way to learn
+    // that the codec its stream is encoded at has changed.
+    if let Some(progress) = &progress {
+        let frames = wait_for(
+            "a ledger-9 protocol version on the idle subscription",
+            Duration::from_secs(120),
+            || async {
+                harness.assert_indexer_healthy("progress observation")?;
+                let frames = progress.frames();
+                Ok(frames
+                    .iter()
+                    .any(|(_, version)| *version >= LEDGER_9_SPEC_VERSION)
+                    .then_some(frames))
+            },
+        )
+        .await?;
+
+        assert!(
+            frames
+                .iter()
+                .any(|(_, version)| *version < LEDGER_9_SPEC_VERSION),
+            "the subscription never reported a ledger-8 protocol version, so it cannot have \
+             observed a crossing: {frames:?}"
+        );
+        assert!(
+            frames.iter().all(|(id, _)| *id == 0),
+            "the watched address received a transaction, so any version it learned could have \
+             come from that instead of from the progress updates: {frames:?}"
+        );
+        println!(
+            "[6] idle subscription observed protocol version {:?} -> {:?} over {} frames, \
+             never receiving a transaction",
+            frames.first().map(|(_, version)| *version),
+            frames.last().map(|(_, version)| *version),
+            frames.len()
+        );
+    }
 
     // --- 7. The node's cNIGHT dust replay actually restored something -------
     //
@@ -846,6 +1009,16 @@ fn start_indexer(dir: &Path, node_rpc_port: u16, api_port: u16) -> anyhow::Resul
             format!("{WS_DIR}/indexer-standalone/config.yaml"),
         )
         .env("APP__INFRA__API__PORT", api_port.to_string())
+        // See PROGRESS_UPDATE_INTERVAL: production polls every 30s and backs a quiet
+        // subscription off to 8x that, which this test has no reason to sit through.
+        .env(
+            "APP__INFRA__API__SUBSCRIPTION__UNSHIELDED_TRANSACTIONS__PROGRESS_UPDATE_INTERVAL",
+            PROGRESS_UPDATE_INTERVAL,
+        )
+        .env(
+            "APP__INFRA__API__SUBSCRIPTION__PROGRESS_CACHE__TIME_TO_LIVE",
+            "1s",
+        )
         .env(
             "APP__INFRA__NODE__URL",
             format!("ws://localhost:{node_rpc_port}"),

--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -47,11 +47,6 @@ let blockHashSurfacePresent = false;
 const SURFACE_ABSENT_REASON =
   'deployed indexer does not serve the block-hash dustGenerations signature';
 
-// midnight-indexer#1463 added protocolVersion to the progress event.
-const PROGRESS_PROTOCOL_VERSION_ABSENT =
-  'DustGenerationsProgress.protocolVersion is absent on this environment (midnight-indexer#1463)';
-let progressProtocolVersionSupported = false;
-
 function encodeDustAddressAsHex(dustAddress: string): string {
   const { words } = bech32m.decode(dustAddress);
   return Buffer.from(bech32m.fromWords(words)).toString('hex');
@@ -309,6 +304,51 @@ async function assertPinnedSnapshotUnlessStale(
 }
 
 /**
+ * Collects the pinned progress events for the oldest block the deployed freshness
+ * window still accepts, preferring an older block over the tip so a pinned-block
+ * assertion is not made against a block that is also the tip. Starts
+ * `IN_WINDOW_OFFSET` back (clamped for a short chain), halves the offset on a
+ * freshness rejection, and falls back to the tip, which is inside every window.
+ */
+async function collectPinnedProgress(
+  wsClient: IndexerWsClient,
+  dustAddress: string,
+  tipBlock: PinnedBlock,
+): Promise<{ block: PinnedBlock; events: DustGenerationsSubscriptionResponse[] }> {
+  const startOffset = Math.min(IN_WINDOW_OFFSET, tipBlock.height - 1);
+
+  for (let offset = startOffset; offset >= MIN_IN_WINDOW_OFFSET; offset = Math.floor(offset / 2)) {
+    const block = await fetchBlock({ height: tipBlock.height - offset });
+    try {
+      return { block, events: await collectPinnedProgressAt(wsClient, dustAddress, block) };
+    } catch (error) {
+      const message = extractSubscriptionErrorMessage(error);
+      if (!message.includes(FRESHNESS_REJECTION)) throw error;
+      log.warn(`Snapshot at tip-${offset} (block ${block.height}) refused: ${message}`);
+    }
+  }
+
+  return {
+    block: tipBlock,
+    events: await collectPinnedProgressAt(wsClient, dustAddress, tipBlock),
+  };
+}
+
+/** One pinned progress-only subscription. Rejections propagate to the caller. */
+function collectPinnedProgressAt(
+  wsClient: IndexerWsClient,
+  dustAddress: string,
+  block: PinnedBlock,
+): Promise<DustGenerationsSubscriptionResponse[]> {
+  return collectDustGenerations(
+    wsClient,
+    { dustAddress, blockHash: block.hash, dtimeCutoffHeight: 0 },
+    30_000,
+    DUST_GENERATIONS_PROGRESS_SUBSCRIPTION,
+  );
+}
+
+/**
  * Skips the current test, recording the reason in the run log as well as the
  * report so a reader of either can tell why coverage was reduced.
  */
@@ -357,11 +397,6 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
         `dustGenerations(blockHash) is absent on ${env.getCurrentEnvironmentName()}; ` +
           'skipping the whole surface',
       );
-    }
-
-    progressProtocolVersionSupported = await isProgressProtocolVersionSupported();
-    if (!progressProtocolVersionSupported) {
-      log.warn(PROGRESS_PROTOCOL_VERSION_ABSENT);
     }
   }, 30_000);
 
@@ -604,62 +639,6 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
         beforeHighestIndex,
         `block ${before.height} should yield a strictly smaller snapshot than block ${after.height}`,
       ).toBeLessThan(afterHighestIndex);
-    }, 90_000);
-
-    /**
-     * Unlike the two transaction progress types, which report the chain tip, this
-     * one reports the protocol version of the snapshot's own block — the same
-     * pinned ledger state the collapsed update is encoded at. A dust wallet
-     * therefore observes an upgrade by re-subscribing at a newer block, not from a
-     * live update: the block-hash subscription completes once emitted.
-     *
-     * The two assertions differ in what they can catch. The collapsed update
-     * comparison is discriminating on any chain, because both values are read from
-     * the same pinned ledger state. The block comparison only diverges from the tip
-     * across a fork boundary, so on an unforked chain it pins the value while the
-     * semantics it guards would fail loudly only after an upgrade.
-     *
-     * @given a valid dust address and the latest block hash
-     * @when a dustGenerations subscription is opened pinned to that block
-     * @then the terminating progress event's protocolVersion equals that block's
-     * @and it equals the protocolVersion of its own final collapsed update, when one
-     *      is present
-     *
-     * midnight-indexer#1463
-     */
-    test('should report the pinned block protocol version in the progress event', async (ctx: TestContext) => {
-      ctx.task!.meta.custom = { labels: ['Subscription', 'Dust', 'Generations', 'Progress'] };
-      if (!blockHashSurfacePresent) return ctx.skip(true, SURFACE_ABSENT_REASON);
-      if (!progressProtocolVersionSupported) {
-        return ctx.skip(true, PROGRESS_PROTOCOL_VERSION_ABSENT);
-      }
-
-      // protocolVersion is a property of the pinned ledger state, so it needs no
-      // registered wallet and no Cardano fixture.
-      const dustAddress = generateDustAddressForNetworkId(env.getNetworkId().toLowerCase());
-      const block = await fetchBlock();
-
-      const events = await collectDustGenerations(
-        indexerWsClient,
-        { dustAddress, blockHash: block.hash, dtimeCutoffHeight: 0 },
-        30_000,
-        DUST_GENERATIONS_PROGRESS_SUBSCRIPTION,
-      );
-
-      const progressEvents = eventsOfType(events, 'DustGenerationsProgress');
-      expect(progressEvents).toHaveLength(1);
-      const progress = progressEvents[0].data!.dustGenerations as DustGenerationsProgress;
-
-      const parsed = DustGenerationsProgressWithProtocolVersionSchema.safeParse(progress);
-      expect(
-        parsed.success,
-        `Progress event schema validation failed: ${JSON.stringify(parsed.error?.format(), null, 2)}`,
-      ).toBe(true);
-
-      expect(progress.protocolVersion).toBe(block.protocolVersion);
-      if (progress.collapsedMerkleTree) {
-        expect(progress.collapsedMerkleTree.protocolVersion).toBe(progress.protocolVersion);
-      }
     }, 90_000);
   });
 
@@ -1042,5 +1021,99 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
       expect(transactions).toHaveLength(1);
       expect(transactions[0].hash).toBe(firstItem.transactionHash);
     }, 60_000);
+  });
+});
+
+// Deliberately outside the undeployed-gated describe above. That gate exists
+// because dust generation *registrations* need a Cardano-side mapping absent on
+// undeployed (#1152), and this case registers nothing: protocolVersion is a
+// property of the pinned ledger state, which every environment has. Undeployed is
+// also the only environment able to serve a locally built indexer, so inheriting
+// the gate would deny this case the one place it can run before a release ships.
+describe('dust generations progress protocol version', () => {
+  const PROGRESS_PROTOCOL_VERSION_ABSENT =
+    'DustGenerationsProgress.protocolVersion is absent on this environment (midnight-indexer#1463)';
+
+  let wsClient: IndexerWsClient;
+  let surfacePresent = false;
+  let protocolVersionPresent = false;
+
+  beforeAll(async () => {
+    surfacePresent = await isBlockHashDustGenerationsSupported();
+    protocolVersionPresent = await isProgressProtocolVersionSupported();
+    if (!surfacePresent) log.warn(SURFACE_ABSENT_REASON);
+    if (!protocolVersionPresent) log.warn(PROGRESS_PROTOCOL_VERSION_ABSENT);
+  }, 30_000);
+
+  beforeEach(async () => {
+    wsClient = new IndexerWsClient();
+    await wsClient.connectionInit();
+  }, 30_000);
+
+  afterEach(async () => {
+    await wsClient.connectionClose();
+  });
+
+  describe('a subscription pinned to a block hash', () => {
+    /**
+     * The snapshot progress event reports the protocol version of its own pinned
+     * block, not the chain tip — the same pinned ledger state its collapsed update
+     * is encoded at. A dust wallet therefore observes an upgrade by re-subscribing
+     * at a newer block rather than from a live update: this subscription completes
+     * once emitted.
+     *
+     * What the two assertions prove, stated precisely, because neither
+     * distinguishes pinned-block from tip semantics on a chain that has not forked:
+     * every block then carries the same protocol version, so both readings agree.
+     * The block comparison pins the reported value against an independently queried
+     * block, and becomes discriminating on any environment retaining history across
+     * a fork boundary. The collapsed update comparison pins internal consistency;
+     * the resolver binds one version from `get_ledger_state_at(blockHash)` and uses
+     * it for both, so it guards that they are not later sourced apart.
+     *
+     * The subscription is pinned to an older in-window block rather than the tip so
+     * the value asserted is that block's own, stepping closer to the tip only when
+     * the deployed freshness window refuses the offset.
+     *
+     * @given a valid dust address and a block hash inside the freshness window,
+     *        older than the tip where the chain and the window allow it
+     * @when a dustGenerations subscription is opened pinned to that block
+     * @then the terminating progress event's protocolVersion equals that block's
+     * @and it equals the protocolVersion of its own final collapsed update, when one
+     *      is present
+     *
+     * midnight-indexer#1463
+     */
+    test('should report the pinned block protocol version in the progress event', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Subscription', 'Dust', 'Generations', 'Progress'] };
+      if (!surfacePresent) return ctx.skip(true, SURFACE_ABSENT_REASON);
+      if (!protocolVersionPresent) return ctx.skip(true, PROGRESS_PROTOCOL_VERSION_ABSENT);
+
+      // A well-formed address for this network is enough — the resolver reads the
+      // version from the pinned ledger state, not from anything the address owns.
+      const dustAddress = generateDustAddressForNetworkId(env.getNetworkId().toLowerCase());
+      const tipBlock = await fetchBlock();
+
+      const { block, events } = await collectPinnedProgress(wsClient, dustAddress, tipBlock);
+      log.debug(
+        `Pinned to block ${block.height} (tip ${tipBlock.height}), ` +
+          `protocolVersion ${block.protocolVersion}`,
+      );
+
+      const progressEvents = eventsOfType(events, 'DustGenerationsProgress');
+      expect(progressEvents).toHaveLength(1);
+      const progress = progressEvents[0].data!.dustGenerations as DustGenerationsProgress;
+
+      const parsed = DustGenerationsProgressWithProtocolVersionSchema.safeParse(progress);
+      expect(
+        parsed.success,
+        `Progress event schema validation failed: ${JSON.stringify(parsed.error?.format(), null, 2)}`,
+      ).toBe(true);
+
+      expect(progress.protocolVersion).toBe(block.protocolVersion);
+      if (progress.collapsedMerkleTree) {
+        expect(progress.collapsedMerkleTree.protocolVersion).toBe(progress.protocolVersion);
+      }
+    }, 90_000);
   });
 });

--- a/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/dust-generations-subscriptions.test.ts
@@ -23,8 +23,16 @@ import {
   DustGenerationsSubscriptionResponse,
 } from '@utils/indexer/websocket-client';
 import { extractSubscriptionErrorMessage } from '@utils/indexer/subscription-error';
-import { isBlockHashDustGenerationsSupported } from '@utils/indexer/schema-feature-probe';
-import { DustGenerationsEventSchema } from '@utils/indexer/graphql/schema';
+import {
+  isBlockHashDustGenerationsSupported,
+  isProgressProtocolVersionSupported,
+} from '@utils/indexer/schema-feature-probe';
+import {
+  DustGenerationsEventSchema,
+  DustGenerationsProgressWithProtocolVersionSchema,
+} from '@utils/indexer/graphql/schema';
+import { DUST_GENERATIONS_PROGRESS_SUBSCRIPTION } from '@utils/indexer/graphql/subscriptions';
+import type { DustGenerationsProgress } from '@utils/indexer/indexer-types';
 import { IndexerHttpClient } from '@utils/indexer/http-client';
 import { env } from 'environment/model';
 import dataProvider from '@utils/testdata-provider';
@@ -38,6 +46,11 @@ const indexerHttpClient = new IndexerHttpClient();
 let blockHashSurfacePresent = false;
 const SURFACE_ABSENT_REASON =
   'deployed indexer does not serve the block-hash dustGenerations signature';
+
+// midnight-indexer#1463 added protocolVersion to the progress event.
+const PROGRESS_PROTOCOL_VERSION_ABSENT =
+  'DustGenerationsProgress.protocolVersion is absent on this environment (midnight-indexer#1463)';
+let progressProtocolVersionSupported = false;
 
 function encodeDustAddressAsHex(dustAddress: string): string {
   const { words } = bech32m.decode(dustAddress);
@@ -74,9 +87,12 @@ async function fetchDustAddress(rewardAddress: string): Promise<string> {
 /**
  * Fetches the block the subscription snapshot is pinned to.
  */
-async function fetchBlock(offset?: {
+async function fetchBlock(offset?: { height: number }): Promise<{
+  hash: string;
   height: number;
-}): Promise<{ hash: string; height: number; dustGenerationEndIndex: number }> {
+  dustGenerationEndIndex: number;
+  protocolVersion: number;
+}> {
   const response = offset
     ? await indexerHttpClient.getBlockByOffset(offset)
     : await indexerHttpClient.getLatestBlock();
@@ -86,6 +102,7 @@ async function fetchBlock(offset?: {
     hash: block.hash,
     height: block.height,
     dustGenerationEndIndex: block.dustGenerationEndIndex!,
+    protocolVersion: block.protocolVersion,
   };
 }
 
@@ -104,6 +121,7 @@ function collectDustGenerations(
   wsClient: IndexerWsClient,
   args: DustGenerationsSubscriptionArgs,
   timeoutMs = 30_000,
+  queryOverride?: string,
 ): Promise<DustGenerationsSubscriptionResponse[]> {
   return new Promise((resolve, reject) => {
     const events: DustGenerationsSubscriptionResponse[] = [];
@@ -146,6 +164,7 @@ function collectDustGenerations(
       args.dustAddress,
       args.blockHash,
       args.dtimeCutoffHeight,
+      queryOverride,
     );
     unsubscribe = subscription.unsubscribe;
   });
@@ -338,6 +357,11 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
         `dustGenerations(blockHash) is absent on ${env.getCurrentEnvironmentName()}; ` +
           'skipping the whole surface',
       );
+    }
+
+    progressProtocolVersionSupported = await isProgressProtocolVersionSupported();
+    if (!progressProtocolVersionSupported) {
+      log.warn(PROGRESS_PROTOCOL_VERSION_ABSENT);
     }
   }, 30_000);
 
@@ -580,6 +604,62 @@ describe.skipIf(env.isUndeployedEnv())('dust generations subscription', () => {
         beforeHighestIndex,
         `block ${before.height} should yield a strictly smaller snapshot than block ${after.height}`,
       ).toBeLessThan(afterHighestIndex);
+    }, 90_000);
+
+    /**
+     * Unlike the two transaction progress types, which report the chain tip, this
+     * one reports the protocol version of the snapshot's own block — the same
+     * pinned ledger state the collapsed update is encoded at. A dust wallet
+     * therefore observes an upgrade by re-subscribing at a newer block, not from a
+     * live update: the block-hash subscription completes once emitted.
+     *
+     * The two assertions differ in what they can catch. The collapsed update
+     * comparison is discriminating on any chain, because both values are read from
+     * the same pinned ledger state. The block comparison only diverges from the tip
+     * across a fork boundary, so on an unforked chain it pins the value while the
+     * semantics it guards would fail loudly only after an upgrade.
+     *
+     * @given a valid dust address and the latest block hash
+     * @when a dustGenerations subscription is opened pinned to that block
+     * @then the terminating progress event's protocolVersion equals that block's
+     * @and it equals the protocolVersion of its own final collapsed update, when one
+     *      is present
+     *
+     * midnight-indexer#1463
+     */
+    test('should report the pinned block protocol version in the progress event', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Subscription', 'Dust', 'Generations', 'Progress'] };
+      if (!blockHashSurfacePresent) return ctx.skip(true, SURFACE_ABSENT_REASON);
+      if (!progressProtocolVersionSupported) {
+        return ctx.skip(true, PROGRESS_PROTOCOL_VERSION_ABSENT);
+      }
+
+      // protocolVersion is a property of the pinned ledger state, so it needs no
+      // registered wallet and no Cardano fixture.
+      const dustAddress = generateDustAddressForNetworkId(env.getNetworkId().toLowerCase());
+      const block = await fetchBlock();
+
+      const events = await collectDustGenerations(
+        indexerWsClient,
+        { dustAddress, blockHash: block.hash, dtimeCutoffHeight: 0 },
+        30_000,
+        DUST_GENERATIONS_PROGRESS_SUBSCRIPTION,
+      );
+
+      const progressEvents = eventsOfType(events, 'DustGenerationsProgress');
+      expect(progressEvents).toHaveLength(1);
+      const progress = progressEvents[0].data!.dustGenerations as DustGenerationsProgress;
+
+      const parsed = DustGenerationsProgressWithProtocolVersionSchema.safeParse(progress);
+      expect(
+        parsed.success,
+        `Progress event schema validation failed: ${JSON.stringify(parsed.error?.format(), null, 2)}`,
+      ).toBe(true);
+
+      expect(progress.protocolVersion).toBe(block.protocolVersion);
+      if (progress.collapsedMerkleTree) {
+        expect(progress.collapsedMerkleTree.protocolVersion).toBe(progress.protocolVersion);
+      }
     }, 90_000);
   });
 

--- a/qa/tests/tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts
@@ -356,10 +356,9 @@ describe('shielded transaction subscriptions', () => {
       expect(highestZswapEndIndex).toBeGreaterThan(0);
 
       // highestZswapEndIndex is exclusive, so the collapsed update query needs (highestZswapEndIndex - 1)
-      const indexerHttpClient = new IndexerHttpClient();
       const endIndex = highestZswapEndIndex - 1;
       log.debug(`Querying collapsed update with startIndex=0, endIndex=${endIndex}`);
-      const response = await indexerHttpClient.getZswapMerkleTreeCollapsedUpdate(0, endIndex);
+      const response = await httpClient.getZswapMerkleTreeCollapsedUpdate(0, endIndex);
 
       expect(response).toBeSuccess();
       expect(response.data?.zswapMerkleTreeCollapsedUpdate).toBeDefined();

--- a/qa/tests/tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/shielded-transaction-subscriptions.test.ts
@@ -31,7 +31,11 @@ import { IndexerHttpClient } from '@utils/indexer/http-client';
 import {
   MerkleTreeCollapsedUpdateSchema,
   ShieldedTransactionEventSchema,
+  ShieldedTransactionsProgressWithProtocolVersionSchema,
 } from '@utils/indexer/graphql/schema';
+import { SHIELDED_TX_PROGRESS_SUBSCRIPTION_BY_SESSION_ID } from '@utils/indexer/graphql/subscriptions';
+import { isProgressProtocolVersionSupported } from '@utils/indexer/schema-feature-probe';
+import type { ShieldedTransactionsProgress } from '@utils/indexer/indexer-types';
 import dataProvider from '@utils/testdata-provider';
 
 // This is longer because it might take some time when
@@ -39,15 +43,29 @@ import dataProvider from '@utils/testdata-provider';
 // it needs to be pulled the first time
 const TOOLKIT_STARTUP_TIMEOUT = 60_000;
 
+const httpClient = new IndexerHttpClient();
+
+// midnight-indexer#1463 added protocolVersion to the progress event. Probed once
+// per file because the document that selects it fails GraphQL validation where the
+// change has not landed.
+const PROGRESS_PROTOCOL_VERSION_ABSENT =
+  'ShieldedTransactionsProgress.protocolVersion is absent on this environment (midnight-indexer#1463)';
+
 describe('shielded transaction subscriptions', () => {
   let randomSeed: string;
   let toolkit: ToolkitWrapper;
   let indexerWsClient: IndexerWsClient;
+  let progressProtocolVersionSupported = false;
 
   beforeAll(async () => {
     // Initialise the toolkit wrapper
     toolkit = new ToolkitWrapper({});
     await toolkit.start();
+
+    progressProtocolVersionSupported = await isProgressProtocolVersionSupported();
+    if (!progressProtocolVersionSupported) {
+      log.warn(PROGRESS_PROTOCOL_VERSION_ABSENT);
+    }
   }, TOOLKIT_STARTUP_TIMEOUT);
 
   afterAll(async () => {
@@ -356,6 +374,67 @@ describe('shielded transaction subscriptions', () => {
         parsed.success,
         `Collapsed update schema validation failed ${JSON.stringify(parsed.error, null, 2)}`,
       ).toBe(true);
+
+      await indexerWsClient.closeWalletSession(sessionId);
+    }, 30_000);
+
+    /**
+     * A wallet with no relevant transactions only ever receives progress events, so
+     * the progress event's protocolVersion is the only way such a wallet observes a
+     * protocol upgrade. It reports the chain tip, which the latest indexed block
+     * reports independently — the block is read after the event so a fork cannot be
+     * straddled the wrong way round.
+     *
+     * @given a valid viewing key and an open wallet session
+     * @when the first ShieldedTransactionsProgress event of the subscription is received
+     * @then its protocolVersion equals the protocolVersion of the latest indexed block
+     * @and the value is non-zero, the sentinel reserved for a chain with no indexed block
+     *
+     * midnight-indexer#1463
+     */
+    test('should report the chain tip protocol version in the progress event', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Subscription', 'Wallet', 'Progress'] };
+      if (!progressProtocolVersionSupported) {
+        return ctx.skip(true, PROGRESS_PROTOCOL_VERSION_ABSENT);
+      }
+
+      const viewingKey = await toolkit.showViewingKey(dataProvider.getFundingSeed());
+      const sessionId: string = await indexerWsClient.openWalletSession(viewingKey);
+
+      // The first progress event is emitted immediately on subscribe, so the 15s
+      // ceiling is generous even under the idle backoff introduced in 4.4.0.
+      const progress = await new Promise<ShieldedTransactionsProgress>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error('Timed out waiting for ShieldedTransactionsProgress event'));
+        }, 15_000);
+
+        const unsubscribe = indexerWsClient.subscribeToShieldedTransactionEvents(
+          {
+            next: (payload) => {
+              const event = payload.data?.shieldedTransactions;
+              if (event?.__typename === 'ShieldedTransactionsProgress') {
+                clearTimeout(timeout);
+                unsubscribe();
+                resolve(event);
+              }
+            },
+          },
+          sessionId,
+          SHIELDED_TX_PROGRESS_SUBSCRIPTION_BY_SESSION_ID,
+        );
+      });
+
+      const latestBlock = await httpClient.getLatestBlock();
+      expect(latestBlock).toBeSuccess();
+
+      const parsed = ShieldedTransactionsProgressWithProtocolVersionSchema.safeParse(progress);
+      expect(
+        parsed.success,
+        `Progress event schema validation failed: ${JSON.stringify(parsed.error?.format(), null, 2)}`,
+      ).toBe(true);
+
+      expect(progress.protocolVersion).toBe(latestBlock.data?.block.protocolVersion);
+      expect(progress.protocolVersion).toBeGreaterThan(0);
 
       await indexerWsClient.closeWalletSession(sessionId);
     }, 30_000);

--- a/qa/tests/tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts
@@ -403,6 +403,9 @@ describe('unshielded transaction subscriptions', async () => {
       const latestBlock = await httpClient.getLatestBlock();
       expect(latestBlock).toBeSuccess();
 
+      // The frame-count and highestTransactionId assertions restate the sibling
+      // test's deliberately: this case sends a different document, so they are the
+      // preconditions the protocolVersion comparison rests on, not a copy.
       expect(messages.length).toBe(1);
       expect(messages[0]).toBeSuccess();
 

--- a/qa/tests/tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts
@@ -18,6 +18,7 @@ import '@utils/logging/test-logging-hooks';
 import { env } from 'environment/model';
 import dataProvider from 'utils/testdata-provider';
 import { GraphQLError } from 'graphql/error/GraphQLError';
+import type { TestContext } from 'vitest';
 import {
   IndexerWsClient,
   SubscriptionHandlers,
@@ -34,11 +35,24 @@ import type {
 import {
   UnshieldedTransactionEventSchema,
   UnshieldedTransactionsProgressSchema,
+  UnshieldedTransactionsProgressWithProtocolVersionSchema,
 } from '@utils/indexer/graphql/schema';
+import { UNSHIELDED_TX_PROGRESS_SUBSCRIPTION_BY_ADDRESS } from '@utils/indexer/graphql/subscriptions';
+import { isProgressProtocolVersionSupported } from '@utils/indexer/schema-feature-probe';
+import { IndexerHttpClient } from '@utils/indexer/http-client';
 import { ToolkitWrapper } from '@utils/toolkit/toolkit-wrapper';
+
+const httpClient = new IndexerHttpClient();
 
 let toolkit: ToolkitWrapper;
 let indexerWsClient: IndexerWsClient;
+
+// midnight-indexer#1463 added protocolVersion to the progress update. Probed once
+// per file because the document that selects it fails GraphQL validation where the
+// change has not landed.
+let progressProtocolVersionSupported = false;
+const PROGRESS_PROTOCOL_VERSION_ABSENT =
+  'UnshieldedTransactionsProgress.protocolVersion is absent on this environment (midnight-indexer#1463)';
 
 /**
  * Factory that returns a stateful stop-condition predicate for
@@ -85,6 +99,7 @@ async function subscribeToUnshieldedTransactionEvents(
   subscriptionParams: UnshieldedTransactionSubscriptionParams,
   stopCondition: (message: UnshieldedTxSubscriptionResponse[]) => boolean,
   timeout: number = 5000,
+  queryOverride?: string,
 ): Promise<UnshieldedTxSubscriptionResponse[]> {
   const receivedUnshieldedTransactions: UnshieldedTxSubscriptionResponse[] = [];
 
@@ -129,6 +144,7 @@ async function subscribeToUnshieldedTransactionEvents(
   const unsubscribe = indexerWsClient.subscribeToUnshieldedTransactionEvents(
     unshieldedTransactionSubscriptionHandler,
     subscriptionParams,
+    queryOverride,
   );
 
   // Once subscribed, we will wait for either the stop condition to be met,
@@ -149,6 +165,11 @@ describe('unshielded transaction subscriptions', async () => {
     toolkit = new ToolkitWrapper({});
     if (toolkit) {
       await toolkit.start();
+    }
+
+    progressProtocolVersionSupported = await isProgressProtocolVersionSupported();
+    if (!progressProtocolVersionSupported) {
+      log.warn(PROGRESS_PROTOCOL_VERSION_ABSENT);
     }
   }, 120000);
 
@@ -348,6 +369,53 @@ describe('unshielded transaction subscriptions', async () => {
 
       // ... with no transactions present for this address -> highestTransactionId must be 0
       expect(transactionProgressEvent.highestTransactionId).toBe(0);
+    });
+
+    /**
+     * An address with no transactions only ever receives progress updates, so the
+     * progress update's protocolVersion is the only way such a wallet observes a
+     * protocol upgrade. It reports the chain tip, which the latest indexed block
+     * reports independently — the block is read after the update so a fork cannot
+     * be straddled the wrong way round.
+     *
+     * @given an unshielded address that has no transactions
+     * @when a subscription to unshielded transaction events is opened for that address
+     * @then exactly one progress update arrives, with highestTransactionId 0
+     * @and its protocolVersion equals the protocolVersion of the latest indexed block
+     * @and the value is non-zero, the sentinel reserved for a chain with no indexed block
+     *
+     * midnight-indexer#1463
+     */
+    test('should report the chain tip protocol version in the progress update, given that address does not have transactions', async (ctx: TestContext) => {
+      ctx.task!.meta.custom = { labels: ['Subscription', 'UnshieldedTokens', 'Progress'] };
+      if (!progressProtocolVersionSupported) {
+        return ctx.skip(true, PROGRESS_PROTOCOL_VERSION_ABSENT);
+      }
+
+      const unshieldedAddress = (await toolkit.showAddress('0'.repeat(64))).unshielded;
+      messages = await subscribeToUnshieldedTransactionEvents(
+        { address: unshieldedAddress },
+        (messages) => messages.length >= 10,
+        5000,
+        UNSHIELDED_TX_PROGRESS_SUBSCRIPTION_BY_ADDRESS,
+      );
+
+      const latestBlock = await httpClient.getLatestBlock();
+      expect(latestBlock).toBeSuccess();
+
+      expect(messages.length).toBe(1);
+      expect(messages[0]).toBeSuccess();
+
+      const progress = messages[0].data?.unshieldedTransactions as UnshieldedTransactionsProgress;
+      const parsed = UnshieldedTransactionsProgressWithProtocolVersionSchema.safeParse(progress);
+      expect(
+        parsed.success,
+        `Progress update schema validation failed: ${JSON.stringify(parsed.error?.format(), null, 2)}`,
+      ).toBe(true);
+
+      expect(progress.highestTransactionId).toBe(0);
+      expect(progress.protocolVersion).toBe(latestBlock.data?.block.protocolVersion);
+      expect(progress.protocolVersion).toBeGreaterThan(0);
     });
 
     /**

--- a/qa/tests/tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts
+++ b/qa/tests/tests/integration/basic/subscriptions/unshielded-transaction-subscriptions.test.ts
@@ -404,8 +404,8 @@ describe('unshielded transaction subscriptions', async () => {
       expect(latestBlock).toBeSuccess();
 
       // The frame-count and highestTransactionId assertions restate the sibling
-      // test's deliberately: this case sends a different document, so they are the
-      // preconditions the protocolVersion comparison rests on, not a copy.
+      // test's deliberately: this case sends a different document, so those are the
+      // preconditions its own protocolVersion comparison rests on, not a copy.
       expect(messages.length).toBe(1);
       expect(messages[0]).toBeSuccess();
 

--- a/qa/tests/tests/smoke/progress-protocol-version-schema.test.ts
+++ b/qa/tests/tests/smoke/progress-protocol-version-schema.test.ts
@@ -17,7 +17,10 @@ import log from '@utils/logging/logger';
 import '@utils/logging/test-logging-hooks';
 import type { TestContext } from 'vitest';
 import { env } from 'environment/model';
-import { isProgressProtocolVersionSupported } from '@utils/indexer/schema-feature-probe';
+import {
+  introspectTypeFields,
+  isProgressProtocolVersionSupported,
+} from '@utils/indexer/schema-feature-probe';
 
 /**
  * Contract guard for the progress `protocolVersion` field (midnight-indexer#1463).
@@ -25,8 +28,8 @@ import { isProgressProtocolVersionSupported } from '@utils/indexer/schema-featur
  * A wallet with nothing to receive learns about a protocol upgrade only from the
  * progress update of the subscription it holds open, so every progress type has to
  * carry the field, as a non-null Int. Deployed builds are not homogeneous, so the
- * whole file gates on the field being served at all and reports which environment
- * lacks it rather than failing there; what it then asserts is that an environment
+ * whole file gates on the field being served at all and names the environment
+ * lacking it rather than failing there; what it then asserts is that an environment
  * carrying the change carries it on all three types, with the right type.
  */
 
@@ -38,40 +41,8 @@ const PROGRESS_TYPES = [
 
 const FIELD_NAME = 'protocolVersion';
 
-const TYPE_FIELDS_QUERY = `
-  query TypeFields($name: String!) {
-    __type(name: $name) {
-      name
-      fields {
-        name
-        type {
-          kind
-          name
-          ofType {
-            kind
-            name
-          }
-        }
-      }
-    }
-  }
-`;
-
-type TypeRef = { kind: string; name: string | null; ofType: TypeRef | null };
-
-type TypeFieldsResponse = {
-  __type: { name: string; fields: { name: string; type: TypeRef }[] } | null;
-};
-
-async function introspectType(typeName: string): Promise<TypeFieldsResponse['__type']> {
-  const response = await fetch(env.getIndexerHttpBaseURL() + '/api/v4/graphql', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ query: TYPE_FIELDS_QUERY, variables: { name: typeName } }),
-  });
-  const json = (await response.json()) as { data: TypeFieldsResponse };
-  return json.data.__type;
-}
+// Enough of the type reference to tell `Int!` from `Int`, `String!` or a list.
+const TYPE_SELECTION = 'type { kind name ofType { kind name } }';
 
 describe('progress protocol version schema', () => {
   let supported = false;
@@ -89,6 +60,9 @@ describe('progress protocol version schema', () => {
   for (const typeName of PROGRESS_TYPES) {
     describe(`${typeName}.${FIELD_NAME}`, () => {
       /**
+       * The progress type serves protocolVersion, typed so a consumer can rely on
+       * always receiving a number.
+       *
        * @given a deployed indexer GraphQL endpoint that serves the progress
        *        protocolVersion field
        * @when the progress type is introspected
@@ -105,18 +79,18 @@ describe('progress protocol version schema', () => {
         }
 
         log.debug(`Introspecting ${typeName} for field ${FIELD_NAME}`);
-        const type = await introspectType(typeName);
-        if (type === null) {
+        const fields = await introspectTypeFields(typeName, TYPE_SELECTION);
+        if (fields === null) {
           return ctx.skip(
             true,
             `type "${typeName}" is not served by ${env.getCurrentEnvironmentName()}`,
           );
         }
 
-        const field = type.fields.find((f) => f.name === FIELD_NAME);
+        const field = fields.find((f) => f.name === FIELD_NAME);
         expect(field, `field "${typeName}.${FIELD_NAME}" not found in schema`).toBeDefined();
-        expect(field!.type.kind, `${typeName}.${FIELD_NAME} should be non-null`).toBe('NON_NULL');
-        expect(field!.type.ofType?.name, `${typeName}.${FIELD_NAME} should be an Int`).toBe('Int');
+        expect(field!.type?.kind, `${typeName}.${FIELD_NAME} should be non-null`).toBe('NON_NULL');
+        expect(field!.type?.ofType?.name, `${typeName}.${FIELD_NAME} should be an Int`).toBe('Int');
       });
     });
   }

--- a/qa/tests/tests/smoke/progress-protocol-version-schema.test.ts
+++ b/qa/tests/tests/smoke/progress-protocol-version-schema.test.ts
@@ -1,0 +1,123 @@
+// This file is part of midnightntwrk/midnight-indexer
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import log from '@utils/logging/logger';
+import '@utils/logging/test-logging-hooks';
+import type { TestContext } from 'vitest';
+import { env } from 'environment/model';
+import { isProgressProtocolVersionSupported } from '@utils/indexer/schema-feature-probe';
+
+/**
+ * Contract guard for the progress `protocolVersion` field (midnight-indexer#1463).
+ *
+ * A wallet with nothing to receive learns about a protocol upgrade only from the
+ * progress update of the subscription it holds open, so every progress type has to
+ * carry the field, as a non-null Int. Deployed builds are not homogeneous, so the
+ * whole file gates on the field being served at all and reports which environment
+ * lacks it rather than failing there; what it then asserts is that an environment
+ * carrying the change carries it on all three types, with the right type.
+ */
+
+const PROGRESS_TYPES = [
+  'UnshieldedTransactionsProgress',
+  'ShieldedTransactionsProgress',
+  'DustGenerationsProgress',
+];
+
+const FIELD_NAME = 'protocolVersion';
+
+const TYPE_FIELDS_QUERY = `
+  query TypeFields($name: String!) {
+    __type(name: $name) {
+      name
+      fields {
+        name
+        type {
+          kind
+          name
+          ofType {
+            kind
+            name
+          }
+        }
+      }
+    }
+  }
+`;
+
+type TypeRef = { kind: string; name: string | null; ofType: TypeRef | null };
+
+type TypeFieldsResponse = {
+  __type: { name: string; fields: { name: string; type: TypeRef }[] } | null;
+};
+
+async function introspectType(typeName: string): Promise<TypeFieldsResponse['__type']> {
+  const response = await fetch(env.getIndexerHttpBaseURL() + '/api/v4/graphql', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: TYPE_FIELDS_QUERY, variables: { name: typeName } }),
+  });
+  const json = (await response.json()) as { data: TypeFieldsResponse };
+  return json.data.__type;
+}
+
+describe('progress protocol version schema', () => {
+  let supported = false;
+
+  beforeAll(async () => {
+    supported = await isProgressProtocolVersionSupported();
+    if (!supported) {
+      log.warn(
+        `progress ${FIELD_NAME} is absent on ${env.getCurrentEnvironmentName()}; ` +
+          'skipping the whole surface (midnight-indexer#1463)',
+      );
+    }
+  }, 30_000);
+
+  for (const typeName of PROGRESS_TYPES) {
+    describe(`${typeName}.${FIELD_NAME}`, () => {
+      /**
+       * @given a deployed indexer GraphQL endpoint that serves the progress
+       *        protocolVersion field
+       * @when the progress type is introspected
+       * @then it exposes protocolVersion as a non-null Int
+       */
+      test('should be served as a non-null Int', async (ctx: TestContext) => {
+        ctx.task!.meta.custom = { labels: ['SchemaValidation', 'Subscription', 'Progress'] };
+        if (!supported) {
+          return ctx.skip(
+            true,
+            `progress ${FIELD_NAME} is absent on ${env.getCurrentEnvironmentName()} ` +
+              '(midnight-indexer#1463)',
+          );
+        }
+
+        log.debug(`Introspecting ${typeName} for field ${FIELD_NAME}`);
+        const type = await introspectType(typeName);
+        if (type === null) {
+          return ctx.skip(
+            true,
+            `type "${typeName}" is not served by ${env.getCurrentEnvironmentName()}`,
+          );
+        }
+
+        const field = type.fields.find((f) => f.name === FIELD_NAME);
+        expect(field, `field "${typeName}.${FIELD_NAME}" not found in schema`).toBeDefined();
+        expect(field!.type.kind, `${typeName}.${FIELD_NAME} should be non-null`).toBe('NON_NULL');
+        expect(field!.type.ofType?.name, `${typeName}.${FIELD_NAME} should be an Int`).toBe('Int');
+      });
+    });
+  }
+});

--- a/qa/tests/utils/indexer/graphql/schema.ts
+++ b/qa/tests/utils/indexer/graphql/schema.ts
@@ -433,6 +433,9 @@ export const UnshieldedTransactionsProgressSchema = z.object({
   highestTransactionId: z.number(),
 });
 
+export const UnshieldedTransactionsProgressWithProtocolVersionSchema =
+  UnshieldedTransactionsProgressSchema.extend({ protocolVersion: z.number() });
+
 export const UnshieldedTxSubscriptionResponseSchema = z.union([
   UnshieldedTransactionEventSchema,
   UnshieldedTransactionsProgressSchema,
@@ -459,6 +462,9 @@ export const ShieldedTransactionsProgressSchema = z.object({
   highestCheckedZswapEndIndex: z.number(),
   highestRelevantZswapEndIndex: z.number(),
 });
+
+export const ShieldedTransactionsProgressWithProtocolVersionSchema =
+  ShieldedTransactionsProgressSchema.extend({ protocolVersion: z.number() });
 
 export const ShieldedTransactionEventSchema = z.union([
   RelevantTransactionSchema,
@@ -510,6 +516,9 @@ export const DustGenerationsProgressSchema = z.object({
   highestIndex: z.number(),
   collapsedMerkleTree: CollapsedMerkleTreeSchema.nullable(),
 });
+
+export const DustGenerationsProgressWithProtocolVersionSchema =
+  DustGenerationsProgressSchema.extend({ protocolVersion: z.number() });
 
 export const DustGenerationDtimeUpdateItemSchema = z.object({
   __typename: z.literal('DustGenerationDtimeUpdateItem'),

--- a/qa/tests/utils/indexer/graphql/subscriptions.ts
+++ b/qa/tests/utils/indexer/graphql/subscriptions.ts
@@ -107,6 +107,53 @@ export const UNSHIELDED_TX_SUBSCRIPTION_BY_ADDRESS = `subscription UnshieldedTxS
     }
 }`;
 
+// Progress-only documents that select `protocolVersion` on the progress updates
+// (midnight-indexer#1463). They are separate operations rather than additions to
+// the documents above on purpose: selecting a field an environment does not serve
+// fails GraphQL validation, so folding it into the shared documents would turn
+// every existing progress test into a hard failure on every environment that does
+// not yet carry the change. Consumers must gate on
+// `isProgressProtocolVersionSupported()` before sending them.
+export const UNSHIELDED_TX_PROGRESS_SUBSCRIPTION_BY_ADDRESS = `subscription UnshieldedTxProgressSubscription($ADDRESS: UnshieldedAddress) {
+    unshieldedTransactions(address: $ADDRESS) {
+        __typename
+        ... on UnshieldedTransactionsProgress {
+            highestTransactionId
+            protocolVersion
+        }
+    }
+}`;
+
+export const SHIELDED_TX_PROGRESS_SUBSCRIPTION_BY_SESSION_ID = `subscription WalletSyncProgressSubscription($SESSION_ID: String) {
+    shieldedTransactions(sessionId: $SESSION_ID) {
+        __typename
+        ... on ShieldedTransactionsProgress {
+            highestZswapEndIndex
+            highestCheckedZswapEndIndex
+            highestRelevantZswapEndIndex
+            protocolVersion
+        }
+    }
+}`;
+
+export const DUST_GENERATIONS_PROGRESS_SUBSCRIPTION = `
+  subscription DustGenerationsProgressSubscription($dustAddress: DustAddress!, $blockHash: HexEncoded!, $dtimeCutoffHeight: Int!) {
+    dustGenerations(dustAddress: $dustAddress, blockHash: $blockHash, dtimeCutoffHeight: $dtimeCutoffHeight) {
+      __typename
+      ... on DustGenerationsProgress {
+        highestIndex
+        protocolVersion
+        collapsedMerkleTree {
+          startIndex
+          endIndex
+          update
+          protocolVersion
+        }
+      }
+    }
+  }
+`;
+
 export const BLOCKS_SUBSCRIPTION_FROM_LATEST_BLOCK = `subscription BlocksSubscriptionFromLatestBlock {
    blocks {
     hash

--- a/qa/tests/utils/indexer/indexer-types.ts
+++ b/qa/tests/utils/indexer/indexer-types.ts
@@ -181,6 +181,8 @@ export interface ShieldedTransactionsProgress {
   highestZswapEndIndex: number;
   highestCheckedZswapEndIndex: number;
   highestRelevantZswapEndIndex: number;
+  /** Chain tip protocol version. Only present when the document selects it. */
+  protocolVersion?: number;
 }
 
 export type UnshieldedTransactionEvent = UnshieldedTransaction | UnshieldedTransactionsProgress;
@@ -188,6 +190,8 @@ export type UnshieldedTransactionEvent = UnshieldedTransaction | UnshieldedTrans
 export interface UnshieldedTransactionsProgress {
   __typename: 'UnshieldedTransactionsProgress';
   highestTransactionId: number;
+  /** Chain tip protocol version. Only present when the document selects it. */
+  protocolVersion?: number;
 }
 
 export interface UnshieldedTransaction {
@@ -634,6 +638,8 @@ export interface DustGenerationsProgress {
   __typename: 'DustGenerationsProgress';
   highestIndex: number;
   collapsedMerkleTree: CollapsedMerkleTree | null;
+  /** Protocol version of the snapshot's block, not the tip. Only present when selected. */
+  protocolVersion?: number;
 }
 
 export interface DustGenerationDtimeUpdateItem {

--- a/qa/tests/utils/indexer/schema-feature-probe.ts
+++ b/qa/tests/utils/indexer/schema-feature-probe.ts
@@ -34,8 +34,10 @@ export interface IntrospectedField {
  * Introspects the deployed schema and returns the fields of a type, or null when
  * the type does not exist. Exported so a test asserting on a field's type resolves
  * the endpoint (and honours `INDEXER_API_VERSION`) exactly as the probe gating it
- * does — a hand-rolled fetch alongside would introspect a different API version. `fieldSelection` adds per-field sub-selections on top
- * of `name` (e.g. `description`, `args { name }`).
+ * does — a hand-rolled fetch alongside would introspect a different API version.
+ *
+ * `fieldSelection` adds per-field sub-selections on top of `name` (e.g.
+ * `description`, `args { name }`, `type { kind name ofType { kind name } }`).
  *
  * Throws when the introspection itself does not succeed — a non-2xx response, a
  * GraphQL error, or a response carrying no `data`. Callers read null as "the

--- a/qa/tests/utils/indexer/schema-feature-probe.ts
+++ b/qa/tests/utils/indexer/schema-feature-probe.ts
@@ -16,15 +16,25 @@
 import { env } from 'environment/model';
 import { retry } from '@utils/retry-helper';
 
-interface IntrospectedField {
+/** A GraphQL type reference as introspection reports it, unwrapped one level. */
+export interface IntrospectedTypeRef {
+  kind: string;
+  name: string | null;
+  ofType: { kind: string; name: string | null } | null;
+}
+
+export interface IntrospectedField {
   name: string;
   description?: string | null;
   args?: { name: string }[];
+  type?: IntrospectedTypeRef;
 }
 
 /**
  * Introspects the deployed schema and returns the fields of a type, or null when
- * the type does not exist. `fieldSelection` adds per-field sub-selections on top
+ * the type does not exist. Exported so a test asserting on a field's type resolves
+ * the endpoint (and honours `INDEXER_API_VERSION`) exactly as the probe gating it
+ * does — a hand-rolled fetch alongside would introspect a different API version. `fieldSelection` adds per-field sub-selections on top
  * of `name` (e.g. `description`, `args { name }`).
  *
  * Throws when the introspection itself does not succeed — a non-2xx response, a
@@ -38,7 +48,7 @@ interface IntrospectedField {
  * Uses native fetch (pattern of http-compression-probe) because the typed
  * IndexerHttpClient methods are bound to domain queries, not introspection.
  */
-async function introspectTypeFields(
+export async function introspectTypeFields(
   typeName: string,
   fieldSelection: string,
 ): Promise<IntrospectedField[] | null> {

--- a/qa/tests/utils/indexer/schema-feature-probe.ts
+++ b/qa/tests/utils/indexer/schema-feature-probe.ts
@@ -141,3 +141,27 @@ export async function isBlockHashDustGenerationsSupported(): Promise<boolean> {
   const dustGenerations = fields?.find((f) => f.name === 'dustGenerations');
   return dustGenerations?.args?.some((arg) => arg.name === 'blockHash') ?? false;
 }
+
+/**
+ * Whether the deployed indexer serves `protocolVersion` on progress updates.
+ *
+ * Added by midnight-indexer#1463 to the progress types of the unshielded, shielded
+ * and dust generations subscriptions, so a wallet with nothing to receive can still
+ * observe a protocol upgrade. Presence on `UnshieldedTransactionsProgress` stands
+ * for the whole change — the three fields land in one commit — which leaves the
+ * smoke check free to assert that all three types really do expose it.
+ *
+ * Probed rather than assumed: a document selecting the field fails GraphQL
+ * validation where the build has not landed, which would turn a missing surface
+ * into a suite of hard failures.
+ */
+export async function isProgressProtocolVersionSupported(): Promise<boolean> {
+  const fields = await introspectTypeFields('UnshieldedTransactionsProgress', '').catch((error) => {
+    throw new Error(
+      `progress protocolVersion probe failed against ${env.getIndexerHttpBaseURL()}: ` +
+        `${(error as Error).message}`,
+      { cause: error },
+    );
+  });
+  return fields?.some((field) => field.name === 'protocolVersion') ?? false;
+}


### PR DESCRIPTION
Relates to midnightntwrk/midnight-indexer#1463 (merged as 3382a382).

## Why

`#1463` added `protocolVersion` to `UnshieldedTransactionsProgress`, `ShieldedTransactionsProgress` and
`DustGenerationsProgress`, so that a wallet with no transactions can observe a protocol upgrade it would
otherwise only learn about from the transactions it receives. Its own tests assert the field is
`> 0`; that passes on a wrong-but-nonzero value, and nothing held a subscription open across an actual
fork — the PR says so itself under "Known gap".

This adds black-box coverage of the value and closes that gap.

## What

**`qa/tests` — the reported value is correct, not merely present**

- Unshielded and shielded progress `protocolVersion` must equal the latest indexed block's
  `protocolVersion` (an independent oracle via `getLatestBlock`, rather than `> 0`).
- Dust-generations progress must report the **pinned snapshot block's** version, not the tip — the one
  place the three types deliberately differ. Pinned to an older in-window block.
- A smoke check introspects all three types and asserts `protocolVersion` is a non-null `Int`, so we can
  say which environments actually serve the field instead of assuming.
- New `isProgressProtocolVersionSupported()` probe gates all four, and `introspectTypeFields` is now
  exported and shared so the gate and the assertion resolve the same endpoint.

The three shared subscription documents are **untouched**: the new cases send separate progress-only
operations through the `queryOverride` parameter the client methods already accepted. Adding the field to
`UNSHIELDED_TX_SUBSCRIPTION_FRAGMENT` would have broken every existing unshielded test on every
environment that does not yet serve it.

**`indexer-tests` — the fork transition (#1463's known gap)**

`hardfork_e2e.rs` now holds an idle unshielded subscription open across the from-genesis 8→9 crossing
and asserts the version goes from the ledger-8 window to the ledger-9 window while `highestTransactionId`
stays 0 — i.e. no transaction ever taught the wallet the version. It also asserts the **second** behaviour
`#1463` changed: the tip version joining idle-backoff change detection, so a subscription that slept
through the fork returns to the base interval.

Measured on a real crossing (poll interval lowered to 2s for the test; production is 30s with an 8×
idle cap, recorded in a comment):

```
[6b] idle subscription observed protocol version 1000000 -> 2001000 over 16 frames,
     never receiving a transaction; poll gap 18.674s before the crossing -> 2.347s after it (base 2s)
```

This lives here rather than in `qa/scripts/test-hardfork-8to9.sh` (whose only oracle is grepping
chain-indexer logs) because this harness already drives the crossing with stage assertions. The QA suite
cannot host it at all: its undeployed provisioner boots a single node tag with no runtime-upgrade path.

**Supporting changes in `indexer-tests`**

- `graphql_ws_client`: `subscribe()` now delegates to a new `subscribe_raw()` (untyped document), so the
  typed operations shared with the main e2e suite are unaffected. The `#[serde(other)]` catch-all is
  **removed** so unknown frames fail loudly again; `Ping`/`Pong` are explicit and the write half is
  retained for the life of the stream so a ping is actually answered.
- `start_indexer` defaults `APP__INFRA__SECRET` (ambient value still wins) and the readiness error now
  carries the tail of `indexer.log`. Without this, a missing ambient secret surfaced as an opaque
  `timed out after 90s waiting for indexer API readiness`, with the real cause
  (`missing field 'secret' for key "INFRA"`) inside a `TempDir` that the failure itself deletes. It cost
  two people a run each. `qa/scripts/test-hardfork-8to9.sh:73` already defaults it and CI supplies it.
  The shared `indexer_log_tail` helper also fixes a pre-existing quirk in the process-exited diagnostic,
  which printed its last ten lines backwards.
- The hardfork test is `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`. On the default
  current-thread runtime the harness's blocking `Command` calls park the only worker, so progress frames
  arrive as one drained burst — which makes any frame-count-based timing inference unsound.

## Validation

`undeployed`, against images built from the change (`INDEXER_TAG` from this branch):

| Suite | Baseline | This branch |
|---|---|---|
| smoke | 26 passed, 1 skipped | 29 passed, 1 skipped |
| integration | 144 passed, 124 skipped, 20 todo | 160 passed, 111 skipped, 20 todo |
| `indexer-tests` `hardfork_e2e` | n/a | 1 passed, 0 failed (262.88s) |
| `indexer-tests` `native_e2e` (standalone) | — | 1 passed, 0 failed |

All six new assertions execute asserted, not skipped. 0 pre-existing failures, 0 new. The integration
`+13` beyond this change's own `+3` is `contract-queries`/`contract-subscriptions` data variance
(both untouched here, both data-gated) as the chain advanced between runs.

`lint`, `audit`, `format`, `tsc --noEmit`, `cargo fmt --check` and `clippy -D warnings` all clean.

## Notes for review

- **This branch touches `indexer-tests/**`, so `changes.non_qa` evaluates true and the full Rust
  pipeline (fmt-check, clippy `-D warnings`, `just test`, doc, both features) runs on this PR.** The
  `graphql_ws_client.rs` change is a shared-module refactor and wants dev-side review.
- **Two limits stated deliberately rather than papered over.** On an unforked chain the dust assertion
  cannot distinguish pinned-block from tip semantics (every block carries the same version) — it guards
  the reported value, and the test's own docs say so. And the `0`-when-nothing-indexed sentinel is not
  covered: `indexer-standalone` starts the API and chain-indexer together and a test can only subscribe
  after `/ready`, so the empty-DB window is milliseconds wide. It belongs dev-side, at
  `Storage::get_latest_protocol_version()` or `polling::latest_protocol_version`.
- Hardfork step `[9]` is non-deterministic on `main` already (a known toolkit cross-fork wallet-replay
  panic self-downgrades to a warning) — pre-existing, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
