### PR TITLE
chore(release): prepare for 4.4.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,38 +4,42 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.4.0-rc.2] - 2026-08-06
+## [4.4.0-rc.4] - 2026-09-02
+
+Release candidate for the ledger-v9 / node-2.x line, cut on top of `4.4.0-rc.3`.
+
+**This is not a drop-in image bump.** It carries the ledger 8→9 hard-fork crossing with the DUST
+reset, and contract state moves out of the database into the ledger arena — which **requires a
+re-index from genesis**, both stores wiped together. Two new migrations per database (Postgres 8→10,
+SQLite 9→11). See [docs/re-indexing.md](docs/re-indexing.md) before deploying.
 
 ### 🚀 Features
 
-- *(indexer)* Index the ledger 8→9 hard-fork crossing (#1395).
-- *(chain-indexer)* Derive block authors from BABE pre-runtime digests (#1321).
-- *(chain-indexer)* Gate BABE author derivation on the presence of `pallet-consensus-engine` (#1377).
+- *(chain-indexer)* Follow the node through the ledger 8→9 hard fork, including the DUST reset (#1444)
 
-### 🐛 Bug Fixes
+  Ledger crates move to 9.1.0 and `NODE_VERSIONS` to 2.1.0-beta.1, matching midnight-node
+  2.1.0-beta.1 crate-for-crate at the fork boundary. The v8→v9 state translation now depends on
+  the ledger team's upstream `v8-to-v9-state-translation` crate directly instead of the re-ported
+  copy of its `StateTranslationTable`, which is the arrangement the node already ships for its own
+  consensus-critical migration.
 
-- Dispatch runtime API and storage calls by the state runtime version at upgrade enactment blocks (#1346).
-- *(indexer-common)* Read the stored count in `ledger-db` `get_root_count` (#1378).
-- Publish multi-architecture manifests for indexer images (#1391).
+  The translation **wipes dust state** (midnight-node #2012, backported as #2057): `first_free`
+  returns to zero and the node replays only cNIGHT's slice of the generating set. Because the wipe
+  happens inside the state translation rather than via a transaction, no `DustGenerationDtimeUpdate`
+  event fires to retire the pre-fork rows — left mixed with the replayed rows they double-count
+  NIGHT balances and carry generation/commitment tree indices that now name different leaves. A new
+  `dust_epoch` column scopes `dust_generation_info` rows to the incarnation of the generation tree
+  they belong to, bumped only by a fork that actually wipes dust, so it stays stable across ledger
+  majors that leave dust alone.
 
-- *(indexer-common)* [**breaking**] Rename the ledger DB's `cache_size` to `cache_max_nodes`, make it a plain node count and raise it to 100000
+  Existing rows are backfilled from the protocol version of the transaction that produced them
+  rather than all defaulting to the pre-fork epoch, so a deployment that already crossed the
+  boundary on an older build returns correct answers straight after the upgrade instead of needing
+  a re-index for this change alone.
 
-  The value has always been a *number of arena nodes* (storage-core's own default is 10000), but it
-  was parsed as a byte size, so the shipped `"1kiB"` meant 1024 nodes — about 100x below where it
-  should be. Operators must rename the key in their config and replace any byte-unit string with a
-  plain integer; the `APP__INFRA__LEDGER_DB__CACHE_SIZE` environment variable becomes
-  `APP__INFRA__LEDGER_DB__CACHE_MAX_NODES`. `0` means unbounded.
+  Covered end to end by `indexer-tests/tests/hardfork_e2e.rs` and `qa/scripts/test-hardfork-8to9.sh`.
 
-### ⚙️ Miscellaneous Tasks
-
-- Add `pallet_session` support for the 2.1.0 runtime upgrade (#1333).
-- Pin `cargo-audit` (#1387).
-
-## [unreleased]
-
-### 🚀 Features
-
-- *(chain-indexer)* [**breaking**] Store contract state as ledger-arena keys instead of blobs
+- *(chain-indexer)* [**breaking**] Store contract state as ledger-arena keys instead of blobs (#1386)
 
   `contract_actions.state` and `contract_actions.zswap_state` are replaced by
   `state_key` and `zswap_state_key`, references into the content-addressed ledger arena that
@@ -67,6 +71,71 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   `arena_metrics_interval` (sample the ledger DB node count every N blocks; disabled by
   default because each sample is a full scan). indexer-api gains a `contract_state_cache`
   section under `api:`.
+
+- *(indexer-api)* Expose `protocolVersion` on all progress updates (#1463)
+
+  `protocolVersion` is added to the wallet, unshielded-UTXO and DUST-generation progress updates,
+  letting a wallet with no relevant transactions or generations observe a protocol upgrade, which
+  it would otherwise only learn about from the items it receives. On snapshot-shaped updates it is
+  the protocol version at the snapshot's block; on tip-shaped updates it is the version currently
+  in effect, and zero means no block has been indexed yet.
+
+### 🐛 Bug Fixes
+
+- *(indexer-api)* Reject unbounded epoch range queries in the SPO series resolvers
+  (`registeredTotalsSeries`, `registeredSpoSeries`, `registeredPresence`) (#1455). A single
+  unauthenticated request with an unbounded `toEpoch` could pin a database connection for
+  minutes-to-hours and drive `indexer-api` toward OOM. Spans wider than 10,000 epochs are now
+  rejected as client errors (GHSA-6746-qxvv-3hwg). Also shipped in `4.3.800-rc.1` on the
+  ledger-v8 line.
+- *(indexer-common)* Renumber the colliding contract-state-keys migration (#1468)
+- *(indexer-api)* Bound concurrent ledger-DB queries to prevent worker starvation (#1440)
+
+### ⚙️ Dependencies
+
+- Bump `h2` to 0.4.17 for RUSTSEC-2026-0258 (#1449)
+
+## [4.4.0-rc.3] - 2026-08-24
+
+### 🚀 Features
+
+- *(indexer-common)* Source secrets from files via `APP__*_FILE` environment variables (#1074).
+
+### 🐛 Bug Fixes
+
+- *(indexer-common)* Use the node-identical stateless cost for `block_fullness` accumulation (#1443).
+- *(indexer-standalone)* Fix SQLite deadlocks and socket bloat in standalone mode (#1094).
+
+### ⚙️ Miscellaneous Tasks
+
+- Add standard issue templates and label-automation dispatchers (#1438).
+
+## [4.4.0-rc.2] - 2026-08-06
+
+### 🚀 Features
+
+- *(indexer)* Index the ledger 8→9 hard-fork crossing (#1395).
+- *(chain-indexer)* Derive block authors from BABE pre-runtime digests (#1321).
+- *(chain-indexer)* Gate BABE author derivation on the presence of `pallet-consensus-engine` (#1377).
+
+### 🐛 Bug Fixes
+
+- Dispatch runtime API and storage calls by the state runtime version at upgrade enactment blocks (#1346).
+- *(indexer-common)* Read the stored count in `ledger-db` `get_root_count` (#1378).
+- Publish multi-architecture manifests for indexer images (#1391).
+
+- *(indexer-common)* [**breaking**] Rename the ledger DB's `cache_size` to `cache_max_nodes`, make it a plain node count and raise it to 100000
+
+  The value has always been a *number of arena nodes* (storage-core's own default is 10000), but it
+  was parsed as a byte size, so the shipped `"1kiB"` meant 1024 nodes — about 100x below where it
+  should be. Operators must rename the key in their config and replace any byte-unit string with a
+  plain integer; the `APP__INFRA__LEDGER_DB__CACHE_SIZE` environment variable becomes
+  `APP__INFRA__LEDGER_DB__CACHE_MAX_NODES`. `0` means unbounded.
+
+### ⚙️ Miscellaneous Tasks
+
+- Add `pallet_session` support for the 2.1.0 runtime upgrade (#1333).
+- Pin `cargo-audit` (#1387).
 
 ## [4.3.5] - 2026-07-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "chain-indexer"
-version = "4.4.0-rc.2"
+version = "4.4.0-rc.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3396,7 +3396,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-api"
-version = "4.4.0-rc.2"
+version = "4.4.0-rc.4"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-standalone"
-version = "4.4.0-rc.2"
+version = "4.4.0-rc.4"
 dependencies = [
  "anyhow",
  "byte-unit-serde",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-tests"
-version = "4.4.0-rc.2"
+version = "4.4.0-rc.4"
 dependencies = [
  "anyhow",
  "bech32",
@@ -7598,7 +7598,7 @@ dependencies = [
 
 [[package]]
 name = "spo-indexer"
-version = "4.4.0-rc.2"
+version = "4.4.0-rc.4"
 dependencies = [
  "anyhow",
  "blake2",
@@ -9158,7 +9158,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-indexer"
-version = "4.4.0-rc.2"
+version = "4.4.0-rc.4"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version       = "4.4.0-rc.2"
+version       = "4.4.0-rc.4"
 edition       = "2024"
 license       = "Apache-2.0"
 readme        = "README.md"


### PR DESCRIPTION
Release prep for `4.4.0-rc.4` on the ledger-v9 / node-2.x line, continuing from
[`v4.4.0-rc.3`](https://github.com/midnightntwrk/midnight-indexer/releases/tag/v4.4.0-rc.3).
Draft so CI runs; no code changes.

## What's in it

- `Cargo.toml` `[workspace.package] version` → `4.4.0-rc.4`, with `Cargo.lock` refreshed
  (6 workspace version lines). Verified with `cargo metadata --locked`, since every Dockerfile
  builds `--locked` and a stale lock fails all five image builds *after* the tag is pushed.
- `CHANGELOG.md`: new `[4.4.0-rc.4]` section for the six commits since rc.3.

## Changelog housekeeping folded in

- **Backfills the `[4.4.0-rc.3]` section.** It was written on `release/4.4.0-rc.3` and never
  merged back, so `main`'s changelog skipped from rc.2 to `[unreleased]` and had no record that
  rc.3 shipped. Copied verbatim from the release branch.
- **Folds the stray `[unreleased]` block into rc.4.** The hand-written #1386 entry was sitting
  *below* the rc.2 section; it now sits in the release it ships in, and cites its PR number.
- **Two entries git-cliff cannot see, added by hand:**
  - **#1444** (`Ledger 8 -> 9 hardfork + DUST migration.`) has a non-conventional subject.
    `cliff.toml` sets `filter_unconventional = true`, which drops unparseable commits *before*
    `commit_parsers` run — so the catch-all `.*` → `💼 Other` parser never sees it. The largest
    change in the release was absent from the generated section. #1094 was lost the same way when
    rc.3 was cut and hand-added then; this is recurring.
  - **#1449** (`chore(deps): bump h2 to 0.4.17`) is a `chore(deps)` skip by design, but it patches
    RUSTSEC-2026-0258, and the `format-release-notes` convention is to include dependency entries
    that are CVE patches.

Reconciled mechanically — every commit in `v4.4.0-rc.2..main` is now accounted for in the section
or is a deliberate `cliff.toml` skip (`chore(deps)`, `chore(ci)`, `test:`).

## Operator-visible: this is NOT a drop-in image bump

- **#1386 requires a re-index from genesis**, with the indexer database and the ledger DB wiped
  **together** — each holds references into the other. chain-indexer refuses to start against a
  database whose contract actions have no keys. See [docs/re-indexing.md](docs/re-indexing.md).
- **#1444 wipes DUST state** as part of the 8→9 state translation.
- Migrations: Postgres 8 → 10, SQLite 9 → 11. GraphQL definitions stay at 105 (`protocolVersion`
  added to three progress-update types).

## After merge

Tag the merge commit with an annotated, GPG-signed tag (`git tag -s -a v4.4.0-rc.4`), push it to
trigger `build-indexer-images`, wait for the `merge-manifests` jobs before pinning any deployment,
then `gh release create v4.4.0-rc.4 --prerelease`.

Per `docs/releasing.md`, the final `4.4.0` stays gated on QA sign-off.

Assisted-by: AI <noreply@ai-assistant>