### PR TITLE
docs: fix registry targets and latest-tag claims

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -47,12 +47,13 @@ Review the prepended section before committing.
 3. **Images publish automatically.** A `v*` tag triggers
    `.github/workflows/build-indexer-images.yaml`, which builds every component
    (`chain-indexer`, `wallet-indexer`, `indexer-api`, `spo-indexer`,
-   `indexer-standalone`) with the `release` profile and pushes semver-tagged
-   images to `ghcr.io/midnight-ntwrk/<component>` (always) and
-   `docker.io/midnightntwrk/<component>` (tag builds only). The same workflow also runs on
-   **main pushes** and **manual dispatch**, tagging those images `<cargo-version>-<short-sha>`
-   with the `dev` profile (GHCR only) - a pre-merge or feature image is identifiable by its
-   `-<sha>` suffix.
+   `indexer-standalone`) with the `release` profile and pushes semver-tagged images to three
+   targets: `ghcr.io/midnight-ntwrk/<component>` and `ghcr.io/midnightntwrk/<component>` on
+   every build, plus `docker.io/midnightntwrk/<component>` on tag builds only.
+   `midnight-ntwrk` is the legacy GitHub org, published alongside the current `midnightntwrk`
+   org until the legacy org is sunset. The same workflow also runs on **main pushes** and
+   **manual dispatch**, tagging those images `<cargo-version>-<short-sha>` with the `dev`
+   profile (GHCR only) - a pre-merge or feature image is identifiable by its `-<sha>` suffix.
 
 ## Scheduling & sign-off
 
@@ -80,8 +81,9 @@ v4.4.0-pre-alpha.14-l91r3-n2r3-bridge-and-events-epics-ca3e554
                   ledger  node                        commit
 ```
 
-These never reach Docker Hub - only semver-pattern tag builds get the
-`midnightntwrk/*` images and `latest`.
+These never reach Docker Hub. Only semver-pattern tag builds get the
+`docker.io/midnightntwrk/*` images. `latest` is narrower still: `latest=auto` skips
+pre-releases, so only a final `vX.Y.Z` carries it.
 
 ## See also
 


### PR DESCRIPTION
# Overview

Three corrections to the image-publishing description in `docs/releasing.md`. Documentation only — no workflow or code changes.

**Registry targets were incomplete.** Step 3 listed `ghcr.io/midnight-ntwrk/<component>` and `docker.io/midnightntwrk/<component>`. #1420 added a third target, `ghcr.io/midnightntwrk`, alongside the legacy `midnight-ntwrk` org, and the doc was never updated. It now lists all three and says which builds reach each, with a sentence on why the legacy org is still published.

**`midnightntwrk/*` was ambiguous.** In the pre-release section that bare form reads as either the Docker Hub org or the GHCR org of the same name. Qualified to `docker.io/midnightntwrk/*`.

**The `latest` claim was wrong.** The doc said semver-pattern tag builds get "the `midnightntwrk/*` images and `latest`", implying every `-rc.N` produces a `latest`. `docker/metadata-action` runs in default `latest=auto` mode, and at the SHA the workflow pins (`dc802804`) pre-releases only extend `{{version}}`:

> Pre-release (rc, beta, alpha) will only extend `{{version}}` (or `{{raw}}` if specified) as tag because they are updated frequently […]

Only a final `vX.Y.Z` carries `latest`. Verified against the pinned SHA's README rather than the action's current docs.

Found while reviewing #1477. That PR restores the Docker Hub target the doc already described; this one closes the remaining gap in the other direction, so the doc and the workflow's `images:` list agree.

## Submission Checklist

- [x] Useful pull request description
- [ ] Tests are provided (if possible)
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [ ] Update README.md file (if relevant)
- [x] Update documentation (if relevant)
- [x] No new todos introduced

## Links

- Follow-up from review of #1477 (restores Docker Hub publishing for tag builds)
- Documents the third registry target added in #1420
- Related: #1384 — `latest` is overwritten by the arm64 build. Deliberately not described here, since that is a bug rather than the intended contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
