### PR TITLE
fix(deps): bump rtrb, spin and chacha20 to clear advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -6197,7 +6197,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20 0.10.0",
+ "chacha20 0.10.2",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
@@ -6573,9 +6573,9 @@ dependencies = [
 
 [[package]]
 name = "rtrb"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ade083ccbb4bf536df69d1f6432cc23deb7acccff86b183f3923a6fd56a1153"
+checksum = "fae8ee26b0371a29a77d2b2d6b3ae13aa81def6f9bf1b1b92a32d279a5e709b7"
 
 [[package]]
 name = "rust_decimal"
@@ -7579,9 +7579,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
# Overview

`cargo-deny` was failing CI on `RUSTSEC-2026-0274` and reporting two yanked
crates. This bumps all three to their patched releases. Lockfile only — no
manifest or source changes, and no other dependency moved.

| Crate | Bump | Reason |
|---|---|---|
| `rtrb` | 0.3.4 → 0.3.5 | `RUSTSEC-2026-0274` — double free / use-after-free in `ReadChunk::commit` when an element's `Drop` panics |
| `chacha20` | 0.10.0 → 0.10.2 | Yanked — SSE4.1 intrinsic (`_mm_extract_epi32`) used in the SSE2 backend |
| `spin` | 0.9.8 → 0.9.9 | Yanked — unsoundness in `Once::{force_into_inner, try_into_inner, into_inner_unchecked}` |

All three arrive transitively: `rtrb` and `chacha20` via `fastrace`, `spin` via
`flume` (`sqlx-sqlite`) and `multer` (`async-graphql`).

## Impact assessment

The `rtrb` advisory is **not reachable here**. `fastrace`'s only use of `rtrb`
is `util/spsc.rs`, which calls `push`/`pop`/`is_abandoned` — never
`read_chunk`/`commit`/`commit_all`, the vulnerable functions. Queue elements
are plain span data with no panicking `Drop`. The bump clears the CI gate and
costs nothing.

`0.3.5` rather than `0.4.0`: the advisory notes `is_abandoned()` changed
behaviour in 0.4.0, and `fastrace` calls exactly that to detect channel
closure.

## Verification

Each new version was reviewed rather than taken on trust:

- **Source diffs** — all three tarballs diffed against their predecessors. Each
  change is confined to the one function its changelog names, with no new
  dependencies, no new `unsafe`, and no build scripts.
- **Provenance** — `.cargo_vcs_info.json` checked against upstream git.
  `rtrb 0.3.5` matches tag `0.3.5` (`a6ba84f`); `chacha20 0.10.2` matches tag
  `chacha20-v0.10.2` (`6b236b7`, reviewed PR #581 in the RustCrypto org).
  `spin 0.9.9` is **not verifiable** — `zesterer/spin-rs` is archived with no
  tags and does not contain the publish commit. Mitigating: published by a
  listed crate owner as part of a same-day coordinated backport across every
  maintained line (0.7.2, 0.8.1, 0.9.9, 0.10.1, 0.11.1, 0.12.2), and the
  tarball-to-tarball diff is the two-line `ManuallyDrop` fix plus tests.
- **Yank patterns** corroborate the stated causes: spin 0.9.0–0.9.8 all yanked;
  chacha20 0.10.0 *and* 0.10.1 yanked.
- **Post-fix scan** — `advisories ok, bans ok, licenses ok, sources ok`.

## Submission Checklist

- [x] Useful pull request description
- [ ] Tests are provided (if possible) — n/a, no functionality added; existing
      suites cover the affected paths (`sqlx-sqlite` and `async-graphql` both
      depend on `spin`)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [x] Update README.md file (if relevant) — n/a
- [x] Update documentation (if relevant) — n/a
- [x] No new todos introduced

## Links

<!-- RUSTSEC-2026-0274: https://rustsec.org/advisories/RUSTSEC-2026-0274 -->
