### PR TITLE
fix(ci): restore Docker Hub publishing for tag builds

### DIFF
--- a/.github/workflows/build-indexer-images.yaml
+++ b/.github/workflows/build-indexer-images.yaml
@@ -84,12 +84,13 @@ jobs:
         env:
           DOCKER_METADATA_SHORT_SHA_LENGTH: 8
         with:
-          # midnight-ntwrk is the legacy GitHub org: dual-publish to the
-          # current midnightntwrk org so internal consumers can migrate,
-          # then the legacy org gets sunset.
+          # midnight-ntwrk is the legacy GitHub org, dual-published to the current
+          # midnightntwrk org until it is sunset. Tag builds also push to Docker
+          # Hub, which is the registry docker-compose.yaml defaults to.
           images: |
             ghcr.io/midnight-ntwrk/${{ matrix.image.name }}
             ghcr.io/midnightntwrk/${{ matrix.image.name }}
+            ${{ github.ref_type == 'tag' && format('midnightntwrk/{0}', matrix.image.name) || '' }}
           flavor: |
             suffix=${{ matrix.platform.suffix }}
           tags: |
@@ -179,11 +180,11 @@ jobs:
         env:
           DOCKER_METADATA_SHORT_SHA_LENGTH: 8
         with:
-          # Keep in sync with the build-and-push images list (legacy org
-          # dual-published with the current midnightntwrk org).
+          # Keep in sync with the images list in build-and-push.
           images: |
             ghcr.io/midnight-ntwrk/${{ matrix.image.name }}
             ghcr.io/midnightntwrk/${{ matrix.image.name }}
+            ${{ github.ref_type == 'tag' && format('midnightntwrk/{0}', matrix.image.name) || '' }}
           tags: |
             type=semver,pattern={{version}}
             ${{ github.ref_type != 'tag' && format('type=sha,prefix={0}-,format=short', env.VERSION) || '' }}


### PR DESCRIPTION
Closes #1470

## Problem

PR #1420 (`82759bf1`) intended to add `ghcr.io/midnightntwrk` alongside the legacy `ghcr.io/midnight-ntwrk` org. It instead **replaced** the Docker Hub entry in both `Setup Docker Metadata` steps:

```diff
-  ${{ github.ref_type == 'tag' && format('midnightntwrk/{0}', matrix.image.name) || '' }}
+  ghcr.io/midnightntwrk/${{ matrix.image.name }}
```

The removed and added lines differ only by the `ghcr.io/` prefix, which is likely how the substitution went unnoticed in review.

## Evidence

- Docker Hub `midnightntwrk/chain-indexer` returns 200 for `4.4.0-rc.2`, 404 for `4.4.0-rc.2-stagenet-hotfix` and `4.4.0-rc.3`. Its newest tag is still `4.4.0-rc.2`, i.e. nothing has been pushed since 2026-08-11.
- `v4.4.0-rc.2` predates `82759bf1`, so the restored line is a previously-working configuration rather than a guess.
- Run [32678612314](https://github.com/midnightntwrk/midnight-indexer/actions/runs/32678612314) (`v4.4.0-rc.3`): all 15 build/merge jobs succeeded, both `Docker Compose Validation` jobs failed, run conclusion `success`.
- `Login to DockerHub` still runs and succeeds, so credentials are not the cause.

## Change

Restores the tag-gated Docker Hub target in the `images:` list of both metadata steps (`build-and-push` and `merge-manifests`), so each carries three targets and the two lists stay in sync. Comments were tightened to the org three-line ceiling; the `merge-manifests` comment was restating the other one and would have gone stale on the next registry change.

Two functional lines. No change to the empty-string fallback for non-tag builds, the `flavor: suffix=` arch suffixing, or the `Login to DockerHub` step.

## Verification

`v4.4.0-rc.4` is not tagged yet, so this lands before the next release and that tag should publish to Docker Hub. Confirm after the next tag build with:

```
docker pull midnightntwrk/chain-indexer:4.4.0-rc.4
```

## Deliberately out of scope

- **`continue-on-error: true` on `docker-compose-validation`.** It detected this regression but could not report it. Making it a gate is a release-blocking policy tradeoff rather than part of this fix.
- **Backfilling `4.4.0-rc.3` and the stagenet hotfix on Docker Hub.** This only affects future tag builds.
- **Compliance gap:** this repository has no `.pre-commit-config.yaml`, which the org hygiene rules require. Belongs in its own scoped PR.

## Note for reviewers

There is a stale unmerged branch `origin/remove-dockerhub-publish` (May 2026) that deliberately disabled Docker Hub publishing, citing a dead org access token. It was never merged and `rc.2` published fine in August, so credentials are live. If GHCR-only has since become the intended direction, the right fix is changing the `docker-compose.yaml` default registry instead of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)